### PR TITLE
feat: candlestick support

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -62,14 +62,21 @@ export default function Index() {
   const [valueLine, setValueLine] = useState(false);
   const [exaggerate, setExaggerate] = useState(false);
 
-  const { data, value, series } = useSimulatedData({
+  const [chartMode, setChartMode] = useState<"single" | "multi">("single");
+  const [displayMode, setDisplayMode] = useState<"line" | "candle">("line");
+
+  // ~20 candles visible in the window; minimum 5s bars
+  const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
+
+  const { data, value, series, candles, liveCandle } = useSimulatedData({
     volatilityMode,
     tradeSource,
     paused,
     startValue,
+    candleWidth: candleWidthSecs,
+    multiSeries: chartMode === "multi",
+    candleAggregation: chartMode === "single" && displayMode === "candle",
   });
-
-  const [chartMode, setChartMode] = useState<"single" | "multi">("single");
   const chartModeSv = useSharedValue<"single" | "multi">("single");
   const volatilitySv = useSharedValue(volatilityMode);
   useEffect(() => {
@@ -120,6 +127,10 @@ export default function Index() {
           <Liveline
             data={data}
             value={value}
+            mode={displayMode}
+            candles={candles}
+            liveCandle={liveCandle}
+            candleWidth={candleWidthSecs}
             accentColor="#3b82f6"
             theme="dark"
             timeWindow={windowSecs}
@@ -192,6 +203,46 @@ export default function Index() {
             </Text>
           </Pressable>
         </View>
+
+        {chartMode === "single" && (
+          <>
+            <Text style={styles.sectionLabel}>Display Mode</Text>
+            <View style={styles.buttonRow}>
+              <Pressable
+                style={[
+                  styles.chip,
+                  displayMode === "line" && styles.chipActive,
+                ]}
+                onPress={() => setDisplayMode("line")}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    displayMode === "line" && styles.chipTextActive,
+                  ]}
+                >
+                  Line
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[
+                  styles.chip,
+                  displayMode === "candle" && styles.chipActive,
+                ]}
+                onPress={() => setDisplayMode("candle")}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    displayMode === "candle" && styles.chipTextActive,
+                  ]}
+                >
+                  Candle
+                </Text>
+              </Pressable>
+            </View>
+          </>
+        )}
 
         <Text style={styles.sectionLabel}>Time Window</Text>
         <View style={styles.buttonRow}>

--- a/sim/useSimulatedData.ts
+++ b/sim/useSimulatedData.ts
@@ -30,6 +30,10 @@ export interface SimulatedDataOptions {
   candleWidth?: number;
   paused?: boolean;
   maxPoints?: number;
+  /** Skip multi-series generation when not displayed (default true). */
+  multiSeries?: boolean;
+  /** Skip candle aggregation when not displayed (default true). */
+  candleAggregation?: boolean;
 }
 
 export interface SimulatedData {
@@ -38,7 +42,7 @@ export interface SimulatedData {
   tradeEvents: SharedValue<TradeEvent[]>;
   series: SharedValue<LivelineSeries[]>;
   candles: SharedValue<CandlePoint[]>;
-  liveCandle: SharedValue<CandlePoint>;
+  liveCandle: SharedValue<CandlePoint | null>;
 }
 
 /**
@@ -65,6 +69,8 @@ export function useSimulatedData(
     candleWidth = 60,
     paused = false,
     maxPoints = 2000,
+    multiSeries = true,
+    candleAggregation = true,
   } = opts;
 
   // JS-side buffers — fast O(1) reads in the tick callback
@@ -80,13 +86,7 @@ export function useSimulatedData(
   const tradeEvents = useSharedValue<TradeEvent[]>([]);
   const series = useSharedValue<LivelineSeries[]>([]);
   const candles = useSharedValue<CandlePoint[]>([]);
-  const liveCandle = useSharedValue<CandlePoint>({
-    time: 0,
-    open: 0,
-    high: 0,
-    low: 0,
-    close: 0,
-  });
+  const liveCandle = useSharedValue<CandlePoint | null>(null);
 
   const bondingCurveRef = useRef<BondingCurveState>(
     createBondingCurve({ basePrice: startValue }),
@@ -111,13 +111,15 @@ export function useSimulatedData(
       history[history.length - 1].value,
       20,
     );
-    const initialSeries = generateMultiSeries({
-      ids: ["yes", "no", "maybe"],
-      colors: ["#3b82f6", "#ef4444", "#f59e0b"],
-      labels: ["Yes", "No", "Maybe"],
-      count: 150,
-      sumToHundred: true,
-    });
+    const initialSeries = multiSeries
+      ? generateMultiSeries({
+          ids: ["yes", "no", "maybe"],
+          colors: ["#3b82f6", "#ef4444", "#f59e0b"],
+          labels: ["Yes", "No", "Maybe"],
+          count: 150,
+          sumToHundred: true,
+        })
+      : [];
 
     buf.current = {
       data: history,
@@ -129,13 +131,17 @@ export function useSimulatedData(
     value.value = history[history.length - 1].value;
     tradeEvents.value = initialTrades;
     series.value = initialSeries;
-    const c = aggregateCandles(history, candleWidth);
-    candles.value = c.candles;
-    liveCandle.value = c.liveCandle;
+    if (candleAggregation) {
+      const c = aggregateCandles(history, candleWidth);
+      candles.value = c.candles;
+      liveCandle.value = c.liveCandle;
+    }
   }, [
     volatilityMode,
     startValue,
     candleWidth,
+    multiSeries,
+    candleAggregation,
     data,
     value,
     tradeEvents,
@@ -164,9 +170,11 @@ export function useSimulatedData(
       value.value = newValue;
 
       // Candles
-      const c = aggregateCandles(b.data, candleWidth);
-      candles.value = c.candles;
-      liveCandle.value = c.liveCandle;
+      if (candleAggregation) {
+        const c = aggregateCandles(b.data, candleWidth);
+        candles.value = c.candles;
+        liveCandle.value = c.liveCandle;
+      }
 
       // Trade events
       if (tradeSource === "bonding-curve") {
@@ -182,18 +190,20 @@ export function useSimulatedData(
       if (b.tradeEvents.length > 50) b.tradeEvents = b.tradeEvents.slice(-50);
       tradeEvents.value = b.tradeEvents;
 
-      // Multi-series — clone before mutating since previous array is frozen
-      b.series = b.series.map((s) => ({ ...s, data: [...s.data] }));
-      stepMultiSeries(b.series, true);
-      for (let i = 0; i < b.series.length; i++) {
-        if (b.series[i].data.length > maxPoints) {
-          b.series[i] = {
-            ...b.series[i],
-            data: b.series[i].data.slice(-maxPoints),
-          };
+      // Multi-series — skip when not displayed
+      if (multiSeries) {
+        b.series = b.series.map((s) => ({ ...s, data: [...s.data] }));
+        stepMultiSeries(b.series, true);
+        for (let i = 0; i < b.series.length; i++) {
+          if (b.series[i].data.length > maxPoints) {
+            b.series[i] = {
+              ...b.series[i],
+              data: b.series[i].data.slice(-maxPoints),
+            };
+          }
         }
+        series.value = b.series;
       }
-      series.value = b.series;
     }, ms);
 
     return () => clearInterval(id);
@@ -204,6 +214,8 @@ export function useSimulatedData(
     startValue,
     maxPoints,
     candleWidth,
+    multiSeries,
+    candleAggregation,
     data,
     value,
     tradeEvents,

--- a/src/Liveline.test.tsx
+++ b/src/Liveline.test.tsx
@@ -1,15 +1,42 @@
 import { fireEvent, render } from "@testing-library/react-native";
 
-import { Liveline } from "./Liveline";
-import type { LivelineSingleProps } from "./types";
 import React from "react";
 import { View } from "react-native";
-import { useSharedValue } from "react-native-reanimated";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
+import { Liveline } from "./Liveline";
+import type { CandlePoint, LivelineSingleProps } from "./types";
 
 function Harness(props: Partial<LivelineSingleProps>) {
   const data = useSharedValue([{ time: 1700000000, value: 50 }]);
   const value = useSharedValue(50);
   return <Liveline data={data} value={value} {...props} />;
+}
+
+function CandleHarness(props: Partial<LivelineSingleProps>) {
+  const data = useSharedValue([{ time: 1700000000, value: 50 }]);
+  const value = useSharedValue(50);
+  const candles: SharedValue<CandlePoint[]> = useSharedValue([
+    { time: 1700000000, open: 48, high: 52, low: 47, close: 50 },
+    { time: 1700000060, open: 50, high: 55, low: 49, close: 53 },
+  ]);
+  const liveCandle: SharedValue<CandlePoint | null> = useSharedValue({
+    time: 1700000120,
+    open: 53,
+    high: 56,
+    low: 51,
+    close: 54,
+  });
+  return (
+    <Liveline
+      data={data}
+      value={value}
+      mode="candle"
+      candles={candles}
+      liveCandle={liveCandle}
+      candleWidth={60}
+      {...props}
+    />
+  );
 }
 
 describe("Liveline", () => {
@@ -114,5 +141,21 @@ describe("Liveline", () => {
         font={{ fontFamily: "Courier", fontSize: 13, fontWeight: "700" }}
       />,
     );
+  });
+
+  it("renders in candle mode", () => {
+    const screen = render(<CandleHarness />);
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+  });
+
+  it("renders candle mode with scrub enabled", () => {
+    render(<CandleHarness scrub />);
+  });
+
+  it("disables gradient in candle mode", () => {
+    render(<CandleHarness gradient />);
   });
 });

--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -12,6 +12,22 @@ import {
   formatValue as defaultFormatValue,
 } from "./format";
 import {
+  resolveChartLayout,
+  useBadge,
+  useCandlePaths,
+  useCanvasLayout,
+  useChartColors,
+  useChartPaths,
+  useChartReveal,
+  useCrosshair,
+  useLiveDot,
+  useModeBlend,
+  useMomentum,
+  useReferenceLine,
+  useXAxis,
+  useYAxis,
+} from "./hooks";
+import {
   resolveBadge,
   resolveFontConfig,
   resolveGradient,
@@ -22,32 +38,19 @@ import {
   resolveXAxis,
   resolveYAxis,
 } from "./resolveConfig";
-import {
-  resolveChartLayout,
-  useBadge,
-  useCanvasLayout,
-  useChartColors,
-  useChartPaths,
-  useChartReveal,
-  useCrosshair,
-  useLiveDot,
-  useMomentum,
-  useReferenceLine,
-  useXAxis,
-  useYAxis,
-} from "./hooks";
 
+import { GestureDetector } from "react-native-gesture-handler";
 import { BadgeOverlay } from "./components/BadgeOverlay";
 import { CrosshairOverlay } from "./components/CrosshairOverlay";
 import { DotOverlay } from "./components/DotOverlay";
-import { GestureDetector } from "react-native-gesture-handler";
-import type { LivelineSingleProps } from "./types";
 import { LoadingOverlay } from "./components/LoadingOverlay";
+import { MultiSeriesTooltipStack } from "./components/MultiSeriesTooltipStack";
 import { ReferenceLineOverlay } from "./components/ReferenceLineOverlay";
 import { ValueLineOverlay } from "./components/ValueLineOverlay";
 import { XAxisOverlay } from "./components/XAxisOverlay";
 import { YAxisOverlay } from "./components/YAxisOverlay";
 import { resolveTheme } from "./theme";
+import type { LivelineSingleProps } from "./types";
 import { useLivelineEngine } from "./useLivelineEngine";
 
 export function Liveline({
@@ -63,6 +66,12 @@ export function Liveline({
   font: fontProp,
   insets,
   style,
+
+  // ── Candlestick ─────────────────────────────────────────────────────────
+  mode = "line",
+  candles,
+  candleWidth = 60,
+  liveCandle,
 
   // ── Behaviour ───────────────────────────────────────────────────────────
   timeWindow = 30,
@@ -87,12 +96,14 @@ export function Liveline({
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
 }: LivelineSingleProps) {
+  const isCandle = mode === "candle";
+
   // ── Resolve feature configs ────────────────────────────────────────────
   const yAxisCfg = resolveYAxis(yAxis);
   const xAxisCfg = resolveXAxis(xAxis);
   const badgeCfg = resolveBadge(badge);
   const scrubCfg = resolveScrub(scrub);
-  const gradientCfg = resolveGradient(gradient);
+  const gradientCfg = isCandle ? null : resolveGradient(gradient);
   const valueLineCfg = resolveValueLine(valueLine);
   const pulseCfg = resolvePulse(pulse);
   const refLineCfg = resolveReferenceLineConfig(referenceLine);
@@ -132,9 +143,18 @@ export function Liveline({
     smoothing,
     exaggerate,
     referenceValue: referenceLine?.value,
+    mode,
+    candles,
+    liveCandle,
   });
 
   const reveal = useChartReveal(loading);
+
+  // ── Mode crossfade (line ↔ candle) ──────────────────────────────────
+  const { lineGroupOpacity, candleGroupOpacity } = useModeBlend(
+    isCandle,
+    reveal.lineOpacity,
+  );
 
   // ── Per-frame derived values ───────────────────────────────────────────
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
@@ -144,6 +164,15 @@ export function Liveline({
     effectivePadding,
     reveal.morphT,
   );
+  const { upBodiesPath, downBodiesPath, upWicksPath, downWicksPath } =
+    useCandlePaths(
+      engine,
+      effectivePadding,
+      candles,
+      liveCandle,
+      candleWidth,
+      isCandle,
+    );
   const { dotX, dotY } = useLiveDot(engine, effectivePadding);
 
   const momentumSV = useMomentum(engine, momentum);
@@ -185,6 +214,10 @@ export function Liveline({
     badgeCfg?.background,
   );
 
+  const candleOpts = isCandle
+    ? { mode, candles, liveCandle, candleWidthSecs: candleWidth }
+    : undefined;
+
   const crosshair = useCrosshair(
     engine,
     effectivePadding,
@@ -194,6 +227,7 @@ export function Liveline({
     skiaFont,
     scrubCfg !== null,
     onScrub,
+    candleOpts,
   );
 
   // ── Derived render values ──────────────────────────────────────────────
@@ -265,8 +299,8 @@ export function Liveline({
             />
           )}
 
-          {/* Chart line — always rendered; morph blends loading → data */}
-          <Group opacity={reveal.lineOpacity}>
+          {/* Chart line (fades out in candle mode) */}
+          <Group opacity={lineGroupOpacity}>
             <Path
               path={linePath}
               style="stroke"
@@ -274,6 +308,28 @@ export function Liveline({
               color={lineProp?.color ?? palette.line}
               strokeCap="round"
               strokeJoin="round"
+            />
+          </Group>
+
+          {/* Candle bodies/wicks (fades in in candle mode) */}
+          <Group opacity={candleGroupOpacity}>
+            <Path
+              path={upWicksPath}
+              style="stroke"
+              strokeWidth={1}
+              color={palette.wickUp}
+            />
+            <Path
+              path={downWicksPath}
+              style="stroke"
+              strokeWidth={1}
+              color={palette.wickDown}
+            />
+            <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
+            <Path
+              path={downBodiesPath}
+              style="fill"
+              color={palette.candleDown}
             />
           </Group>
 
@@ -331,6 +387,15 @@ export function Liveline({
               palette={palette}
               font={skiaFont}
               showTooltip={scrubCfg.tooltip}
+              tooltipBody={
+                isCandle ? (
+                  <MultiSeriesTooltipStack
+                    tooltipLayout={crosshair.tooltipLayout}
+                    font={skiaFont}
+                    palette={palette}
+                  />
+                ) : undefined
+              }
             />
           )}
         </Canvas>

--- a/src/draw/candle.test.ts
+++ b/src/draw/candle.test.ts
@@ -1,0 +1,165 @@
+import type { CandlePoint } from "../types";
+import { buildCandleGeometry } from "./candle";
+
+const pad = { top: 10, right: 10, bottom: 10, left: 10 };
+
+function makeCandle(
+  time: number,
+  open: number,
+  high: number,
+  low: number,
+  close: number,
+): CandlePoint {
+  return { time, open, high, low, close };
+}
+
+describe("buildCandleGeometry", () => {
+  it("returns empty when valRange is zero", () => {
+    const result = buildCandleGeometry(
+      [],
+      null,
+      pad,
+      200,
+      100,
+      0,
+      60,
+      50,
+      50,
+      10,
+    );
+    expect(result.bodies).toEqual([]);
+    expect(result.wicks).toEqual([]);
+  });
+
+  it("returns empty when chart dimensions are zero", () => {
+    const c = [makeCandle(10, 100, 110, 90, 105)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      0,
+      100,
+      0,
+      60,
+      90,
+      110,
+      10,
+    );
+    expect(result.bodies).toEqual([]);
+  });
+
+  it("computes bodies and wicks for a single candle", () => {
+    const c = [makeCandle(30, 100, 120, 80, 110)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      0, // winStart
+      120, // windowSecs
+      80, // displayMin
+      120, // displayMax
+      60, // candleWidthSecs
+    );
+    expect(result.bodies).toHaveLength(1);
+    expect(result.wicks).toHaveLength(1);
+    expect(result.bodies[0].up).toBe(true);
+  });
+
+  it("classifies a down candle correctly", () => {
+    const c = [makeCandle(0, 110, 120, 80, 90)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      0,
+      60,
+      80,
+      120,
+      60,
+    );
+    expect(result.bodies[0].up).toBe(false);
+    expect(result.wicks[0].up).toBe(false);
+  });
+
+  it("includes the live candle", () => {
+    const committed = [makeCandle(0, 100, 110, 90, 105)];
+    const live = makeCandle(60, 105, 115, 95, 112);
+    const result = buildCandleGeometry(
+      committed,
+      live,
+      pad,
+      200,
+      100,
+      0,
+      120,
+      80,
+      120,
+      60,
+    );
+    expect(result.bodies).toHaveLength(2);
+    expect(result.wicks).toHaveLength(2);
+  });
+
+  it("excludes candles outside the visible window", () => {
+    const c = [
+      makeCandle(0, 100, 110, 90, 105),
+      makeCandle(60, 105, 115, 95, 112),
+      makeCandle(120, 112, 125, 100, 120),
+    ];
+    // winStart=200, window=60 => visible [200, 260]. All candles end at t<=180, so none visible.
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      200,
+      60,
+      80,
+      130,
+      60,
+    );
+    expect(result.bodies).toHaveLength(0);
+  });
+
+  it("handles doji (open === close) with minimum body height", () => {
+    const c = [makeCandle(0, 100, 110, 90, 100)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      0,
+      60,
+      90,
+      110,
+      60,
+    );
+    expect(result.bodies[0].h).toBeGreaterThanOrEqual(1);
+    expect(result.bodies[0].up).toBe(true);
+  });
+
+  it("positions body X centered on candle midpoint", () => {
+    const c = [makeCandle(0, 100, 110, 90, 105)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      0,
+      60,
+      90,
+      110,
+      60,
+    );
+    const chartW = 200 - 10 - 10;
+    const xCenter = 10 + ((0 + 30) / 60) * chartW;
+    expect(result.bodies[0].x).toBeCloseTo(xCenter - result.bodies[0].w / 2, 1);
+  });
+});

--- a/src/draw/candle.ts
+++ b/src/draw/candle.ts
@@ -1,0 +1,119 @@
+import type { CandlePoint } from "../types";
+import type { ChartPadding } from "./line";
+
+export interface CandleRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  up: boolean;
+}
+
+export interface CandleWick {
+  x: number;
+  y1: number;
+  y2: number;
+  up: boolean;
+}
+
+export interface CandleGeometry {
+  bodies: CandleRect[];
+  wicks: CandleWick[];
+}
+
+const MIN_BODY_PX = 1;
+const MAX_BODY_PX = 40;
+
+/**
+ * Build screen-space candle bodies and wicks for a visible window.
+ * Pure worklet — no Skia imports, consumed by useCandlePaths.
+ */
+export function buildCandleGeometry(
+  candles: CandlePoint[],
+  liveCandle: CandlePoint | null,
+  padding: ChartPadding,
+  canvasW: number,
+  canvasH: number,
+  winStart: number,
+  windowSecs: number,
+  displayMin: number,
+  displayMax: number,
+  candleWidthSecs: number,
+): CandleGeometry {
+  "worklet";
+  const chartW = canvasW - padding.left - padding.right;
+  const chartH = canvasH - padding.top - padding.bottom;
+  const valRange = displayMax - displayMin;
+
+  if (valRange === 0 || chartW <= 0 || chartH <= 0)
+    return { bodies: [], wicks: [] };
+
+  const toX = (t: number) =>
+    padding.left + ((t - winStart) / windowSecs) * chartW;
+  const toY = (v: number) =>
+    padding.top + ((displayMax - v) / valRange) * chartH;
+
+  const slotPx = (candleWidthSecs / windowSecs) * chartW;
+  const bodyW = Math.max(1, Math.min(slotPx * 0.8, slotPx - 2, MAX_BODY_PX));
+
+  const bodies: CandleRect[] = [];
+  const wicks: CandleWick[] = [];
+
+  const winEnd = winStart + windowSecs;
+  const chartLeft = padding.left;
+  const chartRight = canvasW - padding.right;
+
+  const processCandle = (c: CandlePoint) => {
+    if (c.time + candleWidthSecs < winStart || c.time > winEnd) return;
+
+    const up = c.close >= c.open;
+    const xCenter = toX(c.time + candleWidthSecs / 2);
+
+    // Skip candles whose center is outside the drawable chart area
+    if (xCenter < chartLeft - bodyW / 2 || xCenter > chartRight + bodyW / 2)
+      return;
+
+    const bodyTop = toY(up ? c.close : c.open);
+    const bodyBot = toY(up ? c.open : c.close);
+    const bodyH = Math.max(MIN_BODY_PX, bodyBot - bodyTop);
+
+    // Clamp horizontal extent to the chart area
+    let bx = xCenter - bodyW / 2;
+    let bw = bodyW;
+    if (bx < chartLeft) {
+      bw -= chartLeft - bx;
+      bx = chartLeft;
+    }
+    if (bx + bw > chartRight) {
+      bw = chartRight - bx;
+    }
+    if (bw <= 0) return;
+
+    bodies.push({ x: bx, y: bodyTop, w: bw, h: bodyH, up });
+
+    const wickX = Math.max(chartLeft, Math.min(xCenter, chartRight));
+    const wickTop = toY(c.high);
+    const wickBot = toY(c.low);
+    wicks.push({ x: wickX, y1: wickTop, y2: wickBot, up });
+  };
+
+  // Binary search for first candle overlapping the window
+  let lo = 0;
+  let hi = candles.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (candles[mid].time + candleWidthSecs < winStart) lo = mid + 1;
+    else hi = mid;
+  }
+
+  for (let i = lo; i < candles.length; i++) {
+    if (candles[i].time > winEnd) break;
+    processCandle(candles[i]);
+  }
+
+  if (liveCandle) {
+    processCandle(liveCandle);
+  }
+
+  return { bodies, wicks };
+}

--- a/src/hooks/crosshairShared.ts
+++ b/src/hooks/crosshairShared.ts
@@ -221,6 +221,39 @@ export function computeTooltipLayoutMulti(
   };
 }
 
