### PR TITLE
fix: update data on scrub down

### DIFF
--- a/src/hooks/useCrosshair.test.ts
+++ b/src/hooks/useCrosshair.test.ts
@@ -407,6 +407,25 @@ describe("useCrosshair (hook)", () => {
     expect(result.current.gesture).toBeDefined();
   });
 
+  it("accepts onScrub and still initialises (sync reaction path)", () => {
+    const onScrub = jest.fn();
+    const engine = makeEngine();
+    const { result } = renderHook(() =>
+      useCrosshair(
+        engine,
+        padding,
+        palette,
+        formatValue,
+        formatTime,
+        font,
+        true,
+        onScrub,
+      ),
+    );
+    expect(result.current.gesture).toBeDefined();
+    expect(result.current.scrubActive.value).toBe(false);
+  });
+
   it("uses Android pan minDistance when Platform.OS is android", () => {
     const prev = Platform.OS;
     Object.defineProperty(Platform, "OS", {

--- a/src/hooks/useCrosshair.ts
+++ b/src/hooks/useCrosshair.ts
@@ -2,6 +2,7 @@ import { type SkFont } from "@shopify/react-native-skia";
 import { Platform } from "react-native";
 import { Gesture } from "react-native-gesture-handler";
 import {
+  useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
   type SharedValue,
@@ -157,6 +158,53 @@ export function useCrosshair(
 
   const hasOnScrub = onScrub != null;
 
+  useAnimatedReaction(
+    () => {
+      "worklet";
+      if (!hasOnScrub) return "__idle__";
+      if (!scrubActive.value) return "__inactive__";
+      const time = scrubTime.value;
+      const val = scrubValue.value;
+      const x = scrubX.value;
+      if (val === null || time < 0) return "__pending__";
+      const chartW = engine.canvasWidth.value - padding.left - padding.right;
+      if (chartW <= 0) return "__pending__";
+      const h = engine.canvasHeight.value;
+      const chartH = h - padding.top - padding.bottom;
+      const valRange = engine.displayMax.value - engine.displayMin.value;
+      const dotY =
+        valRange === 0
+          ? padding.top + chartH / 2
+          : padding.top + ((engine.displayMax.value - val) / valRange) * chartH;
+      let candleJson: string | null = null;
+      if (isCandleMode) {
+        const c = scrubCandle.value;
+        if (c) candleJson = JSON.stringify(c);
+      }
+      return JSON.stringify([time, val, x, dotY, candleJson]);
+    },
+    (curr, prev) => {
+      "worklet";
+      if (!hasOnScrub) return;
+      if (
+        curr === "__idle__" ||
+        curr === "__inactive__" ||
+        curr === "__pending__"
+      ) {
+        return;
+      }
+      if (curr === prev) return;
+      const row = JSON.parse(curr) as [
+        number,
+        number,
+        number,
+        number,
+        string | null,
+      ];
+      scheduleOnRN(handleScrub, row[2], row[3], row[0], row[1], row[4]);
+    },
+  );
+
   let gesture = Gesture.Pan()
     .minDistance(Platform.OS === "android" ? 10 : 0)
     .activateAfterLongPress(0)
@@ -175,48 +223,6 @@ export function useCrosshair(
         "worklet";
         if (!enabled) return;
         scrubX.value = e.x;
-
-        if (hasOnScrub) {
-          const now = engine.timestamp.value;
-          const windowSecs = engine.displayWindow.value;
-          const chartW =
-            engine.canvasWidth.value - padding.left - padding.right;
-          if (chartW > 0) {
-            const winStart = now - windowSecs;
-            const fraction = (e.x - padding.left) / chartW;
-            const time = winStart + fraction * windowSecs;
-            const h = engine.canvasHeight.value;
-            const chartH = h - padding.top - padding.bottom;
-            const valRange = engine.displayMax.value - engine.displayMin.value;
-
-            let value: number | null = null;
-            let candleJson: string | null = null;
-
-            if (isCandleMode && candlesSV) {
-              const picked = pickCandleAtTime(
-                candlesSV.value,
-                liveCandleSV?.value ?? null,
-                time,
-                candleWidthSecs,
-              );
-              if (picked) {
-                value = picked.close;
-                candleJson = JSON.stringify(picked);
-              }
-            } else {
-              value = interpolateAtTime(engine.data.value, time);
-            }
-
-            if (value !== null) {
-              const dotY =
-                valRange === 0
-                  ? padding.top + chartH / 2
-                  : padding.top +
-                    ((engine.displayMax.value - value) / valRange) * chartH;
-              scheduleOnRN(handleScrub, e.x, dotY, time, value, candleJson);
-            }
-          }
-        }
       },
     )
     .onFinalize(

--- a/src/hooks/useCrosshairMulti.test.ts
+++ b/src/hooks/useCrosshairMulti.test.ts
@@ -4,9 +4,9 @@ import { Platform } from "react-native";
 import { resolveTheme } from "../theme";
 import type { MultiEngineState } from "../useLivelineEngine";
 import {
-  computeMultiSeriesScrubTooltipLayout,
-  deriveScrubValueMulti,
-  interpolateMultiSeriesAtTime,
+    computeMultiSeriesScrubTooltipLayout,
+    deriveScrubValueMulti,
+    interpolateMultiSeriesAtTime,
 } from "./crosshairMulti";
 import { useCrosshairMulti } from "./useCrosshairMulti";
 
@@ -36,9 +36,7 @@ const formatTime = (t: number) =>
   new Date(t * 1000).toISOString().slice(11, 19);
 
 function makeEngine(
-  overrides: Partial<
-    Record<keyof MultiEngineState, { value: unknown }>
-  > = {},
+  overrides: Partial<Record<keyof MultiEngineState, { value: unknown }>> = {},
 ): MultiEngineState {
   return {
     data: { value: [] },
@@ -322,6 +320,36 @@ describe("useCrosshairMulti (hook)", () => {
       ),
     );
     expect(result.current.gesture).toBeDefined();
+  });
+
+  it("accepts onScrub and still initialises (sync reaction path)", () => {
+    const onScrub = jest.fn();
+    const engine = makeEngine({
+      series: {
+        value: [
+          {
+            id: "a",
+            data: [{ time: 1_700_000_000, value: 5 }],
+            value: 5,
+            color: "#00f",
+          },
+        ],
+      },
+    });
+    const { result } = renderHook(() =>
+      useCrosshairMulti(
+        engine,
+        padding,
+        palette,
+        formatValue,
+        formatTime,
+        font,
+        true,
+        onScrub,
+      ),
+    );
+    expect(result.current.gesture).toBeDefined();
+    expect(result.current.scrubActive.value).toBe(false);
   });
 
   it("uses Android pan minDistance when Platform.OS is android", () => {

--- a/src/hooks/useCrosshairMulti.ts
+++ b/src/hooks/useCrosshairMulti.ts
@@ -1,21 +1,29 @@
 import { type SkFont } from "@shopify/react-native-skia";
 import { Platform } from "react-native";
 import { Gesture } from "react-native-gesture-handler";
-import { useDerivedValue, useSharedValue } from "react-native-reanimated";
+import {
+    useAnimatedReaction,
+    useDerivedValue,
+    useSharedValue,
+} from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import { type ChartPadding } from "../draw/line";
-import type { LivelinePalette, ScrubPointMulti, ScrubSeriesValue } from "../types";
+import type {
+    LivelinePalette,
+    ScrubPointMulti,
+    ScrubSeriesValue,
+} from "../types";
 import type { MultiEngineState } from "../useLivelineEngine";
 import {
-  computeCrosshairOpacity,
-  computeScrubTime,
-  type CrosshairState,
-} from "./crosshairShared";
-import {
-  computeMultiSeriesScrubTooltipLayout,
-  deriveScrubValueMulti,
-  interpolateMultiSeriesAtTime,
+    computeMultiSeriesScrubTooltipLayout,
+    deriveScrubValueMulti,
+    interpolateMultiSeriesAtTime,
 } from "./crosshairMulti";
+import {
+    computeCrosshairOpacity,
+    computeScrubTime,
+    type CrosshairState,
+} from "./crosshairShared";
 
 /**
  * Multi-series crosshair + scrub. Requires `engine.series`.
@@ -93,6 +101,55 @@ export function useCrosshairMulti(
 
   const hasOnScrub = onScrub != null;
 
+  useAnimatedReaction(
+    () => {
+      "worklet";
+      if (!hasOnScrub) return "__idle__";
+      if (!scrubActive.value) return "__inactive__";
+      const time = scrubTime.value;
+      const x = scrubX.value;
+      const chartW = engine.canvasWidth.value - padding.left - padding.right;
+      if (chartW <= 0) return "__pending__";
+      const r = interpolateMultiSeriesAtTime(engine.series.value, time);
+      if (r.primary === null) return "__pending__";
+      const h = engine.canvasHeight.value;
+      const chartH = h - padding.top - padding.bottom;
+      const valRange = engine.displayMax.value - engine.displayMin.value;
+      const dotY =
+        valRange === 0
+          ? padding.top + chartH / 2
+          : padding.top +
+            ((engine.displayMax.value - r.primary) / valRange) * chartH;
+      return JSON.stringify({
+        time,
+        x,
+        y: dotY,
+        primary: r.primary,
+        series: r.seriesValues,
+      });
+    },
+    (curr, prev) => {
+      "worklet";
+      if (!hasOnScrub) return;
+      if (
+        curr === "__idle__" ||
+        curr === "__inactive__" ||
+        curr === "__pending__"
+      ) {
+        return;
+      }
+      if (curr === prev) return;
+      const p = JSON.parse(curr) as {
+        time: number;
+        x: number;
+        y: number;
+        primary: number;
+        series: ScrubSeriesValue[];
+      };
+      scheduleOnRN(handleScrubMulti, p.x, p.y, p.time, p.primary, p.series);
+    },
+  );
+
   let gesture = Gesture.Pan()
     .minDistance(Platform.OS === "android" ? 10 : 0)
     .activateAfterLongPress(0)
@@ -111,38 +168,6 @@ export function useCrosshairMulti(
         "worklet";
         if (!enabled) return;
         scrubX.value = e.x;
-
-        if (hasOnScrub) {
-          const now = engine.timestamp.value;
-          const windowSecs = engine.displayWindow.value;
-          const chartW =
-            engine.canvasWidth.value - padding.left - padding.right;
-          if (chartW > 0) {
-            const winStart = now - windowSecs;
-            const fraction = (e.x - padding.left) / chartW;
-            const time = winStart + fraction * windowSecs;
-            const h = engine.canvasHeight.value;
-            const chartH = h - padding.top - padding.bottom;
-            const valRange = engine.displayMax.value - engine.displayMin.value;
-            const r = interpolateMultiSeriesAtTime(engine.series.value, time);
-            if (r.primary !== null) {
-              const dotY =
-                valRange === 0
-                  ? padding.top + chartH / 2
-                  : padding.top +
-                    ((engine.displayMax.value - r.primary) / valRange) *
-                      chartH;
-              scheduleOnRN(
-                handleScrubMulti,
-                e.x,
-                dotY,
-                time,
-                r.primary,
-                r.seriesValues,
-              );
-            }
-          }
-        }
       },
     )
     .onFinalize(


### PR DESCRIPTION
### TL;DR

Refactored crosshair scrub callbacks to use `useAnimatedReaction` instead of executing directly in pan gesture handlers.

### What changed?

- Moved scrub callback logic from pan gesture `onChange` handlers to `useAnimatedReaction` hooks in both `useCrosshair` and `useCrosshairMulti`
- The reaction monitors scrub state changes and triggers callbacks when scrub data is available and has changed
- Pan gesture handlers now only update the `scrubX` position value
- Added test cases to verify initialization works correctly with the new synchronous reaction path

### How to test?

Run the existing test suites for `useCrosshair` and `useCrosshairMulti` to ensure all functionality remains intact. The new test cases "accepts onScrub and still initialises (sync reaction path)" verify that the hooks initialize properly with the refactored callback mechanism.

### Why make this change?

This refactoring improves performance by separating gesture handling from callback execution. Using `useAnimatedReaction` provides better control over when callbacks are triggered and ensures they only fire when scrub data actually changes, rather than on every pan gesture event.