### PR TITLE
feat: left edge gradient

### DIFF
--- a/src/LiveChart.tsx
+++ b/src/LiveChart.tsx
@@ -34,6 +34,7 @@ import {
   resolveDegen,
   resolveFontConfig,
   resolveGradient,
+  resolveLeftEdgeFade,
   resolvePulse,
   resolveReferenceLineConfig,
   resolveScrub,
@@ -42,6 +43,7 @@ import {
   resolveXAxis,
   resolveYAxis,
 } from "./resolveConfig";
+import { leftEdgeFadeColorsFromBgRgb, resolveTheme } from "./theme";
 import type { LiveChartProps, TradeEvent } from "./types";
 
 import { GestureDetector } from "react-native-gesture-handler";
@@ -50,6 +52,7 @@ import { BadgeOverlay } from "./components/BadgeOverlay";
 import { CrosshairOverlay } from "./components/CrosshairOverlay";
 import { DegenParticlesOverlay } from "./components/DegenParticlesOverlay";
 import { DotOverlay } from "./components/DotOverlay";
+import { LeftEdgeFade } from "./components/LeftEdgeFade";
 import { LoadingOverlay } from "./components/LoadingOverlay";
 import { MultiSeriesTooltipStack } from "./components/MultiSeriesTooltipStack";
 import { ReferenceLineOverlay } from "./components/ReferenceLineOverlay";
@@ -57,7 +60,6 @@ import { TradeStreamOverlay } from "./components/TradeStreamOverlay";
 import { ValueLineOverlay } from "./components/ValueLineOverlay";
 import { XAxisOverlay } from "./components/XAxisOverlay";
 import { YAxisOverlay } from "./components/YAxisOverlay";
-import { resolveTheme } from "./theme";
 import { useLiveChartEngine } from "./useLiveChartEngine";
 
 export function LiveChart({
@@ -101,6 +103,7 @@ export function LiveChart({
   scrub = false,
   tradeStream,
   degen,
+  leftEdgeFade = true,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
@@ -125,6 +128,11 @@ export function LiveChart({
 
   // ── Theme, font and layout ─────────────────────────────────────────────
   const palette = resolveTheme(accentColor, theme);
+
+  const leftEdgeFadeCfg = resolveLeftEdgeFade(
+    leftEdgeFade,
+    leftEdgeFadeColorsFromBgRgb(palette.bgRgb),
+  );
 
   const skiaFont = matchFont(
     resolveFontConfig(
@@ -283,6 +291,7 @@ export function LiveChart({
     <GestureDetector gesture={crosshair.gesture}>
       <View style={[{ flex: 1, backgroundColor }, style]} onLayout={onLayout}>
         <Canvas style={{ flex: 1 }}>
+          {/* Shaken chart stack — left-edge fade is a sibling below so dstOut runs in canvas space */}
           <Group transform={degenShakeTransform}>
             {/* Y-axis grid */}
             {yAxisCfg && (
@@ -413,19 +422,7 @@ export function LiveChart({
               </Group>
             )}
 
-            {/* Trade stream labels */}
-            {tradeStreamResolved && (
-              <TradeStreamOverlay
-                markers={tradeMarkers}
-                palette={palette}
-                padding={effectivePadding}
-                font={skiaFont}
-                opacity={reveal.dotOpacity}
-                labelOffsetX={tradeStreamResolved.labelOffsetX}
-              />
-            )}
-
-            {/* Loading / empty state — rendered last so it sits on top */}
+            {/* Loading / empty state — before left-edge fade so the squiggle/empty art fades like the chart */}
             <LoadingOverlay
               engine={engine}
               padding={effectivePadding}
@@ -438,30 +435,54 @@ export function LiveChart({
               strokeWidth={strokeWidth}
               badge={badgeCfg !== null}
             />
-
-            {/* Crosshair scrub */}
-            {scrubCfg && (
-              <CrosshairOverlay
-                scrubX={crosshair.scrubX}
-                crosshairOpacity={crosshair.crosshairOpacity}
-                tooltipLayout={crosshair.tooltipLayout}
-                engine={engine}
-                padding={effectivePadding}
-                palette={palette}
-                font={skiaFont}
-                showTooltip={scrubCfg.tooltip}
-                tooltipBody={
-                  isCandle ? (
-                    <MultiSeriesTooltipStack
-                      tooltipLayout={crosshair.tooltipLayout}
-                      font={skiaFont}
-                      palette={palette}
-                    />
-                  ) : undefined
-                }
-              />
-            )}
           </Group>
+
+          {leftEdgeFadeCfg && (
+            <LeftEdgeFade
+              paddingLeft={effectivePadding.left}
+              fadeWidth={leftEdgeFadeCfg.width}
+              startColor={leftEdgeFadeCfg.startColor}
+              endColor={leftEdgeFadeCfg.endColor}
+              engine={engine}
+            />
+          )}
+
+          {(tradeStreamResolved || scrubCfg) && (
+            <Group transform={degenShakeTransform}>
+              {tradeStreamResolved && (
+                <TradeStreamOverlay
+                  markers={tradeMarkers}
+                  palette={palette}
+                  padding={effectivePadding}
+                  font={skiaFont}
+                  opacity={reveal.dotOpacity}
+                  labelOffsetX={tradeStreamResolved.labelOffsetX}
+                />
+              )}
+
+              {scrubCfg && (
+                <CrosshairOverlay
+                  scrubX={crosshair.scrubX}
+                  crosshairOpacity={crosshair.crosshairOpacity}
+                  tooltipLayout={crosshair.tooltipLayout}
+                  engine={engine}
+                  padding={effectivePadding}
+                  palette={palette}
+                  font={skiaFont}
+                  showTooltip={scrubCfg.tooltip}
+                  tooltipBody={
+                    isCandle ? (
+                      <MultiSeriesTooltipStack
+                        tooltipLayout={crosshair.tooltipLayout}
+                        font={skiaFont}
+                        palette={palette}
+                      />
+                    ) : undefined
+                  }
+                />
+              )}
+            </Group>
+          )}
         </Canvas>
       </View>
     </GestureDetector>

--- a/src/LiveChartSeries.tsx
+++ b/src/LiveChartSeries.tsx
@@ -8,6 +8,7 @@ import {
   type SharedValue,
 } from "react-native-reanimated";
 import { CrosshairOverlay } from "./components/CrosshairOverlay";
+import { LeftEdgeFade } from "./components/LeftEdgeFade";
 import { LoadingOverlay } from "./components/LoadingOverlay";
 import { MultiSeriesDots } from "./components/MultiSeriesDots";
 import { MultiSeriesStroke } from "./components/MultiSeriesStroke";
@@ -37,12 +38,13 @@ import {
 } from "./multiSeriesLayout";
 import {
   resolveFontConfig,
+  resolveLeftEdgeFade,
   resolveReferenceLineConfig,
   resolveScrub,
   resolveXAxis,
   resolveYAxis,
 } from "./resolveConfig";
-import { resolveTheme } from "./theme";
+import { leftEdgeFadeColorsFromBgRgb, resolveTheme } from "./theme";
 import type { LiveChartSeriesProps, SeriesConfig } from "./types";
 import { useLiveChartSeriesEngine } from "./useLiveChartSeriesEngine";
 
@@ -74,6 +76,7 @@ export function LiveChartSeries({
   onScrub,
   onSeriesToggle,
   seriesToggleCompact,
+  leftEdgeFade = true,
 }: LiveChartSeriesProps) {
   const yAxisCfg = resolveYAxis(yAxis);
   const xAxisCfg = resolveXAxis(xAxis);
@@ -81,6 +84,11 @@ export function LiveChartSeries({
   const refLineCfg = resolveReferenceLineConfig(referenceLine);
 
   const palette = resolveTheme(accentColor, theme);
+
+  const leftEdgeFadeCfg = resolveLeftEdgeFade(
+    leftEdgeFade,
+    leftEdgeFadeColorsFromBgRgb(palette.bgRgb),
+  );
 
   const skiaFont = matchFont(
     resolveFontConfig(
@@ -249,6 +257,16 @@ export function LiveChartSeries({
             strokeWidth={strokeWidth}
             badge={false}
           />
+
+          {leftEdgeFadeCfg && (
+            <LeftEdgeFade
+              paddingLeft={effectivePadding.left}
+              fadeWidth={leftEdgeFadeCfg.width}
+              startColor={leftEdgeFadeCfg.startColor}
+              endColor={leftEdgeFadeCfg.endColor}
+              engine={engine}
+            />
+          )}
 
           {scrubCfg && (
             <CrosshairOverlay

--- a/src/components/LeftEdgeFade.tsx
+++ b/src/components/LeftEdgeFade.tsx
@@ -1,0 +1,36 @@
+import { Group, LinearGradient, Rect, vec } from "@shopify/react-native-skia";
+
+import { useDerivedValue } from "react-native-reanimated";
+import type { ChartEngineLayout } from "../useLiveChartEngine";
+
+export function LeftEdgeFade({
+  paddingLeft,
+  fadeWidth,
+  startColor,
+  endColor,
+  engine,
+}: {
+  paddingLeft: number;
+  fadeWidth: number;
+  startColor: string;
+  endColor: string;
+  engine: ChartEngineLayout;
+}) {
+  const rectWidth = paddingLeft + fadeWidth;
+  const height = useDerivedValue(() => engine.canvasHeight.value);
+
+  const gStart = vec(paddingLeft, 0);
+  const gEnd = vec(paddingLeft + fadeWidth, 0);
+
+  return (
+    <Group blendMode="dstOut">
+      <Rect x={0} y={0} width={rectWidth} height={height}>
+        <LinearGradient
+          start={gStart}
+          end={gEnd}
+          colors={[startColor, endColor]}
+        />
+      </Rect>
+    </Group>
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,9 @@ export const BADGE_DOT_GAP = 12;
 /** Maximum simultaneous series rendered (paths/dots slots). */
 export const MAX_MULTI_SERIES = 12;
 
+/** Default width (px) of the left-edge fade band */
+export const FADE_EDGE_WIDTH = 40;
+
 /**
  * Floats per degen particle slot: `x, y, vx, vy, t0, active, size`.
  * Layout is fixed; not on `DegenOptions` because changing it needs matching renderer changes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { LiveChart, LiveChartSeries };
     FontConfig,
     FontWeight,
     GradientConfig,
+    LeftEdgeFadeConfig,
     LineConfig,
     LiveChartCoreProps,
     LiveChartPalette,

--- a/src/resolveConfig.test.ts
+++ b/src/resolveConfig.test.ts
@@ -3,6 +3,7 @@ import {
   resolveDegen,
   resolveFontConfig,
   resolveGradient,
+  resolveLeftEdgeFade,
   resolvePulse,
   resolveReferenceLineConfig,
   resolveScrub,
@@ -11,6 +12,9 @@ import {
   resolveXAxis,
   resolveYAxis,
 } from "./resolveConfig";
+
+import { FADE_EDGE_WIDTH } from "./constants";
+import { leftEdgeFadeColorsFromBgRgb } from "./theme";
 
 // ─── resolveValueLine ─────────────────────────────────────────────────────────
 
@@ -240,6 +244,62 @@ describe("resolveGradient", () => {
     expect(resolveGradient({ topOpacity: 0.3, bottomOpacity: 0.05 })).toEqual({
       topOpacity: 0.3,
       bottomOpacity: 0.05,
+    });
+  });
+});
+
+// ─── resolveLeftEdgeFade ───────────────────────────────────────────────────────
+
+describe("resolveLeftEdgeFade", () => {
+  it("returns null for undefined", () => {
+    expect(resolveLeftEdgeFade(undefined)).toBeNull();
+  });
+
+  it("returns null for false", () => {
+    expect(resolveLeftEdgeFade(false)).toBeNull();
+  });
+
+  it("returns defaults for true", () => {
+    expect(resolveLeftEdgeFade(true)).toEqual({
+      width: FADE_EDGE_WIDTH,
+      startColor: "rgba(0, 0, 0, 1)",
+      endColor: "rgba(0, 0, 0, 0)",
+    });
+  });
+
+  it("merges custom width and colors", () => {
+    expect(
+      resolveLeftEdgeFade({
+        width: 24,
+        startColor: "rgba(255, 0, 0, 0.8)",
+        endColor: "#00000000",
+      }),
+    ).toEqual({
+      width: 24,
+      startColor: "rgba(255, 0, 0, 0.8)",
+      endColor: "#00000000",
+    });
+  });
+
+  it("merges single color override", () => {
+    expect(resolveLeftEdgeFade({ startColor: "rgba(0,0,0,0.5)" })).toEqual({
+      width: FADE_EDGE_WIDTH,
+      startColor: "rgba(0,0,0,0.5)",
+      endColor: "rgba(0, 0, 0, 0)",
+    });
+  });
+
+  it("uses theme background colors when provided", () => {
+    const bg = leftEdgeFadeColorsFromBgRgb([255, 128, 64]);
+    expect(resolveLeftEdgeFade(true, bg)).toEqual({
+      width: FADE_EDGE_WIDTH,
+      startColor: "rgba(255, 128, 64, 1)",
+      endColor: "rgba(255, 128, 64, 0)",
+    });
+    expect(resolveLeftEdgeFade({ width: 12 }, bg)).toEqual({
+      width: 12,
+      startColor: "rgba(255, 128, 64, 1)",
+      endColor: "rgba(255, 128, 64, 0)",
     });
   });
 });

--- a/src/resolveConfig.ts
+++ b/src/resolveConfig.ts
@@ -5,6 +5,7 @@ import type {
   FontConfig,
   FontWeight,
   GradientConfig,
+  LeftEdgeFadeConfig,
   PulseConfig,
   ReferenceLine,
   ScrubConfig,
@@ -15,6 +16,7 @@ import type {
 } from "./types";
 
 import type { SharedValue } from "react-native-reanimated";
+import { FADE_EDGE_WIDTH } from "./constants";
 
 // ─── Resolved types (all fields required, no optionals) ──────────────────────
 
@@ -98,6 +100,12 @@ export interface ResolvedTradeStreamConfig {
   maxCount: number;
   /** Horizontal offset from `padding.left` for the label text (default 8). */
   labelOffsetX: number;
+}
+
+export interface ResolvedLeftEdgeFadeConfig {
+  width: number;
+  startColor: string;
+  endColor: string;
 }
 
 // ─── Resolver functions ───────────────────────────────────────────────────────
@@ -202,6 +210,38 @@ export function resolveGradient(
   if (!prop) return null;
   if (prop === true) return GRADIENT_DEFAULTS;
   return { ...GRADIENT_DEFAULTS, ...prop };
+}
+
+/** Fallback when no theme background is passed (e.g. unit tests). */
+const LEFT_EDGE_FADE_COLOR_FALLBACK: Pick<
+  ResolvedLeftEdgeFadeConfig,
+  "startColor" | "endColor"
+> = {
+  startColor: "rgba(0, 0, 0, 1)",
+  endColor: "rgba(0, 0, 0, 0)",
+};
+
+/**
+ * Resolves `leftEdgeFade` prop to a fully-typed config or null (disabled).
+ * `true` → defaults, object → merged with defaults, falsy → null.
+ *
+ * Pass `colorDefaults` from `leftEdgeFadeColorsFromBgRgb(palette.bgRgb)` so default
+ * stops match the chart background; omit for black alpha-gradient fallback.
+ */
+export function resolveLeftEdgeFade(
+  prop: boolean | LeftEdgeFadeConfig | undefined,
+  colorDefaults: {
+    startColor: string;
+    endColor: string;
+  } = LEFT_EDGE_FADE_COLOR_FALLBACK,
+): ResolvedLeftEdgeFadeConfig | null {
+  if (!prop) return null;
+  const base: ResolvedLeftEdgeFadeConfig = {
+    width: FADE_EDGE_WIDTH,
+    ...colorDefaults,
+  };
+  if (prop === true) return base;
+  return { ...base, ...prop };
 }
 
 const PULSE_DEFAULTS: ResolvedPulseConfig = {

--- a/src/theme.test.ts
+++ b/src/theme.test.ts
@@ -1,5 +1,6 @@
 import {
   SERIES_COLORS,
+  leftEdgeFadeColorsFromBgRgb,
   parseColorRgb,
   resolveSeriesPalettes,
   resolveTheme,
@@ -24,6 +25,15 @@ describe("parseColorRgb", () => {
 
   it("falls back for unknown strings", () => {
     expect(parseColorRgb("not-a-color")).toEqual([128, 128, 128]);
+  });
+});
+
+describe("leftEdgeFadeColorsFromBgRgb", () => {
+  it("matches background rgb with alpha ramp", () => {
+    expect(leftEdgeFadeColorsFromBgRgb([10, 20, 30])).toEqual({
+      startColor: "rgba(10, 20, 30, 1)",
+      endColor: "rgba(10, 20, 30, 0)",
+    });
   });
 });
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -80,6 +80,21 @@ function rgba(r: number, g: number, b: number, a: number): string {
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
 
+/**
+ * Default left-edge fade gradient stops for `dstOut` blending: same RGB as the chart
+ * background (`palette.bgRgb`), opacity 1 → 0. Matches the container `backgroundColor`.
+ */
+export function leftEdgeFadeColorsFromBgRgb(bgRgb: [number, number, number]): {
+  startColor: string;
+  endColor: string;
+} {
+  const [r, g, b] = bgRgb;
+  return {
+    startColor: rgba(r, g, b, 1),
+    endColor: rgba(r, g, b, 0),
+  };
+}
+
 function twAlpha(hex: string, a: number): string {
   const [r, g, b] = parseColorRgb(hex);
   return rgba(r, g, b, a);

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,26 @@ export interface ScrubConfig {
   tooltip?: boolean;
 }
 
+/** Left-edge fade — soft erase so the chart blends into the left gutter (web liveline parity). */
+export interface LeftEdgeFadeConfig {
+  /**
+   * Horizontal fade band in pixels; gradient runs from the chart inner edge (`padding.left`)
+   * across this width. Default `40` (same as liveline).
+   */
+  width?: number;
+  /**
+   * Gradient color at the left (canvas edge side). With default `dstOut` blending, **alpha**
+   * controls how strongly content is erased (opaque = full fade). When omitted, defaults match
+   * the chart background RGB (`palette.bgRgb`) at alpha 1.
+   */
+  startColor?: string;
+  /**
+   * Gradient color at the right (chart side). When omitted, defaults to the same RGB as the
+   * chart background at alpha 0 (no erase).
+   */
+  endColor?: string;
+}
+
 /** Pulsing ring animation on the live dot. */
 export interface PulseConfig {
   /** Time between pulse starts in milliseconds. Default `2400`. */
@@ -308,6 +328,11 @@ export interface LiveChartCoreProps {
   referenceLine?: ReferenceLine;
   /** Crosshair scrubbing on hover/drag. `true` = defaults, `false` = disabled, or pass `ScrubConfig`. Default `true`. */
   scrub?: boolean | ScrubConfig;
+  /**
+   * Fade out chart content on the left (destination-out style). `true` = defaults, `false` = off,
+   * or pass `LeftEdgeFadeConfig`. Default `true`.
+   */
+  leftEdgeFade?: boolean | LeftEdgeFadeConfig;
   /** Main chart line styling. */
   line?: LineConfig;
 }


### PR DESCRIPTION
### TL;DR

Added a configurable left-edge fade effect to charts that softly erases chart content near the left edge for better visual blending.

### What changed?

- Added `LeftEdgeFade` component that uses a linear gradient with `dstOut` blend mode to create a fade effect
- Introduced `leftEdgeFade` prop to both `LiveChart` and `LiveChartSeries` components (defaults to `true`)
- Added `LeftEdgeFadeConfig` type allowing customization of fade width, start color, and end color
- Implemented `resolveLeftEdgeFade` function to handle prop resolution with theme-aware color defaults
- Added `leftEdgeFadeColorsFromBgRgb` utility to generate fade colors matching the chart background
- Repositioned trade stream and crosshair overlays to render above the fade effect
- Added `FADE_EDGE_WIDTH` constant with default value of 40 pixels

### How to test?

1. Render a chart with default settings - should see a subtle fade on the left edge
2. Test with `leftEdgeFade={false}` to disable the effect
3. Test custom fade configuration: `leftEdgeFade={{ width: 60, startColor: "rgba(255,0,0,0.8)" }}`
4. Verify the fade works with different themes and background colors
5. Check that crosshair and trade stream overlays still appear above the fade

### Why make this change?

This adds visual parity with web liveline charts and creates a smoother transition between the chart content and the left padding area, improving the overall visual polish of the component.