### PR TITLE
fix: let chart go full width when y-axis gone

### DIFF
--- a/app/demo/axes-insets.tsx
+++ b/app/demo/axes-insets.tsx
@@ -25,6 +25,8 @@ export default function AxesInsetsScreen() {
   const [insets, setInsets] = useState<InsetPreset>("default");
   const [gap, setGap] = useState<GapPreset>("default");
   const [which, setWhich] = useState<"single" | "multi">("single");
+  const [badgeOn, setBadgeOn] = useState(true);
+  const [pulseOn, setPulseOn] = useState(true);
 
   const yOn = vis !== "noY" && vis !== "none";
   const xOn = vis !== "noX" && vis !== "none";
@@ -42,7 +44,7 @@ export default function AxesInsetsScreen() {
 
   return (
     <DemoScreen
-      description="Hide Y, X, or both; minGap; insets. Toggle single vs multi chart."
+      description="Hide Y, X, or both; minGap; insets; badge and live-dot pulse (LiveChart). Toggle single vs multi chart."
       chart={
         which === "single" ? (
           <LiveChart
@@ -53,6 +55,8 @@ export default function AxesInsetsScreen() {
             yAxis={yAxis}
             xAxis={xAxis}
             insets={insetCfg}
+            badge={badgeOn}
+            pulse={pulseOn}
             scrub
           />
         ) : (
@@ -94,6 +98,54 @@ export default function AxesInsetsScreen() {
             ]}
           >
             LiveChartSeries
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Badge (LiveChart)</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, badgeOn && demoStyles.chipActive]}
+          onPress={() => setBadgeOn(true)}
+        >
+          <Text
+            style={[demoStyles.chipText, badgeOn && demoStyles.chipTextActive]}
+          >
+            On
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, !badgeOn && demoStyles.chipActive]}
+          onPress={() => setBadgeOn(false)}
+        >
+          <Text
+            style={[demoStyles.chipText, !badgeOn && demoStyles.chipTextActive]}
+          >
+            Off
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Pulse (LiveChart)</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, pulseOn && demoStyles.chipActive]}
+          onPress={() => setPulseOn(true)}
+        >
+          <Text
+            style={[demoStyles.chipText, pulseOn && demoStyles.chipTextActive]}
+          >
+            On
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, !pulseOn && demoStyles.chipActive]}
+          onPress={() => setPulseOn(false)}
+        >
+          <Text
+            style={[demoStyles.chipText, !pulseOn && demoStyles.chipTextActive]}
+          >
+            Off
           </Text>
         </Pressable>
       </View>

--- a/src/LiveChart.tsx
+++ b/src/LiveChart.tsx
@@ -134,6 +134,13 @@ export function LiveChart({
     ),
   );
 
