### PR TITLE
refactor: rename properties and library

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,16 +1,16 @@
 {
   "expo": {
-    "name": "react-native-liveline",
-    "slug": "react-native-liveline",
+    "name": "react-native-livechart",
+    "slug": "react-native-livechart",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "reactnativeliveline",
+    "scheme": "reactnativelivechart",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.brandtnewlabs.react-native-liveline",
+      "bundleIdentifier": "com.brandtnewlabs.react-native-livechart",
       "appleTeamId": "MCL33ZBD7G"
     },
     "android": {
@@ -22,7 +22,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "package": "com.brandtnewlabs.reactnativeliveline"
+      "package": "com.brandtnewlabs.reactnativelivechart"
     },
     "web": {
       "output": "static",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -14,7 +14,7 @@ import Animated, {
 import type { VolatilityMode } from "../sim/generators";
 import { useSimulatedData, type TradeSource } from "../sim/useSimulatedData";
 import type { ScrubPoint, ScrubPointMulti } from "../src";
-import { Liveline, LivelineMulti } from "../src";
+import { LiveChart, LiveChartSeries } from "../src";
 import { formatTime } from "../src/format";
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
@@ -117,7 +117,7 @@ export default function Index() {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>react-native-liveline</Text>
+        <Text style={styles.title}>react-native-livechart</Text>
         <AnimatedTextInput
           editable={false}
           underlineColorAndroid="transparent"
@@ -128,7 +128,7 @@ export default function Index() {
 
       <View style={styles.chartContainer}>
         {chartMode === "single" ? (
-          <Liveline
+          <LiveChart
             data={data}
             value={value}
             mode={displayMode}
@@ -155,7 +155,7 @@ export default function Index() {
             degen={degen ? true : undefined}
           />
         ) : (
-          <LivelineMulti
+          <LiveChartSeries
             series={series}
             accentColor="#3b82f6"
             theme="dark"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 3,
-  "name": "react-native-liveline",
+  "name": "react-native-livechart",
   "packages": {
     "": {
       "dependencies": {
@@ -43,7 +43,7 @@
         "react-test-renderer": "^19.1.0",
         "typescript": "~5.9.2"
       },
-      "name": "react-native-liveline",
+      "name": "react-native-livechart",
       "version": "1.0.0"
     },
     "node_modules/@0no-co/graphql.web": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-liveline",
+  "name": "react-native-livechart",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {

--- a/sim/generators.ts
+++ b/sim/generators.ts
@@ -1,7 +1,7 @@
 import type {
   CandlePoint,
-  LivelinePoint,
-  LivelineSeries,
+  LiveChartPoint,
+  SeriesConfig,
   TradeEvent,
 } from "../src/types";
 
@@ -25,16 +25,16 @@ export interface HistoryOptions {
 }
 
 /**
- * Generate a backfill of LivelinePoint[] using a Gaussian random walk.
+ * Generate a backfill of LiveChartPoint[] using a Gaussian random walk.
  */
-export function generateHistory(opts: HistoryOptions = {}): LivelinePoint[] {
+export function generateHistory(opts: HistoryOptions = {}): LiveChartPoint[] {
   const count = opts.count ?? 150;
   const interval = opts.interval ?? 0.2;
   const volatility = opts.volatility ?? 0.003;
   let value = opts.startValue ?? 100;
   const startTime = opts.startTime ?? Date.now() / 1000 - count * interval;
 
-  const points: LivelinePoint[] = [];
+  const points: LiveChartPoint[] = [];
   for (let i = 0; i < count; i++) {
     const time = startTime + i * interval;
     points.push({ time, value });
@@ -95,7 +95,7 @@ export interface CandleResult {
  * Returns completed candles + the in-progress live candle.
  */
 export function aggregateCandles(
-  ticks: LivelinePoint[],
+  ticks: LiveChartPoint[],
   candleWidth: number,
 ): CandleResult {
   if (ticks.length === 0) {
@@ -249,7 +249,7 @@ export interface MultiSeriesOptions {
  */
 export function generateMultiSeries(
   opts: MultiSeriesOptions,
-): LivelineSeries[] {
+): SeriesConfig[] {
   const {
     ids,
     colors,
@@ -266,7 +266,7 @@ export function generateMultiSeries(
     ? Array(n).fill(100 / n)
     : Array.from({ length: n }, () => 30 + Math.random() * 40);
 
-  const allData: LivelinePoint[][] = ids.map(() => []);
+  const allData: LiveChartPoint[][] = ids.map(() => []);
 
   for (let t = 0; t < count; t++) {
     const time = startTime + t * interval;
@@ -303,7 +303,7 @@ export function generateMultiSeries(
  * Advance all series by one step. Mutates the series data arrays in place.
  */
 export function stepMultiSeries(
-  series: LivelineSeries[],
+  series: SeriesConfig[],
   sumToHundred = false,
 ): void {
   const now = Date.now() / 1000;

--- a/sim/useSimulatedData.ts
+++ b/sim/useSimulatedData.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef } from "react";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import type {
   CandlePoint,
-  LivelinePoint,
-  LivelineSeries,
+  LiveChartPoint,
+  SeriesConfig,
   TradeEvent,
 } from "../src/types";
 import {
@@ -39,10 +39,10 @@ export interface SimulatedDataOptions {
 }
 
 export interface SimulatedData {
-  data: SharedValue<LivelinePoint[]>;
+  data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   tradeStream: SharedValue<TradeEvent[]>;
-  series: SharedValue<LivelineSeries[]>;
+  series: SharedValue<SeriesConfig[]>;
   candles: SharedValue<CandlePoint[]>;
   liveCandle: SharedValue<CandlePoint | null>;
 }
@@ -56,9 +56,9 @@ export interface SimulatedData {
  * Never read SharedValue.value on the JS thread in a hot path.
  */
 interface TickBuffers {
-  data: LivelinePoint[];
+  data: LiveChartPoint[];
   tradeStream: TradeEvent[];
-  series: LivelineSeries[];
+  series: SeriesConfig[];
 }
 
 export function useSimulatedData(
@@ -84,10 +84,10 @@ export function useSimulatedData(
   });
 
   // Shared values — one-way push to UI thread for rendering
-  const data = useSharedValue<LivelinePoint[]>([]);
+  const data = useSharedValue<LiveChartPoint[]>([]);
   const value = useSharedValue(startValue);
   const tradeStream = useSharedValue<TradeEvent[]>([]);
-  const series = useSharedValue<LivelineSeries[]>([]);
+  const series = useSharedValue<SeriesConfig[]>([]);
   const candles = useSharedValue<CandlePoint[]>([]);
   const liveCandle = useSharedValue<CandlePoint | null>(null);
 

--- a/src/LiveChart.test.tsx
+++ b/src/LiveChart.test.tsx
@@ -3,13 +3,13 @@ import { fireEvent, render } from "@testing-library/react-native";
 import React from "react";
 import { View } from "react-native";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
-import { Liveline } from "./Liveline";
-import type { CandlePoint, LivelineSingleProps, TradeEvent } from "./types";
+import { LiveChart } from "./LiveChart";
+import type { CandlePoint, LiveChartProps, TradeEvent } from "./types";
 
-function Harness(props: Partial<LivelineSingleProps>) {
+function Harness(props: Partial<LiveChartProps>) {
   const data = useSharedValue([{ time: 1700000000, value: 50 }]);
   const value = useSharedValue(50);
-  return <Liveline data={data} value={value} {...props} />;
+  return <LiveChart data={data} value={value} {...props} />;
 }
 
 function TradeStreamHarness() {
@@ -19,7 +19,7 @@ function TradeStreamHarness() {
   return <Harness tradeStream={tradeStream} degen={{ scale: 1.2 }} />;
 }
 
-function CandleHarness(props: Partial<LivelineSingleProps>) {
+function CandleHarness(props: Partial<LiveChartProps>) {
   const data = useSharedValue([{ time: 1700000000, value: 50 }]);
   const value = useSharedValue(50);
   const candles: SharedValue<CandlePoint[]> = useSharedValue([
@@ -34,7 +34,7 @@ function CandleHarness(props: Partial<LivelineSingleProps>) {
     close: 54,
   });
   return (
-    <Liveline
+    <LiveChart
       data={data}
       value={value}
       mode="candle"
@@ -46,7 +46,7 @@ function CandleHarness(props: Partial<LivelineSingleProps>) {
   );
 }
 
-describe("Liveline", () => {
+describe("LiveChart", () => {
   it("renders with defaults", () => {
     const screen = render(<Harness />);
     const views = screen.UNSAFE_getAllByType(View);

--- a/src/LiveChart.tsx
+++ b/src/LiveChart.tsx
@@ -42,7 +42,7 @@ import {
   resolveXAxis,
   resolveYAxis,
 } from "./resolveConfig";
-import type { LivelineSingleProps, TradeEvent } from "./types";
+import type { LiveChartProps, TradeEvent } from "./types";
 
 import { GestureDetector } from "react-native-gesture-handler";
 import { useSharedValue } from "react-native-reanimated";
@@ -58,9 +58,9 @@ import { ValueLineOverlay } from "./components/ValueLineOverlay";
 import { XAxisOverlay } from "./components/XAxisOverlay";
 import { YAxisOverlay } from "./components/YAxisOverlay";
 import { resolveTheme } from "./theme";
-import { useLivelineEngine } from "./useLivelineEngine";
+import { useLiveChartEngine } from "./useLiveChartEngine";
 
-export function Liveline({
+export function LiveChart({
   // ── Data ────────────────────────────────────────────────────────────────
   data,
   value,
@@ -104,7 +104,7 @@ export function Liveline({
 
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
-}: LivelineSingleProps) {
+}: LiveChartProps) {
   const emptyTradeStream = useSharedValue<TradeEvent[]>([]);
   const tradeStreamSV = tradeStream ?? emptyTradeStream;
   const isCandle = mode === "candle";
@@ -148,7 +148,7 @@ export function Liveline({
   });
 
   // ── Engine and reveal state ────────────────────────────────────────────
-  const engine = useLivelineEngine({
+  const engine = useLiveChartEngine({
     data,
     value,
     timeWindow,

--- a/src/LiveChartSeries.test.tsx
+++ b/src/LiveChartSeries.test.tsx
@@ -1,14 +1,14 @@
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
-import { LivelineMulti } from "./LivelineMulti";
-import type { LivelineSeries } from "./types";
+import { LiveChartSeries } from "./LiveChartSeries";
+import type { SeriesConfig } from "./types";
 import React from "react";
 import { View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 
-describe("LivelineMulti", () => {
+describe("LiveChartSeries", () => {
   it("renders with default scrub when scrub prop is omitted", async () => {
-    const initial: LivelineSeries[] = [
+    const initial: SeriesConfig[] = [
       {
         id: "a",
         label: "A",
@@ -21,15 +21,15 @@ describe("LivelineMulti", () => {
       },
     ];
     function H() {
-      const series = useSharedValue<LivelineSeries[]>(initial);
-      return <LivelineMulti series={series} />;
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return <LiveChartSeries series={series} />;
     }
     const screen = render(<H />);
     await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
   });
 
   it("renders with scrub, reference line, and compact chips", async () => {
-    const initial: LivelineSeries[] = [
+    const initial: SeriesConfig[] = [
       {
         id: "a",
         label: "A",
@@ -42,9 +42,9 @@ describe("LivelineMulti", () => {
       },
     ];
     function H() {
-      const series = useSharedValue<LivelineSeries[]>(initial);
+      const series = useSharedValue<SeriesConfig[]>(initial);
       return (
-        <LivelineMulti
+        <LiveChartSeries
           series={series}
           scrub={{ tooltip: true }}
           referenceLine={{ value: 11 }}
@@ -62,7 +62,7 @@ describe("LivelineMulti", () => {
   });
 
   it("renders with explicit non-default props", async () => {
-    const initial: LivelineSeries[] = [
+    const initial: SeriesConfig[] = [
       {
         id: "a",
         label: "A",
@@ -75,9 +75,9 @@ describe("LivelineMulti", () => {
       },
     ];
     function H() {
-      const sv = useSharedValue<LivelineSeries[]>(initial);
+      const sv = useSharedValue<SeriesConfig[]>(initial);
       return (
-        <LivelineMulti
+        <LiveChartSeries
           series={sv}
           theme="light"
           accentColor="#ef4444"

--- a/src/LiveChartSeries.tsx
+++ b/src/LiveChartSeries.tsx
@@ -43,15 +43,15 @@ import {
   resolveYAxis,
 } from "./resolveConfig";
 import { resolveTheme } from "./theme";
-import type { LivelineMultiProps, LivelineSeries } from "./types";
-import { useLivelineMultiSeriesEngine } from "./useLivelineMultiSeriesEngine";
+import type { LiveChartSeriesProps, SeriesConfig } from "./types";
+import { useLiveChartSeriesEngine } from "./useLiveChartSeriesEngine";
 
-function lineColorsSig(s: SharedValue<LivelineSeries[]>) {
+function lineColorsSig(s: SharedValue<SeriesConfig[]>) {
   "worklet";
   return lineColorsSignatureFromArray(s.value);
 }
 
-export function LivelineMulti({
+export function LiveChartSeries({
   series,
   theme = "dark",
   accentColor = "#3b82f6",
@@ -74,7 +74,7 @@ export function LivelineMulti({
   onScrub,
   onSeriesToggle,
   seriesToggleCompact,
-}: LivelineMultiProps) {
+}: LiveChartSeriesProps) {
   const yAxisCfg = resolveYAxis(yAxis);
   const xAxisCfg = resolveXAxis(xAxis);
   const scrubCfg = resolveScrub(scrub);
@@ -103,7 +103,7 @@ export function LivelineMulti({
     currentValue: 0,
   });
 
-  const engine = useLivelineMultiSeriesEngine({
+  const engine = useLiveChartSeriesEngine({
     series,
     timeWindow,
     paused,
@@ -120,7 +120,7 @@ export function LivelineMulti({
     Array.from({ length: MAX_MULTI_SERIES }, () => "#ffffff"),
   );
 
-  const syncColors = useCallback((sv: SharedValue<LivelineSeries[]>) => {
+  const syncColors = useCallback((sv: SharedValue<SeriesConfig[]>) => {
     setLineColors(resolveMultiSeriesLineColorsSnapshot(sv.value));
   }, []);
 

--- a/src/components/CrosshairOverlay.tsx
+++ b/src/components/CrosshairOverlay.tsx
@@ -10,8 +10,8 @@ import type { ReactNode } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { type ChartPadding } from "../draw/line";
 import { type TooltipLayout } from "../hooks/crosshairShared";
-import type { LivelinePalette } from "../types";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { LiveChartPalette } from "../types";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 
 const TOOLTIP_RADIUS = 5;
 
@@ -31,7 +31,7 @@ export function CrosshairOverlay({
   tooltipLayout: SharedValue<TooltipLayout>;
   engine: ChartEngineLayout;
   padding: ChartPadding;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   font: SkFont;
   showTooltip?: boolean;
   tooltipBody?: ReactNode;

--- a/src/components/DegenParticlesOverlay.tsx
+++ b/src/components/DegenParticlesOverlay.tsx
@@ -1,8 +1,8 @@
 import { Circle, Group } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { DEGEN_STRIDE } from "../constants";
-import type { LivelinePalette } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { LiveChartPalette } from "../types";
+import type { SingleEngineState } from "../useLiveChartEngine";
 
 type DegenPack = SharedValue<Float64Array<ArrayBuffer>>;
 
@@ -86,7 +86,7 @@ export function DegenParticlesOverlay({
   pack: DegenPack;
   packRevision: SharedValue<number>;
   engine: SingleEngineState;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   particleSlotCount: number;
   particleBurstDurationSec: number;
   particleOpacity: number;

--- a/src/components/DotOverlay.tsx
+++ b/src/components/DotOverlay.tsx
@@ -1,8 +1,8 @@
 import { Circle, Group } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ResolvedPulseConfig } from "../resolveConfig";
-import type { LivelinePalette } from "../types";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { LiveChartPalette } from "../types";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 
 const MIN_PULSE_RADIUS = 9;
 
@@ -15,7 +15,7 @@ export function DotOverlay({
 }: {
   dotX: SharedValue<number>;
   dotY: SharedValue<number>;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   engine: ChartEngineLayout;
   pulse: ResolvedPulseConfig | null;
 }) {

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -16,8 +16,8 @@ import {
 } from "../draw/line";
 import { drawSpline } from "../math/spline";
 import { buildSquigglyPts } from "../math/squiggly";
-import type { LivelinePalette } from "../types";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { LiveChartPalette } from "../types";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 
 const PLACEHOLDER_LABEL_COUNT = 4;
 const RECT_W = 16;
@@ -49,7 +49,7 @@ export function LoadingOverlay({
 }: {
   engine: ChartEngineLayout;
   padding: ChartPadding;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   font: SkFont;
   morphT: SharedValue<number>;
   isLoading: SharedValue<boolean>;

--- a/src/components/MultiSeriesDots.test.tsx
+++ b/src/components/MultiSeriesDots.test.tsx
@@ -1,4 +1,4 @@
-import type { MultiEngineState } from "../useLivelineEngine";
+import type { MultiEngineState } from "../useLiveChartEngine";
 import { MultiSeriesDots } from "./MultiSeriesDots";
 import React from "react";
 import { render } from "@testing-library/react-native";

--- a/src/components/MultiSeriesDots.tsx
+++ b/src/components/MultiSeriesDots.tsx
@@ -2,7 +2,7 @@ import { Circle, Group } from "@shopify/react-native-skia";
 
 import type { ChartPadding } from "../draw/line";
 import { MAX_MULTI_SERIES } from "../constants";
-import type { MultiEngineState } from "../useLivelineEngine";
+import type { MultiEngineState } from "../useLiveChartEngine";
 import { useDerivedValue } from "react-native-reanimated";
 
 function SeriesDotAtIndex({

--- a/src/components/MultiSeriesStroke.tsx
+++ b/src/components/MultiSeriesStroke.tsx
@@ -1,7 +1,7 @@
 import { Group, Path, Skia } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { SERIES_COLORS } from "../theme";
-import type { LivelineSeries } from "../types";
+import type { SeriesConfig } from "../types";
 
 export function MultiSeriesStroke({
   index,
@@ -13,7 +13,7 @@ export function MultiSeriesStroke({
   index: number;
   paths: SharedValue<ReturnType<typeof Skia.Path.Make>[]>;
   opacities: SharedValue<number[]>;
-  series: SharedValue<LivelineSeries[]>;
+  series: SharedValue<SeriesConfig[]>;
   strokeWidth: number;
 }) {
   const path = useDerivedValue(

--- a/src/components/MultiSeriesTooltipStack.tsx
+++ b/src/components/MultiSeriesTooltipStack.tsx
@@ -6,7 +6,7 @@ import {
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { TooltipLayout } from "../hooks/crosshairShared";
-import type { LivelinePalette } from "../types";
+import type { LiveChartPalette } from "../types";
 
 const TOOLTIP_STACK_SLOTS = MAX_MULTI_SERIES + 1;
 
@@ -19,7 +19,7 @@ function TooltipStackLine({
   index: number;
   tooltipLayout: SharedValue<TooltipLayout>;
   font: SkFont;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
 }) {
   const opacity = useDerivedValue(() => {
     const sl = tooltipLayout.value.stackedLines;
@@ -66,7 +66,7 @@ export function MultiSeriesTooltipStack({
 }: {
   tooltipLayout: SharedValue<TooltipLayout>;
   font: SkFont;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
 }) {
   return (
     <Group>

--- a/src/components/SeriesToggleChips.test.tsx
+++ b/src/components/SeriesToggleChips.test.tsx
@@ -1,7 +1,7 @@
 import { SeriesToggleChips, seriesMetaSig } from "./SeriesToggleChips";
 import { fireEvent, render } from "@testing-library/react-native";
 
-import type { LivelineSeries } from "../types";
+import type { SeriesConfig } from "../types";
 import React from "react";
 import { useSharedValue } from "react-native-reanimated";
 
@@ -12,7 +12,7 @@ function ChipsHarness({
   onToggle: (id: string, visible: boolean) => void;
   compact?: boolean;
 }) {
-  const series = useSharedValue<LivelineSeries[]>([
+  const series = useSharedValue<SeriesConfig[]>([
     {
       id: "a",
       label: "Alpha",
@@ -77,7 +77,7 @@ describe("SeriesToggleChips", () => {
 
   it("uses id as chip text when label is omitted", () => {
     function IdOnlyHarness() {
-      const series = useSharedValue<LivelineSeries[]>([
+      const series = useSharedValue<SeriesConfig[]>([
         { id: "idOnly", data: [], value: 1, color: "#333" },
       ]);
       return <SeriesToggleChips series={series} />;
@@ -93,7 +93,7 @@ describe("SeriesToggleChips", () => {
   it("maps multiple series so only the toggled index updates", () => {
     const onToggle = jest.fn();
     function TwoHarness() {
-      const series = useSharedValue<LivelineSeries[]>([
+      const series = useSharedValue<SeriesConfig[]>([
         {
           id: "a",
           label: "A",
@@ -118,7 +118,7 @@ describe("SeriesToggleChips", () => {
 
   it("uses neutral swatch when color is missing", () => {
     function NoColorHarness() {
-      const series = useSharedValue<LivelineSeries[]>([
+      const series = useSharedValue<SeriesConfig[]>([
         {
           id: "plain",
           label: "Plain",

--- a/src/components/SeriesToggleChips.tsx
+++ b/src/components/SeriesToggleChips.tsx
@@ -5,16 +5,16 @@ import {
   useAnimatedReaction,
   type SharedValue,
 } from "react-native-reanimated";
-import type { LivelineSeries } from "../types";
+import type { SeriesConfig } from "../types";
 
 export interface SeriesToggleChipsProps {
-  series: SharedValue<LivelineSeries[]>;
+  series: SharedValue<SeriesConfig[]>;
   compact?: boolean;
   onSeriesToggle?: (id: string, visible: boolean) => void;
 }
 
 /** Exported for tests — mirrors chip labels without subscribing to every data tick. */
-export function seriesMetaSig(s: LivelineSeries[]): string {
+export function seriesMetaSig(s: SeriesConfig[]): string {
   "worklet";
   return s
     .map(
@@ -32,9 +32,9 @@ export function SeriesToggleChips({
   compact,
   onSeriesToggle,
 }: SeriesToggleChipsProps) {
-  const [snapshot, setSnapshot] = useState<LivelineSeries[]>([]);
+  const [snapshot, setSnapshot] = useState<SeriesConfig[]>([]);
 
-  const pullSnapshot = useCallback((sv: SharedValue<LivelineSeries[]>) => {
+  const pullSnapshot = useCallback((sv: SharedValue<SeriesConfig[]>) => {
     setSnapshot(sv.value.slice());
   }, []);
 

--- a/src/components/TradeStreamOverlay.tsx
+++ b/src/components/TradeStreamOverlay.tsx
@@ -6,7 +6,7 @@ import {
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ChartPadding } from "../draw/line";
 import type { TradeMarker } from "../draw/trade";
-import type { LivelinePalette } from "../types";
+import type { LiveChartPalette } from "../types";
 
 const MAX_TRADE_LABELS = 20;
 
@@ -100,7 +100,7 @@ export function TradeStreamOverlay({
   labelOffsetX = 8,
 }: {
   markers: SharedValue<TradeMarker[]>;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   padding: ChartPadding;
   font: SkFont;
   opacity: SharedValue<number>;

--- a/src/components/ValueLineOverlay.tsx
+++ b/src/components/ValueLineOverlay.tsx
@@ -2,7 +2,7 @@ import { DashPathEffect, Path, Skia } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ChartPadding } from "../draw/line";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 
 /**
  * A dashed horizontal line that tracks the live display value — sitting at

--- a/src/components/XAxisOverlay.tsx
+++ b/src/components/XAxisOverlay.tsx
@@ -3,8 +3,8 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ChartPadding } from "../draw/line";
 import type { XAxisEntry } from "../hooks/useXAxis";
 import { measureFontTextWidth } from "../measureFontTextWidth";
-import type { LivelinePalette } from "../types";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { LiveChartPalette } from "../types";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 import { AnimatedLabel } from "./AnimatedLabel";
 
 const MAX_X_LABELS = 10;
@@ -19,7 +19,7 @@ export function XAxisOverlay({
   entries: SharedValue<XAxisEntry[]>;
   engine: ChartEngineLayout;
   padding: ChartPadding;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   font: SkFont;
 }) {
   const axisPath = useDerivedValue(() => {

--- a/src/components/YAxisOverlay.tsx
+++ b/src/components/YAxisOverlay.tsx
@@ -9,8 +9,8 @@ import {
   type ChartPadding,
 } from "../draw/line";
 import { measureFontTextWidth } from "../measureFontTextWidth";
-import type { LivelinePalette } from "../types";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { LiveChartPalette } from "../types";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 import { AnimatedLabel } from "./AnimatedLabel";
 
 const MAX_Y_LABELS = 15;
@@ -26,7 +26,7 @@ export function YAxisOverlay({
   entries: SharedValue<YAxisEntry[]>;
   engine: ChartEngineLayout;
   padding: ChartPadding;
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   font: SkFont;
   /** When true, use the asymmetric pill centering formula so labels align with badge text. */
   badge?: boolean;

--- a/src/components/overlays.test.tsx
+++ b/src/components/overlays.test.tsx
@@ -3,7 +3,7 @@ import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DEFAULT_PADDING } from "../draw/line";
 import { DotOverlay } from "./DotOverlay";
-import type { EngineState } from "../useLivelineEngine";
+import type { EngineState } from "../useLiveChartEngine";
 import { LoadingOverlay } from "./LoadingOverlay";
 import { MultiSeriesTooltipStack } from "./MultiSeriesTooltipStack";
 import React from "react";

--- a/src/draw/line.ts
+++ b/src/draw/line.ts
@@ -5,7 +5,7 @@ import {
   BADGE_PILL_PAD_Y,
   BADGE_TAIL_LEN,
 } from "../constants";
-import type { ChartInsets, LivelinePoint } from "../types";
+import type { ChartInsets, LiveChartPoint } from "../types";
 export {
   BADGE_DOT_GAP,
   BADGE_MARGIN_RIGHT,
@@ -148,7 +148,7 @@ export function resolvePadding(
  * Flat layout avoids ~150 tuple object allocations per frame.
  */
 export function buildLinePoints(
-  data: LivelinePoint[],
+  data: LiveChartPoint[],
   displayValue: number,
   now: number,
   windowSecs: number,

--- a/src/hooks/crosshairMulti.ts
+++ b/src/hooks/crosshairMulti.ts
@@ -1,7 +1,7 @@
 import { type SkFont } from "@shopify/react-native-skia";
 import { type ChartPadding } from "../draw/line";
 import { interpolateAtTime } from "../math/interpolate";
-import type { LivelineSeries, ScrubSeriesValue } from "../types";
+import type { SeriesConfig, ScrubSeriesValue } from "../types";
 import {
   computeTooltipLayoutMulti,
   HIDDEN_TOOLTIP,
@@ -9,7 +9,7 @@ import {
 } from "./crosshairShared";
 
 export function interpolateMultiSeriesAtTime(
-  series: LivelineSeries[],
+  series: SeriesConfig[],
   time: number,
 ): { primary: number | null; seriesValues: ScrubSeriesValue[] } {
   "worklet";
@@ -33,7 +33,7 @@ export function interpolateMultiSeriesAtTime(
 export function deriveScrubValueMulti(
   scrubActive: boolean,
   scrubTime: number,
-  series: LivelineSeries[],
+  series: SeriesConfig[],
 ): number | null {
   "worklet";
   if (!scrubActive || scrubTime < 0) return null;
@@ -45,7 +45,7 @@ export function computeMultiSeriesScrubTooltipLayout(
   scrubActive: boolean,
   scrubX: number,
   scrubTime: number,
-  series: LivelineSeries[],
+  series: SeriesConfig[],
   padding: ChartPadding,
   canvasWidth: number,
   formatValue: (v: number) => string,

--- a/src/hooks/useBadge.test.tsx
+++ b/src/hooks/useBadge.test.tsx
@@ -1,7 +1,7 @@
 import { DEFAULT_PADDING, badgeTailAndCap, pillTextLeftX } from "../draw/line";
 
 import { BADGE_DOT_GAP } from "../constants";
-import type { EngineState } from "../useLivelineEngine";
+import type { EngineState } from "../useLiveChartEngine";
 import type { SkFont } from "@shopify/react-native-skia";
 import { measureFontTextWidth } from "../measureFontTextWidth";
 import { renderHook } from "@testing-library/react-native";

--- a/src/hooks/useBadge.ts
+++ b/src/hooks/useBadge.ts
@@ -18,15 +18,15 @@ import {
 import { hexToRgb, lerpColor } from "../math/color";
 import { lerp } from "../math/lerp";
 import { measureFontTextWidth } from "../measureFontTextWidth";
-import type { BadgeVariant, LivelinePalette, Momentum } from "../types";
-import type { ChartEngineWithLiveValue } from "../useLivelineEngine";
+import type { BadgeVariant, LiveChartPalette, Momentum } from "../types";
+import type { ChartEngineWithLiveValue } from "../useLiveChartEngine";
 
 const TAIL_SPREAD = 2.5;
 
 export function useBadge(
   engine: ChartEngineWithLiveValue,
   padding: ChartPadding,
-  palette: LivelinePalette,
+  palette: LiveChartPalette,
   formatValue: (v: number) => string,
   font: SkFont,
   variant: BadgeVariant = "default",

--- a/src/hooks/useCandlePaths.ts
+++ b/src/hooks/useCandlePaths.ts
@@ -9,7 +9,7 @@ import { buildCandleGeometry } from "../draw/candle";
 import type { ChartPadding } from "../draw/line";
 import { lerp } from "../math/lerp";
 import type { CandlePoint } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 
 const CANDLE_WIDTH_LERP_SPEED = 0.08;
 

--- a/src/hooks/useCanvasLayout.test.tsx
+++ b/src/hooks/useCanvasLayout.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react-native";
-import type { EngineState } from "../useLivelineEngine";
+import type { EngineState } from "../useLiveChartEngine";
 import { useCanvasLayout } from "./useCanvasLayout";
 
 function makeEngine(): EngineState {

--- a/src/hooks/useCanvasLayout.ts
+++ b/src/hooks/useCanvasLayout.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 import type { LayoutChangeEvent } from "react-native";
 
 export function useCanvasLayout(engine: ChartEngineLayout) {

--- a/src/hooks/useChartColors.ts
+++ b/src/hooks/useChartColors.ts
@@ -1,5 +1,5 @@
 import type { ChartPadding } from "../draw/line";
-import type { LivelinePalette } from "../types";
+import type { LiveChartPalette } from "../types";
 import type { ResolvedGradientConfig } from "../resolveConfig";
 import { parseColorRgb } from "../theme";
 import { useMemo } from "react";
@@ -21,7 +21,7 @@ export interface ChartColors {
  * recomputed when inputs change.
  */
 export function useChartColors(
-  palette: LivelinePalette,
+  palette: LiveChartPalette,
   gradientCfg: ResolvedGradientConfig | null,
   accentColor: string,
   layoutHeight: number,

--- a/src/hooks/useChartLayout.ts
+++ b/src/hooks/useChartLayout.ts
@@ -8,10 +8,10 @@ import {
   type ChartPadding,
 } from "../draw/line";
 import { measureFontTextWidth } from "../measureFontTextWidth";
-import type { ChartInsets, LivelinePalette } from "../types";
+import type { ChartInsets, LiveChartPalette } from "../types";
 
 export interface ChartLayoutConfig {
-  palette: LivelinePalette;
+  palette: LiveChartPalette;
   lineWidthOverride?: number;
   insetsOverride?: ChartInsets;
   yAxis: boolean;

--- a/src/hooks/useChartPaths.test.tsx
+++ b/src/hooks/useChartPaths.test.tsx
@@ -1,5 +1,5 @@
 import { DEFAULT_PADDING } from "../draw/line";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 import { useChartPaths } from "./useChartPaths";
 import { useSharedValue } from "react-native-reanimated";

--- a/src/hooks/useChartPaths.ts
+++ b/src/hooks/useChartPaths.ts
@@ -3,7 +3,7 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline } from "../math/spline";
 import { blendPtsY, squigglifyPts } from "../math/squiggly";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 
 export function useChartPaths(
   engine: SingleEngineState,

--- a/src/hooks/useCrosshair.test.ts
+++ b/src/hooks/useCrosshair.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import { interpolateAtTime } from "../math/interpolate";
 import { resolveTheme } from "../theme";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 import {
   computeCandleTooltipLayout,
   computeCrosshairOpacity,

--- a/src/hooks/useCrosshair.ts
+++ b/src/hooks/useCrosshair.ts
@@ -11,8 +11,8 @@ import { scheduleOnRN } from "react-native-worklets";
 import { type ChartPadding } from "../draw/line";
 import { interpolateAtTime } from "../math/interpolate";
 import { pickCandleAtTime } from "../math/pickCandle";
-import type { CandlePoint, LivelinePalette, ScrubPoint } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { CandlePoint, LiveChartPalette, ScrubPoint } from "../types";
+import type { SingleEngineState } from "../useLiveChartEngine";
 import {
   computeCandleTooltipLayout,
   computeCrosshairOpacity,
@@ -48,7 +48,7 @@ export interface CrosshairCandleOpts {
 export function useCrosshair(
   engine: SingleEngineState,
   padding: ChartPadding,
-  _palette: LivelinePalette,
+  _palette: LiveChartPalette,
   formatValue: (v: number) => string,
   formatTime: (t: number) => string,
   font: SkFont,

--- a/src/hooks/useCrosshairMulti.test.ts
+++ b/src/hooks/useCrosshairMulti.test.ts
@@ -2,7 +2,7 @@ import { type SkFont } from "@shopify/react-native-skia";
 import { renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import { resolveTheme } from "../theme";
-import type { MultiEngineState } from "../useLivelineEngine";
+import type { MultiEngineState } from "../useLiveChartEngine";
 import {
     computeMultiSeriesScrubTooltipLayout,
     deriveScrubValueMulti,

--- a/src/hooks/useCrosshairMulti.ts
+++ b/src/hooks/useCrosshairMulti.ts
@@ -9,11 +9,11 @@ import {
 import { scheduleOnRN } from "react-native-worklets";
 import { type ChartPadding } from "../draw/line";
 import type {
-    LivelinePalette,
+    LiveChartPalette,
     ScrubPointMulti,
     ScrubSeriesValue,
 } from "../types";
-import type { MultiEngineState } from "../useLivelineEngine";
+import type { MultiEngineState } from "../useLiveChartEngine";
 import {
     computeMultiSeriesScrubTooltipLayout,
     deriveScrubValueMulti,
@@ -31,7 +31,7 @@ import {
 export function useCrosshairMulti(
   engine: MultiEngineState,
   padding: ChartPadding,
-  _palette: LivelinePalette,
+  _palette: LiveChartPalette,
   formatValue: (v: number) => string,
   formatTime: (t: number) => string,
   font: SkFont,

--- a/src/hooks/useDegen.test.tsx
+++ b/src/hooks/useDegen.test.tsx
@@ -1,13 +1,13 @@
 import { renderHook } from "@testing-library/react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { resolveDegen } from "../resolveConfig";
-import { useLivelineEngine } from "../useLivelineEngine";
+import { useLiveChartEngine } from "../useLiveChartEngine";
 import { useDegen } from "./useDegen";
 
 function useMakeEngine() {
   const data = useSharedValue([{ time: 1_700_000_000, value: 50 }]);
   const value = useSharedValue(50);
-  return useLivelineEngine({ data, value, timeWindow: 100, smoothing: 0.08 });
+  return useLiveChartEngine({ data, value, timeWindow: 100, smoothing: 0.08 });
 }
 
 describe("useDegen", () => {

--- a/src/hooks/useDegen.ts
+++ b/src/hooks/useDegen.ts
@@ -9,7 +9,7 @@ import {
 import { computeShake, spawnBurst, tickParticles } from "../degen/tick";
 import type { ResolvedDegenConfig } from "../resolveConfig";
 import type { Momentum } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 
 export function useDegen(
   engine: SingleEngineState,

--- a/src/hooks/useLiveDot.test.tsx
+++ b/src/hooks/useLiveDot.test.tsx
@@ -1,5 +1,5 @@
 import { DEFAULT_PADDING } from "../draw/line";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 import { useLiveDot } from "./useLiveDot";
 

--- a/src/hooks/useLiveDot.ts
+++ b/src/hooks/useLiveDot.ts
@@ -1,5 +1,5 @@
 import type { ChartPadding } from "../draw/line";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 import { useDerivedValue } from "react-native-reanimated";
 
 export function useLiveDot(engine: SingleEngineState, padding: ChartPadding) {

--- a/src/hooks/useMomentum.test.ts
+++ b/src/hooks/useMomentum.test.ts
@@ -1,7 +1,7 @@
 import { resolveMomentumProp, useMomentum } from "./useMomentum";
 
-import type { LivelinePoint } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { LiveChartPoint } from "../types";
+import type { SingleEngineState } from "../useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 
 const makeData = (values: number[]) =>
@@ -40,7 +40,7 @@ describe("resolveMomentumProp", () => {
   });
 });
 
-function engineWithData(data: LivelinePoint[]): SingleEngineState {
+function engineWithData(data: LiveChartPoint[]): SingleEngineState {
   return {
     data: { value: data },
     value: { value: 0 },

--- a/src/hooks/useMomentum.ts
+++ b/src/hooks/useMomentum.ts
@@ -1,7 +1,7 @@
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { detectMomentum } from "../math/momentum";
 import type { Momentum } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 
 /**
  * Resolve the momentum prop to a detected or forced momentum value.

--- a/src/hooks/useMultiSeriesPaths.test.tsx
+++ b/src/hooks/useMultiSeriesPaths.test.tsx
@@ -1,4 +1,4 @@
-import type { MultiEngineState } from "../useLivelineEngine";
+import type { MultiEngineState } from "../useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 import { useMultiSeriesLinePaths } from "./useMultiSeriesPaths";
 import { useSharedValue } from "react-native-reanimated";

--- a/src/hooks/useMultiSeriesPaths.ts
+++ b/src/hooks/useMultiSeriesPaths.ts
@@ -3,7 +3,7 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline } from "../math/spline";
-import type { MultiEngineState } from "../useLivelineEngine";
+import type { MultiEngineState } from "../useLiveChartEngine";
 
 /**
  * One derived shared value holding up to `MAX_MULTI_SERIES` Skia paths (unused slots are empty paths).

--- a/src/hooks/useReferenceLine.test.tsx
+++ b/src/hooks/useReferenceLine.test.tsx
@@ -1,5 +1,5 @@
 import { DEFAULT_PADDING } from "../draw/line";
-import type { EngineState } from "../useLivelineEngine";
+import type { EngineState } from "../useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 import { useReferenceLine } from "./useReferenceLine";
 

--- a/src/hooks/useReferenceLine.ts
+++ b/src/hooks/useReferenceLine.ts
@@ -3,7 +3,7 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { SkFont } from "@shopify/react-native-skia";
 import type { ChartPadding } from "../draw/line";
 import type { ReferenceLine } from "../types";
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 
 export interface ReferenceLineLayout {
   y: number;

--- a/src/hooks/useTradeStream.test.tsx
+++ b/src/hooks/useTradeStream.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { DEFAULT_PADDING } from "../draw/line";
 import type { TradeEvent } from "../types";
-import { useLivelineEngine } from "../useLivelineEngine";
+import { useLiveChartEngine } from "../useLiveChartEngine";
 import { useTradeStream } from "./useTradeStream";
 
 describe("useTradeStream", () => {
@@ -10,7 +10,7 @@ describe("useTradeStream", () => {
     const { result } = renderHook(() => {
       const data = useSharedValue([{ time: 1_700_000_000, value: 50 }]);
       const value = useSharedValue(50);
-      const engine = useLivelineEngine({
+      const engine = useLiveChartEngine({
         data,
         value,
         timeWindow: 100,
@@ -29,7 +29,7 @@ describe("useTradeStream", () => {
     const { result } = renderHook(() => {
       const data = useSharedValue([{ time: 1_700_000_000, value: 50 }]);
       const value = useSharedValue(50);
-      const engine = useLivelineEngine({
+      const engine = useLiveChartEngine({
         data,
         value,
         timeWindow: 100,

--- a/src/hooks/useTradeStream.ts
+++ b/src/hooks/useTradeStream.ts
@@ -12,7 +12,7 @@ import {
   type TradeStreamState,
 } from "../draw/trade";
 import type { TradeEvent } from "../types";
-import type { SingleEngineState } from "../useLivelineEngine";
+import type { SingleEngineState } from "../useLiveChartEngine";
 
 export function useTradeStream(
   engine: SingleEngineState,

--- a/src/hooks/useXAxis.test.tsx
+++ b/src/hooks/useXAxis.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react-native";
 
 import { DEFAULT_PADDING } from "../draw/line";
-import type { EngineState } from "../useLivelineEngine";
+import type { EngineState } from "../useLiveChartEngine";
 import { useXAxis } from "./useXAxis";
 
 const font = {

--- a/src/hooks/useXAxis.ts
+++ b/src/hooks/useXAxis.ts
@@ -1,6 +1,6 @@
 import { useDerivedValue, useSharedValue } from "react-native-reanimated";
 
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import type { SkFont } from "@shopify/react-native-skia";
 import { lerp } from "../math/lerp";

--- a/src/hooks/useYAxis.test.tsx
+++ b/src/hooks/useYAxis.test.tsx
@@ -1,5 +1,5 @@
 import { DEFAULT_PADDING } from "../draw/line";
-import type { EngineState } from "../useLivelineEngine";
+import type { EngineState } from "../useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 import { useYAxis } from "./useYAxis";
 

--- a/src/hooks/useYAxis.ts
+++ b/src/hooks/useYAxis.ts
@@ -1,6 +1,6 @@
 import { useDerivedValue, useSharedValue } from "react-native-reanimated";
 
-import type { ChartEngineLayout } from "../useLivelineEngine";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import type { SkFont } from "@shopify/react-native-skia";
 import { computeGridEntries } from "../draw/grid";

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,9 +2,9 @@ import * as entry from "./index";
 import * as hooks from "./hooks";
 
 describe("package entry", () => {
-  it("exports Liveline and LivelineMulti", () => {
-    expect(entry.Liveline).toBeDefined();
-    expect(entry.LivelineMulti).toBeDefined();
+  it("exports LiveChart and LiveChartSeries", () => {
+    expect(entry.LiveChart).toBeDefined();
+    expect(entry.LiveChartSeries).toBeDefined();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,37 @@
-import { Liveline } from "./Liveline";
-import { LivelineMulti } from "./LivelineMulti";
+import { LiveChart } from "./LiveChart";
+import { LiveChartSeries } from "./LiveChartSeries";
 
 export { useDegen, useTradeStream } from "./hooks";
-export { Liveline, LivelineMulti };
+export { LiveChart, LiveChartSeries };
 
-  export type {
-    BadgeConfig,
-    BadgeVariant,
-    CandlePoint,
-    ChartInsets,
-    ChartLayout,
-    DegenOptions,
-    FontConfig,
-    FontWeight,
-    GradientConfig,
-    LineConfig,
-    LivelineCoreProps,
-    LivelineMultiProps,
-    LivelinePalette,
-    LivelinePoint,
-    LivelineSeries,
-    LivelineSingleProps,
-    Momentum,
-    OrderbookData,
-    PulseConfig,
-    ReferenceLine,
-    ScrubConfig,
-    ScrubPoint,
-    ScrubPointCore,
-    ScrubPointMulti,
-    ScrubSeriesValue,
-    ThemeMode,
-    TradeEvent,
-    ValueLineConfig,
-    WindowOption,
-    WindowStyle,
-    XAxisConfig,
-    YAxisConfig
-  } from "./types";
+export type {
+  BadgeConfig,
+  BadgeVariant,
+  CandlePoint,
+  ChartInsets,
+  DegenOptions,
+  FontConfig,
+  FontWeight,
+  GradientConfig,
+  LineConfig,
+  LiveChartCoreProps,
+  LiveChartSeriesProps,
+  LiveChartPalette,
+  LiveChartPoint,
+  SeriesConfig,
+  LiveChartProps,
+  Momentum,
+  PulseConfig,
+  ReferenceLine,
+  ScrubConfig,
+  ScrubPoint,
+  ScrubPointCore,
+  ScrubPointMulti,
+  ScrubSeriesValue,
+  ThemeMode,
+  TradeEvent,
+  ValueLineConfig,
+  XAxisConfig,
+  YAxisConfig,
+} from "./types";
 

--- a/src/liveChartEngineTick.test.ts
+++ b/src/liveChartEngineTick.test.ts
@@ -1,4 +1,4 @@
-import { tickLivelineEngineFrame } from "./livelineEngineTick";
+import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
 
 function baseState() {
   return {
@@ -10,10 +10,10 @@ function baseState() {
   };
 }
 
-describe("tickLivelineEngineFrame", () => {
+describe("tickLiveChartEngineFrame", () => {
   it("updates timestamp and returns early when canvas has zero size", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 0,
       canvasHeight: 100,
@@ -31,7 +31,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("lerps display value toward target", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -48,7 +48,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("uses gap ratio zero when display range is zero", () => {
     const s = { ...baseState(), displayMin: 5, displayMax: 5 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -65,7 +65,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("uses adaptive speed when range is positive", () => {
     const s = { ...baseState(), displayMin: 0, displayMax: 10 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -82,7 +82,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("still applies margin from display value when points array is empty", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -100,7 +100,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("includes reference line in range", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -117,7 +117,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("applies exaggerate min range branch", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -137,7 +137,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("applies margin when raw range exceeds minRange", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -157,7 +157,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("lerps displayMin inward when tMin is greater", () => {
     const s = { ...baseState(), displayMin: 100, displayMax: 200 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -177,7 +177,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("lerps displayMax inward when tMax is smaller", () => {
     const s = { ...baseState(), displayMin: 0, displayMax: 5 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -203,7 +203,7 @@ describe("tickLivelineEngineFrame", () => {
       displayWindow: 30,
       timestamp: 1000,
     };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -229,7 +229,7 @@ describe("tickLivelineEngineFrame", () => {
       displayWindow: 30,
       timestamp: 1000,
     };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -253,7 +253,7 @@ describe("tickLivelineEngineFrame", () => {
       time: 900 + i * 0.2,
       value: i * 0.1,
     }));
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -270,7 +270,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("uses minRange fallback when rawRange is zero (exaggerate on)", () => {
     const s = { ...baseState(), displayValue: 7 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -290,7 +290,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("uses minRange fallback when rawRange is zero (exaggerate off)", () => {
     const s = { ...baseState(), displayValue: 7 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -310,7 +310,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("skips y-range block when extrema stay invalid (NaN display value)", () => {
     const s = { ...baseState(), displayValue: NaN };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -328,7 +328,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("uses default clock when nowSeconds is omitted", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -344,7 +344,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("does not move bounds when reference is inside data span", () => {
     const s = baseState();
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -371,7 +371,7 @@ describe("tickLivelineEngineFrame", () => {
       displayWindow: 30,
       timestamp: 1000,
     };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -388,7 +388,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("freezes timestamp when paused=true", () => {
     const s = { ...baseState(), timestamp: 999 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -406,7 +406,7 @@ describe("tickLivelineEngineFrame", () => {
 
   it("still lerps displayWindow when paused=true", () => {
     const s = { ...baseState(), displayWindow: 30 };
-    tickLivelineEngineFrame(s, {
+    tickLiveChartEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -427,7 +427,7 @@ describe("tickLivelineEngineFrame", () => {
   describe("candle mode Y range", () => {
     it("computes displayMin/Max from candle low/high", () => {
       const s = baseState();
-      tickLivelineEngineFrame(s, {
+      tickLiveChartEngineFrame(s, {
         dt: 16.67,
         canvasWidth: 200,
         canvasHeight: 100,
@@ -448,7 +448,7 @@ describe("tickLivelineEngineFrame", () => {
 
     it("includes liveCandle in Y range", () => {
       const s = baseState();
-      tickLivelineEngineFrame(s, {
+      tickLiveChartEngineFrame(s, {
         dt: 16.67,
         canvasWidth: 200,
         canvasHeight: 100,
@@ -469,7 +469,7 @@ describe("tickLivelineEngineFrame", () => {
 
     it("targets liveCandle.close for displayValue", () => {
       const s = baseState();
-      tickLivelineEngineFrame(s, {
+      tickLiveChartEngineFrame(s, {
         dt: 16.67,
         canvasWidth: 200,
         canvasHeight: 100,
@@ -489,7 +489,7 @@ describe("tickLivelineEngineFrame", () => {
 
     it("uses line mode Y range when mode is 'line'", () => {
       const s = baseState();
-      tickLivelineEngineFrame(s, {
+      tickLiveChartEngineFrame(s, {
         dt: 16.67,
         canvasWidth: 200,
         canvasHeight: 100,
@@ -508,7 +508,7 @@ describe("tickLivelineEngineFrame", () => {
 
     it("excludes candles before the visible window", () => {
       const s = baseState();
-      tickLivelineEngineFrame(s, {
+      tickLiveChartEngineFrame(s, {
         dt: 16.67,
         canvasWidth: 200,
         canvasHeight: 100,
@@ -531,7 +531,7 @@ describe("tickLivelineEngineFrame", () => {
 
     it("excludes future candles beyond timestamp", () => {
       const s = baseState();
-      tickLivelineEngineFrame(s, {
+      tickLiveChartEngineFrame(s, {
         dt: 16.67,
         canvasWidth: 200,
         canvasHeight: 100,

--- a/src/liveChartEngineTick.ts
+++ b/src/liveChartEngineTick.ts
@@ -1,4 +1,4 @@
-import type { CandlePoint, LivelinePoint } from "./types";
+import type { CandlePoint, LiveChartPoint } from "./types";
 
 import { ADAPTIVE_SPEED_BOOST } from "./constants";
 import { lerp } from "./math/lerp";
@@ -22,7 +22,7 @@ export interface EngineTickInput {
   exaggerate: boolean;
   referenceValue: number | undefined;
   targetValue: number;
-  points: LivelinePoint[];
+  points: LiveChartPoint[];
   /** Seconds since Unix epoch; defaults to `Date.now() / 1000` */
   nowSeconds?: number;
   /** When true, freeze the viewport timestamp and skip displayWindow lerp */
@@ -36,10 +36,10 @@ export interface EngineTickInput {
 }
 
 /**
- * One frame of the liveline engine (mirrors `useLivelineEngine` worklet body).
+ * One frame of the live chart engine (mirrors `useLiveChartEngine` worklet body).
  * Mutates `state` in place for testability and reuse from the hook.
  */
-export function tickLivelineEngineFrame(
+export function tickLiveChartEngineFrame(
   state: EngineTickMutable,
   input: EngineTickInput,
 ): void {

--- a/src/liveChartSeriesEngineTick.test.ts
+++ b/src/liveChartSeriesEngineTick.test.ts
@@ -1,6 +1,6 @@
-import { tickLivelineEngineMultiFrame } from "./livelineEngineTickMulti";
+import { tickLiveChartSeriesEngineFrame } from "./liveChartSeriesEngineTick";
 
-describe("tickLivelineEngineMultiFrame", () => {
+describe("tickLiveChartSeriesEngineFrame", () => {
   function baseMulti(): {
     displayMin: number;
     displayMax: number;
@@ -21,7 +21,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("lerps per-series tips and updates combined Y-range", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -58,7 +58,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("excludes hidden series from Y-range", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -90,7 +90,7 @@ describe("tickLivelineEngineMultiFrame", () => {
   it("returns early when canvas size is zero", () => {
     const s = baseMulti();
     s.displayValues = [1, 2];
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 0,
       canvasHeight: 100,
@@ -111,7 +111,7 @@ describe("tickLivelineEngineMultiFrame", () => {
     const s = baseMulti();
     s.displayValues = [1, 2, 3];
     s.opacities = [1, 1, 1];
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -135,7 +135,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("expands Y-range with referenceValue outside data span", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -161,7 +161,7 @@ describe("tickLivelineEngineMultiFrame", () => {
     const s = baseMulti();
     s.displayMin = 0;
     s.displayMax = 500;
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -187,7 +187,7 @@ describe("tickLivelineEngineMultiFrame", () => {
     const s = baseMulti();
     s.displayMin = 0;
     s.displayMax = 500;
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -213,7 +213,7 @@ describe("tickLivelineEngineMultiFrame", () => {
     const s = baseMulti();
     s.displayMin = 100;
     s.displayMax = 200;
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -237,7 +237,7 @@ describe("tickLivelineEngineMultiFrame", () => {
   it("does not advance timestamp when paused", () => {
     const s = baseMulti();
     s.timestamp = 500;
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -263,7 +263,7 @@ describe("tickLivelineEngineMultiFrame", () => {
     const s = baseMulti();
     s.displayMin = 50;
     s.displayMax = 50;
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -286,7 +286,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("pulls reference line below data into tMin", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -309,7 +309,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("pulls reference line above data into tMax", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -332,7 +332,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("uses exaggerate margin factors when raw range is wide", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -359,7 +359,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("expands narrow raw range to minRange (symmetric pad)", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -382,7 +382,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("skips Y-range margin block when every series is hidden", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -408,7 +408,7 @@ describe("tickLivelineEngineMultiFrame", () => {
   it("uses Date.now when nowSeconds is omitted", () => {
     const nowSpy = jest.spyOn(Date, "now").mockReturnValue(3_000_000);
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -432,7 +432,7 @@ describe("tickLivelineEngineMultiFrame", () => {
 
   it("uses exaggerate minRange fallback when raw data range is zero", () => {
     const s = baseMulti();
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,
@@ -457,7 +457,7 @@ describe("tickLivelineEngineMultiFrame", () => {
     const s = baseMulti();
     s.displayMin = 0;
     s.displayMax = 10;
-    tickLivelineEngineMultiFrame(s, {
+    tickLiveChartSeriesEngineFrame(s, {
       dt: 16.67,
       canvasWidth: 200,
       canvasHeight: 100,

--- a/src/liveChartSeriesEngineTick.ts
+++ b/src/liveChartSeriesEngineTick.ts
@@ -1,6 +1,6 @@
 import { ADAPTIVE_SPEED_BOOST } from "./constants";
 import { lerp } from "./math/lerp";
-import type { LivelineSeries } from "./types";
+import type { SeriesConfig } from "./types";
 
 export interface MultiEngineTickMutable {
   displayMin: number;
@@ -19,7 +19,7 @@ export interface MultiEngineTickInput {
   smoothing: number;
   exaggerate: boolean;
   referenceValue: number | undefined;
-  series: LivelineSeries[];
+  series: SeriesConfig[];
   nowSeconds?: number;
   paused?: boolean;
 }
@@ -27,9 +27,9 @@ export interface MultiEngineTickInput {
 /**
  * Multi-series frame tick: lerps per-series tips and visibility opacities,
  * combines Y-range over visible series (same margin rules as single-series).
- * Used by `useLivelineMultiSeriesEngine`.
+ * Used by `useLiveChartSeriesEngine`.
  */
-export function tickLivelineEngineMultiFrame(
+export function tickLiveChartSeriesEngineFrame(
   state: MultiEngineTickMutable,
   input: MultiEngineTickInput,
 ): void {

--- a/src/math/interpolate.ts
+++ b/src/math/interpolate.ts
@@ -1,11 +1,11 @@
-import type { LivelinePoint } from "../types";
+import type { LiveChartPoint } from "../types";
 
 /**
  * Binary search to find interpolated value at a given time.
  * Returns null if time is outside data range.
  */
 export function interpolateAtTime(
-  points: LivelinePoint[],
+  points: LiveChartPoint[],
   time: number,
 ): number | null {
   "worklet";

--- a/src/math/momentum.ts
+++ b/src/math/momentum.ts
@@ -1,4 +1,4 @@
-import type { LivelinePoint, Momentum } from "../types";
+import type { LiveChartPoint, Momentum } from "../types";
 
 /**
  * Auto-detect momentum from recent data points.
@@ -6,7 +6,7 @@ import type { LivelinePoint, Momentum } from "../types";
  * but only the last 5 points for active velocity.
  */
 export function detectMomentum(
-  points: LivelinePoint[],
+  points: LiveChartPoint[],
   lookback = 20,
 ): Momentum {
   "worklet";

--- a/src/math/range.ts
+++ b/src/math/range.ts
@@ -1,11 +1,11 @@
-import type { LivelinePoint } from "../types";
+import type { LiveChartPoint } from "../types";
 
 /**
  * Compute visible Y range from data points + current value.
  * Returns { min, max } with margin applied.
  */
 export function computeRange(
-  visible: LivelinePoint[],
+  visible: LiveChartPoint[],
   currentValue: number,
   referenceValue?: number,
   exaggerate?: boolean,

--- a/src/math/squiggly.ts
+++ b/src/math/squiggly.ts
@@ -2,7 +2,7 @@ import type { ChartPadding } from "../draw/line";
 
 /**
  * Composite sine squiggly — two overlapping frequencies with a breathing
- * amplitude envelope. Matches the original web Liveline loading animation.
+ * amplitude envelope. Matches the original web LiveChart loading animation.
  *
  * amplitude = 14 * (0.4 + 0.6 * sin(0.8 * t))   // 5.6 → 22.4px breathing range
  * y = centerY + amplitude * (sin(0.035*x + 1.2*t) + 0.45*sin(0.08*x + 2.1*t))

--- a/src/multiSeriesLayout.test.ts
+++ b/src/multiSeriesLayout.test.ts
@@ -3,13 +3,13 @@ import {
   resolveMultiSeriesLineColorsSnapshot,
 } from "./multiSeriesLayout";
 
-import type { LivelineSeries } from "./types";
+import type { SeriesConfig } from "./types";
 import { MAX_MULTI_SERIES } from "./constants";
 import { SERIES_COLORS } from "./theme";
 
 describe("lineColorsSignatureFromArray", () => {
   it("joins id and color for each series", () => {
-    const a: LivelineSeries[] = [
+    const a: SeriesConfig[] = [
       { id: "a", data: [], value: 1, color: "#f00" },
       { id: "b", data: [], value: 2 },
     ];
@@ -19,7 +19,7 @@ describe("lineColorsSignatureFromArray", () => {
 
 describe("resolveMultiSeriesLineColorsSnapshot", () => {
   it("fills palette slots and pads with white", () => {
-    const a: LivelineSeries[] = [{ id: "a", data: [], value: 1 }];
+    const a: SeriesConfig[] = [{ id: "a", data: [], value: 1 }];
     const snap = resolveMultiSeriesLineColorsSnapshot(a, 3);
     expect(snap[0]).toBe("#3b82f6");
     expect(snap[1]).toBe("#ffffff");
@@ -27,7 +27,7 @@ describe("resolveMultiSeriesLineColorsSnapshot", () => {
   });
 
   it("uses explicit series color when set", () => {
-    const a: LivelineSeries[] = [
+    const a: SeriesConfig[] = [
       { id: "a", data: [], value: 1, color: "#abc" },
     ];
     expect(resolveMultiSeriesLineColorsSnapshot(a)[0]).toBe("#abc");
@@ -40,7 +40,7 @@ describe("resolveMultiSeriesLineColorsSnapshot", () => {
   });
 
   it("cycles SERIES_COLORS by index", () => {
-    const many: LivelineSeries[] = Array.from({ length: 3 }, (_, i) => ({
+    const many: SeriesConfig[] = Array.from({ length: 3 }, (_, i) => ({
       id: `${i}`,
       data: [],
       value: i,

--- a/src/multiSeriesLayout.ts
+++ b/src/multiSeriesLayout.ts
@@ -1,16 +1,16 @@
-import type { LivelineSeries } from "./types";
+import type { SeriesConfig } from "./types";
 import { MAX_MULTI_SERIES } from "./constants";
 import { SERIES_COLORS } from "./theme";
 
 /** Stable signature when series id/color change (not every data tick). */
-export function lineColorsSignatureFromArray(arr: LivelineSeries[]): string {
+export function lineColorsSignatureFromArray(arr: SeriesConfig[]): string {
   "worklet";
   return arr.map((x) => `${x.id}\x1f${x.color ?? ""}`).join("\x1e");
 }
 
 /** Per-slot stroke colors for chips + Skia (empty slots → white). */
 export function resolveMultiSeriesLineColorsSnapshot(
-  arr: LivelineSeries[],
+  arr: SeriesConfig[],
   maxSlots = MAX_MULTI_SERIES,
 ): string[] {
   return Array.from({ length: maxSlots }, (_, i) =>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,4 @@
-import type { LivelinePalette, LivelineSeries, ThemeMode } from "./types";
+import type { LiveChartPalette, SeriesConfig, ThemeMode } from "./types";
 
 /** Parse any CSS color string to [r, g, b]. Handles hex (#rgb, #rrggbb), rgb(), rgba(). */
 export function parseColorRgb(color: string): [number, number, number] {
@@ -25,7 +25,7 @@ function rgba(r: number, g: number, b: number, a: number): string {
  * Derive a full palette from a single accent color + theme mode.
  * Momentum colors are always semantic green/red regardless of accent.
  */
-export function resolveTheme(color: string, mode: ThemeMode): LivelinePalette {
+export function resolveTheme(color: string, mode: ThemeMode): LiveChartPalette {
   const [r, g, b] = parseColorRgb(color);
   const isDark = mode === "dark";
 
@@ -94,10 +94,10 @@ export const SERIES_COLORS = [
 
 /** Derive per-series palettes from series definitions. */
 export function resolveSeriesPalettes(
-  series: LivelineSeries[],
+  series: SeriesConfig[],
   mode: ThemeMode,
-): Map<string, LivelinePalette> {
-  const map = new Map<string, LivelinePalette>();
+): Map<string, LiveChartPalette> {
+  const map = new Map<string, LiveChartPalette>();
   for (let i = 0; i < series.length; i++) {
     const s = series[i];
     const color =

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
-export interface LivelinePoint {
+export interface LiveChartPoint {
   time: number;
   value: number;
 }
@@ -21,7 +21,6 @@ export type FontWeight =
   | "800"
   | "900";
 export type ThemeMode = "light" | "dark";
-export type WindowStyle = "default" | "rounded" | "text";
 export type BadgeVariant = "default" | "minimal";
 
 export interface ReferenceLine {
@@ -88,16 +87,6 @@ export interface ChartInsets {
   left?: number;
 }
 
-export interface WindowOption {
-  label: string;
-  secs: number;
-}
-
-export interface OrderbookData {
-  bids: [number, number][];
-  asks: [number, number][];
-}
-
 export interface TradeEvent {
   side: "buy" | "sell";
   price: number;
@@ -146,9 +135,9 @@ export interface DegenOptions {
   colors?: string | string[];
 }
 
-export interface LivelineSeries {
+export interface SeriesConfig {
   id: string;
-  data: LivelinePoint[];
+  data: LiveChartPoint[];
   value: number;
   color?: string;
   label?: string;
@@ -184,7 +173,7 @@ export interface CandlePoint {
   close: number;
 }
 
-export interface LivelineCoreProps {
+export interface LiveChartCoreProps {
   theme?: ThemeMode;
   accentColor?: string;
   font?: FontConfig;
@@ -205,15 +194,12 @@ export interface LivelineCoreProps {
   line?: LineConfig;
 }
 
-export interface LivelineSingleProps extends LivelineCoreProps {
+export interface LiveChartProps extends LiveChartCoreProps {
   gradient?: boolean | GradientConfig;
   badge?: boolean | BadgeConfig;
   momentum?: boolean | Momentum;
   pulse?: boolean | PulseConfig;
   valueLine?: boolean | ValueLineConfig;
-  windows?: WindowOption[];
-  windowStyle?: WindowStyle;
-  onWindowChange?: (secs: number) => void;
 
   // ── Candlestick mode ──────────────────────────────────────────────────
   /** Chart display mode (default `"line"`). `"candle"` renders OHLC bars. */
@@ -224,16 +210,6 @@ export interface LivelineSingleProps extends LivelineCoreProps {
   candleWidth?: number;
   /** In-progress candle updated each tick. Must be a SharedValue for UI-thread reads. */
   liveCandle?: SharedValue<CandlePoint | null>;
-  /** Morph candles into a line display (future — not wired in Phase 10). */
-  lineMode?: boolean;
-  /** Tick-level data for line-mode density during morph (future — not wired in Phase 10). */
-  lineData?: LivelinePoint[];
-  /** Current tick value for line-mode morph (future — not wired in Phase 10). */
-  lineValue?: number;
-  /** Callback when the built-in line/candle toggle fires (future — no built-in UI in Phase 10). */
-  onModeChange?: (mode: "line" | "candle") => void;
-
-  orderbook?: OrderbookData;
   /**
    * Live trade fills for optional on-chart markers. Read on the UI thread only —
    * pass a `SharedValue` and update from JS via `.value` (same pattern as `data` / `value`).
@@ -241,19 +217,19 @@ export interface LivelineSingleProps extends LivelineCoreProps {
   tradeStream?: SharedValue<TradeEvent[]>;
   /** Particle burst + chart shake on momentum swings (`true` = defaults, or pass `DegenOptions`). */
   degen?: boolean | DegenOptions;
-  data: SharedValue<LivelinePoint[]>;
+  data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   onScrub?: (point: ScrubPoint | null) => void;
 }
 
-export interface LivelineMultiProps extends LivelineCoreProps {
-  series: SharedValue<LivelineSeries[]>;
+export interface LiveChartSeriesProps extends LiveChartCoreProps {
+  series: SharedValue<SeriesConfig[]>;
   onSeriesToggle?: (id: string, visible: boolean) => void;
   seriesToggleCompact?: boolean;
   onScrub?: (point: ScrubPointMulti | null) => void;
 }
 
-export interface LivelinePalette {
+export interface LiveChartPalette {
   line: string;
   lineWidth: number;
 
@@ -299,17 +275,3 @@ export interface LivelinePalette {
   badgeFontSize: number;
 }
 
-export interface ChartLayout {
-  w: number;
-  h: number;
-  pad: Required<ChartInsets>;
-  chartW: number;
-  chartH: number;
-  leftEdge: number;
-  rightEdge: number;
-  minVal: number;
-  maxVal: number;
-  valRange: number;
-  toX: (t: number) => number;
-  toY: (v: number) => number;
-}

--- a/src/useLiveChartEngine.test.tsx
+++ b/src/useLiveChartEngine.test.tsx
@@ -1,12 +1,12 @@
 import { renderHook } from "@testing-library/react-native";
 import { useSharedValue } from "react-native-reanimated";
 import {
-  applyLivelineEngineFrame,
+  applyLiveChartEngineFrame,
   type EngineFrameRefs,
-  useLivelineEngine,
-} from "./useLivelineEngine";
+  useLiveChartEngine,
+} from "./useLiveChartEngine";
 
-describe("applyLivelineEngineFrame", () => {
+describe("applyLiveChartEngineFrame", () => {
   it("runs tick and writes shared values", () => {
     const sv = {
       data: { value: [{ time: 1700000000, value: 10 }] },
@@ -25,7 +25,7 @@ describe("applyLivelineEngineFrame", () => {
       pausedSV: { value: false },
       modeSV: { value: "line" as const },
     };
-    applyLivelineEngineFrame(
+    applyLiveChartEngineFrame(
       { timeSincePreviousFrame: 16.67 },
       sv as unknown as EngineFrameRefs,
     );
@@ -33,12 +33,12 @@ describe("applyLivelineEngineFrame", () => {
   });
 });
 
-describe("useLivelineEngine", () => {
+describe("useLiveChartEngine", () => {
   it("returns shared engine state", () => {
     const { result } = renderHook(() => {
       const data = useSharedValue([{ time: 1700000000, value: 1 }]);
       const value = useSharedValue(1);
-      return useLivelineEngine({
+      return useLiveChartEngine({
         data,
         value,
         timeWindow: 30,
@@ -56,7 +56,7 @@ describe("useLivelineEngine", () => {
     const { result } = renderHook(() => {
       const data = useSharedValue([{ time: 1700000000, value: 1 }]);
       const value = useSharedValue(1);
-      return useLivelineEngine({
+      return useLiveChartEngine({
         data,
         value,
         timeWindow: 30,

--- a/src/useLiveChartEngine.ts
+++ b/src/useLiveChartEngine.ts
@@ -4,11 +4,11 @@ import {
   useSharedValue,
   type SharedValue,
 } from "react-native-reanimated";
-import { tickLivelineEngineFrame } from "./livelineEngineTick";
-import type { CandlePoint, LivelinePoint, LivelineSeries } from "./types";
+import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
+import type { CandlePoint, LiveChartPoint, SeriesConfig } from "./types";
 
 export interface EngineConfig {
-  data: SharedValue<LivelinePoint[]>;
+  data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   timeWindow: number;
   smoothing: number;
@@ -31,16 +31,16 @@ export interface ChartEngineLayout {
 }
 
 export interface SingleEngineState extends ChartEngineLayout {
-  data: SharedValue<LivelinePoint[]>;
+  data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   displayValue: SharedValue<number>;
 }
 
 export interface MultiEngineState extends ChartEngineLayout {
-  data: SharedValue<LivelinePoint[]>;
+  data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   displayValue: SharedValue<number>;
-  series: SharedValue<LivelineSeries[]>;
+  series: SharedValue<SeriesConfig[]>;
   displaySeriesValues: SharedValue<number[]>;
   seriesOpacities: SharedValue<number[]>;
 }
@@ -53,7 +53,7 @@ export type ChartEngineWithLiveValue = ChartEngineLayout & {
 };
 
 export interface EngineFrameRefs {
-  data: SharedValue<LivelinePoint[]>;
+  data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   displayValue: SharedValue<number>;
   displayMin: SharedValue<number>;
@@ -74,9 +74,9 @@ export interface EngineFrameRefs {
 
 /**
  * Shared between the `useFrameCallback` worklet and unit tests.
- * Mutates shared values from a snapshot tick (`tickLivelineEngineFrame`).
+ * Mutates shared values from a snapshot tick (`tickLiveChartEngineFrame`).
  */
-export function applyLivelineEngineFrame(
+export function applyLiveChartEngineFrame(
   frameInfo: { timeSincePreviousFrame?: number | null },
   sv: EngineFrameRefs,
 ): void {
@@ -89,7 +89,7 @@ export function applyLivelineEngineFrame(
     displayWindow: sv.displayWindow.value,
     timestamp: sv.timestamp.value,
   };
-  tickLivelineEngineFrame(state, {
+  tickLiveChartEngineFrame(state, {
     dt,
     canvasWidth: sv.canvasWidth.value,
     canvasHeight: sv.canvasHeight.value,
@@ -112,7 +112,7 @@ export function applyLivelineEngineFrame(
   sv.timestamp.value = state.timestamp;
 }
 
-export function useLivelineEngine(config: EngineConfig): SingleEngineState {
+export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   // Low-frequency config → UI thread via useDerivedValue
   const timeWindow = useDerivedValue(() => config.timeWindow);
   const smoothing = useDerivedValue(() => config.smoothing);
@@ -136,7 +136,7 @@ export function useLivelineEngine(config: EngineConfig): SingleEngineState {
 
   useFrameCallback((frameInfo) => {
     "worklet";
-    applyLivelineEngineFrame(frameInfo, {
+    applyLiveChartEngineFrame(frameInfo, {
       data,
       value,
       displayValue,

--- a/src/useLiveChartSeriesEngine.test.tsx
+++ b/src/useLiveChartSeriesEngine.test.tsx
@@ -1,13 +1,13 @@
 import { renderHook } from "@testing-library/react-native";
 import { useSharedValue } from "react-native-reanimated";
-import type { LivelineSeries } from "./types";
+import type { SeriesConfig } from "./types";
 import {
-  applyLivelineEngineMultiFrame,
+  applyLiveChartSeriesEngineFrame,
   type MultiEngineFrameRefs,
-  useLivelineMultiSeriesEngine,
-} from "./useLivelineMultiSeriesEngine";
+  useLiveChartSeriesEngine,
+} from "./useLiveChartSeriesEngine";
 
-describe("applyLivelineEngineMultiFrame", () => {
+describe("applyLiveChartSeriesEngineFrame", () => {
   it("runs multi tick and writes shared values", () => {
     const sv = {
       series: {
@@ -34,7 +34,7 @@ describe("applyLivelineEngineMultiFrame", () => {
       referenceValue: { value: undefined as number | undefined },
       pausedSV: { value: false },
     };
-    applyLivelineEngineMultiFrame(
+    applyLiveChartSeriesEngineFrame(
       { timeSincePreviousFrame: 16.67 },
       sv as unknown as MultiEngineFrameRefs,
     );
@@ -42,10 +42,10 @@ describe("applyLivelineEngineMultiFrame", () => {
   });
 });
 
-describe("useLivelineMultiSeriesEngine", () => {
+describe("useLiveChartSeriesEngine", () => {
   it("returns engine state with series arrays", () => {
     const { result } = renderHook(() => {
-      const series = useSharedValue<LivelineSeries[]>([
+      const series = useSharedValue<SeriesConfig[]>([
         {
           id: "a",
           data: [{ time: 1_700_000_000, value: 1 }],
@@ -53,7 +53,7 @@ describe("useLivelineMultiSeriesEngine", () => {
           color: "#3b82f6",
         },
       ]);
-      return useLivelineMultiSeriesEngine({
+      return useLiveChartSeriesEngine({
         series,
         timeWindow: 30,
         smoothing: 0.08,

--- a/src/useLiveChartSeriesEngine.ts
+++ b/src/useLiveChartSeriesEngine.ts
@@ -4,12 +4,12 @@ import {
   useSharedValue,
   type SharedValue,
 } from "react-native-reanimated";
-import { tickLivelineEngineMultiFrame } from "./livelineEngineTickMulti";
-import type { LivelinePoint, LivelineSeries } from "./types";
-import type { MultiEngineState } from "./useLivelineEngine";
+import { tickLiveChartSeriesEngineFrame } from "./liveChartSeriesEngineTick";
+import type { LiveChartPoint, SeriesConfig } from "./types";
+import type { MultiEngineState } from "./useLiveChartEngine";
 
 export interface MultiSeriesEngineConfig {
-  series: SharedValue<LivelineSeries[]>;
+  series: SharedValue<SeriesConfig[]>;
   timeWindow: number;
   smoothing: number;
   exaggerate?: boolean;
@@ -18,7 +18,7 @@ export interface MultiSeriesEngineConfig {
 }
 
 export interface MultiEngineFrameRefs {
-  series: SharedValue<LivelineSeries[]>;
+  series: SharedValue<SeriesConfig[]>;
   displaySeriesValues: SharedValue<number[]>;
   seriesOpacities: SharedValue<number[]>;
   displayMin: SharedValue<number>;
@@ -34,7 +34,7 @@ export interface MultiEngineFrameRefs {
   pausedSV: SharedValue<boolean>;
 }
 
-export function applyLivelineEngineMultiFrame(
+export function applyLiveChartSeriesEngineFrame(
   frameInfo: { timeSincePreviousFrame?: number | null },
   sv: MultiEngineFrameRefs,
 ): void {
@@ -51,7 +51,7 @@ export function applyLivelineEngineMultiFrame(
     displayValues,
     opacities,
   };
-  tickLivelineEngineMultiFrame(state, {
+  tickLiveChartSeriesEngineFrame(state, {
     dt,
     canvasWidth: sv.canvasWidth.value,
     canvasHeight: sv.canvasHeight.value,
@@ -75,7 +75,7 @@ export function applyLivelineEngineMultiFrame(
  * UI-thread engine for multi-series charts. Dummies `data` / `value` / `displayValue`
  * mirror single-series fields for hooks that still read them.
  */
-export function useLivelineMultiSeriesEngine(
+export function useLiveChartSeriesEngine(
   config: MultiSeriesEngineConfig,
 ): MultiEngineState {
   const timeWindow = useDerivedValue(() => config.timeWindow);
@@ -94,7 +94,7 @@ export function useLivelineMultiSeriesEngine(
   const displaySeriesValues = useSharedValue<number[]>([]);
   const seriesOpacities = useSharedValue<number[]>([]);
 
-  const data = useSharedValue<LivelinePoint[]>([]);
+  const data = useSharedValue<LiveChartPoint[]>([]);
   const value = useSharedValue(0);
   const displayValue = useSharedValue(0);
 
@@ -102,7 +102,7 @@ export function useLivelineMultiSeriesEngine(
 
   useFrameCallback((frameInfo) => {
     "worklet";
-    applyLivelineEngineMultiFrame(frameInfo, {
+    applyLiveChartSeriesEngineFrame(frameInfo, {
       series,
       displaySeriesValues,
       seriesOpacities,


### PR DESCRIPTION
### TL;DR

Renamed the library from "react-native-liveline" to "react-native-livechart" across all files and components.

### What changed?

- Updated package name from `react-native-liveline` to `react-native-livechart` in package.json and app.json
- Renamed main components from `Liveline` and `LivelineMulti` to `LiveChart` and `LiveChartSeries`
- Updated all type definitions to use `LiveChart` prefix instead of `Liveline` (e.g., `LivelinePoint` → `LiveChartPoint`, `LivelineSeries` → `SeriesConfig`)
- Renamed core engine hooks from `useLivelineEngine` to `useLiveChartEngine` and related multi-series variants
- Updated all internal function names, file names, and references to use the new naming convention
- Changed bundle identifiers and app schemes to reflect the new name

### How to test?

1. Install dependencies with the new package name
2. Import components using the new names: `import { LiveChart, LiveChartSeries } from 'react-native-livechart'`
3. Verify that all existing functionality works with the renamed components
4. Run the test suite to ensure all tests pass with the new naming

### Why make this change?

This appears to be a rebranding effort to better reflect the library's purpose as a comprehensive charting solution rather than just line charts, making the name more descriptive and marketable.