### PR TITLE
feat: badge left position

### DIFF
--- a/app/demo/axes-insets.tsx
+++ b/app/demo/axes-insets.tsx
@@ -25,7 +25,9 @@ export default function AxesInsetsScreen() {
   const [insets, setInsets] = useState<InsetPreset>("default");
   const [gap, setGap] = useState<GapPreset>("default");
   const [which, setWhich] = useState<"single" | "multi">("single");
-  const [badgeOn, setBadgeOn] = useState(true);
+  const [badgePos, setBadgePos] = useState<"off" | "default" | "left">(
+    "default",
+  );
   const [pulseOn, setPulseOn] = useState(true);
 
   const yOn = vis !== "noY" && vis !== "none";
@@ -44,7 +46,7 @@ export default function AxesInsetsScreen() {
 
   return (
     <DemoScreen
-      description="Hide Y, X, or both; minGap; insets; badge and live-dot pulse (LiveChart). Toggle single vs multi chart."
+      description="Hide Y, X, or both; minGap; insets; badge (default / left of dot / off) and pulse (LiveChart). Toggle single vs multi chart."
       chart={
         which === "single" ? (
           <LiveChart
@@ -55,7 +57,13 @@ export default function AxesInsetsScreen() {
             yAxis={yAxis}
             xAxis={xAxis}
             insets={insetCfg}
-            badge={badgeOn}
+            badge={
+              badgePos === "off"
+                ? false
+                : badgePos === "left"
+                  ? { position: "left" }
+                  : true
+            }
             pulse={pulseOn}
             scrub
           />
@@ -104,26 +112,28 @@ export default function AxesInsetsScreen() {
 
       <Text style={demoStyles.sectionLabel}>Badge (LiveChart)</Text>
       <View style={demoStyles.buttonRow}>
-        <Pressable
-          style={[demoStyles.chip, badgeOn && demoStyles.chipActive]}
-          onPress={() => setBadgeOn(true)}
-        >
-          <Text
-            style={[demoStyles.chipText, badgeOn && demoStyles.chipTextActive]}
+        {(
+          [
+            ["default", "Default"],
+            ["off", "Off"],
+            ["left", "Left"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, badgePos === k && demoStyles.chipActive]}
+            onPress={() => setBadgePos(k)}
           >
-            On
-          </Text>
-        </Pressable>
-        <Pressable
-          style={[demoStyles.chip, !badgeOn && demoStyles.chipActive]}
-          onPress={() => setBadgeOn(false)}
-        >
-          <Text
-            style={[demoStyles.chipText, !badgeOn && demoStyles.chipTextActive]}
-          >
-            Off
-          </Text>
-        </Pressable>
+            <Text
+              style={[
+                demoStyles.chipText,
+                badgePos === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
       </View>
 
       <Text style={demoStyles.sectionLabel}>Pulse (LiveChart)</Text>

--- a/src/LiveChart.tsx
+++ b/src/LiveChart.tsx
@@ -124,7 +124,8 @@ export function LiveChart({
   const degenCfg = resolveDegen(degen);
   const tradeStreamResolved = resolveTradeStream(tradeStream);
 
-  const badgeOnLeft = badgeCfg?.position === "left";
+  const badgeUsesRightGutter =
+    badgeCfg !== null && (badgeCfg.position ?? "right") === "right";
 
   // ── Theme, font and layout ─────────────────────────────────────────────
   const palette = resolveTheme(accentColor, theme);
@@ -155,7 +156,7 @@ export function LiveChart({
     insetsOverride: insets,
     yAxis: yAxisCfg !== null,
     badge: badgeCfg !== null,
-    badgeOnLeft,
+    badgeUsesRightGutter,
     xAxis: xAxisCfg !== null,
     font: skiaFont,
     formatValue,
@@ -302,7 +303,7 @@ export function LiveChart({
                   padding={effectivePadding}
                   palette={palette}
                   font={skiaFont}
-                  badge={badgeCfg !== null && !badgeOnLeft}
+                  badge={badgeUsesRightGutter}
                 />
               </Group>
             )}

--- a/src/LiveChartSeries.tsx
+++ b/src/LiveChartSeries.tsx
@@ -104,7 +104,6 @@ export function LiveChartSeries({
     insetsOverride: insets,
     yAxis: yAxisCfg !== null,
     badge: false,
-    badgeOnLeft: false,
     xAxis: xAxisCfg !== null,
     font: skiaFont,
     formatValue,

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -131,6 +131,9 @@ export function LoadingOverlay({
   const emptyTextX = useDerivedValue(() => emptyLayout.value.x);
   const emptyTextY = useDerivedValue(() => emptyLayout.value.y);
   const showText = useDerivedValue(() => (isEmpty.value ? 1 : 0));
+  const emptyLabelText = useDerivedValue(() =>
+    isEmpty.value ? emptyText : "",
+  );
 
   return (
     <Group opacity={groupOpacity}>
@@ -182,7 +185,7 @@ export function LoadingOverlay({
       <SkiaText
         x={emptyTextX}
         y={emptyTextY}
-        text={showText.value > 0 ? emptyText : ""}
+        text={emptyLabelText}
         font={font}
         color={palette.gridLabel}
         opacity={showText}

--- a/src/draw/line.test.ts
+++ b/src/draw/line.test.ts
@@ -3,6 +3,7 @@ import {
   buildLinePoints,
   gutterCenteredTextLeftX,
   minPaddingRightForBadgeYAxisAlign,
+  minPaddingRightForYAxisWithPulse,
   pulseRadialOutset,
   resolveAutoRight,
   resolvePadding,
@@ -37,6 +38,13 @@ describe("pulseRadialOutset", () => {
   it("rounds up fractional totals", () => {
     expect(pulseRadialOutset(10, 1)).toBe(11);
     expect(pulseRadialOutset(9, 1)).toBe(10);
+  });
+});
+
+describe("minPaddingRightForYAxisWithPulse", () => {
+  it("is 2×outlet + label width + gap (default gap 8)", () => {
+    // outlet 22, tw 42 → 44 + 42 + 8 = 94
+    expect(minPaddingRightForYAxisWithPulse(22, 42)).toBe(94);
   });
 });
 

--- a/src/draw/line.ts
+++ b/src/draw/line.ts
@@ -98,8 +98,8 @@ export function resolveAutoRight(yAxis: boolean, badge: boolean): number {
 }
 
 /**
- * Minimum `padding.left` for a left-positioned badge pill.
- * Layout: |canvas edge| BADGE_MARGIN_RIGHT | PAD_X | text | PAD_X | BADGE_DOT_GAP | chart area
+ * Minimum `padding.left` for a badge pill drawn in the left chart margin (label width + horizontal padding + dot gap).
+ * `resolveChartLayout` does not call this; it remains available for custom layouts or `resolvePadding(..., badgeOnLeft: true)`.
  */
 export function minPaddingLeftForBadge(textWidth: number): number {
   return Math.ceil(
@@ -107,9 +107,8 @@ export function minPaddingLeftForBadge(textWidth: number): number {
   );
 }
 
-/** Auto-left-padding: left badge needs space for the pill. */
+/** Default left inset, or a wider inset when `badgeOnLeft` is true (see `minPaddingLeftForBadge`). */
 export function resolveAutoLeft(badgeOnLeft: boolean): number {
-  // Fallback assumes ~7 chars × 7px = 49px at 12px font size.
   if (badgeOnLeft) return minPaddingLeftForBadge(49);
   return DEFAULT_PADDING.left;
 }
@@ -128,6 +127,22 @@ export function pulseRadialOutset(
   strokeWidth: number,
 ): number {
   return Math.ceil(maxRadius + strokeWidth / 2);
+}
+
+/** Extra space beyond label width so the pulse ring does not touch glyphs. */
+const PULSE_Y_AXIS_LABEL_GAP = 8;
+
+/**
+ * Minimum `padding.right` when the live dot (and pulse) sit on the inner edge of the
+ * right gutter and y-axis labels are centered in that gutter (`gutterCenteredTextLeftX`).
+ * Otherwise the pulse can overlap labels to the right of the dot.
+ */
+export function minPaddingRightForYAxisWithPulse(
+  pulseOutlet: number,
+  yAxisLabelTextWidth: number,
+  gap = PULSE_Y_AXIS_LABEL_GAP,
+): number {
+  return Math.ceil(2 * pulseOutlet + yAxisLabelTextWidth + gap);
 }
 
 export function resolvePadding(

--- a/src/hooks/resolveChartLayout.test.ts
+++ b/src/hooks/resolveChartLayout.test.ts
@@ -1,5 +1,9 @@
+import {
+  minPaddingRightForYAxisWithPulse,
+  pulseRadialOutset,
+} from "../draw/line";
+
 import type { SkFont } from "@shopify/react-native-skia";
-import { pulseRadialOutset } from "../draw/line";
 import { resolveTheme } from "../theme";
 import { resolveChartLayout } from "./resolveChartLayout";
 
@@ -233,32 +237,76 @@ describe("resolveChartLayout", () => {
     expect(padding.right).toBe(99);
   });
 
-  // ─── left badge ──────────────────────────────────────────────────────────
+  // ─── badge left of dot (no right gutter, no extra left inset) ─────────────
 
-  it("auto-sizes left padding when badgeOnLeft and font are provided", () => {
+  it("does not inflate left padding when badge uses right gutter disabled", () => {
     const font = mockFont(7);
     const { padding } = resolveChartLayout({
       palette,
       yAxis: false,
       badge: true,
-      badgeOnLeft: true,
+      badgeUsesRightGutter: false,
       font,
       formatValue: fmt,
       currentValue: 42,
     });
-    // Right should shrink to default (badge not on right, no grid)
     expect(padding.right).toBe(12);
-    // Left should be auto-sized to fit the badge
-    expect(padding.left).toBeGreaterThan(12);
+    expect(padding.left).toBe(12);
   });
 
-  it("respects explicit insetsOverride.left", () => {
+  it("sizes right padding like grid-only when badge is on but not in right gutter", () => {
+    const font = mockFont(7);
+    const { padding } = resolveChartLayout({
+      palette,
+      yAxis: true,
+      badge: true,
+      badgeUsesRightGutter: false,
+      font,
+      formatValue: fmt,
+      currentValue: 42,
+    });
+    expect(padding.right).toBe(58);
+    expect(padding.left).toBe(12);
+  });
+
+  it("widens right padding when y-axis and pulse so the ring clears centered labels", () => {
+    const font = mockFont(7);
+    const pulse = { maxRadius: 21, strokeWidth: 1.5 };
+    const outlet = pulseRadialOutset(pulse.maxRadius, pulse.strokeWidth);
+    // Same grid width as "grid-only" without pulse (58) but pulse needs more gutter.
+    const { padding } = resolveChartLayout({
+      palette,
+      yAxis: true,
+      badge: true,
+      badgeUsesRightGutter: false,
+      font,
+      formatValue: fmt,
+      currentValue: 42,
+      pulse,
+    });
+    const tw = 6 * 7; // widest sample "420.00"
+    expect(padding.right).toBe(minPaddingRightForYAxisWithPulse(outlet, tw));
+  });
+
+  it("y-axis + pulse without font uses fallback label width for gutter math", () => {
+    const pulse = { maxRadius: 21, strokeWidth: 1.5 };
+    const outlet = pulseRadialOutset(pulse.maxRadius, pulse.strokeWidth);
+    const { padding } = resolveChartLayout({
+      palette,
+      yAxis: true,
+      badge: false,
+      pulse,
+    });
+    expect(padding.right).toBe(minPaddingRightForYAxisWithPulse(outlet, 49));
+  });
+
+  it("respects explicit insetsOverride.left when badge omits right gutter", () => {
     const { padding } = resolveChartLayout({
       palette,
       insetsOverride: { left: 80 },
       yAxis: false,
       badge: true,
-      badgeOnLeft: true,
+      badgeUsesRightGutter: false,
     });
     expect(padding.left).toBe(80);
   });

--- a/src/hooks/resolveChartLayout.ts
+++ b/src/hooks/resolveChartLayout.ts
@@ -1,7 +1,7 @@
 import type { SkFont } from "@shopify/react-native-skia";
 import {
-  minPaddingLeftForBadge,
   minPaddingRightForBadgeYAxisAlign,
+  minPaddingRightForYAxisWithPulse,
   pulseRadialOutset,
   resolveAutoLeft,
   resolveAutoRight,
@@ -17,8 +17,11 @@ export interface ChartLayoutConfig {
   insetsOverride?: ChartInsets;
   yAxis: boolean;
   badge: boolean;
-  /** When true, badge occupies the left gutter instead of the right. */
-  badgeOnLeft?: boolean;
+  /**
+   * When true (default if omitted and `badge` is true), reserve the wide right gutter for the badge.
+   * Set false when the badge is anchored left of the live dot (`position: "left"`).
+   */
+  badgeUsesRightGutter?: boolean;
   /** When false, bottom inset shrinks (no x-axis labels). Default true. */
   xAxis?: boolean;
   /** Skia font for measuring label width. When provided with formatValue + currentValue, padding auto-sizes. */
@@ -39,9 +42,11 @@ export interface ChartLayoutResult {
 export function resolveChartLayout(
   config: ChartLayoutConfig,
 ): ChartLayoutResult {
-  const badgeOnLeft = config.badgeOnLeft ?? false;
-  const badgeOnRight = config.badge && !badgeOnLeft;
+  const badgeUsesRightGutter =
+    config.badge && (config.badgeUsesRightGutter ?? true);
   const xAxis = config.xAxis ?? true;
+
+  let measuredYAxisLabelWidth: number | undefined;
 
   // ── Right inset ──────────────────────────────────────────────────────────
   let rightPad: number;
@@ -51,47 +56,50 @@ export function resolveChartLayout(
     config.font &&
     config.formatValue &&
     config.currentValue != null &&
-    !badgeOnLeft
+    (badgeUsesRightGutter || !config.badge || config.yAxis)
   ) {
     const v = config.currentValue;
     const samples = [v, v / 10, v / 100, v * 10].map(config.formatValue);
-    const textWidth = Math.max(
+    measuredYAxisLabelWidth = Math.max(
       ...samples.map((s) => measureFontTextWidth(config.font!, s)),
     );
-    rightPad = badgeOnRight
-      ? minPaddingRightForBadgeYAxisAlign(config.font.getSize(), textWidth)
+    rightPad = badgeUsesRightGutter
+      ? minPaddingRightForBadgeYAxisAlign(
+          config.font.getSize(),
+          measuredYAxisLabelWidth,
+        )
       : config.yAxis
-        ? Math.max(textWidth + 16, 44)
+        ? Math.max(measuredYAxisLabelWidth + 16, 44)
         : resolveAutoRight(false, false);
   } else {
-    rightPad = resolveAutoRight(config.yAxis, badgeOnRight);
+    rightPad = resolveAutoRight(config.yAxis, badgeUsesRightGutter);
+  }
+
+  if (config.pulse && config.yAxis && config.insetsOverride?.right == null) {
+    const outlet = pulseRadialOutset(
+      config.pulse.maxRadius,
+      config.pulse.strokeWidth,
+    );
+    const labelW = measuredYAxisLabelWidth ?? 49;
+    rightPad = Math.max(
+      rightPad,
+      minPaddingRightForYAxisWithPulse(outlet, labelW),
+    );
   }
 
   // ── Left inset ───────────────────────────────────────────────────────────
   let leftPad: number;
   if (config.insetsOverride?.left != null) {
     leftPad = config.insetsOverride.left;
-  } else if (
-    badgeOnLeft &&
-    config.font &&
-    config.formatValue &&
-    config.currentValue != null
-  ) {
-    const v = config.currentValue;
-    const samples = [v, v / 10, v / 100, v * 10].map(config.formatValue);
-    const textWidth = Math.max(
-      ...samples.map((s) => measureFontTextWidth(config.font!, s)),
-    );
-    leftPad = minPaddingLeftForBadge(textWidth);
   } else {
-    leftPad = resolveAutoLeft(badgeOnLeft);
+    leftPad = resolveAutoLeft(false);
   }
 
   const base = resolvePadding(
     config.insetsOverride,
     config.yAxis,
-    config.badge,
-    badgeOnLeft,
+    badgeUsesRightGutter,
+    false,
     xAxis,
   );
 

--- a/src/hooks/useBadge.test.tsx
+++ b/src/hooks/useBadge.test.tsx
@@ -1,13 +1,13 @@
+import { BADGE_DOT_GAP, BADGE_PILL_PAD_X } from "../constants";
 import { DEFAULT_PADDING, badgeTailAndCap, pillTextLeftX } from "../draw/line";
 
-import { BADGE_DOT_GAP } from "../constants";
-import type { EngineState } from "../useLiveChartEngine";
 import type { SkFont } from "@shopify/react-native-skia";
-import { measureFontTextWidth } from "../measureFontTextWidth";
 import { renderHook } from "@testing-library/react-native";
-import { resolveTheme } from "../theme";
-import { useBadge } from "./useBadge";
 import { useSharedValue } from "react-native-reanimated";
+import { measureFontTextWidth } from "../measureFontTextWidth";
+import { resolveTheme } from "../theme";
+import type { EngineState } from "../useLiveChartEngine";
+import { useBadge } from "./useBadge";
 
 const font = {
   getSize: () => 12,
@@ -205,13 +205,14 @@ describe("useBadge", () => {
     expect(result.current.value.bgColor.startsWith("rgb")).toBe(true);
   });
 
-  it("renders a left-position badge (no tail, pill in left gutter)", () => {
-    const leftPadding = { top: 12, right: 12, bottom: 28, left: 80 };
-    const eng = makeEngine(400, 300);
+  it("left-position badge is a pill only (ignores showTail)", () => {
+    const w = 400;
+    const pad = { top: 12, right: 64, bottom: 28, left: 12 };
+    const eng = makeEngine(w, 300);
     const { result } = renderHook(() =>
       useBadge(
         eng,
-        leftPadding,
+        pad,
         palette,
         (v) => v.toFixed(2),
         font,
@@ -220,6 +221,17 @@ describe("useBadge", () => {
         undefined,
         "left",
       ),
+    );
+    const dotX = w - pad.right;
+    const text = "50.00";
+    const textW = measureFontTextWidth(font, text);
+    const pillW = 2 * BADGE_PILL_PAD_X + textW;
+    const bodyRight = dotX - BADGE_DOT_GAP;
+    const bodyLeft = bodyRight - pillW;
+    expect(result.current.value.text).toBe(text);
+    expect(result.current.value.textX).toBeCloseTo(
+      (bodyLeft + bodyRight - textW) / 2,
+      4,
     );
     expect(result.current.value.path).toBeDefined();
   });

--- a/src/hooks/useBadge.ts
+++ b/src/hooks/useBadge.ts
@@ -7,6 +7,7 @@ import {
 import {
   BADGE_DOT_GAP,
   BADGE_MARGIN_RIGHT,
+  BADGE_PILL_PAD_X,
   BADGE_PILL_PAD_Y,
   BADGE_TAIL_LEN,
   MS_PER_FRAME_60FPS,
@@ -78,13 +79,15 @@ export function useBadge(
     let textX: number;
 
     if (position === "left") {
-      // Left-gutter badge: simple pill, no tail, anchored to left edge.
-      const bodyLeft = BADGE_MARGIN_RIGHT;
-      const bodyRight = padding.left - BADGE_DOT_GAP;
-      const pillW = bodyRight - bodyLeft;
+      // Pill to the left of the live dot; no tail (`showTail` applies to right gutter only).
+      const dotXPos = w - padding.right;
+      const pillW = 2 * BADGE_PILL_PAD_X + textW;
+      const bodyRight = dotXPos - BADGE_DOT_GAP;
+      const bodyLeft = Math.max(BADGE_MARGIN_RIGHT, bodyRight - pillW);
+      const pillBodyW = bodyRight - bodyLeft;
       textX = (bodyLeft + bodyRight - textW) / 2;
       path.addRRect({
-        rect: { x: bodyLeft, y: badgeY, width: pillW, height: pillH },
+        rect: { x: bodyLeft, y: badgeY, width: pillBodyW, height: pillH },
         rx: r,
         ry: r,
       });


### PR DESCRIPTION
### TL;DR

Enhanced badge positioning in LiveChart to support left-of-dot placement and improved pulse ring collision detection with y-axis labels.

### What changed?

- Added support for badge positioning to the left of the live dot via `position: "left"` configuration
- Replaced boolean `badgeOnLeft` parameter with `badgeUsesRightGutter` for clearer badge gutter management
- Implemented automatic right padding calculation to prevent pulse rings from overlapping y-axis labels
- Updated demo interface to include three badge options: Default, Off, and Left positioning
- Refined badge pill rendering logic for left-positioned badges to anchor relative to the dot position

### How to test?

1. Navigate to the axes-insets demo screen
2. Toggle between the three badge options (Default, Off, Left) to verify positioning
3. Enable pulse animation and observe that it doesn't overlap with y-axis labels
4. Test with different chart configurations to ensure proper spacing in all scenarios

### Why make this change?

This enhancement provides more flexible badge positioning options for LiveChart components while fixing a visual issue where pulse animations could interfere with y-axis label readability. The left positioning option gives developers more control over chart layout, especially in constrained spaces where the right gutter needs to remain minimal.