+/**
+ * Candle-mode tooltip — 5 stacked rows: O, H, L, C (bright) + time (dim).
+ */
+export function computeCandleTooltipLayout(
+  scrubActive: boolean,
+  scrubX: number,
+  candle: { open: number; high: number; low: number; close: number } | null,
+  scrubTime: number,
+  padding: ChartPadding,
+  canvasWidth: number,
+  formatValue: (v: number) => string,
+  formatTime: (t: number) => string,
+  font: SkFont,
+): TooltipLayout {
+  "worklet";
+  if (!scrubActive || !candle) return HIDDEN_TOOLTIP;
+  const lines: { text: string; dim: boolean }[] = [
+    { text: `O ${formatValue(candle.open)}`, dim: false },
+    { text: `H ${formatValue(candle.high)}`, dim: false },
+    { text: `L ${formatValue(candle.low)}`, dim: false },
+    { text: `C ${formatValue(candle.close)}`, dim: false },
+    { text: formatTime(scrubTime), dim: true },
+  ];
+  return computeTooltipLayoutMulti(
+    scrubActive,
+    scrubX,
+    lines,
+    padding,
+    canvasWidth,
+    font,
+  );
+}
+
 /** Single-series scrub value at window time — extracted for tests. */
 export function deriveScrubValueSingle(
   scrubActive: boolean,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useBadge } from "./useBadge";
