### PR TITLE
feat: demo screens

### DIFF
--- a/app/demo/_layout.tsx
+++ b/app/demo/_layout.tsx
@@ -1,0 +1,21 @@
+import { Stack } from "expo-router";
+
+const headerBg = "rgb(10, 10, 10)";
+
+export default function DemoLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerStyle: { backgroundColor: headerBg },
+        headerTintColor: "#fff",
+        headerTitleStyle: {
+          color: "#fff",
+          fontFamily: "monospace",
+          fontSize: 15,
+        },
+        contentStyle: { backgroundColor: headerBg },
+      }}
+    />
+  );
+}

--- a/app/demo/_lib/DemoScreen.tsx
+++ b/app/demo/_lib/DemoScreen.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { ScrollView, Text, View, type ViewStyle } from "react-native";
+import { demoStyles } from "./styles";
+
+type DemoScreenProps = {
+  title?: string;
+  description?: string;
+  chart: ReactNode;
+  chartWrapperStyle?: ViewStyle;
+  children?: ReactNode;
+};
+
+export function DemoScreen({
+  title,
+  description,
+  chart,
+  chartWrapperStyle,
+  children,
+}: DemoScreenProps) {
+  return (
+    <View style={demoStyles.demoRoot}>
+      {title ? <Text style={demoStyles.demoTitle}>{title}</Text> : null}
+      {description ? (
+        <Text style={demoStyles.demoDesc}>{description}</Text>
+      ) : null}
+      <View style={[demoStyles.chartContainer, chartWrapperStyle]}>
+        {chart}
+      </View>
+      <ScrollView
+        style={demoStyles.controlsScroll}
+        contentContainerStyle={demoStyles.controls}
+      >
+        {children}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/demo/_lib/shared.ts
+++ b/app/demo/_lib/shared.ts
@@ -1,0 +1,49 @@
+import type { VolatilityMode } from "../../../sim/generators";
+import type { TradeSource } from "../../../sim/useSimulatedData";
+
+export const ACCENT = "#3b82f6";
+
+export const TIME_WINDOWS: { label: string; secs: number }[] = [
+  { label: "30s", secs: 30 },
+  { label: "1m", secs: 60 },
+  { label: "5m", secs: 300 },
+  { label: "1h", secs: 3_600 },
+  { label: "24h", secs: 86_400 },
+];
+
+export const VOLATILITY_MODES: VolatilityMode[] = [
+  "calm",
+  "normal",
+  "volatile",
+  "chaotic",
+];
+
+export const TRADE_SOURCES: TradeSource[] = ["orderbook", "bonding-curve"];
+
+export const PRICE_RANGES: { label: string; value: number }[] = [
+  { label: "0.001", value: 0.001 },
+  { label: "0.5", value: 0.5 },
+  { label: "50", value: 50 },
+  { label: "100", value: 100 },
+  { label: "1K", value: 1_000 },
+  { label: "10K", value: 10_000 },
+  { label: "67.5K", value: 67_500 },
+  { label: "100K", value: 100_000 },
+  { label: "1M", value: 1_000_000 },
+  { label: "10M", value: 10_000_000 },
+  { label: "100M", value: 100_000_000 },
+];
+
+export const SMOOTHING_PRESETS: { label: string; value: number }[] = [
+  { label: "Sharp", value: 0 },
+  { label: "Default", value: 0.08 },
+  { label: "Smooth", value: 0.5 },
+];
+
+export const ACCENT_PRESETS = [
+  "#3b82f6",
+  "#22c55e",
+  "#eab308",
+  "#ef4444",
+  "#a855f7",
+];

--- a/app/demo/_lib/styles.ts
+++ b/app/demo/_lib/styles.ts
@@ -1,0 +1,80 @@
+import { StyleSheet } from "react-native";
+
+export const demoStyles = StyleSheet.create({
+  demoRoot: {
+    flex: 1,
+    backgroundColor: "rgb(10, 10, 10)",
+  },
+  demoTitle: {
+    color: "rgba(255,255,255,0.45)",
+    fontSize: 12,
+    fontFamily: "monospace",
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    marginBottom: 4,
+  },
+  demoDesc: {
+    color: "rgba(255,255,255,0.35)",
+    fontSize: 11,
+    fontFamily: "monospace",
+    paddingHorizontal: 16,
+    marginBottom: 8,
+    lineHeight: 16,
+  },
+  chartContainer: {
+    height: 300,
+    marginHorizontal: 12,
+  },
+  chartContainerFlex: {
+    flex: 1,
+    marginHorizontal: 12,
+    minHeight: 120,
+  },
+  controlsScroll: {
+    flex: 1,
+  },
+  controls: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 40,
+  },
+  sectionLabel: {
+    color: "rgba(255,255,255,0.4)",
+    fontSize: 11,
+    fontFamily: "monospace",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 8,
+    marginTop: 14,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
+    marginBottom: 8,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: "rgba(255,255,255,0.06)",
+  },
+  chipActive: {
+    backgroundColor: "#3b82f6",
+  },
+  chipText: {
+    color: "rgba(255,255,255,0.6)",
+    fontSize: 13,
+    fontFamily: "monospace",
+  },
+  chipTextActive: {
+    color: "#fff",
+  },
+  scrubReadout: {
+    color: "rgba(255,255,255,0.55)",
+    fontSize: 12,
+    fontFamily: "monospace",
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+});

--- a/app/demo/appearance.tsx
+++ b/app/demo/appearance.tsx
@@ -1,0 +1,254 @@
+import { Platform, Pressable, Text, View } from "react-native";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import type { FontWeight } from "../../src/types";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT_PRESETS } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Appearance" };
+
+const FONT_SIZES = [10, 11, 13, 15] as const;
+const WEIGHTS: FontWeight[] = ["normal", "600", "bold"];
+
+export default function AppearanceScreen() {
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [accent, setAccent] = useState(ACCENT_PRESETS[0]);
+  const [gradientOn, setGradientOn] = useState(true);
+  const [gradientCfg, setGradientCfg] = useState(false);
+  const [lineWide, setLineWide] = useState(false);
+  const [lineColor, setLineColor] = useState(false);
+  const [fontSize, setFontSize] = useState(11);
+  const [fontWeight, setFontWeight] = useState<FontWeight>("normal");
+  const [roundedStyle, setRoundedStyle] = useState(false);
+
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+  });
+
+  const fontFamily = Platform.select({
+    ios: "Menlo",
+    default: "monospace",
+  }) as string;
+
+  return (
+    <DemoScreen
+      description="theme, accent, gradient, line, font, container style"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={accent}
+          theme={theme}
+          gradient={
+            gradientCfg ? { topOpacity: 0.5, bottomOpacity: 0.05 } : gradientOn
+          }
+          line={
+            lineWide || lineColor
+              ? {
+                  width: lineWide ? 4 : 2,
+                  color: lineColor ? "#f472b6" : undefined,
+                }
+              : undefined
+          }
+          font={{
+            fontFamily,
+            fontSize,
+            fontWeight,
+          }}
+          style={
+            roundedStyle
+              ? {
+                  borderRadius: 16,
+                  overflow: "hidden",
+                  margin: 4,
+                }
+              : undefined
+          }
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Theme</Text>
+      <View style={demoStyles.buttonRow}>
+        {(["dark", "light"] as const).map((t) => (
+          <Pressable
+            key={t}
+            style={[demoStyles.chip, theme === t && demoStyles.chipActive]}
+            onPress={() => setTheme(t)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                theme === t && demoStyles.chipTextActive,
+              ]}
+            >
+              {t}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Accent</Text>
+      <View style={demoStyles.buttonRow}>
+        {ACCENT_PRESETS.map((c) => (
+          <Pressable
+            key={c}
+            style={[demoStyles.chip, accent === c && demoStyles.chipActive]}
+            onPress={() => setAccent(c)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                accent === c && demoStyles.chipTextActive,
+              ]}
+            >
+              {c}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Gradient</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[
+            demoStyles.chip,
+            gradientOn && !gradientCfg && demoStyles.chipActive,
+          ]}
+          onPress={() => {
+            setGradientOn(true);
+            setGradientCfg(false);
+          }}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              gradientOn && !gradientCfg && demoStyles.chipTextActive,
+            ]}
+          >
+            On
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, !gradientOn && demoStyles.chipActive]}
+          onPress={() => {
+            setGradientOn(false);
+            setGradientCfg(false);
+          }}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              !gradientOn && demoStyles.chipTextActive,
+            ]}
+          >
+            Off
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, gradientCfg && demoStyles.chipActive]}
+          onPress={() => {
+            setGradientOn(true);
+            setGradientCfg(true);
+          }}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              gradientCfg && demoStyles.chipTextActive,
+            ]}
+          >
+            Custom opacity
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Line</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, lineWide && demoStyles.chipActive]}
+          onPress={() => setLineWide((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, lineWide && demoStyles.chipTextActive]}
+          >
+            Thick stroke
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, lineColor && demoStyles.chipActive]}
+          onPress={() => setLineColor((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              lineColor && demoStyles.chipTextActive,
+            ]}
+          >
+            Pink color
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Font</Text>
+      <View style={demoStyles.buttonRow}>
+        {FONT_SIZES.map((s) => (
+          <Pressable
+            key={s}
+            style={[demoStyles.chip, fontSize === s && demoStyles.chipActive]}
+            onPress={() => setFontSize(s)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                fontSize === s && demoStyles.chipTextActive,
+              ]}
+            >
+              {s}px
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+      <View style={demoStyles.buttonRow}>
+        {WEIGHTS.map((w) => (
+          <Pressable
+            key={w}
+            style={[demoStyles.chip, fontWeight === w && demoStyles.chipActive]}
+            onPress={() => setFontWeight(w)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                fontWeight === w && demoStyles.chipTextActive,
+              ]}
+            >
+              {w}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Container style</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, roundedStyle && demoStyles.chipActive]}
+          onPress={() => setRoundedStyle((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              roundedStyle && demoStyles.chipTextActive,
+            ]}
+          >
+            Rounded + margin
+          </Text>
+        </Pressable>
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/axes-insets.tsx
+++ b/app/demo/axes-insets.tsx
@@ -1,0 +1,185 @@
+import { Pressable, Text, View } from "react-native";
+import { LiveChart, LiveChartSeries } from "../../src";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import type { ChartInsets } from "../../src/types";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Axes & insets" };
+
+type AxisVis = "both" | "noY" | "noX" | "none";
+type InsetPreset = "default" | "tight" | "loose";
+type GapPreset = "default" | "wide";
+
+const INSETS: Record<InsetPreset, ChartInsets | undefined> = {
+  default: undefined,
+  tight: { top: 6, bottom: 16, left: 6, right: 6 },
+  loose: { top: 20, bottom: 40, left: 20, right: 20 },
+};
+
+export default function AxesInsetsScreen() {
+  const [vis, setVis] = useState<AxisVis>("both");
+  const [insets, setInsets] = useState<InsetPreset>("default");
+  const [gap, setGap] = useState<GapPreset>("default");
+  const [which, setWhich] = useState<"single" | "multi">("single");
+
+  const yOn = vis !== "noY" && vis !== "none";
+  const xOn = vis !== "noX" && vis !== "none";
+
+  const yAxis = !yOn ? false : gap === "wide" ? { minGap: 72 } : true;
+  const xAxis = !xOn ? false : gap === "wide" ? { minGap: 100 } : true;
+
+  const { data, value, series } = useSimulatedData({
+    multiSeries: which === "multi",
+    candleAggregation: false,
+    tradeStream: false,
+  });
+
+  const insetCfg = INSETS[insets];
+
+  return (
+    <DemoScreen
+      description="Hide Y, X, or both; minGap; insets. Toggle single vs multi chart."
+      chart={
+        which === "single" ? (
+          <LiveChart
+            data={data}
+            value={value}
+            accentColor={ACCENT}
+            theme="dark"
+            yAxis={yAxis}
+            xAxis={xAxis}
+            insets={insetCfg}
+            scrub
+          />
+        ) : (
+          <LiveChartSeries
+            series={series}
+            accentColor={ACCENT}
+            theme="dark"
+            yAxis={yAxis}
+            xAxis={xAxis}
+            insets={insetCfg}
+            scrub
+          />
+        )
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Chart</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, which === "single" && demoStyles.chipActive]}
+          onPress={() => setWhich("single")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              which === "single" && demoStyles.chipTextActive,
+            ]}
+          >
+            LiveChart
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, which === "multi" && demoStyles.chipActive]}
+          onPress={() => setWhich("multi")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              which === "multi" && demoStyles.chipTextActive,
+            ]}
+          >
+            LiveChartSeries
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Axis visibility</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["both", "Both on"],
+            ["noY", "Hide Y"],
+            ["noX", "Hide X"],
+            ["none", "Hide both"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, vis === k && demoStyles.chipActive]}
+            onPress={() => setVis(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                vis === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Axis minGap (when shown)</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, gap === "default" && demoStyles.chipActive]}
+          onPress={() => setGap("default")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              gap === "default" && demoStyles.chipTextActive,
+            ]}
+          >
+            Default
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, gap === "wide" && demoStyles.chipActive]}
+          onPress={() => setGap("wide")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              gap === "wide" && demoStyles.chipTextActive,
+            ]}
+          >
+            Wide minGap
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Insets</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["default", "Default"],
+            ["tight", "Tight"],
+            ["loose", "Loose"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, insets === k && demoStyles.chipActive]}
+            onPress={() => setInsets(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                insets === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/badge-pulse.tsx
+++ b/app/demo/badge-pulse.tsx
@@ -1,0 +1,123 @@
+import { Pressable, Text, View } from "react-native";
+import type { BadgeConfig, PulseConfig } from "../../src/types";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Badge & pulse" };
+
+type BadgeMode = "on" | "off" | "left" | "minimal" | "noTail" | "customBg";
+
+function resolveBadge(mode: BadgeMode): boolean | BadgeConfig {
+  switch (mode) {
+    case "off":
+      return false;
+    case "on":
+      return true;
+    case "left":
+      return { position: "left" };
+    case "minimal":
+      return { variant: "minimal" };
+    case "noTail":
+      return { tail: false };
+    case "customBg":
+      return { background: "rgba(168,85,247,0.9)" };
+    default:
+      return true;
+  }
+}
+
+type PulseMode = "on" | "off" | "custom";
+
+function resolvePulse(mode: PulseMode): boolean | PulseConfig {
+  if (mode === "off") return false;
+  if (mode === "on") return true;
+  return { interval: 900, maxRadius: 28, duration: 1200, opacity: 0.55 };
+}
+
+export default function BadgePulseScreen() {
+  const [badgeMode, setBadgeMode] = useState<BadgeMode>("on");
+  const [pulseMode, setPulseMode] = useState<PulseMode>("on");
+
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+  });
+
+  return (
+    <DemoScreen
+      description="badge variants and pulse / PulseConfig"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          badge={resolveBadge(badgeMode)}
+          pulse={resolvePulse(pulseMode)}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Badge</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["on", "Default"],
+            ["off", "Off"],
+            ["left", "Left"],
+            ["minimal", "Minimal"],
+            ["noTail", "No tail"],
+            ["customBg", "Purple bg"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, badgeMode === k && demoStyles.chipActive]}
+            onPress={() => setBadgeMode(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                badgeMode === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Pulse</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["on", "Default"],
+            ["off", "Off"],
+            ["custom", "Fast / large"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, pulseMode === k && demoStyles.chipActive]}
+            onPress={() => setPulseMode(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                pulseMode === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -1,0 +1,65 @@
+import { Pressable, Text, View } from "react-native";
+import { ACCENT, TIME_WINDOWS } from "./_lib/shared";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Candlestick" };
+
+export default function CandlestickScreen() {
+  const [windowSecs, setWindowSecs] = useState(300);
+  const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
+
+  const { data, value, candles, liveCandle } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: true,
+    tradeStream: false,
+    candleWidth: candleWidthSecs,
+  });
+
+  return (
+    <DemoScreen
+      description={`mode=candle, candleWidth=${candleWidthSecs}s (from window)`}
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          mode="candle"
+          candles={candles}
+          liveCandle={liveCandle}
+          candleWidth={candleWidthSecs}
+          accentColor={ACCENT}
+          theme="dark"
+          timeWindow={windowSecs}
+          scrub={{ tooltip: true }}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Time window</Text>
+      <View style={demoStyles.buttonRow}>
+        {TIME_WINDOWS.map((w) => (
+          <Pressable
+            key={w.label}
+            style={[
+              demoStyles.chip,
+              windowSecs === w.secs && demoStyles.chipActive,
+            ]}
+            onPress={() => setWindowSecs(w.secs)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                windowSecs === w.secs && demoStyles.chipTextActive,
+              ]}
+            >
+              {w.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/chart-size.tsx
+++ b/app/demo/chart-size.tsx
@@ -1,0 +1,128 @@
+import { Pressable, Text, View } from "react-native";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { ACCENT } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Chart size" };
+
+const HEIGHTS = [120, 220, 300, 420] as const;
+
+export default function ChartSizeScreen() {
+  const [h, setH] = useState<(typeof HEIGHTS)[number]>(300);
+  const [narrow, setNarrow] = useState(false);
+  const [flexFill, setFlexFill] = useState(false);
+
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+  });
+
+  const chart = (
+    <LiveChart
+      data={data}
+      value={value}
+      accentColor={ACCENT}
+      theme="dark"
+      scrub
+      style={flexFill ? { flex: 1 } : undefined}
+    />
+  );
+
+  return (
+    <View style={demoStyles.demoRoot}>
+      <Text style={demoStyles.demoDesc}>
+        Fixed heights, narrow card width, or flex fill inside a fixed outer box.
+      </Text>
+
+      {flexFill ? (
+        <View
+          style={{
+            height: 360,
+            marginHorizontal: narrow ? 40 : 12,
+            marginBottom: 8,
+          }}
+        >
+          {chart}
+        </View>
+      ) : (
+        <View
+          style={{
+            height: h,
+            marginHorizontal: narrow ? 40 : 12,
+            marginBottom: 8,
+          }}
+        >
+          {chart}
+        </View>
+      )}
+
+      <Text style={[demoStyles.sectionLabel, { paddingHorizontal: 16 }]}>
+        Height
+      </Text>
+      <View style={[demoStyles.buttonRow, { paddingHorizontal: 16 }]}>
+        {HEIGHTS.map((px) => (
+          <Pressable
+            key={px}
+            style={[
+              demoStyles.chip,
+              !flexFill && h === px && demoStyles.chipActive,
+            ]}
+            onPress={() => {
+              setFlexFill(false);
+              setH(px);
+            }}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                !flexFill && h === px && demoStyles.chipTextActive,
+              ]}
+            >
+              {px}px
+            </Text>
+          </Pressable>
+        ))}
+        <Pressable
+          style={[demoStyles.chip, flexFill && demoStyles.chipActive]}
+          onPress={() => setFlexFill(true)}
+        >
+          <Text
+            style={[demoStyles.chipText, flexFill && demoStyles.chipTextActive]}
+          >
+            Flex in 360px box
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={[demoStyles.sectionLabel, { paddingHorizontal: 16 }]}>
+        Width
+      </Text>
+      <View style={[demoStyles.buttonRow, { paddingHorizontal: 16 }]}>
+        <Pressable
+          style={[demoStyles.chip, !narrow && demoStyles.chipActive]}
+          onPress={() => setNarrow(false)}
+        >
+          <Text
+            style={[demoStyles.chipText, !narrow && demoStyles.chipTextActive]}
+          >
+            Full margin (12)
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, narrow && demoStyles.chipActive]}
+          onPress={() => setNarrow(true)}
+        >
+          <Text
+            style={[demoStyles.chipText, narrow && demoStyles.chipTextActive]}
+          >
+            Card (40+40 inset)
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/app/demo/degen.tsx
+++ b/app/demo/degen.tsx
@@ -1,0 +1,141 @@
+import { Pressable, Text, View } from "react-native";
+import { ACCENT, VOLATILITY_MODES } from "./_lib/shared";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import type { DegenOptions } from "../../src/types";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Degen" };
+
+type Preset =
+  | "off"
+  | "on"
+  | "minimal"
+  | "heavy"
+  | "noShake"
+  | "downToo"
+  | "customParticles";
+
+function degenFor(p: Preset): boolean | DegenOptions | undefined {
+  switch (p) {
+    case "off":
+      return undefined;
+    case "on":
+      return true;
+    case "minimal":
+      return {
+        scale: 0.65,
+        burstParticleCount: 8,
+        particleBurstDurationSec: 0.6,
+        shakeIntensity: 0.5,
+      };
+    case "heavy":
+      return {
+        scale: 1.35,
+        burstParticleCount: 36,
+        particleBurstDurationSec: 1.4,
+        shakeIntensity: 1.2,
+        particleOpacity: 0.7,
+        spreadAngle: Math.PI * 1.35,
+      };
+    case "noShake":
+      return { shake: false, scale: 1.1 };
+    case "downToo":
+      return { downMomentum: true };
+    case "customParticles":
+      return {
+        particleSizeMin: 2,
+        particleSizeMax: 5,
+        drag: 0.88,
+        speedMin: 40,
+        speedMax: 200,
+        positionJitterX: 40,
+        positionJitterY: 14,
+        colors: ["#f472b6", "#22d3ee", "#fde047"],
+      };
+    default:
+      return undefined;
+  }
+}
+
+export default function DegenScreen() {
+  const [preset, setPreset] = useState<Preset>("on");
+  const [vol, setVol] = useState<(typeof VOLATILITY_MODES)[number]>("volatile");
+
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    volatilityMode: vol,
+  });
+
+  return (
+    <DemoScreen
+      description="DegenOptions presets; use volatile/chaotic to see bursts"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          exaggerate
+          degen={degenFor(preset)}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Preset</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["off", "Off"],
+            ["on", "Default"],
+            ["minimal", "Minimal"],
+            ["heavy", "Heavy"],
+            ["noShake", "No shake"],
+            ["downToo", "Down momentum"],
+            ["customParticles", "Particle colors"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, preset === k && demoStyles.chipActive]}
+            onPress={() => setPreset(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                preset === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Volatility</Text>
+      <View style={demoStyles.buttonRow}>
+        {VOLATILITY_MODES.map((m) => (
+          <Pressable
+            key={m}
+            style={[demoStyles.chip, vol === m && demoStyles.chipActive]}
+            onPress={() => setVol(m)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                vol === m && demoStyles.chipTextActive,
+              ]}
+            >
+              {m}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/edge-cases.tsx
+++ b/app/demo/edge-cases.tsx
@@ -1,0 +1,120 @@
+import { Pressable, Text, View } from "react-native";
+
+import { useState } from "react";
+import { useSharedValue } from "react-native-reanimated";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import type { LiveChartPoint } from "../../src/types";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Loading, empty, formatters" };
+
+/** Worklet-safe — same as toISOString().slice(11, 19) in UTC (Date/toISOString not reliable inside UI worklets). */
+function formatTimeIsoUtcFragment(t: number): string {
+  "worklet";
+  const d = new Date(t * 1000);
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  const ss = String(d.getUTCSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+function formatValueUsd(v: number): string {
+  "worklet";
+  return `$${v.toFixed(2)}`;
+}
+
+export default function EdgeCasesScreen() {
+  const [empty, setEmpty] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [customFormat, setCustomFormat] = useState(false);
+
+  const emptyData = useSharedValue<LiveChartPoint[]>([]);
+  const emptyValue = useSharedValue(100);
+
+  const sim = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    paused: empty,
+  });
+
+  return (
+    <DemoScreen
+      description="loading, empty data, custom formatValue/formatTime (must be worklet-safe — same pattern as src/format.ts)"
+      chart={
+        <LiveChart
+          data={empty ? emptyData : sim.data}
+          value={empty ? emptyValue : sim.value}
+          accentColor={ACCENT}
+          theme="dark"
+          loading={loading}
+          emptyText={empty ? "Nothing to see here" : "No data"}
+          formatValue={customFormat ? formatValueUsd : undefined}
+          formatTime={customFormat ? formatTimeIsoUtcFragment : undefined}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>States</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, empty && demoStyles.chipActive]}
+          onPress={() => setEmpty((e) => !e)}
+        >
+          <Text
+            style={[demoStyles.chipText, empty && demoStyles.chipTextActive]}
+          >
+            Empty data
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, loading && demoStyles.chipActive]}
+          onPress={() => {
+            setLoading(true);
+            setTimeout(() => setLoading(false), 2000);
+          }}
+          disabled={loading}
+        >
+          <Text
+            style={[demoStyles.chipText, loading && demoStyles.chipTextActive]}
+          >
+            {loading ? "Loading…" : "Loading 2s"}
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Formatters</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, !customFormat && demoStyles.chipActive]}
+          onPress={() => setCustomFormat(false)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              !customFormat && demoStyles.chipTextActive,
+            ]}
+          >
+            Default
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, customFormat && demoStyles.chipActive]}
+          onPress={() => setCustomFormat(true)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              customFormat && demoStyles.chipTextActive,
+            ]}
+          >
+            $ + ISO time
+          </Text>
+        </Pressable>
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/horizontal-lines.tsx
+++ b/app/demo/horizontal-lines.tsx
@@ -1,0 +1,118 @@
+import { Pressable, Text, View } from "react-native";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Reference & value lines" };
+
+export default function HorizontalLinesScreen() {
+  const [refOn, setRefOn] = useState(true);
+  const [refStyled, setRefStyled] = useState(false);
+  const [valOn, setValOn] = useState(true);
+  const [valStyled, setValStyled] = useState(false);
+
+  const startValue = 100;
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    startValue,
+  });
+
+  return (
+    <DemoScreen
+      description="referenceLine and valueLine (+ config objects)"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          referenceLine={
+            refOn
+              ? refStyled
+                ? {
+                    value: startValue * 1.05,
+                    label: "+5%",
+                    strokeWidth: 2,
+                    intervals: [6, 4],
+                    color: "#fbbf24",
+                  }
+                : { value: startValue * 1.05, label: "+5%" }
+              : undefined
+          }
+          valueLine={
+            valOn
+              ? valStyled
+                ? {
+                    strokeWidth: 2,
+                    intervals: [4, 6],
+                    color: "#34d399",
+                  }
+                : true
+              : false
+          }
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Reference line</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, refOn && demoStyles.chipActive]}
+          onPress={() => setRefOn((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, refOn && demoStyles.chipTextActive]}
+          >
+            {refOn ? "On" : "Off"}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, refStyled && demoStyles.chipActive]}
+          onPress={() => setRefStyled((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              refStyled && demoStyles.chipTextActive,
+            ]}
+          >
+            Dashed + color
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Value line</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, valOn && demoStyles.chipActive]}
+          onPress={() => setValOn((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, valOn && demoStyles.chipTextActive]}
+          >
+            {valOn ? "On" : "Off"}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, valStyled && demoStyles.chipActive]}
+          onPress={() => setValStyled((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              valStyled && demoStyles.chipTextActive,
+            ]}
+          >
+            Styled dash
+          </Text>
+        </Pressable>
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/line-playback.tsx
+++ b/app/demo/line-playback.tsx
@@ -1,0 +1,116 @@
+import { Pressable, Text, View } from "react-native";
+import { ACCENT, SMOOTHING_PRESETS, TIME_WINDOWS } from "./_lib/shared";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Line & playback" };
+
+export default function LinePlaybackScreen() {
+  const [windowSecs, setWindowSecs] = useState(30);
+  const [paused, setPaused] = useState(false);
+  const [smoothing, setSmoothing] = useState(0.08);
+  const [exaggerate, setExaggerate] = useState(false);
+
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    paused,
+  });
+
+  return (
+    <DemoScreen
+      description="timeWindow, paused, smoothing, exaggerate"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          timeWindow={windowSecs}
+          paused={paused}
+          smoothing={smoothing}
+          exaggerate={exaggerate}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Time window</Text>
+      <View style={demoStyles.buttonRow}>
+        {TIME_WINDOWS.map((w) => (
+          <Pressable
+            key={w.label}
+            style={[
+              demoStyles.chip,
+              windowSecs === w.secs && demoStyles.chipActive,
+            ]}
+            onPress={() => setWindowSecs(w.secs)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                windowSecs === w.secs && demoStyles.chipTextActive,
+              ]}
+            >
+              {w.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Smoothing</Text>
+      <View style={demoStyles.buttonRow}>
+        {SMOOTHING_PRESETS.map((s) => (
+          <Pressable
+            key={s.label}
+            style={[
+              demoStyles.chip,
+              smoothing === s.value && demoStyles.chipActive,
+            ]}
+            onPress={() => setSmoothing(s.value)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                smoothing === s.value && demoStyles.chipTextActive,
+              ]}
+            >
+              {s.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Playback</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, paused && demoStyles.chipActive]}
+          onPress={() => setPaused((p) => !p)}
+        >
+          <Text
+            style={[demoStyles.chipText, paused && demoStyles.chipTextActive]}
+          >
+            {paused ? "Resume" : "Pause"}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, exaggerate && demoStyles.chipActive]}
+          onPress={() => setExaggerate((e) => !e)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              exaggerate && demoStyles.chipTextActive,
+            ]}
+          >
+            Exaggerate
+          </Text>
+        </Pressable>
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/momentum.tsx
+++ b/app/demo/momentum.tsx
@@ -1,0 +1,149 @@
+import { Pressable, Text, View } from "react-native";
+import type { Momentum, MomentumConfig } from "../../src/types";
+import { ACCENT, VOLATILITY_MODES } from "./_lib/shared";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Momentum" };
+
+type Mode = "auto" | "off" | "up" | "down" | "flat" | "sensitive" | "dull";
+
+function resolveMomentum(mode: Mode): boolean | Momentum | MomentumConfig {
+  switch (mode) {
+    case "auto":
+      return true;
+    case "off":
+      return false;
+    case "up":
+      return "up";
+    case "down":
+      return "down";
+    case "flat":
+      return "flat";
+    case "sensitive":
+      return { threshold: 0.06, lookback: 12 };
+    case "dull":
+      return { threshold: 0.22, lookback: 28 };
+    default:
+      return true;
+  }
+}
+
+export default function MomentumScreen() {
+  const [mode, setMode] = useState<Mode>("auto");
+  const [volatility, setVolatility] =
+    useState<(typeof VOLATILITY_MODES)[number]>("volatile");
+  const [exaggerate, setExaggerate] = useState(true);
+
+  const { data, value } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    volatilityMode: volatility,
+  });
+
+  return (
+    <DemoScreen
+      description={
+        "Momentum tints the value badge on the right (green = up, red = down, blue = flat). " +
+        "It eases slowly—wait a second after switching. " +
+        "The live dot stays accent-colored; degen uses momentum separately on its own screen."
+      }
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          momentum={resolveMomentum(mode)}
+          exaggerate={exaggerate}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Sim volatility (auto modes)</Text>
+      <View style={demoStyles.buttonRow}>
+        {VOLATILITY_MODES.map((v) => (
+          <Pressable
+            key={v}
+            style={[demoStyles.chip, volatility === v && demoStyles.chipActive]}
+            onPress={() => setVolatility(v)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                volatility === v && demoStyles.chipTextActive,
+              ]}
+            >
+              {v}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Y scale</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, exaggerate && demoStyles.chipActive]}
+          onPress={() => setExaggerate(true)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              exaggerate && demoStyles.chipTextActive,
+            ]}
+          >
+            Exaggerate (default)
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, !exaggerate && demoStyles.chipActive]}
+          onPress={() => setExaggerate(false)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              !exaggerate && demoStyles.chipTextActive,
+            ]}
+          >
+            Normal scale
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Momentum</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["auto", "Auto"],
+            ["off", "Off"],
+            ["up", "Force up"],
+            ["down", "Force down"],
+            ["flat", "Force flat"],
+            ["sensitive", "Sensitive"],
+            ["dull", "Dull"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, mode === k && demoStyles.chipActive]}
+            onPress={() => setMode(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                mode === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -1,0 +1,285 @@
+import { useRef, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import type { ScrubPointMulti, SeriesConfig } from "../../src/types";
+import { ACCENT, SMOOTHING_PRESETS, TIME_WINDOWS } from "./_lib/shared";
+
+import { useSharedValue } from "react-native-reanimated";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChartSeries } from "../../src";
+import { formatTime } from "../../src/format";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Multi-series" };
+
+export default function MultiSeriesScreen() {
+  const seriesVisibilityRef = useRef<Record<string, boolean>>({});
+  const emptySeries = useSharedValue<SeriesConfig[]>([]);
+
+  const [empty, setEmpty] = useState(false);
+  const [compact, setCompact] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [windowSecs, setWindowSecs] = useState(60);
+  const [smoothing, setSmoothing] = useState(0.08);
+  const [exaggerate, setExaggerate] = useState(false);
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [showRef, setShowRef] = useState(false);
+  const [axisVis, setAxisVis] = useState<"both" | "noY" | "noX" | "none">(
+    "both",
+  );
+  const [readout, setReadout] = useState("—");
+
+  const sim = useSimulatedData({
+    multiSeries: !empty,
+    candleAggregation: false,
+    tradeStream: false,
+    paused,
+    seriesVisibilityRef: empty ? undefined : seriesVisibilityRef,
+  });
+
+  const yOn = axisVis !== "noY" && axisVis !== "none";
+  const xOn = axisVis !== "noX" && axisVis !== "none";
+
+  const seriesSource = empty ? emptySeries : sim.series;
+
+  return (
+    <DemoScreen
+      description="series, onSeriesToggle, scrub, shared core props, axis visibility"
+      chart={
+        <LiveChartSeries
+          series={seriesSource}
+          accentColor={ACCENT}
+          theme={theme}
+          timeWindow={windowSecs}
+          paused={paused}
+          loading={loading}
+          smoothing={smoothing}
+          exaggerate={exaggerate}
+          referenceLine={showRef ? { value: 52, label: "mid" } : undefined}
+          yAxis={yOn}
+          xAxis={xOn}
+          emptyText="No series"
+          seriesToggleCompact={compact}
+          scrub={{ tooltip: true }}
+          onSeriesToggle={
+            empty
+              ? undefined
+              : (id, visible) => {
+                  seriesVisibilityRef.current[id] = visible;
+                  const cur = sim.series.value;
+                  sim.series.value = cur.map((s) =>
+                    s.id === id ? { ...s, visible } : s,
+                  );
+                }
+          }
+          onScrub={(p) => {
+            if (p === null) {
+              setReadout("—");
+              return;
+            }
+            const m = p as ScrubPointMulti;
+            const parts = m.seriesValues.map(
+              (sv) => `${sv.label ?? sv.id}:${sv.value.toFixed(2)}`,
+            );
+            setReadout(
+              `${formatTime(m.time)} · ${parts.join(" · ") || m.value.toFixed(4)}`,
+            );
+          }}
+        />
+      }
+    >
+      <Text style={demoStyles.scrubReadout} numberOfLines={4}>
+        {readout}
+      </Text>
+
+      <Text style={demoStyles.sectionLabel}>Data</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, !empty && demoStyles.chipActive]}
+          onPress={() => setEmpty(false)}
+        >
+          <Text
+            style={[demoStyles.chipText, !empty && demoStyles.chipTextActive]}
+          >
+            Simulated series
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, empty && demoStyles.chipActive]}
+          onPress={() => setEmpty(true)}
+        >
+          <Text
+            style={[demoStyles.chipText, empty && demoStyles.chipTextActive]}
+          >
+            Empty series[]
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Toggle chips</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, compact && demoStyles.chipActive]}
+          onPress={() => setCompact((c) => !c)}
+        >
+          <Text
+            style={[demoStyles.chipText, compact && demoStyles.chipTextActive]}
+          >
+            Compact dots
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Time window</Text>
+      <View style={demoStyles.buttonRow}>
+        {TIME_WINDOWS.slice(0, 4).map((w) => (
+          <Pressable
+            key={w.label}
+            style={[
+              demoStyles.chip,
+              windowSecs === w.secs && demoStyles.chipActive,
+            ]}
+            onPress={() => setWindowSecs(w.secs)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                windowSecs === w.secs && demoStyles.chipTextActive,
+              ]}
+            >
+              {w.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Smoothing</Text>
+      <View style={demoStyles.buttonRow}>
+        {SMOOTHING_PRESETS.map((s) => (
+          <Pressable
+            key={s.label}
+            style={[
+              demoStyles.chip,
+              smoothing === s.value && demoStyles.chipActive,
+            ]}
+            onPress={() => setSmoothing(s.value)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                smoothing === s.value && demoStyles.chipTextActive,
+              ]}
+            >
+              {s.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Playback & theme</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, paused && demoStyles.chipActive]}
+          onPress={() => setPaused((p) => !p)}
+        >
+          <Text
+            style={[demoStyles.chipText, paused && demoStyles.chipTextActive]}
+          >
+            Pause
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, exaggerate && demoStyles.chipActive]}
+          onPress={() => setExaggerate((e) => !e)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              exaggerate && demoStyles.chipTextActive,
+            ]}
+          >
+            Exaggerate
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, loading && demoStyles.chipActive]}
+          onPress={() => {
+            setLoading(true);
+            setTimeout(() => setLoading(false), 2000);
+          }}
+          disabled={loading}
+        >
+          <Text
+            style={[demoStyles.chipText, loading && demoStyles.chipTextActive]}
+          >
+            {loading ? "…" : "Load"}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, theme === "dark" && demoStyles.chipActive]}
+          onPress={() => setTheme("dark")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              theme === "dark" && demoStyles.chipTextActive,
+            ]}
+          >
+            Dark
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, theme === "light" && demoStyles.chipActive]}
+          onPress={() => setTheme("light")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              theme === "light" && demoStyles.chipTextActive,
+            ]}
+          >
+            Light
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, showRef && demoStyles.chipActive]}
+          onPress={() => setShowRef((r) => !r)}
+        >
+          <Text
+            style={[demoStyles.chipText, showRef && demoStyles.chipTextActive]}
+          >
+            Ref line
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Axes</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["both", "Both"],
+            ["noY", "No Y"],
+            ["noX", "No X"],
+            ["none", "None"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, axisVis === k && demoStyles.chipActive]}
+            onPress={() => setAxisVis(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                axisVis === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/playground.tsx
+++ b/app/demo/playground.tsx
@@ -1,0 +1,468 @@
+import { useEffect, useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+} from "react-native-reanimated";
+import type { VolatilityMode } from "../../sim/generators";
+import { useSimulatedData, type TradeSource } from "../../sim/useSimulatedData";
+import type { ScrubPoint, ScrubPointMulti } from "../../src";
+import { LiveChart, LiveChartSeries } from "../../src";
+import { formatTime } from "../../src/format";
+import {
+  PRICE_RANGES,
+  TIME_WINDOWS,
+  TRADE_SOURCES,
+  VOLATILITY_MODES,
+} from "./_lib/shared";
+
+export const options = { title: "Playground" };
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+export default function PlaygroundScreen() {
+  const [volatilityMode, setVolatilityMode] =
+    useState<VolatilityMode>("normal");
+  const [tradeSource, setTradeSource] = useState<TradeSource>("orderbook");
+  const [paused, setPaused] = useState(false);
+  const [windowSecs, setWindowSecs] = useState(30);
+  const [startValue, setStartValue] = useState(100);
+  const [loading, setLoading] = useState(false);
+  const [showRefLine, setShowRefLine] = useState(false);
+  const [valueLine, setValueLine] = useState(false);
+  const [exaggerate, setExaggerate] = useState(false);
+  const [degen, setDegen] = useState(true);
+  const [simTradeStream, setSimTradeStream] = useState(true);
+
+  const [chartMode, setChartMode] = useState<"single" | "multi">("single");
+  const [displayMode, setDisplayMode] = useState<"line" | "candle">("line");
+
+  const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
+
+  const { data, value, series, candles, liveCandle, tradeStream } =
+    useSimulatedData({
+      volatilityMode,
+      tradeSource,
+      paused,
+      startValue,
+      candleWidth: candleWidthSecs,
+      multiSeries: chartMode === "multi",
+      candleAggregation: chartMode === "single" && displayMode === "candle",
+      tradeStream: simTradeStream,
+    });
+  const chartModeSv = useSharedValue<"single" | "multi">("single");
+  const volatilitySv = useSharedValue(volatilityMode);
+  useEffect(() => {
+    chartModeSv.value = chartMode;
+  }, [chartMode, chartModeSv]);
+  useEffect(() => {
+    volatilitySv.value = volatilityMode;
+  }, [volatilityMode, volatilitySv]);
+
+  const scrubPoint = useSharedValue<ScrubPoint | ScrubPointMulti | null>(null);
+
+  const subtitleProps = useAnimatedProps(() => {
+    const sp = scrubPoint.value;
+    if (sp !== null) {
+      const text = `${sp.value.toFixed(6)} · ${formatTime(sp.time)}`;
+      return { text, defaultValue: text };
+    }
+    if (chartModeSv.value === "multi") {
+      const rows = series.value;
+      let txt = "";
+      for (let i = 0; i < rows.length; i++) {
+        if (rows[i].visible === false) continue;
+        if (txt) txt += " · ";
+        txt += `${rows[i].label ?? rows[i].id}: ${rows[i].value.toFixed(2)}`;
+      }
+      if (!txt) txt = "—";
+      return { text: txt, defaultValue: txt };
+    }
+    const text = `${value.value.toFixed(6)} · ${volatilitySv.value}`;
+    return { text, defaultValue: text };
+  });
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>react-native-livechart</Text>
+        <AnimatedTextInput
+          editable={false}
+          underlineColorAndroid="transparent"
+          style={styles.subtitle}
+          animatedProps={subtitleProps}
+        />
+      </View>
+
+      <View style={styles.chartContainer}>
+        {chartMode === "single" ? (
+          <LiveChart
+            data={data}
+            value={value}
+            mode={displayMode}
+            candles={candles}
+            liveCandle={liveCandle}
+            candleWidth={candleWidthSecs}
+            accentColor="#3b82f6"
+            theme="dark"
+            timeWindow={windowSecs}
+            paused={paused}
+            exaggerate={exaggerate}
+            valueLine={valueLine}
+            referenceLine={
+              showRefLine
+                ? { value: startValue * 1.05, label: "+5%" }
+                : undefined
+            }
+            scrub={{ tooltip: true }}
+            loading={loading}
+            onScrub={(point) => {
+              scrubPoint.value = point;
+            }}
+            tradeStream={tradeStream}
+            degen={degen ? true : undefined}
+          />
+        ) : (
+          <LiveChartSeries
+            series={series}
+            accentColor="#3b82f6"
+            theme="dark"
+            timeWindow={windowSecs}
+            paused={paused}
+            exaggerate={exaggerate}
+            referenceLine={
+              showRefLine
+                ? { value: startValue * 1.05, label: "+5%" }
+                : undefined
+            }
+            scrub={{ tooltip: true }}
+            loading={loading}
+            onScrub={(point) => {
+              scrubPoint.value = point;
+            }}
+          />
+        )}
+      </View>
+
+      <ScrollView
+        style={styles.controlsScroll}
+        contentContainerStyle={styles.controls}
+      >
+        <Text style={styles.sectionLabel}>Chart Mode</Text>
+        <View style={styles.buttonRow}>
+          <Pressable
+            style={[styles.chip, chartMode === "single" && styles.chipActive]}
+            onPress={() => setChartMode("single")}
+          >
+            <Text
+              style={[
+                styles.chipText,
+                chartMode === "single" && styles.chipTextActive,
+              ]}
+            >
+              Single series
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.chip, chartMode === "multi" && styles.chipActive]}
+            onPress={() => setChartMode("multi")}
+          >
+            <Text
+              style={[
+                styles.chipText,
+                chartMode === "multi" && styles.chipTextActive,
+              ]}
+            >
+              Multi-series
+            </Text>
+          </Pressable>
+        </View>
+
+        {chartMode === "single" && (
+          <>
+            <Text style={styles.sectionLabel}>Display Mode</Text>
+            <View style={styles.buttonRow}>
+              <Pressable
+                style={[
+                  styles.chip,
+                  displayMode === "line" && styles.chipActive,
+                ]}
+                onPress={() => setDisplayMode("line")}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    displayMode === "line" && styles.chipTextActive,
+                  ]}
+                >
+                  Line
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[
+                  styles.chip,
+                  displayMode === "candle" && styles.chipActive,
+                ]}
+                onPress={() => setDisplayMode("candle")}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    displayMode === "candle" && styles.chipTextActive,
+                  ]}
+                >
+                  Candle
+                </Text>
+              </Pressable>
+            </View>
+          </>
+        )}
+
+        <Text style={styles.sectionLabel}>Time Window</Text>
+        <View style={styles.buttonRow}>
+          {TIME_WINDOWS.map((w) => (
+            <Pressable
+              key={w.label}
+              style={[styles.chip, windowSecs === w.secs && styles.chipActive]}
+              onPress={() => setWindowSecs(w.secs)}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  windowSecs === w.secs && styles.chipTextActive,
+                ]}
+              >
+                {w.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.sectionLabel}>Price Range</Text>
+        <View style={styles.buttonRow}>
+          {PRICE_RANGES.map((r) => (
+            <Pressable
+              key={r.label}
+              style={[styles.chip, startValue === r.value && styles.chipActive]}
+              onPress={() => setStartValue(r.value)}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  startValue === r.value && styles.chipTextActive,
+                ]}
+              >
+                {r.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.sectionLabel}>Volatility</Text>
+        <View style={styles.buttonRow}>
+          {VOLATILITY_MODES.map((mode) => (
+            <Pressable
+              key={mode}
+              style={[
+                styles.chip,
+                volatilityMode === mode && styles.chipActive,
+              ]}
+              onPress={() => setVolatilityMode(mode)}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  volatilityMode === mode && styles.chipTextActive,
+                ]}
+              >
+                {mode}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.sectionLabel}>Trade Source</Text>
+        <View style={styles.buttonRow}>
+          {TRADE_SOURCES.map((source) => (
+            <Pressable
+              key={source}
+              style={[styles.chip, tradeSource === source && styles.chipActive]}
+              onPress={() => setTradeSource(source)}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  tradeSource === source && styles.chipTextActive,
+                ]}
+              >
+                {source}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.sectionLabel}>Chart Options</Text>
+        <View style={styles.buttonRow}>
+          <Pressable
+            style={styles.chip}
+            onPress={() => {
+              setDegen(true);
+              setExaggerate(true);
+              setVolatilityMode("chaotic");
+            }}
+          >
+            <Text style={styles.chipText}>Degen demo</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.chip, simTradeStream && styles.chipActive]}
+            onPress={() => setSimTradeStream((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, simTradeStream && styles.chipTextActive]}
+            >
+              Trade stream
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.chip, degen && styles.chipActive]}
+            onPress={() => setDegen((v) => !v)}
+          >
+            <Text style={[styles.chipText, degen && styles.chipTextActive]}>
+              Degen
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.chip, valueLine && styles.chipActive]}
+            onPress={() => setValueLine((v) => !v)}
+          >
+            <Text style={[styles.chipText, valueLine && styles.chipTextActive]}>
+              Value Line
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, showRefLine && styles.chipActive]}
+            onPress={() => setShowRefLine((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, showRefLine && styles.chipTextActive]}
+            >
+              Ref Line
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, exaggerate && styles.chipActive]}
+            onPress={() => setExaggerate((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, exaggerate && styles.chipTextActive]}
+            >
+              Exaggerate
+            </Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.buttonRow}>
+          <Pressable
+            style={[styles.chip, paused && styles.chipActive]}
+            onPress={() => setPaused((p) => !p)}
+          >
+            <Text style={[styles.chipText, paused && styles.chipTextActive]}>
+              {paused ? "Resume" : "Pause"}
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, loading && styles.chipActive]}
+            onPress={() => {
+              setLoading(true);
+              setTimeout(() => setLoading(false), 2000);
+            }}
+            disabled={loading}
+          >
+            <Text style={[styles.chipText, loading && styles.chipTextActive]}>
+              {loading ? "Loading…" : "Reload"}
+            </Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "rgb(10, 10, 10)",
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingBottom: 12,
+    paddingTop: 8,
+  },
+  title: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "600",
+    fontFamily: "monospace",
+  },
+  subtitle: {
+    color: "rgba(255,255,255,0.5)",
+    fontSize: 13,
+    fontFamily: "monospace",
+    marginTop: 4,
+    padding: 0,
+  },
+  chartContainer: {
+    height: 300,
+    marginHorizontal: 12,
+  },
+  controlsScroll: {
+    flex: 1,
+  },
+  controls: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 40,
+  },
+  sectionLabel: {
+    color: "rgba(255,255,255,0.4)",
+    fontSize: 11,
+    fontFamily: "monospace",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 8,
+    marginTop: 16,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
+    marginBottom: 8,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: "rgba(255,255,255,0.06)",
+  },
+  chipActive: {
+    backgroundColor: "#3b82f6",
+  },
+  chipText: {
+    color: "rgba(255,255,255,0.6)",
+    fontSize: 13,
+    fontFamily: "monospace",
+  },
+  chipTextActive: {
+    color: "#fff",
+  },
+});

