### PR TITLE
refactor: extract hooks and add configurable padding/backgroundColor

### DIFF
--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -3,16 +3,14 @@ import {
   Circle,
   LinearGradient,
   Path,
-  Skia,
   vec,
 } from "@shopify/react-native-skia";
-import { useState } from "react";
-import { View, type LayoutChangeEvent } from "react-native";
-import { useDerivedValue } from "react-native-reanimated";
-import { buildLinePoints, DEFAULT_PADDING } from "./draw/line";
-import { drawSpline } from "./math/spline";
-import { resolveTheme } from "./theme";
+import { useCanvasLayout, useChartPaths, useLiveDot } from "./hooks";
+
 import type { LivelineProps } from "./types";
+import { View } from "react-native";
+import { resolvePadding } from "./draw/line";
+import { resolveTheme } from "./theme";
 import { useLivelineEngine } from "./useLivelineEngine";
 
 export function Liveline({
@@ -26,10 +24,13 @@ export function Liveline({
   referenceLine,
   fill = true,
   lineWidth: lineWidthProp,
+  backgroundColor,
+  padding,
   style,
 }: LivelineProps) {
   const palette = resolveTheme(color, theme);
   const strokeWidth = lineWidthProp ?? palette.lineWidth;
+  const effectivePadding = resolvePadding(padding);
 
   const engine = useLivelineEngine({
     data,
@@ -40,79 +41,14 @@ export function Liveline({
     referenceValue: referenceLine?.value,
   });
 
-  const [layoutHeight, setLayoutHeight] = useState(0);
+  const { layoutHeight, onLayout } = useCanvasLayout(engine);
+  const { linePath, fillPath } = useChartPaths(engine, effectivePadding);
+  const { dotX, dotY } = useLiveDot(engine, effectivePadding);
 
-  const onLayout = (e: LayoutChangeEvent) => {
-    const { width, height } = e.nativeEvent.layout;
-    engine.canvasWidth.value = width;
-    engine.canvasHeight.value = height;
-    setLayoutHeight(height);
-  };
-
-  // ─── Derived paths (UI thread, react to shared value changes) ──────
-
-  const flatPts = useDerivedValue(() =>
-    buildLinePoints(
-      engine.data.value,
-      engine.displayValue.value,
-      engine.timestamp.value,
-      engine.displayWindow.value,
-      engine.displayMin.value,
-      engine.displayMax.value,
-      engine.canvasWidth.value,
-      engine.canvasHeight.value,
-      DEFAULT_PADDING,
-    ),
-  );
-
-  const linePath = useDerivedValue(() => {
-    const pts = flatPts.value;
-    const path = Skia.Path.Make();
-    const n = pts.length >> 1;
-    if (n < 2) return path;
-    path.moveTo(pts[0], pts[1]);
-    drawSpline(path, pts);
-    return path;
-  });
-
-  const fillPath = useDerivedValue(() => {
-    const pts = flatPts.value;
-    const path = Skia.Path.Make();
-    const n = pts.length >> 1;
-    if (n < 2) return path;
-    path.moveTo(pts[0], pts[1]);
-    drawSpline(path, pts);
-    const bottom = engine.canvasHeight.value - DEFAULT_PADDING.bottom;
-    path.lineTo(pts[(n - 1) * 2], bottom);
-    path.lineTo(pts[0], bottom);
-    path.close();
-    return path;
-  });
-
-  const dotX = useDerivedValue(() => {
-    const w = engine.canvasWidth.value;
-    if (w === 0) return -100;
-    return w - DEFAULT_PADDING.right;
-  });
-
-  const dotY = useDerivedValue(() => {
-    const h = engine.canvasHeight.value;
-    if (h === 0) return -100;
-    const chartH = h - DEFAULT_PADDING.top - DEFAULT_PADDING.bottom;
-    const dMin = engine.displayMin.value;
-    const dMax = engine.displayMax.value;
-    const valRange = dMax - dMin;
-    if (valRange === 0) return DEFAULT_PADDING.top + chartH / 2;
-    return (
-      DEFAULT_PADDING.top +
-      ((dMax - engine.displayValue.value) / valRange) * chartH
-    );
-  });
-
-  // ─── Render ────────────────────────────────────────────────────────
-
-  const bgColor = `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
-  const gradientEnd = Math.max(1, layoutHeight - DEFAULT_PADDING.bottom);
+  const bgColor =
+    backgroundColor ??
+    `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
+  const gradientEnd = Math.max(1, layoutHeight - effectivePadding.bottom);
 
   return (
     <View
@@ -123,7 +59,7 @@ export function Liveline({
         {fill && (
           <Path path={fillPath} style="fill">
             <LinearGradient
-              start={vec(0, DEFAULT_PADDING.top)}
+              start={vec(0, effectivePadding.top)}
               end={vec(0, gradientEnd)}
               colors={[palette.fillTop, palette.fillBottom]}
             />

--- a/src/draw/line.ts
+++ b/src/draw/line.ts
@@ -1,4 +1,4 @@
-import type { LivelinePoint } from "../types";
+import type { LivelinePoint, Padding } from "../types";
 
 export interface ChartPadding {
   top: number;
@@ -13,6 +13,16 @@ export const DEFAULT_PADDING: ChartPadding = {
   bottom: 28,
   left: 12,
 };
+
+export function resolvePadding(override?: Padding): ChartPadding {
+  if (!override) return DEFAULT_PADDING;
+  return {
+    top: override.top ?? DEFAULT_PADDING.top,
+    right: override.right ?? DEFAULT_PADDING.right,
+    bottom: override.bottom ?? DEFAULT_PADDING.bottom,
+    left: override.left ?? DEFAULT_PADDING.left,
+  };
+}
 
 /**
  * Build screen-space points as a flat number array [x0, y0, x1, y1, ...].

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,4 @@
+export { useCanvasLayout } from "./useCanvasLayout";
+export { useChartPaths } from "./useChartPaths";
+export { useLiveDot } from "./useLiveDot";
+

--- a/src/hooks/useCanvasLayout.ts
+++ b/src/hooks/useCanvasLayout.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+
+import type { EngineState } from "../useLivelineEngine";
+import type { LayoutChangeEvent } from "react-native";
+
+export function useCanvasLayout(engine: EngineState) {
+  const [layoutHeight, setLayoutHeight] = useState(0);
+
+  const onLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      const { width, height } = e.nativeEvent.layout;
+      engine.canvasWidth.value = width;
+      engine.canvasHeight.value = height;
+      setLayoutHeight(height);
+    },
+    [engine.canvasWidth, engine.canvasHeight],
+  );
+
+  return { layoutHeight, onLayout } as const;
+}

--- a/src/hooks/useChartPaths.ts
+++ b/src/hooks/useChartPaths.ts
@@ -1,0 +1,47 @@
+import { Skia } from "@shopify/react-native-skia";
+import { useDerivedValue } from "react-native-reanimated";
+import { buildLinePoints, type ChartPadding } from "../draw/line";
+import { drawSpline } from "../math/spline";
+import type { EngineState } from "../useLivelineEngine";
+
+export function useChartPaths(engine: EngineState, padding: ChartPadding) {
+  const flatPts = useDerivedValue(() =>
+    buildLinePoints(
+      engine.data.value,
+      engine.displayValue.value,
+      engine.timestamp.value,
+      engine.displayWindow.value,
+      engine.displayMin.value,
+      engine.displayMax.value,
+      engine.canvasWidth.value,
+      engine.canvasHeight.value,
+      padding,
+    ),
+  );
+
+  const linePath = useDerivedValue(() => {
+    const pts = flatPts.value;
+    const path = Skia.Path.Make();
+    const n = pts.length >> 1;
+    if (n < 2) return path;
+    path.moveTo(pts[0], pts[1]);
+    drawSpline(path, pts);
+    return path;
+  });
+
+  const fillPath = useDerivedValue(() => {
+    const pts = flatPts.value;
+    const path = Skia.Path.Make();
+    const n = pts.length >> 1;
+    if (n < 2) return path;
+    path.moveTo(pts[0], pts[1]);
+    drawSpline(path, pts);
+    const bottom = engine.canvasHeight.value - padding.bottom;
+    path.lineTo(pts[(n - 1) * 2], bottom);
+    path.lineTo(pts[0], bottom);
+    path.close();
+    return path;
+  });
+
+  return { linePath, fillPath } as const;
+}

--- a/src/hooks/useLiveDot.ts
+++ b/src/hooks/useLiveDot.ts
@@ -1,0 +1,26 @@
+import type { ChartPadding } from "../draw/line";
+import type { EngineState } from "../useLivelineEngine";
+import { useDerivedValue } from "react-native-reanimated";
+
+export function useLiveDot(engine: EngineState, padding: ChartPadding) {
+  const dotX = useDerivedValue(() => {
+    const w = engine.canvasWidth.value;
+    if (w === 0) return -100;
+    return w - padding.right;
+  });
+
+  const dotY = useDerivedValue(() => {
+    const h = engine.canvasHeight.value;
+    if (h === 0) return -100;
+    const chartH = h - padding.top - padding.bottom;
+    const dMin = engine.displayMin.value;
+    const dMax = engine.displayMax.value;
+    const valRange = dMax - dMin;
+    if (valRange === 0) return padding.top + chartH / 2;
+    return (
+      padding.top + ((dMax - engine.displayValue.value) / valRange) * chartH
+    );
+  });
+
+  return { dotX, dotY } as const;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,7 @@ export interface LivelineProps {
   orderbook?: OrderbookData;
   tradeEvents?: TradeEvent[];
 
+  backgroundColor?: string;
   referenceLine?: ReferenceLine;
   formatValue?: (v: number) => string;
   formatTime?: (t: number) => string;


### PR DESCRIPTION
### TL;DR

Refactored the Liveline component by extracting chart rendering logic into custom hooks and added support for customizable padding and background color.

### What changed?

- Extracted canvas layout management into `useCanvasLayout` hook
- Moved chart path generation logic to `useChartPaths` hook  
- Created `useLiveDot` hook for live dot positioning calculations
- Added `backgroundColor` prop to allow custom background colors
- Added `padding` prop with `resolvePadding` utility function to support configurable chart padding
- Replaced hardcoded `DEFAULT_PADDING` usage with dynamic padding resolution throughout the component

### How to test?

- Verify the chart renders correctly with default settings
- Test the new `backgroundColor` prop by passing different color values
- Test the new `padding` prop by providing custom padding values (top, right, bottom, left)
- Ensure the live dot positioning and chart paths work correctly with custom padding
- Confirm that omitting the new props maintains backward compatibility

### Why make this change?

This refactoring improves code organization by separating concerns into focused hooks, making the main component more readable and maintainable. The new props provide greater customization flexibility for developers who need to adjust the chart's appearance to match their design requirements.