### PR TITLE
feat: reference line and value line

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -58,6 +58,9 @@ export default function Index() {
   const [windowSecs, setWindowSecs] = useState(30);
   const [startValue, setStartValue] = useState(100);
   const [loading, setLoading] = useState(false);
+  const [showRefLine, setShowRefLine] = useState(false);
+  const [valueLine, setValueLine] = useState(false);
+  const [exaggerate, setExaggerate] = useState(false);
 
   const { data, value } = useSimulatedData({
     volatilityMode,
@@ -101,6 +104,11 @@ export default function Index() {
           theme="dark"
           window={windowSecs}
           paused={paused}
+          exaggerate={exaggerate}
+          valueLine={valueLine}
+          referenceLine={
+            showRefLine ? { value: startValue * 1.05, label: "+5%" } : undefined
+          }
           scrub
           scrubTooltip={false}
           loading={loading}
@@ -195,6 +203,40 @@ export default function Index() {
               </Text>
             </Pressable>
           ))}
+        </View>
+
+        <Text style={styles.sectionLabel}>Chart Options</Text>
+        <View style={styles.buttonRow}>
+          <Pressable
+            style={[styles.chip, valueLine && styles.chipActive]}
+            onPress={() => setValueLine((v) => !v)}
+          >
+            <Text style={[styles.chipText, valueLine && styles.chipTextActive]}>
+              Value Line
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, showRefLine && styles.chipActive]}
+            onPress={() => setShowRefLine((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, showRefLine && styles.chipTextActive]}
+            >
+              Ref Line
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, exaggerate && styles.chipActive]}
+            onPress={() => setExaggerate((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, exaggerate && styles.chipTextActive]}
+            >
+              Exaggerate
+            </Text>
+          </Pressable>
         </View>
 
         <View style={styles.buttonRow}>

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -39,6 +39,7 @@ jest.mock("@shopify/react-native-skia", () => {
     Text: View,
     Path: ({ children, ...props }) =>
       React.createElement(View, props, children),
+    DashPathEffect: View,
     LinearGradient: View,
     vec: (x, y) => ({ x, y }),
     matchFont: jest.fn(() => mockFont),

--- a/src/Liveline.test.tsx
+++ b/src/Liveline.test.tsx
@@ -1,12 +1,11 @@
 import { fireEvent, render } from "@testing-library/react-native";
+
+import { Liveline } from "./Liveline";
 import React from "react";
 import { View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
-import { Liveline } from "./Liveline";
 
-function Harness(
-  props: Partial<React.ComponentProps<typeof Liveline>>,
-) {
+function Harness(props: Partial<React.ComponentProps<typeof Liveline>>) {
   const data = useSharedValue([{ time: 1700000000, value: 50 }]);
   const value = useSharedValue(50);
   return <Liveline data={data} value={value} {...props} />;
@@ -37,10 +36,7 @@ describe("Liveline", () => {
 
   it("accepts custom formatters", () => {
     render(
-      <Harness
-        formatValue={(v) => v.toFixed(4)}
-        formatTime={() => "x"}
-      />,
+      <Harness formatValue={(v) => v.toFixed(4)} formatTime={() => "x"} />,
     );
   });
 
@@ -66,5 +62,9 @@ describe("Liveline", () => {
 
   it("renders with paused=true", () => {
     render(<Harness paused />);
+  });
+
+  it("renders with valueLine enabled", () => {
+    render(<Harness valueLine />);
   });
 });

--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -21,6 +21,7 @@ import {
   useGrid,
   useLiveDot,
   useMomentum,
+  useReferenceLine,
   useTimeAxis,
 } from "./hooks";
 
@@ -31,7 +32,9 @@ import { GestureDetector } from "react-native-gesture-handler";
 import { GridOverlay } from "./components/GridOverlay";
 import type { LivelineProps } from "./types";
 import { LoadingOverlay } from "./components/LoadingOverlay";
+import { ReferenceLineOverlay } from "./components/ReferenceLineOverlay";
 import { TimeAxisOverlay } from "./components/TimeAxisOverlay";
+import { ValueLineOverlay } from "./components/ValueLineOverlay";
 import { resolveTheme } from "./theme";
 import { useLivelineEngine } from "./useLivelineEngine";
 
@@ -55,6 +58,7 @@ export function Liveline({
   pulse = true,
   scrub = false,
   scrubTooltip = true,
+  valueLine = false,
   loading = false,
   emptyText = "No data",
   lineWidth: lineWidthProp,
@@ -104,6 +108,13 @@ export function Liveline({
   );
   const { dotX, dotY } = useLiveDot(engine, effectivePadding);
   const momentumSV = useMomentum(engine, momentum);
+  const referenceLineLayout = useReferenceLine(
+    engine,
+    effectivePadding,
+    referenceLine,
+    formatValue,
+    font,
+  );
   const { gridEntries } = useGrid(
     engine,
     effectivePadding,
@@ -174,6 +185,23 @@ export function Liveline({
                 />
               </Path>
             </Group>
+          )}
+
+          {valueLine && (
+            <ValueLineOverlay
+              dotY={dotY}
+              engine={engine}
+              padding={effectivePadding}
+              palette={palette}
+            />
+          )}
+
+          {referenceLine && (
+            <ReferenceLineOverlay
+              layout={referenceLineLayout}
+              palette={palette}
+              font={font}
+            />
           )}
 
           {/* Line path: always rendered; morph handles transition via blended pts */}

--- a/src/components/ReferenceLineOverlay.tsx
+++ b/src/components/ReferenceLineOverlay.tsx
@@ -1,0 +1,61 @@
+import {
+  DashPathEffect,
+  Group,
+  Path,
+  Skia,
+  Text as SkiaText,
+  type SkFont,
+} from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { ReferenceLineLayout } from "../hooks/useReferenceLine";
+import type { LivelinePalette } from "../types";
+
+/**
+ * Renders a dashed horizontal reference line with an optional right-gutter label.
+ * Placed inside the Skia <Canvas>, after the fill and before the chart line.
+ */
+export function ReferenceLineOverlay({
+  layout,
+  palette,
+  font,
+}: {
+  layout: SharedValue<ReferenceLineLayout>;
+  palette: LivelinePalette;
+  font: SkFont;
+}) {
+  const opacity = useDerivedValue(() => (layout.value.visible ? 1 : 0));
+
+  const linePath = useDerivedValue(() => {
+    const l = layout.value;
+    const path = Skia.Path.Make();
+    if (!l.visible) return path;
+    path.moveTo(l.x1, l.y);
+    path.lineTo(l.x2, l.y);
+    return path;
+  });
+
+  const labelX = useDerivedValue(() => layout.value.labelX);
+  const labelY = useDerivedValue(() => layout.value.labelY);
+  const labelText = useDerivedValue(() => layout.value.label);
+
+  return (
+    <Group opacity={opacity}>
+      <Path
+        path={linePath}
+        style="stroke"
+        strokeWidth={1}
+        color={palette.refLine}
+      >
+        <DashPathEffect intervals={[4, 4]} />
+      </Path>
+      <SkiaText
+        x={labelX}
+        y={labelY}
+        text={labelText as unknown as string}
+        font={font}
+        color={palette.refLabel}
+      />
+    </Group>
+  );
+}

--- a/src/components/ValueLineOverlay.tsx
+++ b/src/components/ValueLineOverlay.tsx
@@ -1,0 +1,37 @@
+import { DashPathEffect, Path, Skia } from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { ChartPadding } from "../draw/line";
+import type { LivelinePalette } from "../types";
+import type { EngineState } from "../useLivelineEngine";
+
+/**
+ * A dashed horizontal line that tracks the live display value — sitting at
+ * the same Y as the badge and live dot. Rendered behind the chart line.
+ */
+export function ValueLineOverlay({
+  dotY,
+  engine,
+  padding,
+  palette,
+}: {
+  dotY: SharedValue<number>;
+  engine: EngineState;
+  padding: ChartPadding;
+  palette: LivelinePalette;
+}) {
+  const path = useDerivedValue(() => {
+    const p = Skia.Path.Make();
+    const y = dotY.value;
+    if (y < 0) return p;
+    p.moveTo(padding.left, y);
+    p.lineTo(engine.canvasWidth.value - padding.right, y);
+    return p;
+  });
+
+  return (
+    <Path path={path} style="stroke" strokeWidth={1} color={palette.dashLine}>
+      <DashPathEffect intervals={[4, 4]} />
+    </Path>
+  );
+}

--- a/src/components/overlays.test.tsx
+++ b/src/components/overlays.test.tsx
@@ -7,9 +7,12 @@ import type { EngineState } from "../useLivelineEngine";
 import { GridOverlay } from "./GridOverlay";
 import { LoadingOverlay } from "./LoadingOverlay";
 import React from "react";
+import type { ReferenceLineLayout } from "../hooks/useReferenceLine";
+import { ReferenceLineOverlay } from "./ReferenceLineOverlay";
 import { Skia } from "@shopify/react-native-skia";
 import { TimeAxisOverlay } from "./TimeAxisOverlay";
 import type { TooltipLayout } from "../hooks/useCrosshair";
+import { ValueLineOverlay } from "./ValueLineOverlay";
 import { render } from "@testing-library/react-native";
 import { resolveTheme } from "../theme";
 import { useSharedValue } from "react-native-reanimated";
@@ -396,6 +399,80 @@ describe("TimeAxisOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+});
+
+describe("ReferenceLineOverlay", () => {
+  const visibleLayout: ReferenceLineLayout = {
+    y: 142,
+    x1: 12,
+    x2: 320,
+    label: "50.00",
+    labelX: 324,
+    labelY: 139,
+    visible: true,
+  };
+
+  const invisibleLayout: ReferenceLineLayout = {
+    y: -1,
+    x1: 0,
+    x2: 0,
+    label: "",
+    labelX: 0,
+    labelY: -1,
+    visible: false,
+  };
+
+  it("renders dashed line and label when visible", () => {
+    function Fixture() {
+      const layout = useSharedValue(visibleLayout);
+      return (
+        <ReferenceLineOverlay layout={layout} palette={palette} font={font} />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("renders with zero opacity when not visible", () => {
+    function Fixture() {
+      const layout = useSharedValue(invisibleLayout);
+      return (
+        <ReferenceLineOverlay layout={layout} palette={palette} font={font} />
+      );
+    }
+    render(<Fixture />);
+  });
+});
+
+describe("ValueLineOverlay", () => {
+  it("draws line when dotY is in chart area", () => {
+    function Fixture() {
+      const dotY = useSharedValue(120);
+      return (
+        <ValueLineOverlay
+          dotY={dotY}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("returns empty path when dotY is negative (off-screen)", () => {
+    function Fixture() {
+      const dotY = useSharedValue(-1);
+      return (
+        <ValueLineOverlay
+          dotY={dotY}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
         />
       );
     }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,5 +7,6 @@ export { useCrosshair } from "./useCrosshair";
 export { useGrid } from "./useGrid";
 export { useLiveDot } from "./useLiveDot";
 export { useMomentum } from "./useMomentum";
+export { useReferenceLine } from "./useReferenceLine";
 export { useTimeAxis } from "./useTimeAxis";
 

--- a/src/hooks/useReferenceLine.test.tsx
+++ b/src/hooks/useReferenceLine.test.tsx
@@ -1,0 +1,151 @@
+import { DEFAULT_PADDING } from "../draw/line";
+import type { EngineState } from "../useLivelineEngine";
+import { renderHook } from "@testing-library/react-native";
+import { useReferenceLine } from "./useReferenceLine";
+
+const font = {
+  getSize: () => 12,
+  measureText: (s: string) => ({ x: 0, y: 0, width: s.length * 7, height: 12 }),
+  getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+} as never;
+
+// padding: top=12, right=80, bottom=28, left=12 → chartH = 300-12-28 = 260
+const PADDING = { top: 12, right: 80, bottom: 28, left: 12 };
+const fmt = (v: number) => v.toFixed(2);
+
+function engine(
+  partial: Partial<{
+    canvasWidth: number;
+    canvasHeight: number;
+    displayMin: number;
+    displayMax: number;
+  }> = {},
+): EngineState {
+  return {
+    data: { value: [] },
+    value: { value: 0 },
+    displayValue: { value: 0 },
+    displayMin: { value: partial.displayMin ?? 0 },
+    displayMax: { value: partial.displayMax ?? 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: partial.canvasWidth ?? 400 },
+    canvasHeight: { value: partial.canvasHeight ?? 300 },
+    timestamp: { value: 0 },
+  } as unknown as EngineState;
+}
+
+describe("useReferenceLine", () => {
+  // ── invisible guard branches ───────────────────────────────────────────────
+
+  it("returns invisible when referenceLine is undefined", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, undefined, fmt, font),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("returns invisible when valRange is zero", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine({ displayMin: 50, displayMax: 50 }),
+        PADDING,
+        { value: 50 },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("returns invisible when canvas width is zero", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine({ canvasWidth: 0 }),
+        PADDING,
+        { value: 50 },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("returns invisible when canvas height is zero", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine({ canvasHeight: 0 }),
+        PADDING,
+        { value: 50 },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("returns invisible when ref value projects above the chart area", () => {
+    // ref=110 > displayMax=100 → y < padding.top → clipped
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 110 }, fmt, font),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("returns invisible when ref value projects below the chart area", () => {
+    // ref=-10 < displayMin=0 → y > h - padding.bottom → clipped
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: -10 }, fmt, font),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  // ── visible happy-path ─────────────────────────────────────────────────────
+
+  it("returns visible with correct y for a mid-range value", () => {
+    // chartH = 300 - 12 - 28 = 260; ref=50, range=100
+    // y = 12 + 260 * (1 - (50-0)/100) = 12 + 130 = 142
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 50 }, fmt, font),
+    );
+    const layout = result.current.value;
+    expect(layout.visible).toBe(true);
+    expect(layout.y).toBeCloseTo(142);
+  });
+
+  it("sets x1 = padding.left and x2 = width - padding.right", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 50 }, fmt, font),
+    );
+    const layout = result.current.value;
+    expect(layout.x1).toBe(PADDING.left);
+    expect(layout.x2).toBe(400 - PADDING.right);
+  });
+
+  it("uses the explicit label when provided", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, label: "+5%" },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.label).toBe("+5%");
+  });
+
+  it("falls back to formatValue(ref.value) when no label is provided", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 50 }, fmt, font),
+    );
+    expect(result.current.value.label).toBe("50.00");
+  });
+
+  it("uses DEFAULT_PADDING correctly", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), DEFAULT_PADDING, { value: 50 }, fmt, font),
+    );
+    expect(result.current.value.visible).toBe(true);
+    expect(result.current.value.x1).toBe(DEFAULT_PADDING.left);
+  });
+});

--- a/src/hooks/useReferenceLine.ts
+++ b/src/hooks/useReferenceLine.ts
@@ -1,0 +1,70 @@
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { SkFont } from "@shopify/react-native-skia";
+import type { ChartPadding } from "../draw/line";
+import type { ReferenceLine } from "../types";
+import type { EngineState } from "../useLivelineEngine";
+
+export interface ReferenceLineLayout {
+  y: number;
+  x1: number;
+  x2: number;
+  label: string;
+  labelX: number;
+  labelY: number;
+  visible: boolean;
+}
+
+/**
+ * Derives the screen-space layout for a horizontal reference line.
+ * Returns a shared value that updates each frame as displayMin/Max animate.
+ */
+export function useReferenceLine(
+  engine: EngineState,
+  padding: ChartPadding,
+  referenceLine: ReferenceLine | undefined,
+  formatValue: (v: number) => string,
+  font: SkFont,
+): SharedValue<ReferenceLineLayout> {
+  return useDerivedValue<ReferenceLineLayout>(() => {
+    const invisible: ReferenceLineLayout = {
+      y: -1,
+      x1: 0,
+      x2: 0,
+      label: "",
+      labelX: 0,
+      labelY: -1,
+      visible: false,
+    };
+
+    if (!referenceLine) return invisible;
+
+    const w = engine.canvasWidth.value;
+    const h = engine.canvasHeight.value;
+    const dMin = engine.displayMin.value;
+    const dMax = engine.displayMax.value;
+    const valRange = dMax - dMin;
+
+    if (valRange <= 0 || w === 0 || h === 0) return invisible;
+
+    const chartH = h - padding.top - padding.bottom;
+    const y =
+      padding.top + chartH * (1 - (referenceLine.value - dMin) / valRange);
+
+    // Keep the line within the visible chart area
+    if (y < padding.top || y > h - padding.bottom) return invisible;
+
+    const x1 = padding.left;
+    const x2 = w - padding.right;
+
+    const label = referenceLine.label ?? formatValue(referenceLine.value);
+
+    // Place label in right gutter, vertically centered on the line
+    const fm = font.getMetrics();
+    const baselineOffset = (fm.ascent + fm.descent) / 2;
+    const labelX = x2 + 4;
+    const labelY = y - baselineOffset;
+
+    return { y, x1, x2, label, labelX, labelY, visible: true };
+  });
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,6 +14,7 @@ describe("hooks barrel", () => {
     expect(hooks.useChartPaths).toBeDefined();
     expect(hooks.useGrid).toBeDefined();
     expect(hooks.useLiveDot).toBeDefined();
+    expect(hooks.useReferenceLine).toBeDefined();
     expect(hooks.useTimeAxis).toBeDefined();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,8 @@ export interface LivelineProps {
   scrub?: boolean;
   /** Show the value+time tooltip pill when scrubbing. Defaults to true. */
   scrubTooltip?: boolean;
+  /** Show a dashed horizontal line tracking the live value, aligned with the badge. */
+  valueLine?: boolean;
   exaggerate?: boolean;
   showValue?: boolean;
   valueMomentumColor?: boolean;


### PR DESCRIPTION
### TL;DR

Added chart visualization options including a value line, reference line, and exaggerate mode with corresponding UI controls.

### What changed?

- Added three new chart display options: `valueLine`, `showRefLine`, and `exaggerate` state variables
- Created `ValueLineOverlay` component that renders a dashed horizontal line tracking the live value position
- Created `ReferenceLineOverlay` component that displays a configurable horizontal reference line with optional label
- Added `useReferenceLine` hook to calculate screen-space layout for reference lines
- Integrated new overlays into the main `Liveline` component with proper rendering order
- Added "Chart Options" section to the UI with toggle buttons for all three new features
- Extended `LivelineProps` interface to include `valueLine` prop
- Updated Skia mock in jest setup to include `DashPathEffect`

### How to test?

1. Run the app and navigate to the chart demo
2. Toggle the "Value Line" button to show/hide the dashed line that tracks the current value
3. Toggle the "Ref Line" button to display a reference line at +5% of the start value
4. Toggle the "Exaggerate" button to test the exaggeration feature
5. Verify all chart options work independently and in combination
6. Run the test suite to ensure all new components and hooks are properly tested

### Why make this change?

These visualization enhancements provide users with additional tools to better analyze chart data by offering visual reference points and value tracking capabilities, improving the overall chart reading experience.