--- a/app/demo/scrub.tsx
+++ b/app/demo/scrub.tsx
@@ -1,0 +1,135 @@
+import { Pressable, Text, View } from "react-native";
+
+import { useState } from "react";
+import { useSimulatedData } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { formatTime } from "../../src/format";
+import type { ScrubPoint } from "../../src/types";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Scrub" };
+
+export default function ScrubScreen() {
+  const [scrubMode, setScrubMode] = useState<"off" | "on" | "noTooltip">("on");
+  const [displayMode, setDisplayMode] = useState<"line" | "candle">("line");
+  const [readout, setReadout] = useState("—");
+
+  const windowSecs = 300;
+  const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
+
+  const { data, value, candles, liveCandle } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: displayMode === "candle",
+    tradeStream: false,
+    candleWidth: candleWidthSecs,
+  });
+
+  const scrub =
+    scrubMode === "off"
+      ? false
+      : scrubMode === "on"
+        ? true
+        : { tooltip: false };
+
+  return (
+    <DemoScreen
+      description="Scrub modes; candle mode shows ScrubPoint.candle in readout"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          mode={displayMode}
+          candles={displayMode === "candle" ? candles : undefined}
+          liveCandle={displayMode === "candle" ? liveCandle : undefined}
+          candleWidth={candleWidthSecs}
+          accentColor={ACCENT}
+          theme="dark"
+          timeWindow={windowSecs}
+          scrub={scrub}
+          onScrub={(point) => {
+            if (point === null) {
+              setReadout("— (live)");
+              return;
+            }
+            const sp = point as ScrubPoint;
+            let extra = "";
+            if (sp.candle) {
+              extra = ` | O:${sp.candle.open.toFixed(2)} H:${sp.candle.high.toFixed(2)} L:${sp.candle.low.toFixed(2)} C:${sp.candle.close.toFixed(2)}`;
+            }
+            setReadout(
+              `${sp.value.toFixed(4)} @ ${formatTime(sp.time)}${extra}`,
+            );
+          }}
+        />
+      }
+    >
+      <Text style={demoStyles.scrubReadout} numberOfLines={3}>
+        {readout}
+      </Text>
+
+      <Text style={demoStyles.sectionLabel}>Scrub</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["off", "Off"],
+            ["on", "On + tooltip"],
+            ["noTooltip", "On, no tooltip"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, scrubMode === k && demoStyles.chipActive]}
+            onPress={() => setScrubMode(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                scrubMode === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Display</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[
+            demoStyles.chip,
+            displayMode === "line" && demoStyles.chipActive,
+          ]}
+          onPress={() => setDisplayMode("line")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              displayMode === "line" && demoStyles.chipTextActive,
+            ]}
+          >
+            Line
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[
+            demoStyles.chip,
+            displayMode === "candle" && demoStyles.chipActive,
+          ]}
+          onPress={() => setDisplayMode("candle")}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              displayMode === "candle" && demoStyles.chipTextActive,
+            ]}
+          >
+            Candle (OHLC in readout)
+          </Text>
+        </Pressable>
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/trade-stream.tsx
+++ b/app/demo/trade-stream.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { useSimulatedData, type TradeSource } from "../../sim/useSimulatedData";
+import { LiveChart } from "../../src";
+import { DemoScreen } from "./_lib/DemoScreen";
+import { ACCENT, TRADE_SOURCES, VOLATILITY_MODES } from "./_lib/shared";
+import { demoStyles } from "./_lib/styles";
+
+export const options = { title: "Trade stream" };
+
+export default function TradeStreamScreen() {
+  const [source, setSource] = useState<TradeSource>("orderbook");
+  const [streamOn, setStreamOn] = useState(true);
+  const [vol, setVol] = useState<(typeof VOLATILITY_MODES)[number]>("normal");
+
+  const { data, value, tradeStream } = useSimulatedData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: streamOn,
+    tradeSource: source,
+    volatilityMode: vol,
+  });
+
+  return (
+    <DemoScreen
+      description="tradeStream SharedValue; bonding-curve vs orderbook"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          tradeStream={streamOn ? tradeStream : undefined}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Stream</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, streamOn && demoStyles.chipActive]}
+          onPress={() => setStreamOn(true)}
+        >
+          <Text
+            style={[demoStyles.chipText, streamOn && demoStyles.chipTextActive]}
+          >
+            On
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, !streamOn && demoStyles.chipActive]}
+          onPress={() => setStreamOn(false)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              !streamOn && demoStyles.chipTextActive,
+            ]}
+          >
+            Off
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Trade source</Text>
+      <View style={demoStyles.buttonRow}>
+        {TRADE_SOURCES.map((s) => (
+          <Pressable
+            key={s}
+            style={[demoStyles.chip, source === s && demoStyles.chipActive]}
+            onPress={() => setSource(s)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                source === s && demoStyles.chipTextActive,
+              ]}
+            >
+              {s}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Volatility</Text>
+      <View style={demoStyles.buttonRow}>
+        {VOLATILITY_MODES.map((m) => (
+          <Pressable
+            key={m}
+            style={[demoStyles.chip, vol === m && demoStyles.chipActive]}
+            onPress={() => setVol(m)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                vol === m && demoStyles.chipTextActive,
+              ]}
+            >
+              {m}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,493 +1,144 @@
-import { useEffect, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
-import Animated, {
-  useAnimatedProps,
-  useSharedValue,
-} from "react-native-reanimated";
-import type { VolatilityMode } from "../sim/generators";
-import { useSimulatedData, type TradeSource } from "../sim/useSimulatedData";
-import type { ScrubPoint, ScrubPointMulti } from "../src";
-import { LiveChart, LiveChartSeries } from "../src";
-import { formatTime } from "../src/format";
+import { Link, type Href } from "expo-router";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 
-const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
-
-const TIME_WINDOWS: { label: string; secs: number }[] = [
-  { label: "30s", secs: 30 },
-  { label: "1m", secs: 60 },
-  { label: "5m", secs: 300 },
-  { label: "1h", secs: 3_600 },
-  { label: "24h", secs: 86_400 },
-];
-
-const VOLATILITY_MODES: VolatilityMode[] = [
-  "calm",
-  "normal",
-  "volatile",
-  "chaotic",
-];
-
-const TRADE_SOURCES: TradeSource[] = ["orderbook", "bonding-curve"];
-
-const PRICE_RANGES: { label: string; value: number }[] = [
-  { label: "0.001", value: 0.001 },
-  { label: "0.5", value: 0.5 },
-  { label: "50", value: 50 },
-  { label: "100", value: 100 },
-  { label: "1K", value: 1_000 },
-  { label: "10K", value: 10_000 },
-  { label: "67.5K", value: 67_500 },
-  { label: "100K", value: 100_000 },
-  { label: "1M", value: 1_000_000 },
-  { label: "10M", value: 10_000_000 },
-  { label: "100M", value: 100_000_000 },
+const DEMOS: { href: Href; title: string; blurb: string }[] = [
+  {
+    href: "/demo/playground",
+    title: "Playground",
+    blurb: "All-in-one: single/multi, candles, trades, degen, loading, etc.",
+  },
+  {
+    href: "/demo/line-playback",
+    title: "Line & playback",
+    blurb: "timeWindow, pause, smoothing, exaggerate.",
+  },
+  {
+    href: "/demo/candlestick",
+    title: "Candlestick",
+    blurb: "mode=candle, candles, liveCandle, candleWidth.",
+  },
+  {
+    href: "/demo/appearance",
+    title: "Appearance",
+    blurb: "Theme, accent, gradient, line, font, container style.",
+  },
+  {
+    href: "/demo/axes-insets",
+    title: "Axes & insets",
+    blurb: "Hide X/Y/both, minGap, insets; LiveChart vs LiveChartSeries.",
+  },
+  {
+    href: "/demo/chart-size",
+    title: "Chart size",
+    blurb: "Heights, narrow width, flex fill in fixed box.",
+  },
+  {
+    href: "/demo/badge-pulse",
+    title: "Badge & pulse",
+    blurb: "Badge variants and pulse / PulseConfig.",
+  },
+  {
+    href: "/demo/momentum",
+    title: "Momentum",
+    blurb:
+      "Badge tint vs auto/forced/config; volatility + exaggerate to see changes.",
+  },
+  {
+    href: "/demo/scrub",
+    title: "Scrub",
+    blurb: "Scrub modes, onScrub readout, candle OHLC payload.",
+  },
+  {
+    href: "/demo/horizontal-lines",
+    title: "Reference & value lines",
+    blurb: "referenceLine and valueLine styling.",
+  },
+  {
+    href: "/demo/trade-stream",
+    title: "Trade stream",
+    blurb: "Markers, orderbook vs bonding-curve.",
+  },
+  {
+    href: "/demo/degen",
+    title: "Degen",
+    blurb: "Particles, shake, DegenOptions presets.",
+  },
+  {
+    href: "/demo/edge-cases",
+    title: "Loading, empty, formatters",
+    blurb: "loading, empty data, formatValue / formatTime.",
+  },
+  {
+    href: "/demo/multi-series",
+    title: "Multi-series",
+    blurb: "LiveChartSeries, toggles, scrub, shared core props.",
+  },
 ];
 
 export default function Index() {
-  const [volatilityMode, setVolatilityMode] =
-    useState<VolatilityMode>("normal");
-  const [tradeSource, setTradeSource] = useState<TradeSource>("orderbook");
-  const [paused, setPaused] = useState(false);
-  const [windowSecs, setWindowSecs] = useState(30);
-  const [startValue, setStartValue] = useState(100);
-  const [loading, setLoading] = useState(false);
-  const [showRefLine, setShowRefLine] = useState(false);
-  const [valueLine, setValueLine] = useState(false);
-  const [exaggerate, setExaggerate] = useState(false);
-  const [degen, setDegen] = useState(true);
-  const [simTradeStream, setSimTradeStream] = useState(true);
-
-  const [chartMode, setChartMode] = useState<"single" | "multi">("single");
-  const [displayMode, setDisplayMode] = useState<"line" | "candle">("line");
-
-  // ~20 candles visible in the window; minimum 5s bars
-  const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
-
-  const { data, value, series, candles, liveCandle, tradeStream } =
-    useSimulatedData({
-      volatilityMode,
-      tradeSource,
-      paused,
-      startValue,
-      candleWidth: candleWidthSecs,
-      multiSeries: chartMode === "multi",
-      candleAggregation: chartMode === "single" && displayMode === "candle",
-      tradeStream: simTradeStream,
-    });
-  const chartModeSv = useSharedValue<"single" | "multi">("single");
-  const volatilitySv = useSharedValue(volatilityMode);
-  useEffect(() => {
-    chartModeSv.value = chartMode;
-  }, [chartMode, chartModeSv]);
-  useEffect(() => {
-    volatilitySv.value = volatilityMode;
-  }, [volatilityMode, volatilitySv]);
-
-  // Shared value updated by onScrub on the JS thread; null = live mode
-  const scrubPoint = useSharedValue<ScrubPoint | ScrubPointMulti | null>(null);
-
-  const subtitleProps = useAnimatedProps(() => {
-    const sp = scrubPoint.value;
-    if (sp !== null) {
-      const text = `${sp.value.toFixed(6)} · ${formatTime(sp.time)}`;
-      return { text, defaultValue: text };
-    }
-    if (chartModeSv.value === "multi") {
-      const rows = series.value;
-      let txt = "";
-      for (let i = 0; i < rows.length; i++) {
-        if (rows[i].visible === false) continue;
-        if (txt) txt += " · ";
-        txt += `${rows[i].label ?? rows[i].id}: ${rows[i].value.toFixed(2)}`;
-      }
-      if (!txt) txt = "—";
-      return { text: txt, defaultValue: txt };
-    }
-    const text = `${value.value.toFixed(6)} · ${volatilitySv.value}`;
-    return { text, defaultValue: text };
-  });
-
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.title}>react-native-livechart</Text>
-        <AnimatedTextInput
-          editable={false}
-          underlineColorAndroid="transparent"
-          style={styles.subtitle}
-          animatedProps={subtitleProps}
-        />
-      </View>
-
-      <View style={styles.chartContainer}>
-        {chartMode === "single" ? (
-          <LiveChart
-            data={data}
-            value={value}
-            mode={displayMode}
-            candles={candles}
-            liveCandle={liveCandle}
-            candleWidth={candleWidthSecs}
-            accentColor="#3b82f6"
-            theme="dark"
-            timeWindow={windowSecs}
-            paused={paused}
-            exaggerate={exaggerate}
-            valueLine={valueLine}
-            referenceLine={
-              showRefLine
-                ? { value: startValue * 1.05, label: "+5%" }
-                : undefined
-            }
-            scrub={{ tooltip: true }}
-            loading={loading}
-            onScrub={(point) => {
-              scrubPoint.value = point;
-            }}
-            tradeStream={tradeStream}
-            degen={degen ? true : undefined}
-          />
-        ) : (
-          <LiveChartSeries
-            series={series}
-            accentColor="#3b82f6"
-            theme="dark"
-            timeWindow={windowSecs}
-            paused={paused}
-            exaggerate={exaggerate}
-            referenceLine={
-              showRefLine
-                ? { value: startValue * 1.05, label: "+5%" }
-                : undefined
-            }
-            scrub={{ tooltip: true }}
-            loading={loading}
-            onScrub={(point) => {
-              scrubPoint.value = point;
-            }}
-          />
-        )}
-      </View>
-
+    <View style={styles.root}>
+      <Text style={styles.title}>LiveChart demos</Text>
+      <Text style={styles.subtitle}>
+        Open a screen to manually test one feature area.
+      </Text>
       <ScrollView
-        style={styles.controlsScroll}
-        contentContainerStyle={styles.controls}
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
       >
-        <Text style={styles.sectionLabel}>Chart Mode</Text>
-        <View style={styles.buttonRow}>
-          <Pressable
-            style={[styles.chip, chartMode === "single" && styles.chipActive]}
-            onPress={() => setChartMode("single")}
-          >
-            <Text
-              style={[
-                styles.chipText,
-                chartMode === "single" && styles.chipTextActive,
-              ]}
-            >
-              Single series
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.chip, chartMode === "multi" && styles.chipActive]}
-            onPress={() => setChartMode("multi")}
-          >
-            <Text
-              style={[
-                styles.chipText,
-                chartMode === "multi" && styles.chipTextActive,
-              ]}
-            >
-              Multi-series
-            </Text>
-          </Pressable>
-        </View>
-
-        {chartMode === "single" && (
-          <>
-            <Text style={styles.sectionLabel}>Display Mode</Text>
-            <View style={styles.buttonRow}>
-              <Pressable
-                style={[
-                  styles.chip,
-                  displayMode === "line" && styles.chipActive,
-                ]}
-                onPress={() => setDisplayMode("line")}
-              >
-                <Text
-                  style={[
-                    styles.chipText,
-                    displayMode === "line" && styles.chipTextActive,
-                  ]}
-                >
-                  Line
-                </Text>
-              </Pressable>
-              <Pressable
-                style={[
-                  styles.chip,
-                  displayMode === "candle" && styles.chipActive,
-                ]}
-                onPress={() => setDisplayMode("candle")}
-              >
-                <Text
-                  style={[
-                    styles.chipText,
-                    displayMode === "candle" && styles.chipTextActive,
-                  ]}
-                >
-                  Candle
-                </Text>
-              </Pressable>
-            </View>
-          </>
-        )}
-
-        <Text style={styles.sectionLabel}>Time Window</Text>
-        <View style={styles.buttonRow}>
-          {TIME_WINDOWS.map((w) => (
-            <Pressable
-              key={w.label}
-              style={[styles.chip, windowSecs === w.secs && styles.chipActive]}
-              onPress={() => setWindowSecs(w.secs)}
-            >
-              <Text
-                style={[
-                  styles.chipText,
-                  windowSecs === w.secs && styles.chipTextActive,
-                ]}
-              >
-                {w.label}
-              </Text>
+        {DEMOS.map((d) => (
+          <Link key={d.title} href={d.href} asChild>
+            <Pressable style={styles.row}>
+              <Text style={styles.rowTitle}>{d.title}</Text>
+              <Text style={styles.rowBlurb}>{d.blurb}</Text>
             </Pressable>
-          ))}
-        </View>
-
-        <Text style={styles.sectionLabel}>Price Range</Text>
-        <View style={styles.buttonRow}>
-          {PRICE_RANGES.map((r) => (
-            <Pressable
-              key={r.label}
-              style={[styles.chip, startValue === r.value && styles.chipActive]}
-              onPress={() => setStartValue(r.value)}
-            >
-              <Text
-                style={[
-                  styles.chipText,
-                  startValue === r.value && styles.chipTextActive,
-                ]}
-              >
-                {r.label}
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-
-        <Text style={styles.sectionLabel}>Volatility</Text>
-        <View style={styles.buttonRow}>
-          {VOLATILITY_MODES.map((mode) => (
-            <Pressable
-              key={mode}
-              style={[
-                styles.chip,
-                volatilityMode === mode && styles.chipActive,
-              ]}
-              onPress={() => setVolatilityMode(mode)}
-            >
-              <Text
-                style={[
-                  styles.chipText,
-                  volatilityMode === mode && styles.chipTextActive,
-                ]}
-              >
-                {mode}
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-
-        <Text style={styles.sectionLabel}>Trade Source</Text>
-        <View style={styles.buttonRow}>
-          {TRADE_SOURCES.map((source) => (
-            <Pressable
-              key={source}
-              style={[styles.chip, tradeSource === source && styles.chipActive]}
-              onPress={() => setTradeSource(source)}
-            >
-              <Text
-                style={[
-                  styles.chipText,
-                  tradeSource === source && styles.chipTextActive,
-                ]}
-              >
-                {source}
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-
-        <Text style={styles.sectionLabel}>Chart Options</Text>
-        <View style={styles.buttonRow}>
-          <Pressable
-            style={styles.chip}
-            onPress={() => {
-              setDegen(true);
-              setExaggerate(true);
-              setVolatilityMode("chaotic");
-            }}
-          >
-            <Text style={styles.chipText}>Degen demo</Text>
-          </Pressable>
-          <Pressable
-            style={[styles.chip, simTradeStream && styles.chipActive]}
-            onPress={() => setSimTradeStream((v) => !v)}
-          >
-            <Text
-              style={[styles.chipText, simTradeStream && styles.chipTextActive]}
-            >
-              Trade stream
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.chip, degen && styles.chipActive]}
-            onPress={() => setDegen((v) => !v)}
-          >
-            <Text style={[styles.chipText, degen && styles.chipTextActive]}>
-              Degen
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.chip, valueLine && styles.chipActive]}
-            onPress={() => setValueLine((v) => !v)}
-          >
-            <Text style={[styles.chipText, valueLine && styles.chipTextActive]}>
-              Value Line
-            </Text>
-          </Pressable>
-
-          <Pressable
-            style={[styles.chip, showRefLine && styles.chipActive]}
-            onPress={() => setShowRefLine((v) => !v)}
-          >
-            <Text
-              style={[styles.chipText, showRefLine && styles.chipTextActive]}
-            >
-              Ref Line
-            </Text>
-          </Pressable>
-
-          <Pressable
-            style={[styles.chip, exaggerate && styles.chipActive]}
-            onPress={() => setExaggerate((v) => !v)}
-          >
-            <Text
-              style={[styles.chipText, exaggerate && styles.chipTextActive]}
-            >
-              Exaggerate
-            </Text>
-          </Pressable>
-        </View>
-
-        <View style={styles.buttonRow}>
-          <Pressable
-            style={[styles.chip, paused && styles.chipActive]}
-            onPress={() => setPaused((p) => !p)}
-          >
-            <Text style={[styles.chipText, paused && styles.chipTextActive]}>
-              {paused ? "Resume" : "Pause"}
-            </Text>
-          </Pressable>
-
-          <Pressable
-            style={[styles.chip, loading && styles.chipActive]}
-            onPress={() => {
-              setLoading(true);
-              setTimeout(() => setLoading(false), 2000);
-            }}
-            disabled={loading}
-          >
-            <Text style={[styles.chipText, loading && styles.chipTextActive]}>
-              {loading ? "Loading…" : "Reload"}
-            </Text>
-          </Pressable>
-        </View>
+          </Link>
+        ))}
       </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  root: {
     flex: 1,
     backgroundColor: "rgb(10, 10, 10)",
-    paddingTop: 60,
-  },
-  header: {
-    paddingHorizontal: 20,
-    paddingBottom: 12,
+    paddingTop: 56,
   },
   title: {
     color: "#fff",
-    fontSize: 18,
+    fontSize: 22,
     fontWeight: "600",
     fontFamily: "monospace",
+    paddingHorizontal: 20,
   },
   subtitle: {
-    color: "rgba(255,255,255,0.5)",
+    color: "rgba(255,255,255,0.45)",
     fontSize: 13,
     fontFamily: "monospace",
-    marginTop: 4,
-    padding: 0,
-  },
-  chartContainer: {
-    height: 300,
-    marginHorizontal: 12,
-  },
-  controlsScroll: {
-    flex: 1,
-  },
-  controls: {
     paddingHorizontal: 20,
-    paddingTop: 20,
-    paddingBottom: 40,
+    marginTop: 6,
+    marginBottom: 16,
   },
-  sectionLabel: {
+  scroll: { flex: 1 },
+  scrollContent: { paddingHorizontal: 20, paddingBottom: 40 },
+  row: {
+    marginTop: 14,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(255,255,255,0.12)",
+  },
+  rowTitle: {
+    color: "#60a5fa",
+    fontSize: 16,
+    fontFamily: "monospace",
+    fontWeight: "600",
+  },
+  rowBlurb: {
     color: "rgba(255,255,255,0.4)",
-    fontSize: 11,
+    fontSize: 12,
     fontFamily: "monospace",
-    textTransform: "uppercase",
-    letterSpacing: 1,
-    marginBottom: 8,
-    marginTop: 16,
-  },
-  buttonRow: {
-    flexDirection: "row",
-    gap: 8,
-    flexWrap: "wrap",
-    marginBottom: 8,
-  },
-  chip: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 8,
-    backgroundColor: "rgba(255,255,255,0.06)",
-  },
-  chipActive: {
-    backgroundColor: "#3b82f6",
-  },
-  chipText: {
-    color: "rgba(255,255,255,0.6)",
-    fontSize: 13,
-    fontFamily: "monospace",
-  },
-  chipTextActive: {
-    color: "#fff",
+    lineHeight: 17,
+    marginTop: 6,
   },
 });

--- a/sim/useSimulatedData.ts
+++ b/sim/useSimulatedData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import type {
   CandlePoint,
@@ -36,6 +36,11 @@ export interface SimulatedDataOptions {
   candleAggregation?: boolean;
   /** Skip synthetic trade events when not displayed (default true). */
   tradeStream?: boolean;
+  /**
+   * When using multi-series, merge `visible` from this ref each tick so `onSeriesToggle`
+   * can persist (demo / gallery).
+   */
+  seriesVisibilityRef?: RefObject<Record<string, boolean>>;
 }
 
 export interface SimulatedData {
@@ -74,6 +79,7 @@ export function useSimulatedData(
     multiSeries = true,
     candleAggregation = true,
     tradeStream: tradeStreamEnabled = true,
+    seriesVisibilityRef,
   } = opts;
 
   // JS-side buffers — fast O(1) reads in the tick callback
@@ -200,7 +206,14 @@ export function useSimulatedData(
 
       // Multi-series — skip when not displayed
       if (multiSeries) {
-        b.series = b.series.map((s) => ({ ...s, data: [...s.data] }));
+        b.series = b.series.map((s) => {
+          const vis = seriesVisibilityRef?.current[s.id];
+          return {
+            ...s,
+            data: [...s.data],
+            ...(vis !== undefined ? { visible: vis } : {}),
+          };
+        });
         stepMultiSeries(b.series, true);
         for (let i = 0; i < b.series.length; i++) {
           if (b.series[i].data.length > maxPoints) {

--- a/src/hooks/useMomentum.test.ts
+++ b/src/hooks/useMomentum.test.ts
@@ -1,8 +1,8 @@
 import { resolveMomentumProp, useMomentum } from "./useMomentum";
 
+import { renderHook } from "@testing-library/react-native";
 import type { LiveChartPoint } from "../types";
 import type { SingleEngineState } from "../useLiveChartEngine";
-import { renderHook } from "@testing-library/react-native";
 
 const makeData = (values: number[]) =>
   values.map((v, i) => ({ time: i * 0.2, value: v }));


### PR DESCRIPTION
### TL;DR

Added a comprehensive demo application with 14 specialized screens showcasing different LiveChart features and configurations.

### What changed?

Created a new demo application structure with:

- **Demo layout and shared components**: Added `_layout.tsx` with dark theme navigation, `DemoScreen.tsx` wrapper component, and shared styling/constants
- **14 feature-specific demo screens**: Each screen focuses on testing specific LiveChart functionality:
  - Playground: All-in-one interactive demo
  - Line & playback: Time windows, smoothing, pause controls
  - Candlestick: Candle mode with OHLC data
  - Appearance: Themes, colors, fonts, styling
  - Axes & insets: Axis visibility and spacing controls
  - Chart size: Different dimensions and flex layouts
  - Badge & pulse: Value badge and pulse animations
  - Momentum: Price momentum indicators
  - Scrub: Interactive chart scrubbing
  - Reference & value lines: Horizontal line overlays
  - Trade stream: Live trade markers
  - Degen: Particle effects and animations
  - Edge cases: Loading states and formatters
  - Multi-series: Multiple data series management
- **Enhanced simulation system**: Extended `useSimulatedData` with series visibility tracking for interactive toggles
- **Updated main index**: Converted from single playground to demo navigation menu

### How to test?

1. Run the app and navigate through the demo screens from the main menu
2. Each screen has interactive controls to test specific features
3. Use the "Playground" screen for comprehensive testing of multiple features together
4. Test different combinations of settings on each specialized screen

### Why make this change?

This provides a structured way to test and demonstrate individual LiveChart features in isolation, making it easier to:
- Verify specific functionality works correctly
- Showcase capabilities to users
- Debug issues with particular features
- Understand how different props and configurations affect chart behavior