### PR TITLE
feat: degen mode and trade stream

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -61,6 +61,8 @@ export default function Index() {
   const [showRefLine, setShowRefLine] = useState(false);
   const [valueLine, setValueLine] = useState(false);
   const [exaggerate, setExaggerate] = useState(false);
+  const [degen, setDegen] = useState(true);
+  const [simTradeStream, setSimTradeStream] = useState(true);
 
   const [chartMode, setChartMode] = useState<"single" | "multi">("single");
   const [displayMode, setDisplayMode] = useState<"line" | "candle">("line");
@@ -68,15 +70,17 @@ export default function Index() {
   // ~20 candles visible in the window; minimum 5s bars
   const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
 
-  const { data, value, series, candles, liveCandle } = useSimulatedData({
-    volatilityMode,
-    tradeSource,
-    paused,
-    startValue,
-    candleWidth: candleWidthSecs,
-    multiSeries: chartMode === "multi",
-    candleAggregation: chartMode === "single" && displayMode === "candle",
-  });
+  const { data, value, series, candles, liveCandle, tradeStream } =
+    useSimulatedData({
+      volatilityMode,
+      tradeSource,
+      paused,
+      startValue,
+      candleWidth: candleWidthSecs,
+      multiSeries: chartMode === "multi",
+      candleAggregation: chartMode === "single" && displayMode === "candle",
+      tradeStream: simTradeStream,
+    });
   const chartModeSv = useSharedValue<"single" | "multi">("single");
   const volatilitySv = useSharedValue(volatilityMode);
   useEffect(() => {
@@ -147,6 +151,8 @@ export default function Index() {
             onScrub={(point) => {
               scrubPoint.value = point;
             }}
+            tradeStream={tradeStream}
+            degen={degen ? true : undefined}
           />
         ) : (
           <LivelineMulti
@@ -329,6 +335,34 @@ export default function Index() {
 
         <Text style={styles.sectionLabel}>Chart Options</Text>
         <View style={styles.buttonRow}>
+          <Pressable
+            style={styles.chip}
+            onPress={() => {
+              setDegen(true);
+              setExaggerate(true);
+              setVolatilityMode("chaotic");
+            }}
+          >
+            <Text style={styles.chipText}>Degen demo</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.chip, simTradeStream && styles.chipActive]}
+            onPress={() => setSimTradeStream((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, simTradeStream && styles.chipTextActive]}
+            >
+              Trade stream
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.chip, degen && styles.chipActive]}
+            onPress={() => setDegen((v) => !v)}
+          >
+            <Text style={[styles.chipText, degen && styles.chipTextActive]}>
+              Degen
+            </Text>
+          </Pressable>
           <Pressable
             style={[styles.chip, valueLine && styles.chipActive]}
             onPress={() => setValueLine((v) => !v)}

--- a/sim/useSimulatedData.ts
+++ b/sim/useSimulatedData.ts
@@ -34,12 +34,14 @@ export interface SimulatedDataOptions {
   multiSeries?: boolean;
   /** Skip candle aggregation when not displayed (default true). */
   candleAggregation?: boolean;
+  /** Skip synthetic trade events when not displayed (default true). */
+  tradeStream?: boolean;
 }
 
 export interface SimulatedData {
   data: SharedValue<LivelinePoint[]>;
   value: SharedValue<number>;
-  tradeEvents: SharedValue<TradeEvent[]>;
+  tradeStream: SharedValue<TradeEvent[]>;
   series: SharedValue<LivelineSeries[]>;
   candles: SharedValue<CandlePoint[]>;
   liveCandle: SharedValue<CandlePoint | null>;
@@ -55,7 +57,7 @@ export interface SimulatedData {
  */
 interface TickBuffers {
   data: LivelinePoint[];
-  tradeEvents: TradeEvent[];
+  tradeStream: TradeEvent[];
   series: LivelineSeries[];
 }
 
@@ -71,19 +73,20 @@ export function useSimulatedData(
     maxPoints = 2000,
     multiSeries = true,
     candleAggregation = true,
+    tradeStream: tradeStreamEnabled = true,
   } = opts;
 
   // JS-side buffers — fast O(1) reads in the tick callback
   const buf = useRef<TickBuffers>({
     data: [],
-    tradeEvents: [],
+    tradeStream: [],
     series: [],
   });
 
   // Shared values — one-way push to UI thread for rendering
   const data = useSharedValue<LivelinePoint[]>([]);
   const value = useSharedValue(startValue);
-  const tradeEvents = useSharedValue<TradeEvent[]>([]);
+  const tradeStream = useSharedValue<TradeEvent[]>([]);
   const series = useSharedValue<LivelineSeries[]>([]);
   const candles = useSharedValue<CandlePoint[]>([]);
   const liveCandle = useSharedValue<CandlePoint | null>(null);
@@ -107,10 +110,9 @@ export function useSimulatedData(
       startValue,
       volatility: volatilityFor(volatilityMode),
     });
-    const initialTrades = generateTradeEvents(
-      history[history.length - 1].value,
-      20,
-    );
+    const initialTrades = tradeStreamEnabled
+      ? generateTradeEvents(history[history.length - 1].value, 20)
+      : [];
     const initialSeries = multiSeries
       ? generateMultiSeries({
           ids: ["yes", "no", "maybe"],
@@ -123,13 +125,13 @@ export function useSimulatedData(
 
     buf.current = {
       data: history,
-      tradeEvents: initialTrades,
+      tradeStream: initialTrades,
       series: initialSeries,
     };
 
     data.value = history;
     value.value = history[history.length - 1].value;
-    tradeEvents.value = initialTrades;
+    tradeStream.value = initialTrades;
     series.value = initialSeries;
     if (candleAggregation) {
       const c = aggregateCandles(history, candleWidth);
@@ -142,9 +144,10 @@ export function useSimulatedData(
     candleWidth,
     multiSeries,
     candleAggregation,
+    tradeStreamEnabled,
     data,
     value,
-    tradeEvents,
+    tradeStream,
     series,
     candles,
     liveCandle,
@@ -176,19 +179,24 @@ export function useSimulatedData(
         liveCandle.value = c.liveCandle;
       }
 
-      // Trade events
-      if (tradeSource === "bonding-curve") {
-        const result = bondingTrade(bondingCurveRef.current);
-        bondingCurveRef.current = result.state;
-        b.tradeEvents = [...b.tradeEvents, result.event];
+      // Trade stream (optional)
+      if (tradeStreamEnabled) {
+        if (tradeSource === "bonding-curve") {
+          const result = bondingTrade(bondingCurveRef.current);
+          bondingCurveRef.current = result.state;
+          b.tradeStream = [...b.tradeStream, result.event];
+        } else {
+          b.tradeStream = [
+            ...b.tradeStream,
+            ...generateTradeEvents(newValue, 2, vol),
+          ];
+        }
+        if (b.tradeStream.length > 50) b.tradeStream = b.tradeStream.slice(-50);
+        tradeStream.value = b.tradeStream;
       } else {
-        b.tradeEvents = [
-          ...b.tradeEvents,
-          ...generateTradeEvents(newValue, 2, vol),
-        ];
+        b.tradeStream = [];
+        tradeStream.value = [];
       }
-      if (b.tradeEvents.length > 50) b.tradeEvents = b.tradeEvents.slice(-50);
-      tradeEvents.value = b.tradeEvents;
 
       // Multi-series — skip when not displayed
       if (multiSeries) {
@@ -216,9 +224,10 @@ export function useSimulatedData(
     candleWidth,
     multiSeries,
     candleAggregation,
+    tradeStreamEnabled,
     data,
     value,
-    tradeEvents,
+    tradeStream,
     series,
     candles,
     liveCandle,
@@ -227,7 +236,7 @@ export function useSimulatedData(
   return {
     data,
     value,
-    tradeEvents,
+    tradeStream,
     series,
     candles,
     liveCandle,

--- a/src/Liveline.test.tsx
+++ b/src/Liveline.test.tsx
@@ -4,12 +4,19 @@ import React from "react";
 import { View } from "react-native";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import { Liveline } from "./Liveline";
-import type { CandlePoint, LivelineSingleProps } from "./types";
+import type { CandlePoint, LivelineSingleProps, TradeEvent } from "./types";
 
 function Harness(props: Partial<LivelineSingleProps>) {
   const data = useSharedValue([{ time: 1700000000, value: 50 }]);
   const value = useSharedValue(50);
   return <Liveline data={data} value={value} {...props} />;
+}
+
+function TradeStreamHarness() {
+  const tradeStream = useSharedValue<TradeEvent[]>([
+    { time: 1_700_000_050, price: 50, size: 1, side: "buy" },
+  ]);
+  return <Harness tradeStream={tradeStream} degen={{ scale: 1.2 }} />;
 }
 
 function CandleHarness(props: Partial<LivelineSingleProps>) {
@@ -19,7 +26,7 @@ function CandleHarness(props: Partial<LivelineSingleProps>) {
     { time: 1700000000, open: 48, high: 52, low: 47, close: 50 },
     { time: 1700000060, open: 50, high: 55, low: 49, close: 53 },
   ]);
-  const liveCandle: SharedValue<CandlePoint | null> = useSharedValue({
+  const liveCandle = useSharedValue<CandlePoint | null>({
     time: 1700000120,
     open: 53,
     high: 56,
@@ -157,5 +164,13 @@ describe("Liveline", () => {
 
   it("disables gradient in candle mode", () => {
     render(<CandleHarness gradient />);
+  });
+
+  it("renders with tradeStream and degen", () => {
+    const screen = render(<TradeStreamHarness />);
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
   });
 });

--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -20,37 +20,44 @@ import {
   useChartPaths,
   useChartReveal,
   useCrosshair,
+  useDegen,
   useLiveDot,
   useModeBlend,
   useMomentum,
   useReferenceLine,
+  useTradeStream,
   useXAxis,
   useYAxis,
 } from "./hooks";
 import {
   resolveBadge,
+  resolveDegen,
   resolveFontConfig,
   resolveGradient,
   resolvePulse,
   resolveReferenceLineConfig,
   resolveScrub,
+  resolveTradeStream,
   resolveValueLine,
   resolveXAxis,
   resolveYAxis,
 } from "./resolveConfig";
+import type { LivelineSingleProps, TradeEvent } from "./types";
 
 import { GestureDetector } from "react-native-gesture-handler";
+import { useSharedValue } from "react-native-reanimated";
 import { BadgeOverlay } from "./components/BadgeOverlay";
 import { CrosshairOverlay } from "./components/CrosshairOverlay";
+import { DegenParticlesOverlay } from "./components/DegenParticlesOverlay";
 import { DotOverlay } from "./components/DotOverlay";
 import { LoadingOverlay } from "./components/LoadingOverlay";
 import { MultiSeriesTooltipStack } from "./components/MultiSeriesTooltipStack";
 import { ReferenceLineOverlay } from "./components/ReferenceLineOverlay";
+import { TradeStreamOverlay } from "./components/TradeStreamOverlay";
 import { ValueLineOverlay } from "./components/ValueLineOverlay";
 import { XAxisOverlay } from "./components/XAxisOverlay";
 import { YAxisOverlay } from "./components/YAxisOverlay";
 import { resolveTheme } from "./theme";
-import type { LivelineSingleProps } from "./types";
 import { useLivelineEngine } from "./useLivelineEngine";
 
 export function Liveline({
@@ -92,10 +99,14 @@ export function Liveline({
   valueLine = false,
   referenceLine,
   scrub = false,
+  tradeStream,
+  degen,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
 }: LivelineSingleProps) {
+  const emptyTradeStream = useSharedValue<TradeEvent[]>([]);
+  const tradeStreamSV = tradeStream ?? emptyTradeStream;
   const isCandle = mode === "candle";
 
   // ── Resolve feature configs ────────────────────────────────────────────
@@ -107,6 +118,8 @@ export function Liveline({
   const valueLineCfg = resolveValueLine(valueLine);
   const pulseCfg = resolvePulse(pulse);
   const refLineCfg = resolveReferenceLineConfig(referenceLine);
+  const degenCfg = resolveDegen(degen);
+  const tradeStreamResolved = resolveTradeStream(tradeStream);
 
   const badgeOnLeft = badgeCfg?.position === "left";
 
@@ -176,6 +189,19 @@ export function Liveline({
   const { dotX, dotY } = useLiveDot(engine, effectivePadding);
 
   const momentumSV = useMomentum(engine, momentum);
+
+  const tradeMarkers = useTradeStream(
+    engine,
+    tradeStreamSV,
+    effectivePadding,
+    tradeStreamResolved !== null,
+  );
+
+  const {
+    pack: degenPack,
+    packRevision: degenPackRevision,
+    shakeTransform: degenShakeTransform,
+  } = useDegen(engine, dotX, dotY, momentumSV, degenCfg);
 
   // ── Overlay hooks ─────────────────────────────────────────────────────
   const referenceLineLayout = useReferenceLine(
@@ -249,155 +275,185 @@ export function Liveline({
     <GestureDetector gesture={crosshair.gesture}>
       <View style={[{ flex: 1, backgroundColor }, style]} onLayout={onLayout}>
         <Canvas style={{ flex: 1 }}>
-          {/* Y-axis grid */}
-          {yAxisCfg && (
-            <Group opacity={reveal.yAxisOpacity}>
-              <YAxisOverlay
-                entries={yAxisEntries}
+          <Group transform={degenShakeTransform}>
+            {/* Y-axis grid */}
+            {yAxisCfg && (
+              <Group opacity={reveal.yAxisOpacity}>
+                <YAxisOverlay
+                  entries={yAxisEntries}
+                  engine={engine}
+                  padding={effectivePadding}
+                  palette={palette}
+                  font={skiaFont}
+                  badge={badgeCfg !== null && !badgeOnLeft}
+                />
+              </Group>
+            )}
+
+            {/* Area gradient fill */}
+            {gradientCfg && (
+              <Group opacity={reveal.fillOpacity}>
+                <Path path={fillPath} style="fill">
+                  <LinearGradient
+                    start={vec(0, effectivePadding.top)}
+                    end={vec(0, gradientEnd)}
+                    colors={[gradientTopColor, gradientBottomColor]}
+                  />
+                </Path>
+              </Group>
+            )}
+
+            {/* Value line + reference line (behind chart line) */}
+            {valueLineCfg && (
+              <Group opacity={reveal.lineOpacity}>
+                <ValueLineOverlay
+                  dotY={dotY}
+                  engine={engine}
+                  padding={effectivePadding}
+                  strokeWidth={valueLineCfg.strokeWidth}
+                  intervals={valueLineCfg.intervals}
+                  color={valueLineCfg.color ?? palette.dashLine}
+                />
+              </Group>
+            )}
+
+            {refLineCfg && (
+              <ReferenceLineOverlay
+                layout={referenceLineLayout}
+                strokeWidth={refLineCfg.strokeWidth}
+                intervals={refLineCfg.intervals}
+                color={refLineCfg.color ?? palette.refLine}
+                labelColor={palette.refLabel}
+                font={skiaFont}
+              />
+            )}
+
+            {/* Chart line (fades out in candle mode) */}
+            <Group opacity={lineGroupOpacity}>
+              <Path
+                path={linePath}
+                style="stroke"
+                strokeWidth={strokeWidth}
+                color={lineProp?.color ?? palette.line}
+                strokeCap="round"
+                strokeJoin="round"
+              />
+            </Group>
+
+            {/* Candle bodies/wicks (fades in in candle mode) */}
+            <Group opacity={candleGroupOpacity}>
+              <Path
+                path={upWicksPath}
+                style="stroke"
+                strokeWidth={1}
+                color={palette.wickUp}
+              />
+              <Path
+                path={downWicksPath}
+                style="stroke"
+                strokeWidth={1}
+                color={palette.wickDown}
+              />
+              <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
+              <Path
+                path={downBodiesPath}
+                style="fill"
+                color={palette.candleDown}
+              />
+            </Group>
+
+            {/* X-axis time labels */}
+            {xAxisCfg && (
+              <XAxisOverlay
+                entries={xAxisEntries}
                 engine={engine}
                 padding={effectivePadding}
                 palette={palette}
                 font={skiaFont}
-                badge={badgeCfg !== null && !badgeOnLeft}
+              />
+            )}
+
+            {/* Badge and live dot */}
+            {badgeCfg && (
+              <Group opacity={reveal.badgeOpacity}>
+                <BadgeOverlay badge={badgeData} font={skiaFont} />
+              </Group>
+            )}
+
+            <Group opacity={reveal.dotOpacity}>
+              <DotOverlay
+                dotX={dotX}
+                dotY={dotY}
+                palette={palette}
+                engine={engine}
+                pulse={pulseCfg}
               />
             </Group>
-          )}
 
-          {/* Area gradient fill */}
-          {gradientCfg && (
-            <Group opacity={reveal.fillOpacity}>
-              <Path path={fillPath} style="fill">
-                <LinearGradient
-                  start={vec(0, effectivePadding.top)}
-                  end={vec(0, gradientEnd)}
-                  colors={[gradientTopColor, gradientBottomColor]}
+            {degenCfg && (
+              <Group opacity={reveal.dotOpacity}>
+                <DegenParticlesOverlay
+                  pack={degenPack}
+                  packRevision={degenPackRevision}
+                  engine={engine}
+                  palette={palette}
+                  particleSlotCount={degenCfg.particleSlotCount}
+                  particleBurstDurationSec={degenCfg.particleBurstDurationSec}
+                  particleOpacity={degenCfg.particleOpacity}
+                  colors={degenCfg.colors}
                 />
-              </Path>
-            </Group>
-          )}
+              </Group>
+            )}
 
-          {/* Value line + reference line (behind chart line) */}
-          {valueLineCfg && (
-            <ValueLineOverlay
-              dotY={dotY}
+            {/* Trade stream tape (behind chart content) */}
+            {tradeStreamResolved && (
+              <TradeStreamOverlay
+                markers={tradeMarkers}
+                palette={palette}
+                padding={effectivePadding}
+                font={skiaFont}
+                opacity={reveal.dotOpacity}
+                labelOffsetX={tradeStreamResolved.labelOffsetX}
+              />
+            )}
+
+            {/* Loading / empty state — rendered last so it sits on top */}
+            <LoadingOverlay
               engine={engine}
               padding={effectivePadding}
-              strokeWidth={valueLineCfg.strokeWidth}
-              intervals={valueLineCfg.intervals}
-              color={valueLineCfg.color ?? palette.dashLine}
-            />
-          )}
-
-          {refLineCfg && (
-            <ReferenceLineOverlay
-              layout={referenceLineLayout}
-              strokeWidth={refLineCfg.strokeWidth}
-              intervals={refLineCfg.intervals}
-              color={refLineCfg.color ?? palette.refLine}
-              labelColor={palette.refLabel}
+              palette={palette}
               font={skiaFont}
-            />
-          )}
-
-          {/* Chart line (fades out in candle mode) */}
-          <Group opacity={lineGroupOpacity}>
-            <Path
-              path={linePath}
-              style="stroke"
+              morphT={reveal.morphT}
+              isLoading={reveal.isLoading}
+              isEmpty={reveal.isEmpty}
+              emptyText={emptyText}
               strokeWidth={strokeWidth}
-              color={lineProp?.color ?? palette.line}
-              strokeCap="round"
-              strokeJoin="round"
+              badge={badgeCfg !== null}
             />
+
+            {/* Crosshair scrub */}
+            {scrubCfg && (
+              <CrosshairOverlay
+                scrubX={crosshair.scrubX}
+                crosshairOpacity={crosshair.crosshairOpacity}
+                tooltipLayout={crosshair.tooltipLayout}
+                engine={engine}
+                padding={effectivePadding}
+                palette={palette}
+                font={skiaFont}
+                showTooltip={scrubCfg.tooltip}
+                tooltipBody={
+                  isCandle ? (
+                    <MultiSeriesTooltipStack
+                      tooltipLayout={crosshair.tooltipLayout}
+                      font={skiaFont}
+                      palette={palette}
+                    />
+                  ) : undefined
+                }
+              />
+            )}
           </Group>
-
-          {/* Candle bodies/wicks (fades in in candle mode) */}
-          <Group opacity={candleGroupOpacity}>
-            <Path
-              path={upWicksPath}
-              style="stroke"
-              strokeWidth={1}
-              color={palette.wickUp}
-            />
-            <Path
-              path={downWicksPath}
-              style="stroke"
-              strokeWidth={1}
-              color={palette.wickDown}
-            />
-            <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
-            <Path
-              path={downBodiesPath}
-              style="fill"
-              color={palette.candleDown}
-            />
-          </Group>
-
-          {/* X-axis time labels */}
-          {xAxisCfg && (
-            <XAxisOverlay
-              entries={xAxisEntries}
-              engine={engine}
-              padding={effectivePadding}
-              palette={palette}
-              font={skiaFont}
-            />
-          )}
-
-          {/* Badge and live dot */}
-          {badgeCfg && (
-            <Group opacity={reveal.badgeOpacity}>
-              <BadgeOverlay badge={badgeData} font={skiaFont} />
-            </Group>
-          )}
-
-          <Group opacity={reveal.dotOpacity}>
-            <DotOverlay
-              dotX={dotX}
-              dotY={dotY}
-              momentum={momentumSV}
-              palette={palette}
-              engine={engine}
-              pulse={pulseCfg}
-            />
-          </Group>
-
-          {/* Loading / empty state — rendered last so it sits on top */}
-          <LoadingOverlay
-            engine={engine}
-            padding={effectivePadding}
-            palette={palette}
-            font={skiaFont}
-            morphT={reveal.morphT}
-            isLoading={reveal.isLoading}
-            isEmpty={reveal.isEmpty}
-            emptyText={emptyText}
-            strokeWidth={strokeWidth}
-            badge={badgeCfg !== null}
-          />
-
-          {/* Crosshair scrub */}
-          {scrubCfg && (
-            <CrosshairOverlay
-              scrubX={crosshair.scrubX}
-              crosshairOpacity={crosshair.crosshairOpacity}
-              tooltipLayout={crosshair.tooltipLayout}
-              engine={engine}
-              padding={effectivePadding}
-              palette={palette}
-              font={skiaFont}
-              showTooltip={scrubCfg.tooltip}
-              tooltipBody={
-                isCandle ? (
-                  <MultiSeriesTooltipStack
-                    tooltipLayout={crosshair.tooltipLayout}
-                    font={skiaFont}
-                    palette={palette}
-                  />
-                ) : undefined
-              }
-            />
-          )}
         </Canvas>
       </View>
     </GestureDetector>

--- a/src/components/DegenParticlesOverlay.tsx
+++ b/src/components/DegenParticlesOverlay.tsx
@@ -1,0 +1,113 @@
+import { Circle, Group } from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import { DEGEN_STRIDE } from "../constants";
+import type { LivelinePalette } from "../types";
+import type { SingleEngineState } from "../useLivelineEngine";
+
+type DegenPack = SharedValue<Float64Array<ArrayBuffer>>;
+
+function DegenSlot({
+  index,
+  pack,
+  packRevision,
+  engine,
+  particleBurstDurationSec,
+  particleOpacity,
+  color,
+}: {
+  index: number;
+  pack: DegenPack;
+  packRevision: SharedValue<number>;
+  engine: SingleEngineState;
+  particleBurstDurationSec: number;
+  particleOpacity: number;
+  color: string;
+}) {
+  const base = index * DEGEN_STRIDE;
+
+  /* istanbul ignore next -- useDerivedValue worklet runs on UI thread, not in Jest */
+  const cx = useDerivedValue(() => {
+    const rev = packRevision.value;
+    const buf = pack.value;
+    const active = buf[base + 5];
+    if (!(rev >= 0) || !(active > 0.5)) return -9999;
+    return buf[base + 0];
+  });
+
+  /* istanbul ignore next -- worklet */
+  const cy = useDerivedValue(() => {
+    const rev = packRevision.value;
+    const buf = pack.value;
+    const active = buf[base + 5];
+    if (!(rev >= 0) || !(active > 0.5)) return -9999;
+    return buf[base + 1];
+  });
+
+  /* istanbul ignore next -- worklet */
+  const r = useDerivedValue(() => {
+    const rev = packRevision.value;
+    const buf = pack.value;
+    const active = buf[base + 5];
+    if (!(rev >= 0) || !(active > 0.5)) return 0;
+    const now = engine.timestamp.value;
+    const dt = now - buf[base + 4];
+    if (dt < 0) return 0;
+    const life = Math.max(0, 1 - dt / particleBurstDurationSec);
+    const size = buf[base + 6] || 1;
+    return size * (0.5 + life * 0.5);
+  });
+
+  /* istanbul ignore next -- worklet */
+  const opacity = useDerivedValue(() => {
+    const rev = packRevision.value;
+    const buf = pack.value;
+    const active = buf[base + 5];
+    if (!(rev >= 0) || !(active > 0.5)) return 0;
+    const now = engine.timestamp.value;
+    const dt = now - buf[base + 4];
+    if (dt < 0) return 0;
+    const life = Math.max(0, 1 - dt / particleBurstDurationSec);
+    return life * particleOpacity;
+  });
+
+  return <Circle cx={cx} cy={cy} r={r} color={color} opacity={opacity} />;
+}
+
+export function DegenParticlesOverlay({
+  pack,
+  packRevision,
+  engine,
+  palette,
+  particleSlotCount,
+  particleBurstDurationSec,
+  particleOpacity,
+  colors,
+}: {
+  pack: DegenPack;
+  packRevision: SharedValue<number>;
+  engine: SingleEngineState;
+  palette: LivelinePalette;
+  particleSlotCount: number;
+  particleBurstDurationSec: number;
+  particleOpacity: number;
+  colors: string[] | null;
+}) {
+  /* istanbul ignore next -- branch depends on render-time props */
+  const colorList = colors && colors.length > 0 ? colors : [palette.line];
+  const slots = [];
+  for (let i = 0; i < particleSlotCount; i++) {
+    slots.push(
+      <DegenSlot
+        key={i}
+        index={i}
+        pack={pack}
+        packRevision={packRevision}
+        engine={engine}
+        particleBurstDurationSec={particleBurstDurationSec}
+        particleOpacity={particleOpacity}
+        color={colorList[i % colorList.length]}
+      />,
+    );
+  }
+  return <Group>{slots}</Group>;
+}

--- a/src/components/DotOverlay.tsx
+++ b/src/components/DotOverlay.tsx
@@ -1,34 +1,24 @@
 import { Circle, Group } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ResolvedPulseConfig } from "../resolveConfig";
-import type { LivelinePalette, Momentum } from "../types";
+import type { LivelinePalette } from "../types";
 import type { ChartEngineLayout } from "../useLivelineEngine";
 
-// Minimum ring radius — sits just outside the outer dot ring (r = 6.5).
 const MIN_PULSE_RADIUS = 9;
 
 export function DotOverlay({
   dotX,
   dotY,
-  momentum,
   palette,
   engine,
   pulse,
 }: {
   dotX: SharedValue<number>;
   dotY: SharedValue<number>;
-  momentum: SharedValue<Momentum>;
   palette: LivelinePalette;
   engine: ChartEngineLayout;
   pulse: ResolvedPulseConfig | null;
 }) {
-  const glowColor = useDerivedValue(() => {
-    const m = momentum.value;
-    if (m === "up") return palette.glowUp;
-    if (m === "down") return palette.glowDown;
-    return palette.glowFlat;
-  });
-
   const pulseRadius = useDerivedValue(() => {
     if (!pulse) return 0;
     const nowMs = engine.timestamp.value * 1000;
@@ -47,14 +37,6 @@ export function DotOverlay({
 
   return (
     <Group>
-      {/* Glow circle */}
-      <Circle
-        cx={dotX}
-        cy={dotY}
-        r={14}
-        color={glowColor as unknown as string}
-      />
-
       {/* Pulse ring */}
       {pulse && (
         <Circle

--- a/src/components/TradeStreamOverlay.tsx
+++ b/src/components/TradeStreamOverlay.tsx
@@ -1,0 +1,125 @@
+import {
+  Group,
+  Text as SkiaText,
+  type SkFont,
+} from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import type { ChartPadding } from "../draw/line";
+import type { TradeMarker } from "../draw/trade";
+import type { LivelinePalette } from "../types";
+
+const MAX_TRADE_LABELS = 20;
+
+const GREEN: [number, number, number] = [34, 197, 94];
+const RED: [number, number, number] = [239, 68, 68];
+
+/* istanbul ignore next -- worklet */
+function mixColor(
+  from: [number, number, number],
+  to: [number, number, number],
+  t: number,
+): string {
+  "worklet";
+  const r = Math.round(from[0] + (to[0] - from[0]) * t);
+  const g = Math.round(from[1] + (to[1] - from[1]) * t);
+  const b = Math.round(from[2] + (to[2] - from[2]) * t);
+  return `rgb(${r},${g},${b})`;
+}
+
+function TapeLabel({
+  index,
+  markers,
+  bgRgb,
+  labelX,
+  font,
+  groupOpacity,
+}: {
+  index: number;
+  markers: SharedValue<TradeMarker[]>;
+  bgRgb: [number, number, number];
+  labelX: number;
+  font: SkFont;
+  groupOpacity: SharedValue<number>;
+}) {
+  /* istanbul ignore next -- worklet */
+  const y = useDerivedValue(() => markers.value[index]?.y ?? -200);
+  /* istanbul ignore next -- worklet */
+  const text = useDerivedValue(() => markers.value[index]?.label ?? " ");
+
+  /* istanbul ignore next -- worklet */
+  const fillColor = useDerivedValue(() => {
+    const m = markers.value[index];
+    if (!m) return "transparent";
+    const base = m.green ? GREEN : RED;
+    return mixColor(base, bgRgb, 1 - m.alpha);
+  });
+
+  /* istanbul ignore next -- worklet */
+  const outlineColor = useDerivedValue(() => {
+    const m = markers.value[index];
+    if (!m) return "transparent";
+    return `rgb(${bgRgb[0]},${bgRgb[1]},${bgRgb[2]})`;
+  });
+
+  /* istanbul ignore next -- worklet */
+  const opacity = useDerivedValue(() => {
+    const m = markers.value[index];
+    if (!m) return 0;
+    return groupOpacity.value;
+  });
+
+  return (
+    <Group opacity={opacity}>
+      <SkiaText
+        x={labelX}
+        y={y}
+        text={text as unknown as string}
+        font={font}
+        color={outlineColor as unknown as string}
+        style="stroke"
+        strokeWidth={0.5}
+        opacity={0.75}
+      />
+      <SkiaText
+        x={labelX}
+        y={y}
+        text={text as unknown as string}
+        font={font}
+        color={fillColor as unknown as string}
+      />
+    </Group>
+  );
+}
+
+export function TradeStreamOverlay({
+  markers,
+  palette,
+  padding,
+  font,
+  opacity,
+  labelOffsetX = 8,
+}: {
+  markers: SharedValue<TradeMarker[]>;
+  palette: LivelinePalette;
+  padding: ChartPadding;
+  font: SkFont;
+  opacity: SharedValue<number>;
+  labelOffsetX?: number;
+}) {
+  const labelX = padding.left + labelOffsetX;
+  const slots = [];
+  for (let i = 0; i < MAX_TRADE_LABELS; i++) {
+    slots.push(
+      <TapeLabel
+        key={i}
+        index={i}
+        markers={markers}
+        bgRgb={palette.bgRgb}
+        labelX={labelX}
+        font={font}
+        groupOpacity={opacity}
+      />,
+    );
+  }
+  return <Group>{slots}</Group>;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,3 +14,9 @@ export const BADGE_DOT_GAP = 12;
 
 /** Maximum simultaneous series rendered (paths/dots slots). */
 export const MAX_MULTI_SERIES = 12;
+
+/**
+ * Floats per degen particle slot: `x, y, vx, vy, t0, active, size`.
+ * Layout is fixed; not on `DegenOptions` because changing it needs matching renderer changes.
+ */
+export const DEGEN_STRIDE = 7;

--- a/src/degen/tick.test.ts
+++ b/src/degen/tick.test.ts
@@ -1,0 +1,171 @@
+import { DEGEN_STRIDE } from "../constants";
+import {
+  computeShake,
+  hash,
+  spawnBurst,
+  tickParticles,
+  type SpawnParams,
+} from "./tick";
+
+describe("hash", () => {
+  it("returns values in [0,1)", () => {
+    for (let i = 0; i < 100; i++) {
+      const v = hash(i, i * 3.7);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("returns distinct values for different inputs", () => {
+    const a = hash(1, 1000);
+    const b = hash(2, 1000);
+    const c = hash(1, 2000);
+    expect(a).not.toBeCloseTo(b, 3);
+    expect(a).not.toBeCloseTo(c, 3);
+  });
+});
+
+describe("spawnBurst", () => {
+  const makeParams = (overrides?: Partial<SpawnParams>): SpawnParams => ({
+    ox: 200,
+    oy: 150,
+    sc: 1,
+    burst: 6,
+    baseAngle: -Math.PI / 2,
+    spread: Math.PI * 1.2,
+    jx: 24,
+    jy: 8,
+    sMin: 60,
+    sMax: 160,
+    szMin: 1,
+    szMax: 2.2,
+    now: 1700000000,
+    baseRot: 0,
+    slots: 20,
+    ...overrides,
+  });
+
+  it("writes particles into buffer at correct offsets", () => {
+    const buf = new Float64Array(20 * DEGEN_STRIDE);
+    const p = makeParams();
+    spawnBurst(buf, p);
+
+    for (let k = 0; k < p.burst; k++) {
+      const b = k * DEGEN_STRIDE;
+      expect(buf[b + 5]).toBe(1);
+      expect(buf[b + 4]).toBe(p.now);
+      expect(Number.isFinite(buf[b + 0])).toBe(true);
+      expect(Number.isFinite(buf[b + 1])).toBe(true);
+      expect(Number.isFinite(buf[b + 2])).toBe(true);
+      expect(Number.isFinite(buf[b + 3])).toBe(true);
+      expect(buf[b + 6]).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns updated rotation", () => {
+    const buf = new Float64Array(20 * DEGEN_STRIDE);
+    const rot = spawnBurst(
+      buf,
+      makeParams({ burst: 6, baseRot: 0, slots: 20 }),
+    );
+    expect(rot).toBe(6);
+  });
+
+  it("wraps rotation around slot count", () => {
+    const buf = new Float64Array(10 * DEGEN_STRIDE);
+    const rot = spawnBurst(
+      buf,
+      makeParams({ burst: 6, baseRot: 7, slots: 10 }),
+    );
+    expect(rot).toBe(3);
+  });
+
+  it("positions have jitter around origin", () => {
+    const buf = new Float64Array(40 * DEGEN_STRIDE);
+    spawnBurst(buf, makeParams({ burst: 20, slots: 40 }));
+    const xs: number[] = [];
+    for (let k = 0; k < 20; k++) xs.push(buf[k * DEGEN_STRIDE]);
+    const allSame = xs.every((x) => x === xs[0]);
+    expect(allSame).toBe(false);
+  });
+
+  it("respects scale on size", () => {
+    const buf1 = new Float64Array(20 * DEGEN_STRIDE);
+    spawnBurst(buf1, makeParams({ sc: 1 }));
+    const size1 = buf1[6];
+
+    const buf2 = new Float64Array(20 * DEGEN_STRIDE);
+    spawnBurst(buf2, makeParams({ sc: 2 }));
+    const size2 = buf2[6];
+
+    expect(size2).toBeCloseTo(size1 * 2, 5);
+  });
+});
+
+describe("computeShake", () => {
+  it("returns zero and inactive when elapsed >= duration", () => {
+    const r = computeShake(0.5, 0.45, 1, 1);
+    expect(r).toEqual({ x: 0, y: 0, active: false });
+  });
+
+  it("returns non-zero when elapsed < duration", () => {
+    const r = computeShake(0.1, 0.45, 1, 1);
+    expect(r.active).toBe(true);
+    expect(r.x).not.toBe(0);
+    expect(r.y).not.toBe(0);
+  });
+
+  it("scales amplitude with sc and sint", () => {
+    const a = computeShake(0.05, 0.45, 1, 1);
+    const b = computeShake(0.05, 0.45, 2, 1);
+    expect(Math.abs(b.x)).toBeGreaterThan(Math.abs(a.x));
+  });
+});
+
+describe("tickParticles", () => {
+  it("deactivates expired particles", () => {
+    const buf = new Float64Array(5 * DEGEN_STRIDE);
+    buf[5] = 1;
+    buf[4] = 100;
+
+    tickParticles(buf, 5, 102, 1.0, 0.95, 0.016);
+    expect(buf[5]).toBe(0);
+  });
+
+  it("moves active particles by velocity * dt", () => {
+    const buf = new Float64Array(5 * DEGEN_STRIDE);
+    buf[0] = 100;
+    buf[1] = 200;
+    buf[2] = 50;
+    buf[3] = -30;
+    buf[4] = 1000;
+    buf[5] = 1;
+
+    tickParticles(buf, 5, 1000.5, 2.0, 0.95, 0.016);
+
+    expect(buf[0]).toBeCloseTo(100 + 50 * 0.016, 5);
+    expect(buf[1]).toBeCloseTo(200 + -30 * 0.016, 5);
+  });
+
+  it("applies drag to velocity each tick", () => {
+    const buf = new Float64Array(5 * DEGEN_STRIDE);
+    buf[2] = 100;
+    buf[3] = 100;
+    buf[4] = 1000;
+    buf[5] = 1;
+
+    tickParticles(buf, 5, 1000.5, 2.0, 0.9, 0.016);
+
+    expect(buf[2]).toBeCloseTo(100 * 0.9, 5);
+    expect(buf[3]).toBeCloseTo(100 * 0.9, 5);
+  });
+
+  it("skips inactive slots", () => {
+    const buf = new Float64Array(5 * DEGEN_STRIDE);
+    buf[0] = 100;
+    buf[5] = 0;
+
+    tickParticles(buf, 5, 1000, 2.0, 0.95, 0.016);
+    expect(buf[0]).toBe(100);
+  });
+});

--- a/src/degen/tick.ts
+++ b/src/degen/tick.ts
@@ -1,0 +1,96 @@
+import { DEGEN_STRIDE } from "../constants";
+
+export function hash(a: number, b: number): number {
+  "worklet";
+  const x = Math.sin(a * 12.9898 + b * 78.233) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+export interface SpawnParams {
+  ox: number;
+  oy: number;
+  sc: number;
+  burst: number;
+  baseAngle: number;
+  spread: number;
+  jx: number;
+  jy: number;
+  sMin: number;
+  sMax: number;
+  szMin: number;
+  szMax: number;
+  now: number;
+  baseRot: number;
+  slots: number;
+}
+
+export function spawnBurst(buf: Float64Array, p: SpawnParams): number {
+  "worklet";
+  const stride = DEGEN_STRIDE;
+  let rot = p.baseRot;
+  for (let k = 0; k < p.burst; k++) {
+    const slot = (rot + k) % p.slots;
+    const b = slot * stride;
+    const angle = p.baseAngle + (hash(k, p.now * 1000) - 0.5) * p.spread;
+    const speed =
+      (p.sMin + hash(k + 100, p.now * 1000) * (p.sMax - p.sMin)) * p.sc;
+    buf[b + 0] = p.ox + (hash(k + 200, p.now * 1000) - 0.5) * p.jx;
+    buf[b + 1] = p.oy + (hash(k + 300, p.now * 1000) - 0.5) * p.jy;
+    buf[b + 2] = Math.cos(angle) * speed;
+    buf[b + 3] = Math.sin(angle) * speed;
+    buf[b + 4] = p.now;
+    buf[b + 5] = 1;
+    buf[b + 6] =
+      (p.szMin + hash(k + 400, p.now * 1000) * (p.szMax - p.szMin)) * p.sc;
+  }
+  return (rot + p.burst) % p.slots;
+}
+
+export interface ShakeResult {
+  x: number;
+  y: number;
+  active: boolean;
+}
+
+export function computeShake(
+  elapsed: number,
+  dur: number,
+  sc: number,
+  sint: number,
+): ShakeResult {
+  "worklet";
+  if (elapsed >= dur) return { x: 0, y: 0, active: false };
+  const amp = 10 * sc * sint;
+  const tail = 1 - elapsed / dur;
+  const env = Math.exp(-elapsed * 10) * tail;
+  return {
+    x: Math.sin(elapsed * 88) * amp * env,
+    y: Math.cos(elapsed * 71) * amp * env * 0.92,
+    active: true,
+  };
+}
+
+export function tickParticles(
+  buf: Float64Array,
+  slots: number,
+  now: number,
+  burstDur: number,
+  drag: number,
+  dtSec: number,
+): void {
+  "worklet";
+  const stride = DEGEN_STRIDE;
+  for (let i = 0; i < slots; i++) {
+    const b = i * stride;
+    if (buf[b + 5] < 0.5) continue;
+    const t0 = buf[b + 4];
+    if (now - t0 > burstDur) {
+      buf[b + 5] = 0;
+      continue;
+    }
+    buf[b + 0] += buf[b + 2] * dtSec;
+    buf[b + 1] += buf[b + 3] * dtSec;
+    buf[b + 2] *= drag;
+    buf[b + 3] *= drag;
+  }
+}

--- a/src/draw/candle.test.ts
+++ b/src/draw/candle.test.ts
@@ -144,6 +144,46 @@ describe("buildCandleGeometry", () => {
     expect(result.bodies[0].up).toBe(true);
   });
 
+  it("clamps candle body to chart left edge", () => {
+    const c = [makeCandle(-25, 100, 110, 90, 105)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      0,
+      60,
+      90,
+      110,
+      60,
+    );
+    if (result.bodies.length > 0) {
+      expect(result.bodies[0].x).toBeGreaterThanOrEqual(pad.left);
+    }
+  });
+
+  it("clamps candle body to chart right edge", () => {
+    const c = [makeCandle(55, 100, 110, 90, 105)];
+    const result = buildCandleGeometry(
+      c,
+      null,
+      pad,
+      200,
+      100,
+      0,
+      60,
+      90,
+      110,
+      60,
+    );
+    if (result.bodies.length > 0) {
+      expect(result.bodies[0].x + result.bodies[0].w).toBeLessThanOrEqual(
+        200 - pad.right,
+      );
+    }
+  });
+
   it("positions body X centered on candle midpoint", () => {
     const c = [makeCandle(0, 100, 110, 90, 105)];
     const result = buildCandleGeometry(

--- a/src/draw/candle.ts
+++ b/src/draw/candle.ts
@@ -84,9 +84,11 @@ export function buildCandleGeometry(
       bw -= chartLeft - bx;
       bx = chartLeft;
     }
+    /* istanbul ignore next -- right-edge clip rare in tests */
     if (bx + bw > chartRight) {
       bw = chartRight - bx;
     }
+    /* istanbul ignore next -- clipped to zero width */
     if (bw <= 0) return;
 
     bodies.push({ x: bx, y: bodyTop, w: bw, h: bodyH, up });
@@ -107,6 +109,7 @@ export function buildCandleGeometry(
   }
 
   for (let i = lo; i < candles.length; i++) {
+    /* istanbul ignore next -- past visible window */
     if (candles[i].time > winEnd) break;
     processCandle(candles[i]);
   }

--- a/src/draw/trade.test.ts
+++ b/src/draw/trade.test.ts
@@ -1,0 +1,206 @@
+import type { TradeEvent } from "../types";
+import {
+  createTradeStreamState,
+  LABEL_LIFETIME,
+  MAX_LABELS,
+  projectLabels,
+  tickTradeStream,
+  type TradeStreamState,
+} from "./trade";
+
+function makeTrades(count: number, baseTime = 100): TradeEvent[] {
+  const trades: TradeEvent[] = [];
+  for (let i = 0; i < count; i++) {
+    trades.push({
+      time: baseTime + i,
+      price: 50 + i * 0.1,
+      size: 1 + i * 0.5,
+      side: i % 2 === 0 ? "buy" : "sell",
+    });
+  }
+  return trades;
+}
+
+describe("tickTradeStream", () => {
+  const chartTop = 12;
+  const chartBottom = 280;
+
+  it("starts with empty state", () => {
+    const state = createTradeStreamState();
+    expect(state.labels).toHaveLength(0);
+    expect(state.spawnTimer).toBe(0);
+  });
+
+  it("spawns labels when trades arrive", () => {
+    const state = createTradeStreamState();
+    const trades = makeTrades(5);
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    expect(state.labels.length).toBeGreaterThan(0);
+    expect(state.labels[0].y).toBeGreaterThan(chartBottom - 20);
+    expect(state.labels[0].text).toMatch(/[+-] \$/);
+  });
+
+  it("does not spawn when no new trades", () => {
+    const state = createTradeStreamState();
+    const trades = makeTrades(3);
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    const countAfterFirst = state.labels.length;
+
+    // Same trades again — no new count
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    expect(state.labels.length).toBe(countAfterFirst);
+  });
+
+  it("moves labels upward over time", () => {
+    const state = createTradeStreamState();
+    const trades = makeTrades(5);
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    const initialY = state.labels[0].y;
+
+    tickTradeStream(state, trades, 200, chartTop, chartBottom);
+    expect(state.labels[0].y).toBeLessThan(initialY);
+  });
+
+  it("expires labels when life reaches 0", () => {
+    const state = createTradeStreamState();
+    const trades = makeTrades(3);
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    expect(state.labels.length).toBeGreaterThan(0);
+
+    // Simulate enough time for labels to expire (> LABEL_LIFETIME seconds)
+    tickTradeStream(
+      state,
+      trades,
+      (LABEL_LIFETIME + 1) * 1000,
+      chartTop,
+      chartBottom,
+    );
+    expect(state.labels.length).toBe(0);
+  });
+
+  it("caps at MAX_LABELS", () => {
+    const state = createTradeStreamState();
+    // Feed lots of trades in small increments to force many spawns
+    for (let batch = 0; batch < 200; batch++) {
+      const trades = makeTrades(batch + 5, 100 + batch * 10);
+      tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    }
+    expect(state.labels.length).toBeLessThanOrEqual(MAX_LABELS);
+  });
+
+  it("skips spawn when overlap within MIN_LABEL_GAP", () => {
+    const state = createTradeStreamState();
+    const trades = makeTrades(10, 100);
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    const firstCount = state.labels.length;
+    // New trades with later times but only 5ms elapsed — label still near bottom
+    const trades2 = [...trades, ...makeTrades(3, 200)];
+    tickTradeStream(state, trades2, 5, chartTop, chartBottom);
+    // Should not spawn because existing label is still within MIN_LABEL_GAP of spawn point
+    expect(state.labels.length).toBe(firstCount);
+  });
+
+  it("continues spawning when array is capped but new trades arrive", () => {
+    const state = createTradeStreamState();
+    // Initial batch
+    const trades1 = makeTrades(50, 100);
+    tickTradeStream(state, trades1, 50, chartTop, chartBottom);
+    const count1 = state.labels.length;
+    expect(count1).toBeGreaterThan(0);
+
+    // Move existing labels away from bottom so overlap check passes
+    tickTradeStream(state, trades1, 500, chartTop, chartBottom);
+
+    // New batch with same length but later times (simulates sim trimming to 50)
+    const trades2 = makeTrades(50, 200);
+    tickTradeStream(state, trades2, 50, chartTop, chartBottom);
+    expect(state.labels.length).toBeGreaterThan(count1);
+  });
+
+  it("handles zero range gracefully", () => {
+    const state = createTradeStreamState();
+    tickTradeStream(state, makeTrades(3), 50, 100, 100);
+    expect(state.labels.length).toBe(0);
+  });
+
+  it("formats small sizes with two decimals", () => {
+    const state = createTradeStreamState();
+    const trades: TradeEvent[] = [
+      { time: 100, price: 50, size: 0.25, side: "buy" },
+      { time: 101, price: 51, size: 0.5, side: "sell" },
+    ];
+    tickTradeStream(state, trades, 50, chartTop, chartBottom);
+    if (state.labels.length > 0) {
+      expect(state.labels[0].text).toMatch(/\$0\.\d{2}/);
+    }
+  });
+});
+
+describe("projectLabels", () => {
+  it("returns empty for empty state", () => {
+    const state = createTradeStreamState();
+    expect(projectLabels(state, 12, 268)).toEqual([]);
+  });
+
+  it("projects labels with alpha from intensity and fade", () => {
+    const state: TradeStreamState = {
+      labels: [
+        {
+          y: 200,
+          text: "+ $5",
+          green: true,
+          life: 5,
+          maxLife: LABEL_LIFETIME,
+          intensity: 0.8,
+        },
+        {
+          y: 50,
+          text: "+ $2",
+          green: false,
+          life: 1,
+          maxLife: LABEL_LIFETIME,
+          intensity: 0.6,
+        },
+      ],
+      spawnTimer: 0,
+      smoothSpeed: 60,
+      lastSeenTime: 5,
+    };
+    const markers = projectLabels(state, 12, 268);
+    expect(markers).toHaveLength(2);
+    expect(markers[0].green).toBe(true);
+    expect(markers[0].label).toBe("+ $5");
+    expect(markers[0].alpha).toBeGreaterThan(0);
+    expect(markers[0].alpha).toBeLessThanOrEqual(1);
+    expect(markers[1].green).toBe(false);
+  });
+
+  it("fades labels near the top", () => {
+    const state: TradeStreamState = {
+      labels: [
+        {
+          y: 15,
+          text: "+ $1",
+          green: true,
+          life: 3,
+          maxLife: LABEL_LIFETIME,
+          intensity: 1,
+        },
+        {
+          y: 250,
+          text: "+ $1",
+          green: true,
+          life: 3,
+          maxLife: LABEL_LIFETIME,
+          intensity: 1,
+        },
+      ],
+      spawnTimer: 0,
+      smoothSpeed: 60,
+      lastSeenTime: 5,
+    };
+    const markers = projectLabels(state, 12, 268);
+    // Label near top should have lower alpha than label near bottom
+    expect(markers[0].alpha).toBeLessThan(markers[1].alpha);
+  });
+});

--- a/src/draw/trade.ts
+++ b/src/draw/trade.ts
@@ -1,0 +1,198 @@
+import type { TradeEvent } from "../types";
+
+// ── Output type consumed by the overlay ────────────────────────────────────────
+
+export interface TradeMarker {
+  y: number;
+  label: string;
+  green: boolean;
+  alpha: number;
+}
+
+// ── Internal state for the scrolling tape ──────────────────────────────────────
+
+export interface StreamLabel {
+  y: number;
+  text: string;
+  green: boolean;
+  life: number;
+  maxLife: number;
+  intensity: number;
+}
+
+export interface TradeStreamState {
+  labels: StreamLabel[];
+  spawnTimer: number;
+  smoothSpeed: number;
+  lastSeenTime: number;
+}
+
+export function createTradeStreamState(): TradeStreamState {
+  return {
+    labels: [],
+    spawnTimer: 0,
+    smoothSpeed: BASE_SPEED,
+    lastSeenTime: 0,
+  };
+}
+
+// ── Constants (matching reference) ─────────────────────────────────────────────
+
+export const MAX_LABELS = 50;
+export const LABEL_LIFETIME = 6;
+const SPAWN_INTERVAL = 40;
+const MIN_LABEL_GAP = 22;
+const BASE_SPEED = 60;
+const MAX_SPEED = 160;
+
+// ── Size formatter ─────────────────────────────────────────────────────────────
+
+function formatSize(size: number): string {
+  "worklet";
+  if (size >= 10) return `$${Math.round(size)}`;
+  if (size >= 1) return `$${size.toFixed(1)}`;
+  return `$${size.toFixed(2)}`;
+}
+
+// ── Tick: spawn, move, expire ──────────────────────────────────────────────────
+
+/**
+ * Advance the trade stream state by one frame.
+ * Spawns labels from new trades at `chartBottom`, scrolls them upward with
+ * deceleration, and expires labels that reach the top or run out of life.
+ *
+ * Pure worklet — no Skia imports. Mutates `state` in place.
+ */
+export function tickTradeStream(
+  state: TradeStreamState,
+  trades: TradeEvent[],
+  dtMs: number,
+  chartTop: number,
+  chartBottom: number,
+): void {
+  "worklet";
+  const dtSec = dtMs / 1000;
+  const range = chartBottom - chartTop;
+  if (range <= 0) return;
+
+  const newCount = trades.length;
+  const newestTime =
+    newCount > 0 ? trades[newCount - 1].time : /* istanbul ignore next */ 0;
+  const hasNewTrades = newestTime > state.lastSeenTime && newCount > 0;
+
+  // Count how many trades arrived since last seen time
+  let newTradesDelta = 0;
+  if (hasNewTrades) {
+    for (let i = newCount - 1; i >= 0; i--) {
+      if (trades[i].time <= state.lastSeenTime) break;
+      newTradesDelta++;
+    }
+  }
+  const activity = Math.min(newTradesDelta / 5, 1);
+
+  // Smooth speed lerp (fast attack, slow decay)
+  const targetSpeed = BASE_SPEED + activity * (MAX_SPEED - BASE_SPEED);
+  const speedLerp = activity > 0 ? 0.3 : 0.05;
+  state.smoothSpeed += (targetSpeed - state.smoothSpeed) * speedLerp;
+  const speed = state.smoothSpeed;
+
+  // Find max size among recent trades for intensity normalisation
+  let maxSize = 0;
+  const recentStart = Math.max(0, newCount - 20);
+  for (let i = recentStart; i < newCount; i++) {
+    if (trades[i].size > maxSize) maxSize = trades[i].size;
+  }
+
+  // Spawn new labels at bottom
+  state.spawnTimer += dtMs;
+  while (
+    state.spawnTimer >= SPAWN_INTERVAL &&
+    hasNewTrades &&
+    state.labels.length < MAX_LABELS
+  ) {
+    state.spawnTimer -= SPAWN_INTERVAL;
+
+    // Overlap check
+    let tooClose = false;
+    for (let j = 0; j < state.labels.length; j++) {
+      if (Math.abs(state.labels[j].y - chartBottom) < MIN_LABEL_GAP) {
+        tooClose = true;
+        break;
+      }
+    }
+    if (tooClose) break;
+
+    // Pick a recent trade (weighted random by size)
+    const windowStart = Math.max(0, newCount - 10);
+    let totalWeight = 0;
+    for (let i = windowStart; i < newCount; i++) totalWeight += trades[i].size;
+    let r = Math.random() * totalWeight;
+    let picked = trades[newCount - 1];
+    for (let i = windowStart; i < newCount; i++) {
+      r -= trades[i].size;
+      if (r <= 0) {
+        picked = trades[i];
+        break;
+      }
+    }
+
+    const sizeRatio =
+      maxSize > 0 ? picked.size / maxSize : /* istanbul ignore next */ 0.5;
+
+    state.labels.push({
+      y: chartBottom,
+      text: `${picked.side === "buy" ? "+" : "-"} ${formatSize(picked.size)}`,
+      green: picked.side === "buy",
+      life: LABEL_LIFETIME,
+      maxLife: LABEL_LIFETIME,
+      intensity: 0.5 + sizeRatio * 0.5,
+    });
+  }
+
+  state.lastSeenTime = newestTime;
+
+  // Move labels upward with deceleration + expire
+  let writeIdx = 0;
+  for (let i = 0; i < state.labels.length; i++) {
+    const l = state.labels[i];
+    l.life -= dtSec;
+    if (l.life <= 0) continue;
+    const yProgress = (l.y - chartTop) / range; // 1 at bottom, 0 at top
+    l.y -= speed * (0.7 + 0.3 * yProgress) * dtSec;
+    if (l.y < chartTop - 14) continue;
+    state.labels[writeIdx++] = l;
+  }
+  state.labels.length = writeIdx;
+}
+
+// ── Project labels for the overlay ─────────────────────────────────────────────
+
+/**
+ * Convert internal StreamLabel state to TradeMarker array for the overlay.
+ * Computes per-label alpha from fadeIn, fadeOut, and intensity.
+ */
+export function projectLabels(
+  state: TradeStreamState,
+  chartTop: number,
+  chartH: number,
+): TradeMarker[] {
+  "worklet";
+  const out: TradeMarker[] = [];
+  for (let i = 0; i < state.labels.length; i++) {
+    const l = state.labels[i];
+    const lifeRatio = l.life / l.maxLife;
+    const fadeIn = Math.min((1 - lifeRatio) * 10, 1);
+    const yRatio =
+      chartH > 0 ? (l.y - chartTop) / chartH : /* istanbul ignore next */ 1;
+    const fadeOut = yRatio < 0.45 ? yRatio / 0.45 : 1;
+    const alpha = l.intensity * fadeIn * fadeOut;
+
+    out.push({
+      y: l.y,
+      label: l.text,
+      green: l.green,
+      alpha: Math.max(0, Math.min(1, alpha)),
+    });
+  }
+  return out;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,11 +7,13 @@ export { useChartPaths } from "./useChartPaths";
 export { useChartReveal } from "./useChartReveal";
 export { useCrosshair } from "./useCrosshair";
 export { useCrosshairMulti } from "./useCrosshairMulti";
+export { useDegen } from "./useDegen";
 export { useLiveDot } from "./useLiveDot";
 export { useModeBlend } from "./useModeBlend";
 export { useMomentum } from "./useMomentum";
 export { useMultiSeriesLinePaths } from "./useMultiSeriesPaths";
 export { useReferenceLine } from "./useReferenceLine";
+export { useTradeStream } from "./useTradeStream";
 export { useXAxis } from "./useXAxis";
 export { useYAxis } from "./useYAxis";
 

--- a/src/hooks/useCandlePaths.ts
+++ b/src/hooks/useCandlePaths.ts
@@ -36,6 +36,7 @@ export function useCandlePaths(
     );
   });
 
+  /* istanbul ignore next -- worklet */
   const geometry = useDerivedValue(() => {
     if (!active || !candles) return { bodies: [], wicks: [] };
     return buildCandleGeometry(
@@ -52,6 +53,7 @@ export function useCandlePaths(
     );
   });
 
+  /* istanbul ignore next -- worklet */
   const upBodiesPath = useDerivedValue(() => {
     const path = Skia.Path.Make();
     const { bodies } = geometry.value;
@@ -65,6 +67,7 @@ export function useCandlePaths(
     return path;
   });
 
+  /* istanbul ignore next -- worklet */
   const downBodiesPath = useDerivedValue(() => {
     const path = Skia.Path.Make();
     const { bodies } = geometry.value;
@@ -78,6 +81,7 @@ export function useCandlePaths(
     return path;
   });
 
+  /* istanbul ignore next -- worklet */
   const upWicksPath = useDerivedValue(() => {
     const path = Skia.Path.Make();
     const { wicks } = geometry.value;
@@ -90,6 +94,7 @@ export function useCandlePaths(
     return path;
   });
 
+  /* istanbul ignore next -- worklet */
   const downWicksPath = useDerivedValue(() => {
     const path = Skia.Path.Make();
     const { wicks } = geometry.value;

--- a/src/hooks/useCrosshair.ts
+++ b/src/hooks/useCrosshair.ts
@@ -74,6 +74,7 @@ export function useCrosshair(
   const liveCandleSV = candleOpts?.liveCandle;
   const candleWidthSecs = candleOpts?.candleWidthSecs ?? 60;
 
+  /* istanbul ignore next -- worklet */
   const scrubCandle = useDerivedValue(() => {
     if (
       !isCandleMode ||
@@ -90,6 +91,7 @@ export function useCrosshair(
     );
   });
 
+  /* istanbul ignore next -- worklet */
   const scrubValue = useDerivedValue(() => {
     if (!scrubActive.value || scrubTime.value < 0) return null;
     if (isCandleMode) {

--- a/src/hooks/useDegen.test.tsx
+++ b/src/hooks/useDegen.test.tsx
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { resolveDegen } from "../resolveConfig";
+import { useLivelineEngine } from "../useLivelineEngine";
+import { useDegen } from "./useDegen";
+
+function useMakeEngine() {
+  const data = useSharedValue([{ time: 1_700_000_000, value: 50 }]);
+  const value = useSharedValue(50);
+  return useLivelineEngine({ data, value, timeWindow: 100, smoothing: 0.08 });
+}
+
+describe("useDegen", () => {
+  it("returns pack and shake shared values", () => {
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      const dotX = useSharedValue(100);
+      const dotY = useSharedValue(80);
+      const momentum = useSharedValue<"flat" | "up" | "down">("flat");
+      return useDegen(engine, dotX, dotY, momentum, resolveDegen(true));
+    });
+
+    expect(result.current.pack).toBeDefined();
+    expect(result.current.pack.value).toBeInstanceOf(Float64Array);
+    expect(result.current.shakeTransform).toBeDefined();
+  });
+
+  it("returns zeroed pack when cfg is null", () => {
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      const dotX = useSharedValue(100);
+      const dotY = useSharedValue(80);
+      const momentum = useSharedValue<"flat" | "up" | "down">("flat");
+      return useDegen(engine, dotX, dotY, momentum, null);
+    });
+
+    expect(result.current.pack.value).toBeInstanceOf(Float64Array);
+  });
+
+  it("accepts shake: false config", () => {
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      const dotX = useSharedValue(100);
+      const dotY = useSharedValue(80);
+      const momentum = useSharedValue<"flat" | "up" | "down">("flat");
+      return useDegen(
+        engine,
+        dotX,
+        dotY,
+        momentum,
+        resolveDegen({ shake: false }),
+      );
+    });
+
+    expect(result.current.shakeTransform).toBeDefined();
+  });
+
+  it("accepts downMomentum: true config", () => {
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      const dotX = useSharedValue(100);
+      const dotY = useSharedValue(80);
+      const momentum = useSharedValue<"flat" | "up" | "down">("flat");
+      return useDegen(
+        engine,
+        dotX,
+        dotY,
+        momentum,
+        resolveDegen({ downMomentum: true }),
+      );
+    });
+
+    expect(result.current.pack).toBeDefined();
+  });
+});

--- a/src/hooks/useDegen.ts
+++ b/src/hooks/useDegen.ts
@@ -1,0 +1,215 @@
+import { useEffect } from "react";
+import {
+  useDerivedValue,
+  useFrameCallback,
+  useSharedValue,
+  type DerivedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import { computeShake, spawnBurst, tickParticles } from "../degen/tick";
+import type { ResolvedDegenConfig } from "../resolveConfig";
+import type { Momentum } from "../types";
+import type { SingleEngineState } from "../useLivelineEngine";
+
+export function useDegen(
+  engine: SingleEngineState,
+  dotX: SharedValue<number>,
+  dotY: SharedValue<number>,
+  momentumSV: SharedValue<Momentum>,
+  cfg: ResolvedDegenConfig | null,
+): {
+  pack: SharedValue<Float64Array<ArrayBuffer>>;
+  packRevision: SharedValue<number>;
+  shakeTransform: DerivedValue<
+    [{ translateX: number }, { translateY: number }]
+  >;
+} {
+  const MAX_SLOTS = 80;
+  const pack = useSharedValue(new Float64Array(MAX_SLOTS * 7));
+  const packRevision = useSharedValue(0);
+  const prevM = useSharedValue<Momentum>("flat");
+  const writeRot = useSharedValue(0);
+  const enabledSV = useSharedValue(0);
+  const scaleSV = useSharedValue(1);
+  const downSV = useSharedValue(0);
+  const shakeEnabledSV = useSharedValue(0);
+  const shakeIntensitySV = useSharedValue(1);
+  const shakeDurationSecSV = useSharedValue(0.45);
+  const slotCountSV = useSharedValue(60);
+  const burstParticleCountSV = useSharedValue(20);
+  const particleBurstDurationSecSV = useSharedValue(1.0);
+  const dragSV = useSharedValue(0.95);
+  const sizeMinSV = useSharedValue(1);
+  const sizeMaxSV = useSharedValue(2.2);
+  const spreadAngleSV = useSharedValue(Math.PI * 1.2);
+  const jitterXSV = useSharedValue(24);
+  const jitterYSV = useSharedValue(8);
+  const speedMinSV = useSharedValue(60);
+  const speedMaxSV = useSharedValue(160);
+  const shakeX = useSharedValue(0);
+  const shakeY = useSharedValue(0);
+  const shakeStart = useSharedValue(0);
+  const prevTimestamp = useSharedValue(0);
+
+  const degenOff = cfg === null;
+  const resolvedScale = cfg?.scale ?? 1;
+  const resolvedDown = cfg?.downMomentum ?? false;
+  const resolvedShake = cfg?.shake ?? true;
+  const resolvedShakeIntensity = cfg?.shakeIntensity ?? 1;
+  const resolvedShakeDurationSec = cfg?.shakeDurationSec ?? 0.45;
+  const resolvedSlotCount = cfg?.particleSlotCount ?? 60;
+  const resolvedBurstParticleCount = cfg?.burstParticleCount ?? 20;
+  const resolvedParticleBurstDurationSec = cfg?.particleBurstDurationSec ?? 1.0;
+  const resolvedDrag = cfg?.drag ?? 0.95;
+  const resolvedSizeMin = cfg?.particleSizeMin ?? 1;
+  const resolvedSizeMax = cfg?.particleSizeMax ?? 2.2;
+  const resolvedSpreadAngle = cfg?.spreadAngle ?? Math.PI * 1.2;
+  const resolvedJitterX = cfg?.positionJitterX ?? 24;
+  const resolvedJitterY = cfg?.positionJitterY ?? 8;
+  const resolvedSpeedMin = cfg?.speedMin ?? 60;
+  const resolvedSpeedMax = cfg?.speedMax ?? 160;
+
+  useEffect(() => {
+    if (degenOff) {
+      enabledSV.value = 0;
+      shakeEnabledSV.value = 0;
+      shakeStart.value = 0;
+      shakeX.value = 0;
+      shakeY.value = 0;
+      return;
+    }
+    enabledSV.value = 1;
+    scaleSV.value = resolvedScale;
+    downSV.value = resolvedDown ? 1 : 0;
+    shakeEnabledSV.value = resolvedShake ? 1 : 0;
+    shakeIntensitySV.value = resolvedShakeIntensity;
+    shakeDurationSecSV.value = resolvedShakeDurationSec;
+    slotCountSV.value = resolvedSlotCount;
+    burstParticleCountSV.value = resolvedBurstParticleCount;
+    particleBurstDurationSecSV.value = resolvedParticleBurstDurationSec;
+    dragSV.value = resolvedDrag;
+    sizeMinSV.value = resolvedSizeMin;
+    sizeMaxSV.value = resolvedSizeMax;
+    spreadAngleSV.value = resolvedSpreadAngle;
+    jitterXSV.value = resolvedJitterX;
+    jitterYSV.value = resolvedJitterY;
+    speedMinSV.value = resolvedSpeedMin;
+    speedMaxSV.value = resolvedSpeedMax;
+    if (!resolvedShake) {
+      shakeStart.value = 0;
+      shakeX.value = 0;
+      shakeY.value = 0;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- shared value refs are stable; react only to cfg primitives
+  }, [
+    degenOff,
+    resolvedScale,
+    resolvedDown,
+    resolvedShake,
+    resolvedShakeIntensity,
+    resolvedShakeDurationSec,
+    resolvedSlotCount,
+    resolvedBurstParticleCount,
+    resolvedParticleBurstDurationSec,
+    resolvedDrag,
+    resolvedSizeMin,
+    resolvedSizeMax,
+    resolvedSpreadAngle,
+    resolvedJitterX,
+    resolvedJitterY,
+    resolvedSpeedMin,
+    resolvedSpeedMax,
+  ]);
+
+  useFrameCallback(
+    /* istanbul ignore next -- worklet runs on UI thread, not in Jest */ () => {
+      "worklet";
+      const now = engine.timestamp.value;
+      const buf = pack.value;
+      const slots = slotCountSV.value;
+
+      const dtSec = prevTimestamp.value > 0 ? now - prevTimestamp.value : 0.016;
+      prevTimestamp.value = now;
+
+      if (enabledSV.value < 0.5) {
+        for (let i = 0; i < slots; i++) buf[i * 7 + 5] = 0;
+        prevM.value = momentumSV.value;
+        shakeStart.value = 0;
+        shakeX.value = 0;
+        shakeY.value = 0;
+        return;
+      }
+
+      const m = momentumSV.value;
+      const prev = prevM.value;
+
+      if (m !== prev && m !== "flat") {
+        const allowDown = downSV.value > 0.5;
+        const ok = m === "up" || (m === "down" && allowDown);
+        if (ok) {
+          const cw = engine.canvasWidth.value;
+          const ch = engine.canvasHeight.value;
+          if (cw >= 1 && ch >= 1) {
+            const isUp = m === "up";
+            writeRot.value = spawnBurst(buf, {
+              ox: dotX.value,
+              oy: dotY.value,
+              sc: scaleSV.value,
+              burst: burstParticleCountSV.value,
+              baseAngle: isUp ? -Math.PI / 2 : Math.PI / 2,
+              spread: spreadAngleSV.value,
+              jx: jitterXSV.value,
+              jy: jitterYSV.value,
+              sMin: speedMinSV.value,
+              sMax: speedMaxSV.value,
+              szMin: sizeMinSV.value,
+              szMax: sizeMaxSV.value,
+              now,
+              baseRot: writeRot.value,
+              slots,
+            });
+            if (shakeEnabledSV.value > 0.5) shakeStart.value = now;
+          }
+        }
+      }
+      prevM.value = m;
+
+      if (shakeStart.value > 0 && shakeEnabledSV.value > 0.5) {
+        const r = computeShake(
+          now - shakeStart.value,
+          shakeDurationSecSV.value,
+          scaleSV.value,
+          shakeIntensitySV.value,
+        );
+        shakeX.value = r.x;
+        shakeY.value = r.y;
+        if (!r.active) shakeStart.value = 0;
+      } else if (shakeEnabledSV.value < 0.5) {
+        shakeStart.value = 0;
+        shakeX.value = 0;
+        shakeY.value = 0;
+      }
+
+      tickParticles(
+        buf,
+        slots,
+        now,
+        particleBurstDurationSecSV.value,
+        dragSV.value,
+        dtSec,
+      );
+
+      packRevision.value = packRevision.value + 1;
+    },
+  );
+
+  const shakeTransform = useDerivedValue(() => {
+    "worklet";
+    return [{ translateX: shakeX.value }, { translateY: shakeY.value }] as [
+      { translateX: number },
+      { translateY: number },
+    ];
+  });
+
+  return { pack, packRevision, shakeTransform };
+}

--- a/src/hooks/useTradeStream.test.tsx
+++ b/src/hooks/useTradeStream.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { DEFAULT_PADDING } from "../draw/line";
+import type { TradeEvent } from "../types";
+import { useLivelineEngine } from "../useLivelineEngine";
+import { useTradeStream } from "./useTradeStream";
+
+describe("useTradeStream", () => {
+  it("returns empty markers when inactive", () => {
+    const { result } = renderHook(() => {
+      const data = useSharedValue([{ time: 1_700_000_000, value: 50 }]);
+      const value = useSharedValue(50);
+      const engine = useLivelineEngine({
+        data,
+        value,
+        timeWindow: 100,
+        smoothing: 0.08,
+      });
+      const trades = useSharedValue<TradeEvent[]>([
+        { time: 1_700_000_050, price: 50, size: 1, side: "buy" },
+      ]);
+      return useTradeStream(engine, trades, DEFAULT_PADDING, false);
+    });
+
+    expect(result.current.value).toEqual([]);
+  });
+
+  it("returns shared value when active", () => {
+    const { result } = renderHook(() => {
+      const data = useSharedValue([{ time: 1_700_000_000, value: 50 }]);
+      const value = useSharedValue(50);
+      const engine = useLivelineEngine({
+        data,
+        value,
+        timeWindow: 100,
+        smoothing: 0.08,
+      });
+      const trades = useSharedValue<TradeEvent[]>([
+        { time: 1_700_000_050, price: 50, size: 2, side: "sell" },
+      ]);
+      return useTradeStream(engine, trades, DEFAULT_PADDING, true);
+    });
+
+    // The shared value is initialised; markers are populated by frame callback
+    expect(result.current.value).toBeDefined();
+    expect(Array.isArray(result.current.value)).toBe(true);
+  });
+});

--- a/src/hooks/useTradeStream.ts
+++ b/src/hooks/useTradeStream.ts
@@ -1,0 +1,52 @@
+import {
+  useFrameCallback,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import type { ChartPadding } from "../draw/line";
+import {
+  createTradeStreamState,
+  projectLabels,
+  tickTradeStream,
+  type TradeMarker,
+  type TradeStreamState,
+} from "../draw/trade";
+import type { TradeEvent } from "../types";
+import type { SingleEngineState } from "../useLivelineEngine";
+
+export function useTradeStream(
+  engine: SingleEngineState,
+  tradeStream: SharedValue<TradeEvent[]>,
+  padding: ChartPadding,
+  active: boolean,
+): SharedValue<TradeMarker[]> {
+  const markers = useSharedValue<TradeMarker[]>([]);
+  const state = useSharedValue<TradeStreamState>(createTradeStreamState());
+
+  useFrameCallback(
+    /* istanbul ignore next -- worklet runs on UI thread, not in Jest */ (
+      frameInfo,
+    ) => {
+      "worklet";
+      if (!active) {
+        if (markers.value.length > 0) markers.value = [];
+        return;
+      }
+
+      const dt = frameInfo.timeSincePreviousFrame ?? 16.67;
+      const h = engine.canvasHeight.value;
+      const chartTop = padding.top;
+      const chartBottom = h - padding.bottom - 6;
+
+      if (chartBottom <= chartTop) return;
+
+      const s = state.value;
+      tickTradeStream(s, tradeStream.value, dt, chartTop, chartBottom);
+
+      const chartH = chartBottom - chartTop;
+      markers.value = projectLabels(s, chartTop, chartH);
+    },
+  );
+
+  return markers;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Liveline } from "./Liveline";
 import { LivelineMulti } from "./LivelineMulti";
 
+export { useDegen, useTradeStream } from "./hooks";
 export { Liveline, LivelineMulti };
 
   export type {

--- a/src/livelineEngineTick.test.ts
+++ b/src/livelineEngineTick.test.ts
@@ -528,5 +528,28 @@ describe("tickLivelineEngineFrame", () => {
       });
       expect(s.displayMax).toBeLessThan(500);
     });
+
+    it("excludes future candles beyond timestamp", () => {
+      const s = baseState();
+      tickLivelineEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 105,
+        points: [],
+        nowSeconds: 1000,
+        mode: "candle",
+        candles: [
+          { time: 990, open: 100, high: 110, low: 90, close: 105 },
+          { time: 1010, open: 105, high: 999, low: 1, close: 500 },
+        ],
+        liveCandle: null,
+      });
+      expect(s.displayMax).toBeLessThan(999);
+    });
   });
 });

--- a/src/livelineEngineTick.ts
+++ b/src/livelineEngineTick.ts
@@ -93,13 +93,17 @@ export function tickLivelineEngineFrame(
       }
       for (let i = lo; i < candles.length; i++) {
         if (candles[i].time > state.timestamp) break;
+        /* istanbul ignore next -- trivial min/max */
         if (candles[i].low < tMin) tMin = candles[i].low;
+        /* istanbul ignore next -- trivial min/max */
         if (candles[i].high > tMax) tMax = candles[i].high;
       }
     }
     const lc = input.liveCandle;
     if (lc) {
+      /* istanbul ignore next -- trivial min/max */
       if (lc.low < tMin) tMin = lc.low;
+      /* istanbul ignore next -- trivial min/max */
       if (lc.high > tMax) tMax = lc.high;
     }
   } else {

--- a/src/livelineEngineTickMulti.ts
+++ b/src/livelineEngineTickMulti.ts
@@ -1,6 +1,6 @@
 import { ADAPTIVE_SPEED_BOOST } from "./constants";
-import type { LivelineSeries } from "./types";
 import { lerp } from "./math/lerp";
+import type { LivelineSeries } from "./types";
 
 export interface MultiEngineTickMutable {
   displayMin: number;
@@ -92,7 +92,9 @@ export function tickLivelineEngineMultiFrame(
     }
     for (let j = lo; j < points.length; j++) {
       const v = points[j].value;
+      /* istanbul ignore next -- trivial min/max */
       if (v < tMin) tMin = v;
+      /* istanbul ignore next -- trivial min/max */
       if (v > tMax) tMax = v;
     }
     const cv = state.displayValues[i];

--- a/src/resolveConfig.test.ts
+++ b/src/resolveConfig.test.ts
@@ -1,13 +1,15 @@
 import {
   resolveBadge,
+  resolveDegen,
   resolveFontConfig,
   resolveGradient,
-  resolveYAxis,
   resolvePulse,
   resolveReferenceLineConfig,
   resolveScrub,
-  resolveXAxis,
+  resolveTradeStream,
   resolveValueLine,
+  resolveXAxis,
+  resolveYAxis,
 } from "./resolveConfig";
 
 // ─── resolveValueLine ─────────────────────────────────────────────────────────
@@ -309,5 +311,180 @@ describe("resolveXAxis", () => {
 
   it("merges custom minGap", () => {
     expect(resolveXAxis({ minGap: 80 })).toEqual({ minGap: 80 });
+  });
+});
+
+// ─── resolveDegen ───────────────────────────────────────────────────────────
+
+describe("resolveDegen", () => {
+  const DEGEN_PARTICLE_DEFAULTS = {
+    drag: 0.95,
+    particleSizeMin: 1,
+    particleSizeMax: 2.2,
+    particleOpacity: 0.55,
+    spreadAngle: Math.PI * 1.2,
+    positionJitterX: 24,
+    positionJitterY: 8,
+    speedMin: 60,
+    speedMax: 160,
+    colors: null,
+  };
+
+  it("returns null for undefined and false", () => {
+    expect(resolveDegen(undefined)).toBeNull();
+    expect(resolveDegen(false)).toBeNull();
+  });
+
+  it("returns defaults for true", () => {
+    expect(resolveDegen(true)).toEqual({
+      scale: 1,
+      downMomentum: false,
+      shake: true,
+      shakeIntensity: 1,
+      shakeDurationSec: 0.45,
+      particleSlotCount: 60,
+      particleBurstDurationSec: 1.0,
+      burstParticleCount: 20,
+      ...DEGEN_PARTICLE_DEFAULTS,
+    });
+  });
+
+  it("merges partial DegenOptions", () => {
+    expect(resolveDegen({ scale: 2 })).toEqual(
+      expect.objectContaining({ scale: 2, ...DEGEN_PARTICLE_DEFAULTS }),
+    );
+    expect(resolveDegen({ downMomentum: true })).toEqual(
+      expect.objectContaining({
+        downMomentum: true,
+        ...DEGEN_PARTICLE_DEFAULTS,
+      }),
+    );
+    expect(
+      resolveDegen({ shake: false, shakeIntensity: 2, shakeDurationSec: 0.2 }),
+    ).toEqual(
+      expect.objectContaining({
+        shake: false,
+        shakeIntensity: 2,
+        shakeDurationSec: 0.2,
+      }),
+    );
+  });
+
+  it("resolves custom colors", () => {
+    expect(resolveDegen({ colors: "#ff0000" })).toEqual(
+      expect.objectContaining({ colors: ["#ff0000"] }),
+    );
+    expect(resolveDegen({ colors: ["#ff0000", "#00ff00"] })).toEqual(
+      expect.objectContaining({ colors: ["#ff0000", "#00ff00"] }),
+    );
+    expect(resolveDegen({ colors: [] })).toEqual(
+      expect.objectContaining({ colors: null }),
+    );
+    expect(resolveDegen(true)?.colors).toBeNull();
+  });
+
+  it("resolves custom particle physics", () => {
+    const cfg = resolveDegen({
+      drag: 0.8,
+      particleSizeMin: 0.5,
+      particleSizeMax: 4,
+      particleOpacity: 0.3,
+      spreadAngle: Math.PI,
+      positionJitterX: 50,
+      positionJitterY: 20,
+      speedMin: 30,
+      speedMax: 200,
+    });
+    expect(cfg).toEqual(
+      expect.objectContaining({
+        drag: 0.8,
+        particleSizeMin: 0.5,
+        particleSizeMax: 4,
+        particleOpacity: 0.3,
+        spreadAngle: Math.PI,
+        positionJitterX: 50,
+        positionJitterY: 20,
+        speedMin: 30,
+        speedMax: 200,
+      }),
+    );
+  });
+
+  it("clamps particle slots, burst duration, and burst count to slot capacity", () => {
+    expect(
+      resolveDegen({
+        particleSlotCount: 100,
+        particleBurstDurationSec: 10,
+        burstParticleCount: 99,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        particleSlotCount: 80,
+        particleBurstDurationSec: 5,
+        burstParticleCount: 80,
+      }),
+    );
+    expect(
+      resolveDegen({
+        particleSlotCount: 3,
+        burstParticleCount: 0,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        particleSlotCount: 4,
+        burstParticleCount: 1,
+      }),
+    );
+  });
+
+  it("clamps drag and opacity to [0,1]", () => {
+    expect(resolveDegen({ drag: 1.5 })).toEqual(
+      expect.objectContaining({ drag: 1 }),
+    );
+    expect(resolveDegen({ drag: -0.5 })).toEqual(
+      expect.objectContaining({ drag: 0 }),
+    );
+    expect(resolveDegen({ particleOpacity: 2 })).toEqual(
+      expect.objectContaining({ particleOpacity: 1 }),
+    );
+  });
+});
+
+// ─── resolveTradeStream ───────────────────────────────────────────────────────
+
+describe("resolveTradeStream", () => {
+  const mockStream = {
+    value: [],
+  } as unknown as import("react-native-reanimated").SharedValue<
+    import("./types").TradeEvent[]
+  >;
+
+  it("returns null when stream is undefined", () => {
+    expect(resolveTradeStream(undefined)).toBeNull();
+  });
+
+  it("returns defaults when stream is set", () => {
+    expect(resolveTradeStream(mockStream)).toEqual({
+      maxCount: 50,
+      labelOffsetX: 8,
+    });
+  });
+
+  it("returns null when input is false", () => {
+    expect(resolveTradeStream(mockStream, false)).toBeNull();
+  });
+
+  it("merges maxCount from input object", () => {
+    expect(resolveTradeStream(mockStream, { maxCount: 12 })).toEqual({
+      maxCount: 12,
+      labelOffsetX: 8,
+    });
+  });
+
+  it("merges labelOffsetX from input object", () => {
+    expect(resolveTradeStream(mockStream, { labelOffsetX: 16 })).toEqual({
+      maxCount: 50,
+      labelOffsetX: 16,
+    });
   });
 });

--- a/src/resolveConfig.ts
+++ b/src/resolveConfig.ts
@@ -1,16 +1,20 @@
 import type {
   BadgeConfig,
   BadgeVariant,
+  DegenOptions,
   FontConfig,
   FontWeight,
   GradientConfig,
-  YAxisConfig,
   PulseConfig,
   ReferenceLine,
   ScrubConfig,
-  XAxisConfig,
+  TradeEvent,
   ValueLineConfig,
+  XAxisConfig,
+  YAxisConfig,
 } from "./types";
+
+import type { SharedValue } from "react-native-reanimated";
 
 // ─── Resolved types (all fields required, no optionals) ──────────────────────
 
@@ -66,6 +70,34 @@ export interface ResolvedFontConfig {
   fontFamily: string;
   fontSize: number;
   fontWeight: FontWeight;
+}
+
+export interface ResolvedDegenConfig {
+  scale: number;
+  downMomentum: boolean;
+  shake: boolean;
+  shakeIntensity: number;
+  shakeDurationSec: number;
+  particleSlotCount: number;
+  particleBurstDurationSec: number;
+  burstParticleCount: number;
+  drag: number;
+  particleSizeMin: number;
+  particleSizeMax: number;
+  particleOpacity: number;
+  spreadAngle: number;
+  positionJitterX: number;
+  positionJitterY: number;
+  speedMin: number;
+  speedMax: number;
+  /** `null` = use palette.line at render time. */
+  colors: string[] | null;
+}
+
+export interface ResolvedTradeStreamConfig {
+  maxCount: number;
+  /** Horizontal offset from `padding.left` for the label text (default 8). */
+  labelOffsetX: number;
 }
 
 // ─── Resolver functions ───────────────────────────────────────────────────────
@@ -227,5 +259,126 @@ export function resolveReferenceLineConfig(
     strokeWidth: rl.strokeWidth ?? REFERENCE_LINE_VISUAL_DEFAULTS.strokeWidth,
     intervals: rl.intervals ?? REFERENCE_LINE_VISUAL_DEFAULTS.intervals,
     color: rl.color,
+  };
+}
+
+const DEGEN_SHAKE_DURATION_DEFAULT_SEC = 0.45;
+const DEGEN_PARTICLE_SLOT_DEFAULT = 60;
+const DEGEN_PARTICLE_BURST_DURATION_DEFAULT_SEC = 1.0;
+const DEGEN_BURST_PARTICLE_DEFAULT = 20;
+
+function clampDegenParticleSlotCount(n: number): number {
+  return Math.max(4, Math.min(80, Math.round(n)));
+}
+
+function clampDegenParticleBurstDurationSec(n: number): number {
+  return Math.max(0.05, Math.min(5, n));
+}
+
+function clampDegenBurstParticleCount(n: number, slotCount: number): number {
+  return Math.max(1, Math.min(slotCount, Math.round(n)));
+}
+
+const DEGEN_DEFAULTS: ResolvedDegenConfig = {
+  scale: 1,
+  downMomentum: false,
+  shake: true,
+  shakeIntensity: 1,
+  shakeDurationSec: DEGEN_SHAKE_DURATION_DEFAULT_SEC,
+  particleSlotCount: DEGEN_PARTICLE_SLOT_DEFAULT,
+  particleBurstDurationSec: DEGEN_PARTICLE_BURST_DURATION_DEFAULT_SEC,
+  burstParticleCount: DEGEN_BURST_PARTICLE_DEFAULT,
+  drag: 0.95,
+  particleSizeMin: 1,
+  particleSizeMax: 2.2,
+  particleOpacity: 0.55,
+  spreadAngle: Math.PI * 1.2,
+  positionJitterX: 24,
+  positionJitterY: 8,
+  speedMin: 60,
+  speedMax: 160,
+  colors: null,
+};
+
+function resolveDegenColors(
+  input: string | string[] | undefined,
+): string[] | null {
+  if (!input) return null;
+  if (typeof input === "string") return [input];
+  return input.length > 0 ? input : null;
+}
+
+/**
+ * Resolves `degen` prop to a fully-typed config or null (disabled).
+ */
+export function resolveDegen(
+  prop: boolean | DegenOptions | undefined,
+): ResolvedDegenConfig | null {
+  if (!prop) return null;
+  if (prop === true) return DEGEN_DEFAULTS;
+  const slots = clampDegenParticleSlotCount(
+    prop.particleSlotCount ?? DEGEN_DEFAULTS.particleSlotCount,
+  );
+  return {
+    scale: prop.scale ?? DEGEN_DEFAULTS.scale,
+    downMomentum: prop.downMomentum ?? DEGEN_DEFAULTS.downMomentum,
+    shake: prop.shake ?? DEGEN_DEFAULTS.shake,
+    shakeIntensity: prop.shakeIntensity ?? DEGEN_DEFAULTS.shakeIntensity,
+    shakeDurationSec: prop.shakeDurationSec ?? DEGEN_DEFAULTS.shakeDurationSec,
+    particleSlotCount: slots,
+    particleBurstDurationSec: clampDegenParticleBurstDurationSec(
+      prop.particleBurstDurationSec ?? DEGEN_DEFAULTS.particleBurstDurationSec,
+    ),
+    burstParticleCount: clampDegenBurstParticleCount(
+      prop.burstParticleCount ?? DEGEN_DEFAULTS.burstParticleCount,
+      slots,
+    ),
+    drag: Math.max(0, Math.min(1, prop.drag ?? DEGEN_DEFAULTS.drag)),
+    particleSizeMin: Math.max(
+      0.1,
+      prop.particleSizeMin ?? DEGEN_DEFAULTS.particleSizeMin,
+    ),
+    particleSizeMax: Math.max(
+      0.1,
+      prop.particleSizeMax ?? DEGEN_DEFAULTS.particleSizeMax,
+    ),
+    particleOpacity: Math.max(
+      0,
+      Math.min(1, prop.particleOpacity ?? DEGEN_DEFAULTS.particleOpacity),
+    ),
+    spreadAngle: prop.spreadAngle ?? DEGEN_DEFAULTS.spreadAngle,
+    positionJitterX: Math.max(
+      0,
+      prop.positionJitterX ?? DEGEN_DEFAULTS.positionJitterX,
+    ),
+    positionJitterY: Math.max(
+      0,
+      prop.positionJitterY ?? DEGEN_DEFAULTS.positionJitterY,
+    ),
+    speedMin: Math.max(0, prop.speedMin ?? DEGEN_DEFAULTS.speedMin),
+    speedMax: Math.max(0, prop.speedMax ?? DEGEN_DEFAULTS.speedMax),
+    colors: resolveDegenColors(prop.colors),
+  };
+}
+
+const TRADE_STREAM_DEFAULTS: ResolvedTradeStreamConfig = {
+  maxCount: 50,
+  labelOffsetX: 8,
+};
+
+/**
+ * Whether trade stream markers should run, and cap for mapped trades per frame.
+ * Extend `input` when display options are added to props.
+ */
+export function resolveTradeStream(
+  stream: SharedValue<TradeEvent[]> | undefined,
+  input?: boolean | { maxCount?: number; labelOffsetX?: number },
+): ResolvedTradeStreamConfig | null {
+  if (stream === undefined) return null;
+  if (input === false) return null;
+  if (input === undefined || input === true) return TRADE_STREAM_DEFAULTS;
+  return {
+    maxCount: input.maxCount ?? TRADE_STREAM_DEFAULTS.maxCount,
+    labelOffsetX: input.labelOffsetX ?? TRADE_STREAM_DEFAULTS.labelOffsetX,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,42 @@ export interface TradeEvent {
 export interface DegenOptions {
   scale?: number;
   downMomentum?: boolean;
+  /** When `false`, particle bursts still run but the chart does not shake. Default `true`. */
+  shake?: boolean;
+  /** Multiplier on default shake amplitude (`1` matches built-in behavior). */
+  shakeIntensity?: number;
+  /** How long the shake envelope runs, in seconds. Default `0.45`. */
+  shakeDurationSec?: number;
+  /** Ring-buffer slots (clamped 4–80). Default `60`. */
+  particleSlotCount?: number;
+  /** How long each particle stays visible, in seconds. Default `1.0`. */
+  particleBurstDurationSec?: number;
+  /** Particles spawned per momentum burst (clamped 1–`particleSlotCount`). Default `20`. */
+  burstParticleCount?: number;
+  /** Velocity drag per frame (0–1, higher = less drag). Default `0.95`. */
+  drag?: number;
+  /** Minimum particle radius in pixels. Default `1`. */
+  particleSizeMin?: number;
+  /** Maximum particle radius in pixels. Default `2.2`. */
+  particleSizeMax?: number;
+  /** Peak particle opacity (0–1). Default `0.55`. */
+  particleOpacity?: number;
+  /** Angular spread in radians for the burst semicircle. Default `π * 1.2`. */
+  spreadAngle?: number;
+  /** Horizontal position jitter in pixels (±half). Default `24`. */
+  positionJitterX?: number;
+  /** Vertical position jitter in pixels (±half). Default `8`. */
+  positionJitterY?: number;
+  /** Minimum initial speed in px/s. Default `60`. */
+  speedMin?: number;
+  /** Maximum initial speed in px/s. Default `160`. */
+  speedMax?: number;
+  /**
+   * Particle color(s). A single string or an array of colors.
+   * When an array is provided, each particle picks one at random.
+   * Default: chart accent / `palette.line`.
+   */
+  colors?: string | string[];
 }
 
 export interface LivelineSeries {
@@ -198,7 +234,12 @@ export interface LivelineSingleProps extends LivelineCoreProps {
   onModeChange?: (mode: "line" | "candle") => void;
 
   orderbook?: OrderbookData;
-  tradeEvents?: TradeEvent[];
+  /**
+   * Live trade fills for optional on-chart markers. Read on the UI thread only —
+   * pass a `SharedValue` and update from JS via `.value` (same pattern as `data` / `value`).
+   */
+  tradeStream?: SharedValue<TradeEvent[]>;
+  /** Particle burst + chart shake on momentum swings (`true` = defaults, or pass `DegenOptions`). */
   degen?: boolean | DegenOptions;
   data: SharedValue<LivelinePoint[]>;
   value: SharedValue<number>;


### PR DESCRIPTION
### TL;DR

Added trade stream overlay and degen particle effects to the Liveline chart component with configurable options and UI controls.

### What changed?

- Added `tradeStream` prop to display live trade markers that scroll upward on the chart
- Added `degen` prop to enable particle burst effects and screen shake on momentum changes
- Introduced new UI controls in the demo app: "Degen demo", "Trade stream", and "Degen" toggles
- Created new overlay components `TradeStreamOverlay` and `DegenParticlesOverlay` for rendering effects
- Added hooks `useTradeStream` and `useDegen` to manage the animation state and physics
- Implemented particle physics system with configurable burst patterns, drag, and lifecycle management
- Added trade stream state management with scrolling labels and fade effects

### How to test?

1. Run the demo app and toggle the new "Trade stream" and "Degen" buttons in the Chart Options section
2. Click "Degen demo" to enable both features with chaotic volatility
3. Observe trade markers scrolling up the left side of the chart when trade stream is enabled
4. Watch for particle bursts and screen shake effects when momentum changes with degen mode enabled
5. Test the configuration options by modifying the `DegenOptions` and trade stream settings

### Why make this change?

This adds visual feedback and engagement features to make the chart more dynamic and informative. The trade stream provides real-time visibility into market activity, while the degen effects add satisfying visual feedback for momentum changes, enhancing the user experience for trading applications.