+export { useCandlePaths } from "./useCandlePaths";
 export { useCanvasLayout } from "./useCanvasLayout";
 export { useChartColors } from "./useChartColors";
 export { resolveChartLayout } from "./useChartLayout";
@@ -7,6 +8,7 @@ export { useChartReveal } from "./useChartReveal";
 export { useCrosshair } from "./useCrosshair";
 export { useCrosshairMulti } from "./useCrosshairMulti";
 export { useLiveDot } from "./useLiveDot";
+export { useModeBlend } from "./useModeBlend";
 export { useMomentum } from "./useMomentum";
 export { useMultiSeriesLinePaths } from "./useMultiSeriesPaths";
 export { useReferenceLine } from "./useReferenceLine";

--- a/src/hooks/useCandlePaths.ts
+++ b/src/hooks/useCandlePaths.ts
@@ -1,0 +1,106 @@
+import { Skia } from "@shopify/react-native-skia";
+import {
+  useDerivedValue,
+  useFrameCallback,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import { buildCandleGeometry } from "../draw/candle";
+import type { ChartPadding } from "../draw/line";
+import { lerp } from "../math/lerp";
+import type { CandlePoint } from "../types";
+import type { SingleEngineState } from "../useLivelineEngine";
+
+const CANDLE_WIDTH_LERP_SPEED = 0.08;
+
+export function useCandlePaths(
+  engine: SingleEngineState,
+  padding: ChartPadding,
+  candles: SharedValue<CandlePoint[]> | undefined,
+  liveCandle: SharedValue<CandlePoint | null> | undefined,
+  candleWidthSecs: number,
+  active: boolean,
+) {
+  const targetCandleWidth = useDerivedValue(() => candleWidthSecs);
+  const displayCandleWidth = useSharedValue(candleWidthSecs);
+
+  useFrameCallback((frameInfo) => {
+    "worklet";
+    if (!active) return;
+    const dt = frameInfo.timeSincePreviousFrame ?? 16.67;
+    displayCandleWidth.value = lerp(
+      displayCandleWidth.value,
+      targetCandleWidth.value,
+      CANDLE_WIDTH_LERP_SPEED,
+      dt,
+    );
+  });
+
+  const geometry = useDerivedValue(() => {
+    if (!active || !candles) return { bodies: [], wicks: [] };
+    return buildCandleGeometry(
+      candles.value,
+      liveCandle?.value ?? null,
+      padding,
+      engine.canvasWidth.value,
+      engine.canvasHeight.value,
+      engine.timestamp.value - engine.displayWindow.value,
+      engine.displayWindow.value,
+      engine.displayMin.value,
+      engine.displayMax.value,
+      displayCandleWidth.value,
+    );
+  });
+
+  const upBodiesPath = useDerivedValue(() => {
+    const path = Skia.Path.Make();
+    const { bodies } = geometry.value;
+    for (let i = 0; i < bodies.length; i++) {
+      if (bodies[i].up) {
+        path.addRect(
+          Skia.XYWHRect(bodies[i].x, bodies[i].y, bodies[i].w, bodies[i].h),
+        );
+      }
+    }
+    return path;
+  });
+
+  const downBodiesPath = useDerivedValue(() => {
+    const path = Skia.Path.Make();
+    const { bodies } = geometry.value;
+    for (let i = 0; i < bodies.length; i++) {
+      if (!bodies[i].up) {
+        path.addRect(
+          Skia.XYWHRect(bodies[i].x, bodies[i].y, bodies[i].w, bodies[i].h),
+        );
+      }
+    }
+    return path;
+  });
+
+  const upWicksPath = useDerivedValue(() => {
+    const path = Skia.Path.Make();
+    const { wicks } = geometry.value;
+    for (let i = 0; i < wicks.length; i++) {
+      if (wicks[i].up) {
+        path.moveTo(wicks[i].x, wicks[i].y1);
+        path.lineTo(wicks[i].x, wicks[i].y2);
+      }
+    }
+    return path;
+  });
+
+  const downWicksPath = useDerivedValue(() => {
+    const path = Skia.Path.Make();
+    const { wicks } = geometry.value;
+    for (let i = 0; i < wicks.length; i++) {
+      if (!wicks[i].up) {
+        path.moveTo(wicks[i].x, wicks[i].y1);
+        path.lineTo(wicks[i].x, wicks[i].y2);
+      }
+    }
+    return path;
+  });
+
+  return { upBodiesPath, downBodiesPath, upWicksPath, downWicksPath } as const;
+}

--- a/src/hooks/useCrosshair.test.ts
+++ b/src/hooks/useCrosshair.test.ts
@@ -5,6 +5,7 @@ import { interpolateAtTime } from "../math/interpolate";
 import { resolveTheme } from "../theme";
 import type { SingleEngineState } from "../useLivelineEngine";
 import {
+  computeCandleTooltipLayout,
   computeCrosshairOpacity,
   computeScrubTime,
   computeTooltipLayout,
@@ -429,5 +430,127 @@ describe("useCrosshair (hook)", () => {
       configurable: true,
       value: prev,
     });
+  });
+});
+
+// ─── computeCandleTooltipLayout ──────────────────────────────────────────────
+
+describe("computeCandleTooltipLayout", () => {
+  const candle = { open: 100, high: 120, low: 90, close: 110 };
+
+  it("returns hidden when inactive", () => {
+    const layout = computeCandleTooltipLayout(
+      false,
+      100,
+      candle,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    expect(layout.x).toBe(-400);
+  });
+
+  it("returns hidden when candle is null", () => {
+    const layout = computeCandleTooltipLayout(
+      true,
+      100,
+      null,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    expect(layout.x).toBe(-400);
+  });
+
+  it("builds 5 stacked lines: O, H, L, C + time", () => {
+    const layout = computeCandleTooltipLayout(
+      true,
+      100,
+      candle,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    expect(layout.stackedLines).toBeDefined();
+    expect(layout.stackedLines).toHaveLength(5);
+  });
+
+  it("shows OHLC values in order", () => {
+    const layout = computeCandleTooltipLayout(
+      true,
+      100,
+      candle,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    const texts = layout.stackedLines!.map((l) => l.text);
+    expect(texts[0]).toContain("O");
+    expect(texts[0]).toContain("100.00");
+    expect(texts[1]).toContain("H");
+    expect(texts[1]).toContain("120.00");
+    expect(texts[2]).toContain("L");
+    expect(texts[2]).toContain("90.00");
+    expect(texts[3]).toContain("C");
+    expect(texts[3]).toContain("110.00");
+  });
+
+  it("dims only the time row", () => {
+    const layout = computeCandleTooltipLayout(
+      true,
+      100,
+      candle,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    const dims = layout.stackedLines!.map((l) => l.dim);
+    expect(dims).toEqual([false, false, false, false, true]);
+  });
+
+  it("uses formatTime for the last row", () => {
+    const layout = computeCandleTooltipLayout(
+      true,
+      100,
+      candle,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    expect(layout.stackedLines![4].text).toBe(formatTime(1000));
+  });
+
+  it("pill dimensions are positive", () => {
+    const layout = computeCandleTooltipLayout(
+      true,
+      100,
+      candle,
+      1000,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+    );
+    expect(layout.w).toBeGreaterThan(0);
+    expect(layout.h).toBeGreaterThan(0);
   });
 });

--- a/src/hooks/useCrosshair.ts
+++ b/src/hooks/useCrosshair.ts
@@ -4,32 +4,42 @@ import { Gesture } from "react-native-gesture-handler";
 import {
   useDerivedValue,
   useSharedValue,
+  type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import { type ChartPadding } from "../draw/line";
 import { interpolateAtTime } from "../math/interpolate";
-import type { LivelinePalette, ScrubPoint } from "../types";
+import { pickCandleAtTime } from "../math/pickCandle";
+import type { CandlePoint, LivelinePalette, ScrubPoint } from "../types";
 import type { SingleEngineState } from "../useLivelineEngine";
 import {
+  computeCandleTooltipLayout,
   computeCrosshairOpacity,
   computeScrubTime,
-  type CrosshairState,
   deriveCrosshairTooltipSingle,
-  deriveScrubValueSingle,
+  type CrosshairState,
 } from "./crosshairShared";
 
 export type { CrosshairState, TooltipLayout } from "./crosshairShared";
 export type { ScrubPoint };
 
-export {
-  computeCrosshairOpacity,
-  computeScrubTime,
-  computeTooltipLayout,
-  computeTooltipLayoutMulti,
-  deriveCrosshairTooltipSingle,
-  deriveScrubValueSingle,
-  HIDDEN_TOOLTIP,
-} from "./crosshairShared";
+  export {
+    computeCandleTooltipLayout,
+    computeCrosshairOpacity,
+    computeScrubTime,
+    computeTooltipLayout,
+    computeTooltipLayoutMulti,
+    deriveCrosshairTooltipSingle,
+    deriveScrubValueSingle,
+    HIDDEN_TOOLTIP
+  } from "./crosshairShared";
+
+export interface CrosshairCandleOpts {
+  mode: "line" | "candle";
+  candles?: SharedValue<CandlePoint[]>;
+  liveCandle?: SharedValue<CandlePoint | null>;
+  candleWidthSecs: number;
+}
 
 /**
  * Single-series crosshair + scrub. Use `useCrosshairMulti` for multi-series charts.
@@ -43,6 +53,7 @@ export function useCrosshair(
   font: SkFont,
   enabled: boolean,
   onScrub?: (point: ScrubPoint | null) => void,
+  candleOpts?: CrosshairCandleOpts,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -58,13 +69,34 @@ export function useCrosshair(
     ),
   );
 
-  const scrubValue = useDerivedValue(() =>
-    deriveScrubValueSingle(
-      scrubActive.value,
+  const isCandleMode = candleOpts?.mode === "candle";
+  const candlesSV = candleOpts?.candles;
+  const liveCandleSV = candleOpts?.liveCandle;
+  const candleWidthSecs = candleOpts?.candleWidthSecs ?? 60;
+
+  const scrubCandle = useDerivedValue(() => {
+    if (
+      !isCandleMode ||
+      !candlesSV ||
+      !scrubActive.value ||
+      scrubTime.value < 0
+    )
+      return null;
+    return pickCandleAtTime(
+      candlesSV.value,
+      liveCandleSV?.value ?? null,
       scrubTime.value,
-      engine.data.value,
-    ),
-  );
+      candleWidthSecs,
+    );
+  });
+
+  const scrubValue = useDerivedValue(() => {
+    if (!scrubActive.value || scrubTime.value < 0) return null;
+    if (isCandleMode) {
+      return scrubCandle.value?.close ?? null;
+    }
+    return interpolateAtTime(engine.data.value, scrubTime.value);
+  });
 
   const crosshairOpacity = useDerivedValue(() =>
     computeCrosshairOpacity(
@@ -75,8 +107,21 @@ export function useCrosshair(
     ),
   );
 
-  const tooltipLayout = useDerivedValue(() =>
-    deriveCrosshairTooltipSingle(
+  const tooltipLayout = useDerivedValue(() => {
+    if (isCandleMode) {
+      return computeCandleTooltipLayout(
+        scrubActive.value,
+        scrubX.value,
+        scrubCandle.value,
+        scrubTime.value,
+        padding,
+        engine.canvasWidth.value,
+        formatValue,
+        formatTime,
+        font,
+      );
+    }
+    return deriveCrosshairTooltipSingle(
       scrubActive.value,
       scrubX.value,
       scrubTime.value,
@@ -86,12 +131,21 @@ export function useCrosshair(
       formatValue,
       formatTime,
       font,
-    ),
-  );
+    );
+  });
 
   /* istanbul ignore next -- invoked only via scheduleOnRN from UI-thread gesture */
-  function handleScrub(x: number, y: number, time: number, value: number) {
-    onScrub?.({ time, value, x, y });
+  function handleScrub(
+    x: number,
+    y: number,
+    time: number,
+    value: number,
+    candleJson: string | null,
+  ) {
+    const candle: CandlePoint | undefined = candleJson
+      ? (JSON.parse(candleJson) as CandlePoint)
+      : undefined;
+    onScrub?.({ time, value, x, y, candle });
   }
 
   /* istanbul ignore next */
@@ -132,14 +186,32 @@ export function useCrosshair(
             const h = engine.canvasHeight.value;
             const chartH = h - padding.top - padding.bottom;
             const valRange = engine.displayMax.value - engine.displayMin.value;
-            const value = interpolateAtTime(engine.data.value, time);
+
+            let value: number | null = null;
+            let candleJson: string | null = null;
+
+            if (isCandleMode && candlesSV) {
+              const picked = pickCandleAtTime(
+                candlesSV.value,
+                liveCandleSV?.value ?? null,
+                time,
+                candleWidthSecs,
+              );
+              if (picked) {
+                value = picked.close;
+                candleJson = JSON.stringify(picked);
+              }
+            } else {
+              value = interpolateAtTime(engine.data.value, time);
+            }
+
             if (value !== null) {
               const dotY =
                 valRange === 0
                   ? padding.top + chartH / 2
                   : padding.top +
                     ((engine.displayMax.value - value) / valRange) * chartH;
-              scheduleOnRN(handleScrub, e.x, dotY, time, value);
+              scheduleOnRN(handleScrub, e.x, dotY, time, value, candleJson);
             }
           }
         }

--- a/src/hooks/useModeBlend.test.ts
+++ b/src/hooks/useModeBlend.test.ts
@@ -1,0 +1,104 @@
+import { renderHook } from "@testing-library/react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { useModeBlend } from "./useModeBlend";
+
+describe("useModeBlend", () => {
+  it("starts at 0 when isCandle is false", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(1);
+      return useModeBlend(false, lineOpacity);
+    });
+    expect(result.current.modeBlend.value).toBe(0);
+  });
+
+  it("starts at 1 when isCandle is true", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(1);
+      return useModeBlend(true, lineOpacity);
+    });
+    expect(result.current.modeBlend.value).toBe(1);
+  });
+
+  it("lineGroupOpacity is 1 when line mode and lineOpacity is 1", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(1);
+      return useModeBlend(false, lineOpacity);
+    });
+    expect(result.current.lineGroupOpacity.value).toBeCloseTo(1);
+  });
+
+  it("candleGroupOpacity is 0 when line mode", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(1);
+      return useModeBlend(false, lineOpacity);
+    });
+    expect(result.current.candleGroupOpacity.value).toBeCloseTo(0);
+  });
+
+  it("lineGroupOpacity is 0 when candle mode", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(1);
+      return useModeBlend(true, lineOpacity);
+    });
+    expect(result.current.lineGroupOpacity.value).toBeCloseTo(0);
+  });
+
+  it("candleGroupOpacity is 1 when candle mode and lineOpacity is 1", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(1);
+      return useModeBlend(true, lineOpacity);
+    });
+    expect(result.current.candleGroupOpacity.value).toBeCloseTo(1);
+  });
+
+  it("scales both opacities by lineOpacity", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(0.5);
+      return useModeBlend(false, lineOpacity);
+    });
+    expect(result.current.lineGroupOpacity.value).toBeCloseTo(0.5);
+    expect(result.current.candleGroupOpacity.value).toBeCloseTo(0);
+  });
+
+  it("both opacities are 0 when lineOpacity is 0", () => {
+    const { result } = renderHook(() => {
+      const lineOpacity = useSharedValue(0);
+      return useModeBlend(true, lineOpacity);
+    });
+    expect(result.current.lineGroupOpacity.value).toBe(0);
+    expect(result.current.candleGroupOpacity.value).toBe(0);
+  });
+
+  it("triggers animation when isCandle toggles", () => {
+    const { result, rerender } = renderHook(
+      (props: { isCandle: boolean }) => {
+        const lineOpacity = useSharedValue(1);
+        return useModeBlend(props.isCandle, lineOpacity);
+      },
+      { initialProps: { isCandle: false } },
+    );
+    expect(result.current.modeBlend.value).toBe(0);
+
+    rerender({ isCandle: true });
+
+    // withTiming has been called — in the test mock it may resolve
+    // immediately or stay at 0; either way it's >= 0.
+    expect(result.current.modeBlend.value).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns to 0 when switching back to line mode", () => {
+    const { result, rerender } = renderHook(
+      (props: { isCandle: boolean }) => {
+        const lineOpacity = useSharedValue(1);
+        return useModeBlend(props.isCandle, lineOpacity);
+      },
+      { initialProps: { isCandle: true } },
+    );
+    expect(result.current.modeBlend.value).toBe(1);
+
+    rerender({ isCandle: false });
+
+    // Animation triggered back toward 0
+    expect(result.current.modeBlend.value).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/hooks/useModeBlend.ts
+++ b/src/hooks/useModeBlend.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import {
+  Easing,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+  type SharedValue,
+} from "react-native-reanimated";
+
+const MODE_BLEND_DURATION_MS = 300;
+
+export interface ModeBlendState {
+  /** 0 = fully line, 1 = fully candle */
+  modeBlend: SharedValue<number>;
+  /** line opacity = reveal.lineOpacity * (1 - modeBlend) */
+  lineGroupOpacity: SharedValue<number>;
+  /** candle opacity = reveal.lineOpacity * modeBlend */
+  candleGroupOpacity: SharedValue<number>;
+}
+
+/**
+ * Animated crossfade between line and candle chart layers.
+ *
+ * `modeBlend` animates 0→1 when `isCandle` becomes true, 1→0 when false.
+ * The derived opacities multiply by `lineOpacity` from `useChartReveal`
+ * so the reveal and mode-switch animations compose correctly.
+ */
+export function useModeBlend(
+  isCandle: boolean,
+  lineOpacity: SharedValue<number>,
+): ModeBlendState {
+  const modeBlend = useSharedValue(isCandle ? 1 : 0);
+
+  useEffect(() => {
+    modeBlend.value = withTiming(isCandle ? 1 : 0, {
+      duration: MODE_BLEND_DURATION_MS,
+      easing: Easing.inOut(Easing.ease),
+    });
+  }, [isCandle, modeBlend]);
+
+  const lineGroupOpacity = useDerivedValue(
+    () => lineOpacity.value * (1 - modeBlend.value),
+  );
+
+  const candleGroupOpacity = useDerivedValue(
+    () => lineOpacity.value * modeBlend.value,
+  );
+
+  return { modeBlend, lineGroupOpacity, candleGroupOpacity };
+}

--- a/src/livelineEngineTick.test.ts
+++ b/src/livelineEngineTick.test.ts
@@ -422,4 +422,111 @@ describe("tickLivelineEngineFrame", () => {
     expect(s.displayWindow).toBeGreaterThan(30);
     expect(s.displayWindow).toBeLessThan(60);
   });
+
+  // ── Candle mode ────────────────────────────────────────────────────────
+  describe("candle mode Y range", () => {
+    it("computes displayMin/Max from candle low/high", () => {
+      const s = baseState();
+      tickLivelineEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 105,
+        points: [],
+        nowSeconds: 1000,
+        mode: "candle",
+        candles: [{ time: 980, open: 100, high: 120, low: 80, close: 110 }],
+        liveCandle: null,
+      });
+      expect(s.displayMin).toBeLessThan(80);
+      expect(s.displayMax).toBeGreaterThan(120);
+    });
+
+    it("includes liveCandle in Y range", () => {
+      const s = baseState();
+      tickLivelineEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 105,
+        points: [],
+        nowSeconds: 1000,
+        mode: "candle",
+        candles: [{ time: 980, open: 100, high: 110, low: 90, close: 105 }],
+        liveCandle: { time: 1000, open: 105, high: 130, low: 85, close: 120 },
+      });
+      expect(s.displayMin).toBeLessThan(85);
+      expect(s.displayMax).toBeGreaterThan(130);
+    });
+
+    it("targets liveCandle.close for displayValue", () => {
+      const s = baseState();
+      tickLivelineEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 50,
+        points: [],
+        nowSeconds: 1000,
+        mode: "candle",
+        candles: [],
+        liveCandle: { time: 990, open: 100, high: 120, low: 80, close: 115 },
+      });
+      expect(s.displayValue).toBeGreaterThan(0);
+    });
+
+    it("uses line mode Y range when mode is 'line'", () => {
+      const s = baseState();
+      tickLivelineEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 50,
+        points: [{ time: 1000, value: 50 }],
+        nowSeconds: 1000,
+        mode: "line",
+        candles: [{ time: 980, open: 100, high: 200, low: 10, close: 105 }],
+      });
+      expect(s.displayMax).toBeLessThan(200);
+    });
+
+    it("excludes candles before the visible window", () => {
+      const s = baseState();
+      tickLivelineEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 105,
+        points: [],
+        nowSeconds: 1000,
+        mode: "candle",
+        candles: [
+          { time: 900, open: 1, high: 500, low: 0, close: 2 },
+          { time: 990, open: 100, high: 110, low: 90, close: 105 },
+        ],
+        liveCandle: null,
+      });
+      expect(s.displayMax).toBeLessThan(500);
+    });
+  });
 });