+  const pulseConfig = pulseCfg
+    ? {
+        maxRadius: pulseCfg.maxRadius,
+        strokeWidth: pulseCfg.strokeWidth,
+      }
+    : null;
+
   const { strokeWidth, padding: effectivePadding } = resolveChartLayout({
     palette,
     lineWidthOverride: lineProp?.width,
@@ -145,6 +152,7 @@ export function LiveChart({
     font: skiaFont,
     formatValue,
     currentValue: value.value,
+    pulse: pulseConfig,
   });
 
   // ── Engine and reveal state ────────────────────────────────────────────

--- a/src/components/DotOverlay.tsx
+++ b/src/components/DotOverlay.tsx
@@ -8,6 +8,11 @@ const MIN_PULSE_RADIUS = 9;
 const DOT_OUTER_RADIUS = 6.5;
 const DOT_INNER_RADIUS = 3.5;
 
+/**
+ * Live dot + expanding pulse ring. Peak ring size uses `pulse.maxRadius` and
+ * `pulse.strokeWidth`; chart padding reserves the same outer extent via
+ * `pulseRadialOutset` in `draw/line.ts` (see `resolveChartLayout`).
+ */
 export function DotOverlay({
   dotX,
   dotY,

--- a/src/draw/line.test.ts
+++ b/src/draw/line.test.ts
@@ -3,6 +3,7 @@ import {
   buildLinePoints,
   gutterCenteredTextLeftX,
   minPaddingRightForBadgeYAxisAlign,
+  pulseRadialOutset,
   resolveAutoRight,
   resolvePadding,
 } from "./line";
@@ -17,6 +18,25 @@ describe("minPaddingRightForBadgeYAxisAlign", () => {
   it("returns DOT_GAP + tl + 2×PAD_X + textWidth + MARGIN_RIGHT (tl=14 for 12px font)", () => {
     // 12 + 14 + 20 + 35 + 4 = 85
     expect(minPaddingRightForBadgeYAxisAlign(12, 35)).toBe(85);
+  });
+});
+
+describe("pulseRadialOutset", () => {
+  it("ceil(maxRadius + strokeWidth/2) for default pulse-like values", () => {
+    expect(pulseRadialOutset(21, 1.5)).toBe(22);
+  });
+
+  it("handles integer sum without fractional waste", () => {
+    expect(pulseRadialOutset(20, 2)).toBe(21);
+  });
+
+  it("uses maxRadius alone when strokeWidth is zero", () => {
+    expect(pulseRadialOutset(15, 0)).toBe(15);
+  });
+
+  it("rounds up fractional totals", () => {
+    expect(pulseRadialOutset(10, 1)).toBe(11);
+    expect(pulseRadialOutset(9, 1)).toBe(10);
   });
 });
 

--- a/src/draw/line.ts
+++ b/src/draw/line.ts
@@ -114,6 +114,22 @@ export function resolveAutoLeft(badgeOnLeft: boolean): number {
   return DEFAULT_PADDING.left;
 }
 
+/**
+ * Minimum inset from the canvas edge so the live-dot pulse ring is not clipped.
+ * Matches `DotOverlay`: circle radius up to `maxRadius` with a centered stroke.
+ *
+ * Used by `resolveChartLayout` when `pulse` is set; keep in sync with `DotOverlay` pulse rendering.
+ *
+ * @see `resolveChartLayout` in `hooks/resolveChartLayout.ts`
+ * @see `DotOverlay` in `components/DotOverlay.tsx`
+ */
+export function pulseRadialOutset(
+  maxRadius: number,
+  strokeWidth: number,
+): number {
+  return Math.ceil(maxRadius + strokeWidth / 2);
+}
+
 export function resolvePadding(
   override?: ChartInsets,
   yAxis = false,

--- a/src/hooks/resolveChartLayout.test.ts
+++ b/src/hooks/resolveChartLayout.test.ts
@@ -1,6 +1,7 @@
 import type { SkFont } from "@shopify/react-native-skia";
-import { resolveChartLayout } from "./resolveChartLayout";
+import { pulseRadialOutset } from "../draw/line";
 import { resolveTheme } from "../theme";
+import { resolveChartLayout } from "./resolveChartLayout";
 
 const palette = resolveTheme("#3b82f6", "dark");
 
@@ -107,6 +108,52 @@ describe("resolveChartLayout", () => {
     // samples: "42.00"(5ch), "4.20"(4ch), "0.42"(4ch), "420.00"(6ch) → max 6ch×7=42px
     // yAxis: max(42+16, 44) = 58
     expect(padding.right).toBe(58);
+  });
+
+  it("uses minimal right padding when y-axis and badge are off (font path)", () => {
+    const font = mockFont(7);
+    const { padding } = resolveChartLayout({
+      palette,
+      yAxis: false,
+      badge: false,
+      font,
+      formatValue: fmt,
+      currentValue: 42,
+    });
+    expect(padding.right).toBe(12);
+  });
+
+  it("expands top/right/bottom for live dot pulse when y-axis and badge are off", () => {
+    const font = mockFont(7);
+    const { padding } = resolveChartLayout({
+      palette,
+      yAxis: false,
+      badge: false,
+      font,
+      formatValue: fmt,
+      currentValue: 42,
+      pulse: { maxRadius: 21, strokeWidth: 1.5 },
+    });
+    const outlet = pulseRadialOutset(21, 1.5);
+    expect(padding.right).toBe(outlet);
+    expect(padding.top).toBe(outlet);
+    expect(padding.bottom).toBe(28);
+    expect(padding.left).toBe(12);
+  });
+
+  it("does not shrink insets below pulse outlet when right inset override is tight", () => {
+    const { padding } = resolveChartLayout({
+      palette,
+      yAxis: false,
+      badge: false,
+      insetsOverride: { right: 6, top: 6, bottom: 6, left: 6 },
+      pulse: { maxRadius: 20, strokeWidth: 2 },
+    });
+    const outlet = pulseRadialOutset(20, 2);
+    expect(padding.right).toBe(outlet);
+    expect(padding.top).toBe(outlet);
+    expect(padding.bottom).toBe(outlet);
+    expect(padding.left).toBe(6);
   });
 
   it("auto-sizes right padding from formatted value width (badge)", () => {

--- a/src/hooks/resolveChartLayout.ts
+++ b/src/hooks/resolveChartLayout.ts
@@ -2,6 +2,7 @@ import type { SkFont } from "@shopify/react-native-skia";
 import {
   minPaddingLeftForBadge,
   minPaddingRightForBadgeYAxisAlign,
+  pulseRadialOutset,
   resolveAutoLeft,
   resolveAutoRight,
   resolvePadding,
@@ -26,6 +27,8 @@ export interface ChartLayoutConfig {
   formatValue?: (v: number) => string;
   /** Current value read from SharedValue on JS thread — used to produce a sample label for measurement */
   currentValue?: number;
+  /** Live dot pulse (LiveChart); expands top/right/bottom insets so the ring is not clipped. */
+  pulse?: { maxRadius: number; strokeWidth: number } | null;
 }
 
 export interface ChartLayoutResult {
@@ -57,7 +60,9 @@ export function resolveChartLayout(
     );
     rightPad = badgeOnRight
       ? minPaddingRightForBadgeYAxisAlign(config.font.getSize(), textWidth)
-      : Math.max(textWidth + 16, 44);
+      : config.yAxis
+        ? Math.max(textWidth + 16, 44)
+        : resolveAutoRight(false, false);
   } else {
     rightPad = resolveAutoRight(config.yAxis, badgeOnRight);
   }
@@ -90,8 +95,22 @@ export function resolveChartLayout(
     xAxis,
   );
 
+  let padding: ChartPadding = { ...base, right: rightPad, left: leftPad };
+  if (config.pulse) {
+    const outlet = pulseRadialOutset(
+      config.pulse.maxRadius,
+      config.pulse.strokeWidth,
+    );
+    padding = {
+      ...padding,
+      right: Math.max(padding.right, outlet),
+      top: Math.max(padding.top, outlet),
+      bottom: Math.max(padding.bottom, outlet),
+    };
+  }
+
   return {
     strokeWidth: config.lineWidthOverride ?? config.palette.lineWidth,
-    padding: { ...base, right: rightPad, left: leftPad },
+    padding,
   };
 }


### PR DESCRIPTION
### TL;DR

Added badge and pulse toggle controls to the axes-insets demo screen for testing LiveChart features.

### What changed?

- Added `badgeOn` and `pulseOn` state variables with toggle controls in the demo UI
- Passed these props to the `LiveChart` component to control badge visibility and live-dot pulse animation
- Implemented `pulseRadialOutset` function to calculate minimum canvas insets needed to prevent pulse ring clipping
- Enhanced `resolveChartLayout` to automatically expand top/right/bottom padding when pulse is enabled
- Added comprehensive test coverage for the new pulse padding calculations

### How to test?

1. Navigate to the axes-insets demo screen
2. Toggle the "Badge" and "Pulse" controls to see their effects on the LiveChart
3. Verify that the pulse ring is not clipped at canvas edges when enabled
4. Test with different axis visibility and inset configurations to ensure proper padding

### Why make this change?

This enables proper testing and demonstration of LiveChart's badge and pulse features while ensuring the pulse animation renders correctly without being clipped by the canvas boundaries. The automatic padding adjustment prevents visual artifacts when the pulse ring extends beyond the chart area.