### PR TITLE
feat: add loading state with animated reveal transition

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,7 +4,7 @@ import { Stack } from "expo-router";
 export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <Stack />
+      <Stack screenOptions={{ headerShown: false }} />
     </GestureHandlerRootView>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -48,6 +48,7 @@ export default function Index() {
   const [tradeSource, setTradeSource] = useState<TradeSource>("orderbook");
   const [paused, setPaused] = useState(false);
   const [startValue, setStartValue] = useState(100);
+  const [loading, setLoading] = useState(false);
 
   const { data, value } = useSimulatedData({
     volatilityMode,
@@ -91,6 +92,7 @@ export default function Index() {
           theme="dark"
           scrub
           scrubTooltip={false}
+          loading={loading}
           onScrub={(point) => {
             scrubPoint.value = point;
           }}
@@ -164,14 +166,29 @@ export default function Index() {
           ))}
         </View>
 
-        <Pressable
-          style={[styles.chip, paused && styles.chipActive]}
-          onPress={() => setPaused((p) => !p)}
-        >
-          <Text style={[styles.chipText, paused && styles.chipTextActive]}>
-            {paused ? "Resume" : "Pause"}
-          </Text>
-        </Pressable>
+        <View style={styles.buttonRow}>
+          <Pressable
+            style={[styles.chip, paused && styles.chipActive]}
+            onPress={() => setPaused((p) => !p)}
+          >
+            <Text style={[styles.chipText, paused && styles.chipTextActive]}>
+              {paused ? "Resume" : "Pause"}
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, loading && styles.chipActive]}
+            onPress={() => {
+              setLoading(true);
+              setTimeout(() => setLoading(false), 2000);
+            }}
+            disabled={loading}
+          >
+            <Text style={[styles.chipText, loading && styles.chipTextActive]}>
+              {loading ? "Loading…" : "Reload"}
+            </Text>
+          </Pressable>
+        </View>
       </ScrollView>
     </View>
   );

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -33,6 +33,9 @@ jest.mock("@shopify/react-native-skia", () => {
     Canvas: View,
     Circle: View,
     Group: View,
+    Line: View,
+    Rect: View,
+    RoundedRect: View,
     Text: View,
     Path: ({ children, ...props }) =>
       React.createElement(View, props, children),

--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -1,5 +1,6 @@
 import {
   Canvas,
+  Group,
   LinearGradient,
   Path,
   matchFont,
@@ -15,6 +16,7 @@ import {
   useBadge,
   useCanvasLayout,
   useChartPaths,
+  useChartReveal,
   useCrosshair,
   useGrid,
   useLiveDot,
@@ -28,6 +30,7 @@ import { DotOverlay } from "./components/DotOverlay";
 import { GestureDetector } from "react-native-gesture-handler";
 import { GridOverlay } from "./components/GridOverlay";
 import type { LivelineProps } from "./types";
+import { LoadingOverlay } from "./components/LoadingOverlay";
 import { TimeAxisOverlay } from "./components/TimeAxisOverlay";
 import { resolveTheme } from "./theme";
 import { useLivelineEngine } from "./useLivelineEngine";
@@ -51,6 +54,8 @@ export function Liveline({
   pulse = true,
   scrub = false,
   scrubTooltip = true,
+  loading = false,
+  emptyText = "No data",
   lineWidth: lineWidthProp,
   formatValue = defaultFormatValue,
   formatTime = defaultFormatTime,
@@ -87,8 +92,14 @@ export function Liveline({
     referenceValue: referenceLine?.value,
   });
 
+  const reveal = useChartReveal(loading);
+
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
-  const { linePath, fillPath } = useChartPaths(engine, effectivePadding);
+  const { linePath, fillPath } = useChartPaths(
+    engine,
+    effectivePadding,
+    reveal.morphT,
+  );
   const { dotX, dotY } = useLiveDot(engine, effectivePadding);
   const momentumSV = useMomentum(engine, momentum);
   const { gridEntries } = useGrid(
@@ -139,34 +150,41 @@ export function Liveline({
       >
         <Canvas style={{ flex: 1 }}>
           {grid && (
-            <GridOverlay
-              entries={gridEntries}
-              engine={engine}
-              padding={effectivePadding}
-              palette={palette}
-              font={font}
-              badge={badge}
-            />
+            <Group opacity={reveal.gridOpacity}>
+              <GridOverlay
+                entries={gridEntries}
+                engine={engine}
+                padding={effectivePadding}
+                palette={palette}
+                font={font}
+                badge={badge}
+              />
+            </Group>
           )}
 
           {fill && (
-            <Path path={fillPath} style="fill">
-              <LinearGradient
-                start={vec(0, effectivePadding.top)}
-                end={vec(0, gradientEnd)}
-                colors={[palette.fillTop, palette.fillBottom]}
-              />
-            </Path>
+            <Group opacity={reveal.fillOpacity}>
+              <Path path={fillPath} style="fill">
+                <LinearGradient
+                  start={vec(0, effectivePadding.top)}
+                  end={vec(0, gradientEnd)}
+                  colors={[palette.fillTop, palette.fillBottom]}
+                />
+              </Path>
+            </Group>
           )}
 
-          <Path
-            path={linePath}
-            style="stroke"
-            strokeWidth={strokeWidth}
-            color={palette.line}
-            strokeCap="round"
-            strokeJoin="round"
-          />
+          {/* Line path: always rendered; morph handles transition via blended pts */}
+          <Group opacity={reveal.lineOpacity}>
+            <Path
+              path={linePath}
+              style="stroke"
+              strokeWidth={strokeWidth}
+              color={palette.line}
+              strokeCap="round"
+              strokeJoin="round"
+            />
+          </Group>
 
           <TimeAxisOverlay
             entries={timeEntries}
@@ -176,15 +194,34 @@ export function Liveline({
             font={font}
           />
 
-          {badge && <BadgeOverlay badge={badgeData} font={font} />}
+          {badge && (
+            <Group opacity={reveal.badgeOpacity}>
+              <BadgeOverlay badge={badgeData} font={font} />
+            </Group>
+          )}
 
-          <DotOverlay
-            dotX={dotX}
-            dotY={dotY}
-            momentum={momentumSV}
-            palette={palette}
+          <Group opacity={reveal.dotOpacity}>
+            <DotOverlay
+              dotX={dotX}
+              dotY={dotY}
+              momentum={momentumSV}
+              palette={palette}
+              engine={engine}
+              pulse={pulse}
+            />
+          </Group>
+
+          <LoadingOverlay
             engine={engine}
-            pulse={pulse}
+            padding={effectivePadding}
+            palette={palette}
+            font={font}
+            morphT={reveal.morphT}
+            isLoading={reveal.isLoading}
+            isEmpty={reveal.isEmpty}
+            emptyText={emptyText}
+            strokeWidth={strokeWidth}
+            badge={badge}
           />
 
           {scrub && (

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,192 @@
+import {
+  Group,
+  Path,
+  RoundedRect,
+  Skia,
+  Text as SkiaText,
+  type SkFont,
+} from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import { BADGE_DOT_GAP } from "../constants";
+import {
+  badgeTailAndCap,
+  gutterCenteredTextLeftX,
+  pillTextLeftX,
+  type ChartPadding,
+} from "../draw/line";
+import { drawSpline } from "../math/spline";
+import { buildSquigglyPts } from "../math/squiggly";
+import type { LivelinePalette } from "../types";
+import type { EngineState } from "../useLivelineEngine";
+
+const PLACEHOLDER_LABEL_COUNT = 4;
+const RECT_W = 16;
+const RECT_H = 4;
+const RECT_R = 4;
+const RECT_SPACING = 32;
+
+function buildSplinePath(pts: number[]) {
+  "worklet";
+  const path = Skia.Path.Make();
+  const n = pts.length >> 1;
+  if (n < 2) return path;
+  path.moveTo(pts[0], pts[1]);
+  drawSpline(path, pts);
+  return path;
+}
+
+export function LoadingOverlay({
+  engine,
+  padding,
+  palette,
+  font,
+  morphT,
+  isLoading,
+  isEmpty,
+  emptyText,
+  strokeWidth,
+  badge = false,
+}: {
+  engine: EngineState;
+  padding: ChartPadding;
+  palette: LivelinePalette;
+  font: SkFont;
+  morphT: SharedValue<number>;
+  isLoading: SharedValue<boolean>;
+  isEmpty: SharedValue<boolean>;
+  emptyText: string;
+  strokeWidth: number;
+  /** Mirror the badge prop so labels align with GridOverlay's label positions. */
+  badge?: boolean;
+}) {
+  // Same left-inset formula as GridOverlay (only used when badge=true)
+  const leftInset = BADGE_DOT_GAP + badgeTailAndCap(font.getSize());
+  // Squiggly path — animated each frame via timestamp
+  const squigglyPath = useDerivedValue(() => {
+    if (!isLoading.value && !isEmpty.value && morphT.value >= 1) {
+      return Skia.Path.Make();
+    }
+    const pts = buildSquigglyPts(
+      engine.canvasWidth.value,
+      engine.canvasHeight.value,
+      padding,
+      engine.timestamp.value,
+    );
+    return buildSplinePath(pts);
+  });
+
+  // Fades out quickly as the reveal animation begins (first 33% of morphT)
+  const groupOpacity = useDerivedValue(() => {
+    if (!isLoading.value && !isEmpty.value) {
+      return Math.max(0, 1 - morphT.value * 3);
+    }
+    return 1;
+  });
+
+  // Placeholder Y-axis rects: skeleton pills centred in the right gutter
+  const labelLayout = useDerivedValue(() => {
+    const w = engine.canvasWidth.value;
+    const h = engine.canvasHeight.value;
+    if (w === 0 || h === 0) {
+      return { x: -200, ys: [0, 0, 0, 0] as [number, number, number, number] };
+    }
+    const chartH = h - padding.top - padding.bottom;
+    // Mirror GridOverlay: pillTextLeftX when badge is on, gutterCenteredTextLeftX otherwise
+    const x = badge
+      ? pillTextLeftX(w, padding.right, leftInset, RECT_W)
+      : gutterCenteredTextLeftX(w, padding.right, RECT_W);
+    // Centre the group of rects around the chart's vertical midpoint
+    const groupH = (PLACEHOLDER_LABEL_COUNT - 1) * RECT_SPACING;
+    const groupStartCY = padding.top + chartH / 2 - groupH / 2;
+    const ys: [number, number, number, number] = [0, 0, 0, 0];
+    for (let i = 0; i < PLACEHOLDER_LABEL_COUNT; i++) {
+      const rowCenterY = groupStartCY + i * RECT_SPACING;
+      ys[i] = rowCenterY - RECT_H / 2; // top of rect so center lands on rowCenterY
+    }
+    return { x, ys };
+  });
+
+  // X and Y positions for the placeholder rects
+  const lx = useDerivedValue(() => labelLayout.value.x);
+  const ly0 = useDerivedValue(() => labelLayout.value.ys[0]);
+  const ly1 = useDerivedValue(() => labelLayout.value.ys[1]);
+  const ly2 = useDerivedValue(() => labelLayout.value.ys[2]);
+  const ly3 = useDerivedValue(() => labelLayout.value.ys[3]);
+
+  // Empty-state text: centered in the chart area
+  const emptyLayout = useDerivedValue(() => {
+    const w = engine.canvasWidth.value;
+    const h = engine.canvasHeight.value;
+    if (w === 0 || h === 0) return { x: 0, y: 0 };
+    const fm = font.getMetrics();
+    const textW = font.measureText(emptyText).width;
+    const chartCentreX = (padding.left + w - padding.right) / 2;
+    const chartCentreY = (padding.top + h - padding.bottom) / 2;
+    return {
+      x: chartCentreX - textW / 2,
+      y: chartCentreY - (fm.ascent + fm.descent) / 2,
+    };
+  });
+
+  const emptyTextX = useDerivedValue(() => emptyLayout.value.x);
+  const emptyTextY = useDerivedValue(() => emptyLayout.value.y);
+  const showText = useDerivedValue(() => isEmpty.value);
+
+  return (
+    <Group opacity={groupOpacity}>
+      {/* Squiggly loading line */}
+      <Path
+        path={squigglyPath}
+        style="stroke"
+        strokeWidth={strokeWidth}
+        color={palette.gridLine}
+        strokeCap="round"
+        strokeJoin="round"
+      />
+
+      {/* Skeleton Y-axis label placeholders */}
+      <RoundedRect
+        x={lx}
+        y={ly0}
+        width={RECT_W}
+        height={RECT_H}
+        r={RECT_R}
+        color={palette.gridLine}
+      />
+      <RoundedRect
+        x={lx}
+        y={ly1}
+        width={RECT_W}
+        height={RECT_H}
+        r={RECT_R}
+        color={palette.gridLine}
+      />
+      <RoundedRect
+        x={lx}
+        y={ly2}
+        width={RECT_W}
+        height={RECT_H}
+        r={RECT_R}
+        color={palette.gridLine}
+      />
+      <RoundedRect
+        x={lx}
+        y={ly3}
+        width={RECT_W}
+        height={RECT_H}
+        r={RECT_R}
+        color={palette.gridLine}
+      />
+
+      {/* Empty state label */}
+      <SkiaText
+        x={emptyTextX}
+        y={emptyTextY}
+        text={showText.value ? emptyText : ("" as unknown as string)}
+        font={font}
+        color={palette.gridLabel}
+        opacity={showText as unknown as number}
+      />
+    </Group>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useBadge } from "./useBadge";
 export { useCanvasLayout } from "./useCanvasLayout";
 export { resolveChartLayout } from "./useChartLayout";
 export { useChartPaths } from "./useChartPaths";
+export { useChartReveal } from "./useChartReveal";
 export { useCrosshair } from "./useCrosshair";
 export { useGrid } from "./useGrid";
 export { useLiveDot } from "./useLiveDot";

--- a/src/hooks/useChartPaths.ts
+++ b/src/hooks/useChartPaths.ts
@@ -1,12 +1,17 @@
 import { Skia } from "@shopify/react-native-skia";
-import { useDerivedValue } from "react-native-reanimated";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline } from "../math/spline";
+import { blendPtsY, squigglifyPts } from "../math/squiggly";
 import type { EngineState } from "../useLivelineEngine";
 
-export function useChartPaths(engine: EngineState, padding: ChartPadding) {
-  const flatPts = useDerivedValue(() =>
-    buildLinePoints(
+export function useChartPaths(
+  engine: EngineState,
+  padding: ChartPadding,
+  morphT?: SharedValue<number>,
+) {
+  const flatPts = useDerivedValue(() => {
+    const realPts = buildLinePoints(
       engine.data.value,
       engine.displayValue.value,
       engine.timestamp.value,
@@ -16,8 +21,26 @@ export function useChartPaths(engine: EngineState, padding: ChartPadding) {
       engine.canvasWidth.value,
       engine.canvasHeight.value,
       padding,
-    ),
-  );
+    );
+
+    // Skip blending when fully revealed or no morphT provided
+    const t = morphT?.value ?? 1;
+    if (t >= 1 || realPts.length === 0) return realPts;
+
+    // Compute squiggly Y values at the same X positions as the real line
+    const centerY =
+      (engine.canvasHeight.value - padding.bottom + padding.top) / 2;
+    const squigglyPts = squigglifyPts(realPts, engine.timestamp.value, centerY);
+
+    // Blend center-out: centre of chart reveals first, edges last
+    return blendPtsY(
+      squigglyPts,
+      realPts,
+      t,
+      padding,
+      engine.canvasWidth.value,
+    );
+  });
 
   const linePath = useDerivedValue(() => {
     const pts = flatPts.value;

--- a/src/hooks/useChartReveal.test.ts
+++ b/src/hooks/useChartReveal.test.ts
@@ -1,0 +1,109 @@
+import { revealRamp, useChartReveal } from "./useChartReveal";
+
+import { renderHook } from "@testing-library/react-native";
+
+// ─── revealRamp ───────────────────────────────────────────────────────────────
+
+describe("revealRamp", () => {
+  it("returns 0 at morphT=0 for any delay", () => {
+    expect(revealRamp(0, 0)).toBe(0);
+    expect(revealRamp(0, 0.3)).toBe(0);
+    expect(revealRamp(0, 0.55)).toBe(0);
+  });
+
+  it("returns 1 at morphT=1 for any delay", () => {
+    expect(revealRamp(1, 0)).toBe(1);
+    expect(revealRamp(1, 0.15)).toBe(1);
+    expect(revealRamp(1, 0.55)).toBe(1);
+  });
+
+  it("returns 0 before the delay threshold", () => {
+    // delay=0.4: no reveal until morphT > 0.4
+    expect(revealRamp(0.39, 0.4)).toBe(0);
+  });
+
+  it("starts revealing at the delay threshold", () => {
+    // delay=0.4, morphT=0.4: (0.4-0.4)/(1-0.4)=0 → smoothstep(0)=0
+    expect(revealRamp(0.4, 0.4)).toBe(0);
+    // morphT slightly above delay → just started
+    expect(revealRamp(0.41, 0.4)).toBeGreaterThan(0);
+  });
+
+  it("reaches 1 at morphT=1 regardless of delay", () => {
+    for (const delay of [0, 0.1, 0.3, 0.55]) {
+      expect(revealRamp(1, delay)).toBeCloseTo(1);
+    }
+  });
+
+  it("is monotonically non-decreasing", () => {
+    const delay = 0.15;
+    let prev = revealRamp(0, delay);
+    for (let t = 0.05; t <= 1; t += 0.05) {
+      const cur = revealRamp(t, delay);
+      expect(cur).toBeGreaterThanOrEqual(prev - 1e-10);
+      prev = cur;
+    }
+  });
+
+  it("returns 0 when delay >= 1", () => {
+    expect(revealRamp(0.9, 1)).toBe(0);
+    expect(revealRamp(1, 1)).toBe(0);
+  });
+
+  it("fill reveals before grid (lower delay)", () => {
+    // fill delay=0.05, grid delay=0.15; at morphT=0.1 fill > 0, grid = 0
+    expect(revealRamp(0.1, 0.05)).toBeGreaterThan(0);
+    expect(revealRamp(0.1, 0.15)).toBe(0);
+  });
+
+  it("dot reveals before badge", () => {
+    // dot delay=0.4, badge delay=0.55; at morphT=0.5: dot > 0, badge = 0
+    expect(revealRamp(0.5, 0.4)).toBeGreaterThan(0);
+    expect(revealRamp(0.5, 0.55)).toBe(0);
+  });
+});
+
+// ─── useChartReveal (hook smoke tests) ───────────────────────────────────────
+
+describe("useChartReveal (hook)", () => {
+  it("morphT starts at 0 when loading=true", () => {
+    const { result } = renderHook(() => useChartReveal(true));
+    expect(result.current.morphT.value).toBe(0);
+  });
+
+  it("morphT starts at 1 when loading=false", () => {
+    const { result } = renderHook(() => useChartReveal(false));
+    expect(result.current.morphT.value).toBe(1);
+  });
+
+  it("isLoading is true when loading=true", () => {
+    const { result } = renderHook(() => useChartReveal(true));
+    expect(result.current.isLoading.value).toBe(true);
+  });
+
+  it("isLoading is false when loading=false", () => {
+    const { result } = renderHook(() => useChartReveal(false));
+    expect(result.current.isLoading.value).toBe(false);
+  });
+
+  it("isEmpty starts false (controlled externally)", () => {
+    const { result } = renderHook(() => useChartReveal(false));
+    expect(result.current.isEmpty.value).toBe(false);
+  });
+
+  it("all stagger opacities are 0 when morphT=0 (loading=true)", () => {
+    const { result } = renderHook(() => useChartReveal(true));
+    expect(result.current.gridOpacity.value).toBe(0);
+    expect(result.current.fillOpacity.value).toBe(0);
+    expect(result.current.dotOpacity.value).toBe(0);
+    expect(result.current.badgeOpacity.value).toBe(0);
+  });
+
+  it("all stagger opacities are 1 when morphT=1 (loading=false)", () => {
+    const { result } = renderHook(() => useChartReveal(false));
+    expect(result.current.gridOpacity.value).toBeCloseTo(1);
+    expect(result.current.fillOpacity.value).toBeCloseTo(1);
+    expect(result.current.dotOpacity.value).toBeCloseTo(1);
+    expect(result.current.badgeOpacity.value).toBeCloseTo(1);
+  });
+});

--- a/src/hooks/useChartReveal.ts
+++ b/src/hooks/useChartReveal.ts
@@ -1,0 +1,109 @@
+import { useEffect } from "react";
+import {
+  Easing,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+  type SharedValue,
+} from "react-native-reanimated";
+import { smoothstep } from "../math/squiggly";
+
+const REVEAL_DURATION_MS = 600;
+
+/**
+ * Per-overlay reveal delay (fraction of morphT at which the overlay starts
+ * fading in). Earlier delays = earlier appearance.
+ */
+const DELAY = {
+  fill: 0.05,
+  grid: 0.15,
+  line: 0.0,
+  dot: 0.4,
+  badge: 0.55,
+} as const;
+
+/**
+ * Maps a [0,1] morphT to a [0,1] opacity, starting at `delay` and reaching
+ * 1 at morphT=1. Uses smoothstep for a polished ease-in/out.
+ */
+export function revealRamp(morphT: number, delay: number): number {
+  "worklet";
+  if (delay >= 1) return 0;
+  return smoothstep((morphT - delay) / (1 - delay));
+}
+
+export interface ChartRevealState {
+  /** 0 = fully squiggly (loading), 1 = fully live chart */
+  morphT: SharedValue<number>;
+  /** True while loading=true */
+  isLoading: SharedValue<boolean>;
+  /** True when loading=false but no data (set externally via isEmpty.value) */
+  isEmpty: SharedValue<boolean>;
+  gridOpacity: SharedValue<number>;
+  fillOpacity: SharedValue<number>;
+  lineOpacity: SharedValue<number>;
+  dotOpacity: SharedValue<number>;
+  badgeOpacity: SharedValue<number>;
+}
+
+/**
+ * Drives the loading → reveal → live state machine.
+ *
+ * - When `loading` is true: morphT=0, overlays hidden, LoadingOverlay visible.
+ * - When `loading` becomes false: animate morphT 0→1 over 600ms; each overlay
+ *   fades in staggered via revealRamp.
+ * - When `loading` was never true (default): morphT starts at 1, no animation.
+ *
+ * NOTE: The empty state (isEmpty) is NOT auto-detected from data length here,
+ * because SharedValue changes do not trigger React re-renders. Instead, set
+ * isEmpty.value directly from a useAnimatedReaction in the parent, or simply
+ * pass loading=true until data is ready.
+ */
+export function useChartReveal(loading: boolean): ChartRevealState {
+  // Start fully revealed if loading was never requested
+  const morphT = useSharedValue(loading ? 0 : 1);
+  const isLoading = useSharedValue(loading);
+  const isEmpty = useSharedValue(false);
+
+  useEffect(() => {
+    if (loading) {
+      morphT.value = 0;
+      isLoading.value = true;
+      isEmpty.value = false;
+    } else {
+      isLoading.value = false;
+      // Animate reveal only if we were in loading state (morphT < 1)
+      if (morphT.value < 1) {
+        morphT.value = withTiming(1, {
+          duration: REVEAL_DURATION_MS,
+          easing: Easing.out(Easing.cubic),
+        });
+      }
+    }
+  }, [loading]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const gridOpacity = useDerivedValue(() =>
+    revealRamp(morphT.value, DELAY.grid),
+  );
+  const fillOpacity = useDerivedValue(() =>
+    revealRamp(morphT.value, DELAY.fill),
+  );
+  const lineOpacity = useDerivedValue(() =>
+    revealRamp(morphT.value, DELAY.line),
+  );
+  const dotOpacity = useDerivedValue(() => revealRamp(morphT.value, DELAY.dot));
+  const badgeOpacity = useDerivedValue(() =>
+    revealRamp(morphT.value, DELAY.badge),
+  );
+
+  return {
+    morphT,
+    isLoading,
+    isEmpty,
+    gridOpacity,
+    fillOpacity,
+    lineOpacity,
+    dotOpacity,
+    badgeOpacity,
+  };
+}

--- a/src/math/squiggly.test.ts
+++ b/src/math/squiggly.test.ts
@@ -1,0 +1,155 @@
+import {
+  blendPtsY,
+  buildSquigglyPts,
+  smoothstep,
+  squigglifyPts,
+  squigglyYAt,
+} from "./squiggly";
+
+const padding = { top: 12, right: 80, bottom: 28, left: 12 };
+
+// ─── squigglyYAt ─────────────────────────────────────────────────────────────
+
+describe("squigglyYAt", () => {
+  it("returns centerY when amplitude terms cancel (degenerate)", () => {
+    // amplitude is always 8*(0.6+0.4*sin(...)) ∈ [3.2, 12.8]; result near centerY
+    const y = squigglyYAt(0, 100, 0);
+    // at x=0, t=0: sin(0)=0, sin(0)=0 → y = 100
+    expect(y).toBeCloseTo(100);
+  });
+
+  it("produces different values at different x", () => {
+    const y1 = squigglyYAt(10, 100, 1);
+    const y2 = squigglyYAt(50, 100, 1);
+    expect(y1).not.toBeCloseTo(y2);
+  });
+
+  it("produces different values at different t", () => {
+    const y1 = squigglyYAt(30, 100, 0);
+    const y2 = squigglyYAt(30, 100, Math.PI);
+    expect(y1).not.toBeCloseTo(y2);
+  });
+
+  it("amplitude stays within expected range around centerY", () => {
+    for (let t = 0; t < 10; t += 0.5) {
+      for (let x = 0; x < 400; x += 20) {
+        const y = squigglyYAt(x, 100, t);
+        // max amplitude = 14*1 = 14, composite ≤ 1.45 → max deviation ≈ 20.3
+        expect(Math.abs(y - 100)).toBeLessThanOrEqual(25);
+      }
+    }
+  });
+});
+
+// ─── buildSquigglyPts ────────────────────────────────────────────────────────
+
+describe("buildSquigglyPts", () => {
+  it("returns empty for zero canvas", () => {
+    expect(buildSquigglyPts(0, 0, padding, 0)).toEqual([]);
+  });
+
+  it("returns paired [x,y] flat array", () => {
+    const pts = buildSquigglyPts(400, 300, padding, 1);
+    expect(pts.length % 2).toBe(0);
+    expect(pts.length).toBeGreaterThan(0);
+  });
+
+  it("X values span from padding.left to right chart edge", () => {
+    const pts = buildSquigglyPts(400, 300, padding, 0);
+    const xs = pts.filter((_, i) => i % 2 === 0);
+    expect(xs[0]).toBeCloseTo(padding.left);
+    expect(xs[xs.length - 1]).toBeCloseTo(400 - padding.right);
+  });
+
+  it("produces different shapes at different timestamps", () => {
+    const pts1 = buildSquigglyPts(400, 300, padding, 0);
+    const pts2 = buildSquigglyPts(400, 300, padding, 2);
+    // Y values should differ
+    const diff = pts1.some(
+      (v, i) => i % 2 === 1 && Math.abs(v - pts2[i]) > 0.01,
+    );
+    expect(diff).toBe(true);
+  });
+});
+
+// ─── squigglifyPts ───────────────────────────────────────────────────────────
+
+describe("squigglifyPts", () => {
+  it("preserves X, replaces Y", () => {
+    const flatPts = [10, 50, 50, 60, 90, 55];
+    const out = squigglifyPts(flatPts, 0, 100);
+    // X values unchanged
+    expect(out[0]).toBe(10);
+    expect(out[2]).toBe(50);
+    expect(out[4]).toBe(90);
+    // Y values are squiggly — centered near 100 but not the original input values
+    expect(out[1]).not.toBeCloseTo(50);
+    expect(out[3]).not.toBeCloseTo(60);
+    // All Y values should be within the squiggly amplitude range of centerY (100)
+    expect(Math.abs(out[1] - 100)).toBeLessThanOrEqual(25);
+    expect(Math.abs(out[3] - 100)).toBeLessThanOrEqual(25);
+  });
+
+  it("returns same length as input", () => {
+    const pts = [10, 20, 30, 40, 50, 60, 70, 80];
+    expect(squigglifyPts(pts, 1, 150).length).toBe(8);
+  });
+});
+
+// ─── smoothstep ──────────────────────────────────────────────────────────────
+
+describe("smoothstep", () => {
+  it("returns 0 at t=0", () => expect(smoothstep(0)).toBe(0));
+  it("returns 1 at t=1", () => expect(smoothstep(1)).toBe(1));
+  it("returns 0.5 at t=0.5", () => expect(smoothstep(0.5)).toBe(0.5));
+  it("clamps below 0", () => expect(smoothstep(-1)).toBe(0));
+  it("clamps above 1", () => expect(smoothstep(2)).toBe(1));
+  it("is monotonically increasing", () => {
+    let prev = smoothstep(0);
+    for (let t = 0.1; t <= 1; t += 0.1) {
+      const cur = smoothstep(t);
+      expect(cur).toBeGreaterThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+});
+
+// ─── blendPtsY ───────────────────────────────────────────────────────────────
+
+describe("blendPtsY", () => {
+  const canvasWidth = 400;
+  // chartCentreX = (12 + 400 - 80) / 2 = 166
+
+  it("returns 'to' pts when morphT=1 (full reveal)", () => {
+    const from = [12, 100, 166, 100, 320, 100];
+    const to = [12, 50, 166, 60, 320, 55];
+    const result = blendPtsY(from, to, 1, padding, canvasWidth);
+    // All weights should be smoothstep((1 - dist*0.5)/0.5) ≥ some value
+    // Centre point (dist=0): weight = smoothstep(2) = 1 → blendedY = toY
+    expect(result[3]).toBeCloseTo(60); // centre Y
+  });
+
+  it("centre point reveals before edge points at morphT=0.5", () => {
+    const centreX = (padding.left + canvasWidth - padding.right) / 2;
+    const from = [centreX, 100, 320, 100];
+    const to = [centreX, 0, 320, 0];
+    const result = blendPtsY(from, to, 0.5, padding, canvasWidth);
+    // Centre (dist=0): weight=smoothstep(1)=1 → blendedY=0
+    expect(result[1]).toBeCloseTo(0);
+    // Edge (dist=1): weight=smoothstep(0)=0 → blendedY=100
+    expect(result[3]).toBeCloseTo(100);
+  });
+
+  it("returns 'to' X values regardless of morphT", () => {
+    const from = [10, 100, 50, 100];
+    const to = [10, 50, 50, 50];
+    const result = blendPtsY(from, to, 0, padding, canvasWidth);
+    expect(result[0]).toBe(10);
+    expect(result[2]).toBe(50);
+  });
+
+  it("returns 'to' when from is empty", () => {
+    const to = [10, 20, 30, 40];
+    expect(blendPtsY([], to, 0.5, padding, canvasWidth)).toEqual(to);
+  });
+});

--- a/src/math/squiggly.ts
+++ b/src/math/squiggly.ts
@@ -1,0 +1,108 @@
+import type { ChartPadding } from "../draw/line";
+
+/**
+ * Composite sine squiggly — two overlapping frequencies with a breathing
+ * amplitude envelope. Matches the original web Liveline loading animation.
+ *
+ * amplitude = 14 * (0.4 + 0.6 * sin(0.8 * t))   // 5.6 → 22.4px breathing range
+ * y = centerY + amplitude * (sin(0.035*x + 1.2*t) + 0.45*sin(0.08*x + 2.1*t))
+ */
+export function squigglyYAt(x: number, centerY: number, t: number): number {
+  "worklet";
+  const amplitude = 14 * (0.4 + 0.6 * Math.sin(0.8 * t));
+  return (
+    centerY +
+    amplitude *
+      (Math.sin(0.035 * x + 1.2 * t) + 0.45 * Math.sin(0.08 * x + 2.1 * t))
+  );
+}
+
+/**
+ * Build a flat [x0,y0,x1,y1,...] point array for a standalone squiggly line
+ * spanning the full chart area (used in loading / empty state).
+ * Points are spaced ~4px apart for smooth curves.
+ */
+export function buildSquigglyPts(
+  canvasWidth: number,
+  canvasHeight: number,
+  padding: ChartPadding,
+  t: number,
+): number[] {
+  "worklet";
+  const leftEdge = padding.left;
+  const rightEdge = canvasWidth - padding.right;
+  const chartW = rightEdge - leftEdge;
+  if (chartW <= 0 || canvasHeight <= 0) return [];
+
+  const centerY = (canvasHeight - padding.bottom + padding.top) / 2;
+  const step = 4;
+  const count = Math.ceil(chartW / step) + 1;
+  const pts: number[] = new Array(count * 2);
+  for (let i = 0; i < count; i++) {
+    const x = leftEdge + Math.min(i * step, chartW);
+    pts[i * 2] = x;
+    pts[i * 2 + 1] = squigglyYAt(x, centerY, t);
+  }
+  return pts;
+}
+
+/**
+ * Given a real flat-pts array (from buildLinePoints), replace each Y with the
+ * squiggly Y at the same X. Used during the morph reveal.
+ */
+export function squigglifyPts(
+  flatPts: number[],
+  t: number,
+  centerY: number,
+): number[] {
+  "worklet";
+  const n = flatPts.length;
+  const out: number[] = new Array(n);
+  for (let i = 0; i < n; i += 2) {
+    out[i] = flatPts[i];
+    out[i + 1] = squigglyYAt(flatPts[i], centerY, t);
+  }
+  return out;
+}
+
+/**
+ * Smoothstep — maps t ∈ [0,1] to a smooth 0→1 curve (no clamping required
+ * when t is already in range, but clamps gracefully outside).
+ */
+export function smoothstep(t: number): number {
+  "worklet";
+  const c = Math.min(1, Math.max(0, t));
+  return c * c * (3 - 2 * c);
+}
+
+/**
+ * Blend two flat-pts arrays center-out, driven by morphT ∈ [0,1].
+ * Points near the horizontal centre of the chart reveal first; edges last.
+ *
+ * For each point, a per-point weight is computed:
+ *   distFromCentre = |x - chartCentreX| / (chartW / 2)   // 0=centre, 1=edge
+ *   weight = smoothstep((morphT - distFromCentre * 0.5) / 0.5)
+ *   blendedY = fromY + (toY - fromY) * weight
+ */
+export function blendPtsY(
+  from: number[],
+  to: number[],
+  morphT: number,
+  padding: ChartPadding,
+  canvasWidth: number,
+): number[] {
+  "worklet";
+  const n = from.length;
+  if (n === 0) return to;
+  const chartCentreX = (padding.left + canvasWidth - padding.right) / 2;
+  const halfChartW = (canvasWidth - padding.left - padding.right) / 2;
+  const out: number[] = new Array(n);
+  for (let i = 0; i < n; i += 2) {
+    out[i] = to[i]; // X always from real pts
+    const distFromCentre =
+      halfChartW > 0 ? Math.abs(from[i] - chartCentreX) / halfChartW : 0;
+    const weight = smoothstep((morphT - distFromCentre * 0.5) / 0.5);
+    out[i + 1] = from[i + 1] + (to[i + 1] - from[i + 1]) * weight;
+  }
+  return out;
+}


### PR DESCRIPTION
### TL;DR

Added a loading state animation system with squiggly placeholder lines and staggered reveal transitions for chart components.

### What changed?

- **Loading State Management**: Added `loading` and `emptyText` props to the Liveline component with a new `useChartReveal` hook that manages the transition from loading to live chart state
- **Squiggly Animation**: Implemented animated squiggly placeholder lines using composite sine waves that display during loading states
- **Staggered Reveal**: Chart elements (fill, grid, line, dot, badge) now fade in with staggered timing using smoothstep easing when transitioning from loading to live state
- **Loading Overlay**: Created a new `LoadingOverlay` component that shows animated squiggly lines, skeleton placeholder rectangles for Y-axis labels, and empty state text
- **Center-Out Morphing**: The transition from squiggly to real chart data uses center-out blending where the middle of the chart reveals first, then spreads to the edges
- **Demo Integration**: Added a "Reload" button in the demo app that triggers a 2-second loading state to showcase the new animation
- **Header Removal**: Disabled the default navigation header in the app layout

### How to test?

1. Run the demo app and tap the new "Reload" button to see the loading animation
2. Observe the squiggly placeholder line that animates while loading
3. Watch the staggered reveal animation as components fade in: fill → grid → line → dot → badge
4. Test with empty data states to see the "No data" message
5. Verify the center-out morphing effect during the transition

### Why make this change?

This enhances the user experience by providing visual feedback during data loading states instead of showing empty or static charts. The squiggly animation and staggered reveals create a polished, professional feel that matches modern data visualization libraries while maintaining smooth 60fps performance through Reanimated worklets.