--- a/src/livelineEngineTick.ts
+++ b/src/livelineEngineTick.ts
@@ -1,5 +1,6 @@
+import type { CandlePoint, LivelinePoint } from "./types";
+
 import { ADAPTIVE_SPEED_BOOST } from "./constants";
-import type { LivelinePoint } from "./types";
 import { lerp } from "./math/lerp";
 
 export { ADAPTIVE_SPEED_BOOST } from "./constants";
@@ -26,6 +27,12 @@ export interface EngineTickInput {
   nowSeconds?: number;
   /** When true, freeze the viewport timestamp and skip displayWindow lerp */
   paused?: boolean;
+  /** Chart mode — `"candle"` uses OHLC bars for Y range instead of line points. */
+  mode?: "line" | "candle";
+  /** Committed OHLC bars (sorted by time). Used when mode is `"candle"`. */
+  candles?: CandlePoint[];
+  /** In-progress candle. Included in Y range when mode is `"candle"`. */
+  liveCandle?: CandlePoint | null;
 }
 
 /**
@@ -45,7 +52,10 @@ export function tickLivelineEngineFrame(
   if (input.canvasWidth === 0 || input.canvasHeight === 0) return;
 
   const speed = input.smoothing;
-  const target = input.targetValue;
+  let target = input.targetValue;
+  if (input.mode === "candle" && input.liveCandle) {
+    target = input.liveCandle.close;
+  }
 
   const range = state.displayMax - state.displayMin;
   const gapRatio =
@@ -66,23 +76,46 @@ export function tickLivelineEngineFrame(
     input.dt,
   );
 
-  const points = input.points;
   const winStart = state.timestamp - state.displayWindow;
-
-  let lo = 0;
-  let hi = points.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (points[mid].time < winStart) lo = mid + 1;
-    else hi = mid;
-  }
 
   let tMin = Infinity;
   let tMax = -Infinity;
-  for (let i = lo; i < points.length; i++) {
-    const v = points[i].value;
-    if (v < tMin) tMin = v;
-    if (v > tMax) tMax = v;
+
+  if (input.mode === "candle") {
+    const candles = input.candles;
+    if (candles && candles.length > 0) {
+      let lo = 0;
+      let hi = candles.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (candles[mid].time < winStart) lo = mid + 1;
+        else hi = mid;
+      }
+      for (let i = lo; i < candles.length; i++) {
+        if (candles[i].time > state.timestamp) break;
+        if (candles[i].low < tMin) tMin = candles[i].low;
+        if (candles[i].high > tMax) tMax = candles[i].high;
+      }
+    }
+    const lc = input.liveCandle;
+    if (lc) {
+      if (lc.low < tMin) tMin = lc.low;
+      if (lc.high > tMax) tMax = lc.high;
+    }
+  } else {
+    const points = input.points;
+    let lo = 0;
+    let hi = points.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (points[mid].time < winStart) lo = mid + 1;
+      else hi = mid;
+    }
+    for (let i = lo; i < points.length; i++) {
+      const v = points[i].value;
+      if (v < tMin) tMin = v;
+      if (v > tMax) tMax = v;
+    }
   }
 
   const cv = state.displayValue;

--- a/src/math/pickCandle.test.ts
+++ b/src/math/pickCandle.test.ts
@@ -1,0 +1,75 @@
+import type { CandlePoint } from "../types";
+import { pickCandleAtTime } from "./pickCandle";
+
+const makeCandle = (
+  time: number,
+  o = 100,
+  h = 110,
+  l = 90,
+  c = 105,
+): CandlePoint => ({
+  time,
+  open: o,
+  high: h,
+  low: l,
+  close: c,
+});
+
+describe("pickCandleAtTime", () => {
+  const candles: CandlePoint[] = [
+    makeCandle(1000),
+    makeCandle(1060),
+    makeCandle(1120),
+  ];
+  const width = 60;
+
+  it("returns null for empty candles and no live candle", () => {
+    expect(pickCandleAtTime([], null, 1030, width)).toBeNull();
+  });
+
+  it("picks a candle whose bucket contains the time", () => {
+    const result = pickCandleAtTime(candles, null, 1030, width);
+    expect(result).toEqual(candles[0]);
+  });
+
+  it("picks the second candle at 1060", () => {
+    const result = pickCandleAtTime(candles, null, 1060, width);
+    expect(result).toEqual(candles[1]);
+  });
+
+  it("picks the last candle near its end", () => {
+    const result = pickCandleAtTime(candles, null, 1179, width);
+    expect(result).toEqual(candles[2]);
+  });
+
+  it("returns null before the first candle", () => {
+    expect(pickCandleAtTime(candles, null, 999, width)).toBeNull();
+  });
+
+  it("returns null after the last candle ends", () => {
+    expect(pickCandleAtTime(candles, null, 1180, width)).toBeNull();
+  });
+
+  it("picks the live candle when time falls in its bucket", () => {
+    const live = makeCandle(1180, 100, 115, 95, 108);
+    const result = pickCandleAtTime(candles, live, 1200, width);
+    expect(result).toEqual(live);
+  });
+
+  it("prefers the live candle over committed candles when overlapping", () => {
+    const live = makeCandle(1120, 100, 120, 80, 110);
+    const result = pickCandleAtTime(candles, live, 1140, width);
+    expect(result).toEqual(live);
+  });
+
+  it("falls back to committed candle when time is outside live bucket", () => {
+    const live = makeCandle(1180, 100, 115, 95, 108);
+    const result = pickCandleAtTime(candles, live, 1090, width);
+    expect(result).toEqual(candles[1]);
+  });
+
+  it("returns null when time is between candle gaps", () => {
+    const sparse = [makeCandle(1000), makeCandle(1200)];
+    expect(pickCandleAtTime(sparse, null, 1100, width)).toBeNull();
+  });
+});

--- a/src/math/pickCandle.ts
+++ b/src/math/pickCandle.ts
@@ -1,0 +1,42 @@
+import type { CandlePoint } from "../types";
+
+/**
+ * Find the candle whose time bucket contains `time`.
+ * Each candle spans [candle.time, candle.time + candleWidthSecs).
+ * Includes the live candle if it overlaps. Returns null if no match.
+ */
+export function pickCandleAtTime(
+  candles: CandlePoint[],
+  liveCandle: CandlePoint | null,
+  time: number,
+  candleWidthSecs: number,
+): CandlePoint | null {
+  "worklet";
+  if (
+    liveCandle &&
+    time >= liveCandle.time &&
+    time < liveCandle.time + candleWidthSecs
+  ) {
+    return liveCandle;
+  }
+
+  if (candles.length === 0) return null;
+
+  // Binary search: find the last candle with time <= scrub time
+  let lo = 0;
+  let hi = candles.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (candles[mid].time <= time) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  // hi is now the index of the last candle with time <= time
+  if (hi < 0) return null;
+
+  const c = candles[hi];
+  if (time >= c.time && time < c.time + candleWidthSecs) {
+    return c;
+  }
+
+  return null;
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -53,6 +53,11 @@ export function resolveTheme(color: string, mode: ThemeMode): LivelinePalette {
     badgeBg: color,
     badgeText: "#ffffff",
 
+    candleUp: "#22c55e",
+    candleDown: "#ef4444",
+    wickUp: isDark ? "rgba(34, 197, 94, 0.7)" : "rgba(22, 163, 74, 0.8)",
+    wickDown: isDark ? "rgba(239, 68, 68, 0.7)" : "rgba(220, 38, 38, 0.8)",
+
     dashLine: rgba(r, g, b, 0.4),
 
     refLine: isDark ? "rgba(255, 255, 255, 0.15)" : "rgba(0, 0, 0, 0.12)",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import type { SharedValue } from "react-native-reanimated";
 import type { ViewStyle } from "react-native";
+import type { SharedValue } from "react-native-reanimated";
 
 export interface LivelinePoint {
   time: number;
@@ -178,14 +178,25 @@ export interface LivelineSingleProps extends LivelineCoreProps {
   windows?: WindowOption[];
   windowStyle?: WindowStyle;
   onWindowChange?: (secs: number) => void;
+
+  // ── Candlestick mode ──────────────────────────────────────────────────
+  /** Chart display mode (default `"line"`). `"candle"` renders OHLC bars. */
   mode?: "line" | "candle";
-  candles?: CandlePoint[];
+  /** Committed OHLC bars, sorted by `time`. Must be a SharedValue for UI-thread reads. */
+  candles?: SharedValue<CandlePoint[]>;
+  /** Seconds per candle bucket (e.g. 60 for 1-minute bars). */
   candleWidth?: number;
-  liveCandle?: CandlePoint;
+  /** In-progress candle updated each tick. Must be a SharedValue for UI-thread reads. */
+  liveCandle?: SharedValue<CandlePoint | null>;
+  /** Morph candles into a line display (future — not wired in Phase 10). */
   lineMode?: boolean;
+  /** Tick-level data for line-mode density during morph (future — not wired in Phase 10). */
   lineData?: LivelinePoint[];
+  /** Current tick value for line-mode morph (future — not wired in Phase 10). */
   lineValue?: number;
+  /** Callback when the built-in line/candle toggle fires (future — no built-in UI in Phase 10). */
   onModeChange?: (mode: "line" | "candle") => void;
+
   orderbook?: OrderbookData;
   tradeEvents?: TradeEvent[];
   degen?: boolean | DegenOptions;
@@ -222,6 +233,11 @@ export interface LivelinePalette {
   badgeOuterShadow: string;
   badgeBg: string;
   badgeText: string;
+
+  candleUp: string;
+  candleDown: string;
+  wickUp: string;
+  wickDown: string;
 
   dashLine: string;
 

--- a/src/useLivelineEngine.test.tsx
+++ b/src/useLivelineEngine.test.tsx
@@ -23,6 +23,7 @@ describe("applyLivelineEngineFrame", () => {
       exaggerateSV: { value: false },
       referenceValue: { value: undefined as number | undefined },
       pausedSV: { value: false },
+      modeSV: { value: "line" as const },
     };
     applyLivelineEngineFrame(
       { timeSincePreviousFrame: 16.67 },

--- a/src/useLivelineEngine.ts
+++ b/src/useLivelineEngine.ts
@@ -5,7 +5,7 @@ import {
   type SharedValue,
 } from "react-native-reanimated";
 import { tickLivelineEngineFrame } from "./livelineEngineTick";
-import type { LivelinePoint, LivelineSeries } from "./types";
+import type { CandlePoint, LivelinePoint, LivelineSeries } from "./types";
 
 export interface EngineConfig {
   data: SharedValue<LivelinePoint[]>;
@@ -15,6 +15,9 @@ export interface EngineConfig {
   exaggerate?: boolean;
   referenceValue?: number;
   paused?: boolean;
+  mode?: "line" | "candle";
+  candles?: SharedValue<CandlePoint[]>;
+  liveCandle?: SharedValue<CandlePoint | null>;
 }
 
 /** Canvas, time window, and Y-range — shared by single- and multi-series engines. */
@@ -64,6 +67,9 @@ export interface EngineFrameRefs {
   exaggerateSV: SharedValue<boolean>;
   referenceValue: SharedValue<number | undefined>;
   pausedSV: SharedValue<boolean>;
+  modeSV: SharedValue<"line" | "candle">;
+  candles?: SharedValue<CandlePoint[]>;
+  liveCandle?: SharedValue<CandlePoint | null>;
 }
 
 /**
@@ -95,6 +101,9 @@ export function applyLivelineEngineFrame(
     points: sv.data.value,
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
+    mode: sv.modeSV.value,
+    candles: sv.candles?.value,
+    liveCandle: sv.liveCandle?.value,
   });
   sv.displayValue.value = state.displayValue;
   sv.displayMin.value = state.displayMin;
@@ -110,6 +119,7 @@ export function useLivelineEngine(config: EngineConfig): SingleEngineState {
   const exaggerateSV = useDerivedValue(() => config.exaggerate ?? false);
   const referenceValue = useDerivedValue(() => config.referenceValue);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
+  const modeSV = useDerivedValue(() => config.mode ?? "line");
 
   // Animation state (mutated on UI thread each frame)
   const displayValue = useSharedValue(0);
@@ -122,7 +132,7 @@ export function useLivelineEngine(config: EngineConfig): SingleEngineState {
 
   // High-frequency data reads directly from the caller's shared values —
   // no useDerivedValue bridging, no closure serialization per tick.
-  const { data, value } = config;
+  const { data, value, candles, liveCandle } = config;
 
   useFrameCallback((frameInfo) => {
     "worklet";
@@ -141,6 +151,9 @@ export function useLivelineEngine(config: EngineConfig): SingleEngineState {
       exaggerateSV,
       referenceValue,
       pausedSV,
+      modeSV,
+      candles,
+      liveCandle,
     });
   });
 


### PR DESCRIPTION
### TL;DR

Added candlestick chart support to the Liveline component with animated transitions between line and candle modes.

### What changed?

Added comprehensive candlestick chart functionality:

- **New candle mode**: Added `mode` prop accepting `"line"` or `"candle"` values
- **Candle data props**: Added `candles`, `liveCandle`, and `candleWidth` props for OHLC data
- **Animated mode switching**: Implemented smooth crossfade transitions between line and candle displays using `useModeBlend` hook
- **Candle rendering**: Created `useCandlePaths` hook to generate separate paths for up/down candle bodies and wicks
- **Candle-specific crosshair**: Enhanced scrub functionality to show OHLC tooltip when in candle mode
- **Y-axis adaptation**: Modified engine to compute display range from candle high/low values instead of line points
- **Performance optimization**: Added conditional data processing to skip multi-series and candle aggregation when not displayed
- **Theme colors**: Added candle-specific colors (`candleUp`, `candleDown`, `wickUp`, `wickDown`) to the palette
- **Display mode UI**: Added toggle buttons in the demo app to switch between line and candle modes

### How to test?

1. Run the demo app and switch to single chart mode
2. Use the new "Display Mode" toggle to switch between Line and Candle views
3. Verify smooth animated transitions between modes
4. Test scrubbing in candle mode to see OHLC tooltip
5. Confirm that gradient is automatically disabled in candle mode
6. Test with different time windows to see candle width adaptation

### Why make this change?

Candlestick charts are essential for financial data visualization, providing more information than simple line charts by showing open, high, low, and close values. This enhancement makes the Liveline component suitable for trading applications and financial dashboards while maintaining the existing smooth animations and performance characteristics.