### PR TITLE
feat: empty state

### DIFF
--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -2,8 +2,10 @@ import { Pressable, Text, View } from "react-native";
 import { ACCENT, TIME_WINDOWS } from "./_lib/shared";
 
 import { useState } from "react";
+import { useSharedValue } from "react-native-reanimated";
 import { useSimulatedData } from "../../sim/useSimulatedData";
 import { LiveChart } from "../../src";
+import type { CandlePoint } from "../../src/types";
 import { DemoScreen } from "./_lib/DemoScreen";
 import { demoStyles } from "./_lib/styles";
 
@@ -11,7 +13,11 @@ export const options = { title: "Candlestick" };
 
 export default function CandlestickScreen() {
   const [windowSecs, setWindowSecs] = useState(300);
+  const [stripCandles, setStripCandles] = useState(false);
   const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
+
+  const emptyCandles = useSharedValue<CandlePoint[]>([]);
+  const nullLive = useSharedValue<CandlePoint | null>(null);
 
   const { data, value, candles, liveCandle } = useSimulatedData({
     multiSeries: false,
@@ -22,14 +28,14 @@ export default function CandlestickScreen() {
 
   return (
     <DemoScreen
-      description={`mode=candle, candleWidth=${candleWidthSecs}s (from window)`}
+      description={`mode=candle, candleWidth=${candleWidthSecs}s. Needs ≥2 committed candles for the chart (live bar alone is not enough).`}
       chart={
         <LiveChart
           data={data}
           value={value}
           mode="candle"
-          candles={candles}
-          liveCandle={liveCandle}
+          candles={stripCandles ? emptyCandles : candles}
+          liveCandle={stripCandles ? nullLive : liveCandle}
           candleWidth={candleWidthSecs}
           accentColor={ACCENT}
           theme="dark"
@@ -38,6 +44,23 @@ export default function CandlestickScreen() {
         />
       }
     >
+      <Text style={demoStyles.sectionLabel}>Data</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, stripCandles && demoStyles.chipActive]}
+          onPress={() => setStripCandles((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              stripCandles && demoStyles.chipTextActive,
+            ]}
+          >
+            No committed candles
+          </Text>
+        </Pressable>
+      </View>
+
       <Text style={demoStyles.sectionLabel}>Time window</Text>
       <View style={demoStyles.buttonRow}>
         {TIME_WINDOWS.map((w) => (

--- a/app/demo/chart-size.tsx
+++ b/app/demo/chart-size.tsx
@@ -1,8 +1,10 @@
 import { Pressable, Text, View } from "react-native";
 
 import { useState } from "react";
+import { useSharedValue } from "react-native-reanimated";
 import { useSimulatedData } from "../../sim/useSimulatedData";
 import { LiveChart } from "../../src";
+import type { LiveChartPoint } from "../../src/types";
 import { ACCENT } from "./_lib/shared";
 import { demoStyles } from "./_lib/styles";
 
@@ -14,6 +16,10 @@ export default function ChartSizeScreen() {
   const [h, setH] = useState<(typeof HEIGHTS)[number]>(300);
   const [narrow, setNarrow] = useState(false);
   const [flexFill, setFlexFill] = useState(false);
+  const [empty, setEmpty] = useState(false);
+
+  const emptyData = useSharedValue<LiveChartPoint[]>([]);
+  const emptyValue = useSharedValue(0);
 
   const { data, value } = useSimulatedData({
     multiSeries: false,
@@ -23,8 +29,8 @@ export default function ChartSizeScreen() {
 
   const chart = (
     <LiveChart
-      data={data}
-      value={value}
+      data={empty ? emptyData : data}
+      value={empty ? emptyValue : value}
       accentColor={ACCENT}
       theme="dark"
       scrub
@@ -36,6 +42,7 @@ export default function ChartSizeScreen() {
     <View style={demoStyles.demoRoot}>
       <Text style={demoStyles.demoDesc}>
         Fixed heights, narrow card width, or flex fill inside a fixed outer box.
+        Toggle empty to check loading/empty shell and label at small sizes.
       </Text>
 
       {flexFill ? (
@@ -120,6 +127,22 @@ export default function ChartSizeScreen() {
             style={[demoStyles.chipText, narrow && demoStyles.chipTextActive]}
           >
             Card (40+40 inset)
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={[demoStyles.sectionLabel, { paddingHorizontal: 16 }]}>
+        Empty shell
+      </Text>
+      <View style={[demoStyles.buttonRow, { paddingHorizontal: 16 }]}>
+        <Pressable
+          style={[demoStyles.chip, empty && demoStyles.chipActive]}
+          onPress={() => setEmpty((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, empty && demoStyles.chipTextActive]}
+          >
+            No data
           </Text>
         </Pressable>
       </View>

--- a/app/demo/edge-cases.tsx
+++ b/app/demo/edge-cases.tsx
@@ -9,7 +9,7 @@ import { DemoScreen } from "./_lib/DemoScreen";
 import { ACCENT } from "./_lib/shared";
 import { demoStyles } from "./_lib/styles";
 
-export const options = { title: "Loading, empty, formatters" };
+export const options = { title: "Empty, loading, formatters" };
 
 /** Worklet-safe — same as toISOString().slice(11, 19) in UTC (Date/toISOString not reliable inside UI worklets). */
 function formatTimeIsoUtcFragment(t: number): string {
@@ -28,30 +28,38 @@ function formatValueUsd(v: number): string {
 
 export default function EdgeCasesScreen() {
   const [empty, setEmpty] = useState(false);
+  const [onePoint, setOnePoint] = useState(false);
   const [loading, setLoading] = useState(false);
   const [customFormat, setCustomFormat] = useState(false);
 
   const emptyData = useSharedValue<LiveChartPoint[]>([]);
   const emptyValue = useSharedValue(100);
+  const singlePointData = useSharedValue<LiveChartPoint[]>([
+    { time: Date.now() / 1000, value: 100 },
+  ]);
 
   const sim = useSimulatedData({
     multiSeries: false,
     candleAggregation: false,
     tradeStream: false,
-    paused: empty,
+    paused: empty || onePoint,
   });
+
+  const chartData = empty ? emptyData : onePoint ? singlePointData : sim.data;
+  const chartValue = empty || onePoint ? emptyValue : sim.value;
+  const showEmptyShell = empty || onePoint;
 
   return (
     <DemoScreen
-      description="loading, empty data, custom formatValue/formatTime (must be worklet-safe — same pattern as src/format.ts)"
+      description="The chart stays in loading/empty shell until there are at least two line points and loading is false. One point only still counts as empty. formatValue/formatTime must be worklet-safe (same pattern as src/format.ts)."
       chart={
         <LiveChart
-          data={empty ? emptyData : sim.data}
-          value={empty ? emptyValue : sim.value}
+          data={chartData}
+          value={chartValue}
           accentColor={ACCENT}
           theme="dark"
           loading={loading}
-          emptyText={empty ? "Nothing to see here" : "No data"}
+          emptyText={showEmptyShell ? "Nothing to see here" : "No data"}
           formatValue={customFormat ? formatValueUsd : undefined}
           formatTime={customFormat ? formatTimeIsoUtcFragment : undefined}
           scrub={false}
@@ -62,12 +70,28 @@ export default function EdgeCasesScreen() {
       <View style={demoStyles.buttonRow}>
         <Pressable
           style={[demoStyles.chip, empty && demoStyles.chipActive]}
-          onPress={() => setEmpty((e) => !e)}
+          onPress={() => {
+            setEmpty((e) => !e);
+            if (!empty) setOnePoint(false);
+          }}
         >
           <Text
             style={[demoStyles.chipText, empty && demoStyles.chipTextActive]}
           >
-            Empty data
+            No points
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, onePoint && demoStyles.chipActive]}
+          onPress={() => {
+            setOnePoint((o) => !o);
+            if (!onePoint) setEmpty(false);
+          }}
+        >
+          <Text
+            style={[demoStyles.chipText, onePoint && demoStyles.chipTextActive]}
+          >
+            1 point only
           </Text>
         </Pressable>
         <Pressable

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -45,7 +45,7 @@ export default function MultiSeriesScreen() {
 
   return (
     <DemoScreen
-      description="series, onSeriesToggle, scrub, shared core props, axis visibility"
+      description="series, onSeriesToggle, scrub, axis visibility. Chart stays empty until at least one series has ≥2 points (toggle No series for shell)."
       chart={
         <LiveChartSeries
           series={seriesSource}

--- a/app/demo/playground.tsx
+++ b/app/demo/playground.tsx
@@ -16,6 +16,11 @@ import { useSimulatedData, type TradeSource } from "../../sim/useSimulatedData";
 import type { ScrubPoint, ScrubPointMulti } from "../../src";
 import { LiveChart, LiveChartSeries } from "../../src";
 import { formatTime } from "../../src/format";
+import type {
+  CandlePoint,
+  LiveChartPoint,
+  SeriesConfig,
+} from "../../src/types";
 import {
   PRICE_RANGES,
   TIME_WINDOWS,
@@ -35,6 +40,7 @@ export default function PlaygroundScreen() {
   const [windowSecs, setWindowSecs] = useState(30);
   const [startValue, setStartValue] = useState(100);
   const [loading, setLoading] = useState(false);
+  const [forceEmpty, setForceEmpty] = useState(false);
   const [showRefLine, setShowRefLine] = useState(false);
   const [valueLine, setValueLine] = useState(false);
   const [exaggerate, setExaggerate] = useState(false);
@@ -68,6 +74,12 @@ export default function PlaygroundScreen() {
 
   const scrubPoint = useSharedValue<ScrubPoint | ScrubPointMulti | null>(null);
 
+  const emptyLineData = useSharedValue<LiveChartPoint[]>([]);
+  const emptyLineValue = useSharedValue(0);
+  const emptyMultiSeries = useSharedValue<SeriesConfig[]>([]);
+  const emptyCandles = useSharedValue<CandlePoint[]>([]);
+  const nullLiveCandle = useSharedValue<CandlePoint | null>(null);
+
   const subtitleProps = useAnimatedProps(() => {
     const sp = scrubPoint.value;
     if (sp !== null) {
@@ -93,6 +105,10 @@ export default function PlaygroundScreen() {
     <View style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>react-native-livechart</Text>
+        <Text style={styles.hint}>
+          Chart reveals after ≥2 points (or ≥2 candles) and loading off — use
+          Empty + Reload to preview.
+        </Text>
         <AnimatedTextInput
           editable={false}
           underlineColorAndroid="transparent"
@@ -104,11 +120,17 @@ export default function PlaygroundScreen() {
       <View style={styles.chartContainer}>
         {chartMode === "single" ? (
           <LiveChart
-            data={data}
-            value={value}
+            data={forceEmpty ? emptyLineData : data}
+            value={forceEmpty ? emptyLineValue : value}
             mode={displayMode}
-            candles={candles}
-            liveCandle={liveCandle}
+            candles={
+              displayMode === "candle" && forceEmpty ? emptyCandles : candles
+            }
+            liveCandle={
+              displayMode === "candle" && forceEmpty
+                ? nullLiveCandle
+                : liveCandle
+            }
             candleWidth={candleWidthSecs}
             accentColor="#3b82f6"
             theme="dark"
@@ -131,7 +153,7 @@ export default function PlaygroundScreen() {
           />
         ) : (
           <LiveChartSeries
-            series={series}
+            series={forceEmpty ? emptyMultiSeries : series}
             accentColor="#3b82f6"
             theme="dark"
             timeWindow={windowSecs}
@@ -392,6 +414,17 @@ export default function PlaygroundScreen() {
               {loading ? "Loading…" : "Reload"}
             </Text>
           </Pressable>
+
+          <Pressable
+            style={[styles.chip, forceEmpty && styles.chipActive]}
+            onPress={() => setForceEmpty((v) => !v)}
+          >
+            <Text
+              style={[styles.chipText, forceEmpty && styles.chipTextActive]}
+            >
+              Empty data
+            </Text>
+          </Pressable>
         </View>
       </ScrollView>
     </View>
@@ -420,6 +453,13 @@ const styles = StyleSheet.create({
     fontFamily: "monospace",
     marginTop: 4,
     padding: 0,
+  },
+  hint: {
+    color: "rgba(255,255,255,0.35)",
+    fontSize: 11,
+    fontFamily: "monospace",
+    marginTop: 6,
+    lineHeight: 15,
   },
   chartContainer: {
     height: 300,

--- a/src/LiveChart.tsx
+++ b/src/LiveChart.tsx
@@ -21,10 +21,12 @@ import {
   useChartReveal,
   useCrosshair,
   useDegen,
+  useLiveChartHasData,
   useLiveDot,
   useModeBlend,
   useMomentum,
   useReferenceLine,
+  useSingleChartReverseMorphInputs,
   useTradeStream,
   useXAxis,
   useYAxis,
@@ -164,9 +166,33 @@ export function LiveChart({
     pulse: pulseConfig,
   });
 
-  // ── Engine and reveal state ────────────────────────────────────────────
-  const engine = useLiveChartEngine({
+  // ── Reveal state ────────────────────────────────────────────
+  // ≥2 line points or ≥2 committed candles; morphT=1 only when !loading && hasData.
+  const { hasData, initialMorphT } = useLiveChartHasData({
+    isCandle,
     data,
+    candles,
+    loading,
+  });
+
+  const reveal = useChartReveal(loading, hasData, initialMorphT);
+
+  // After data clears, keep last snapshot until morphT finishes dropping (web parity).
+  const { lineEngineData, candlesEngine, liveEngine } =
+    useSingleChartReverseMorphInputs({
+      isCandle,
+      data,
+      candles,
+      liveCandle,
+      hasData,
+      morphT: reveal.morphT,
+    });
+
+  // ── Engine ─────────────────────────────────────────────────────────────
+  // Line mode: tick + paths use `lineEngineData` (stash when reversing). Candle mode:
+  // parent `data` stays tick/line-morph input; OHLC uses candlesEngine + liveEngine.
+  const engine = useLiveChartEngine({
+    data: isCandle ? data : lineEngineData,
     value,
     timeWindow,
     paused,
@@ -174,11 +200,9 @@ export function LiveChart({
     exaggerate,
     referenceValue: referenceLine?.value,
     mode,
-    candles,
-    liveCandle,
+    candles: isCandle ? candlesEngine : candles,
+    liveCandle: isCandle ? liveEngine : liveCandle,
   });
-
-  const reveal = useChartReveal(loading);
 
   // ── Mode crossfade (line ↔ candle) ──────────────────────────────────
   const { lineGroupOpacity, candleGroupOpacity } = useModeBlend(
@@ -198,8 +222,9 @@ export function LiveChart({
     useCandlePaths(
       engine,
       effectivePadding,
-      candles,
-      liveCandle,
+      // Match engine: stashed candles while reverse-morphing in candle mode.
+      isCandle ? candlesEngine : candles,
+      isCandle ? liveEngine : liveCandle,
       candleWidth,
       isCandle,
     );
@@ -257,8 +282,14 @@ export function LiveChart({
     badgeCfg?.background,
   );
 
+  // Scrub/crosshair must see the same stash-backed candles as the engine.
   const candleOpts = isCandle
-    ? { mode, candles, liveCandle, candleWidthSecs: candleWidth }
+    ? {
+        mode,
+        candles: candlesEngine,
+        liveCandle: liveEngine,
+        candleWidthSecs: candleWidth,
+      }
     : undefined;
 
   const crosshair = useCrosshair(

--- a/src/LiveChartSeries.tsx
+++ b/src/LiveChartSeries.tsx
@@ -1,10 +1,11 @@
 import { Canvas, Group, matchFont } from "@shopify/react-native-skia";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Platform, View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import {
   runOnJS,
   useAnimatedReaction,
+  useDerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
 import { CrosshairOverlay } from "./components/CrosshairOverlay";
@@ -28,6 +29,7 @@ import {
   useChartReveal,
   useCrosshairMulti,
   useMultiSeriesLinePaths,
+  useMultiSeriesReverseMorphInputs,
   useReferenceLine,
   useXAxis,
   useYAxis,
@@ -110,16 +112,34 @@ export function LiveChartSeries({
     currentValue: 0,
   });
 
-  const engine = useLiveChartSeriesEngine({
+  const hasData = useDerivedValue(() =>
+    series.value.some((s) => s.data.length >= 2),
+  );
+
+  const morphInitRef = useRef<number | null>(null);
+  if (morphInitRef.current === null) {
+    const anyReady = series.value.some((s) => s.data.length >= 2);
+    morphInitRef.current = loading ? 0 : anyReady ? 1 : 0;
+  }
+
+  const reveal = useChartReveal(loading, hasData, morphInitRef.current);
+
+  // Stash last multi-series snapshot while morphT collapses (reverse morph).
+  const effectiveSeries = useMultiSeriesReverseMorphInputs({
     series,
+    hasData,
+    morphT: reveal.morphT,
+  });
+
+  // Engine + strokes read effectiveSeries; chips/onSeriesToggle still use prop `series`.
+  const engine = useLiveChartSeriesEngine({
+    series: effectiveSeries,
     timeWindow,
     paused,
     smoothing,
     exaggerate,
     referenceValue: referenceLine?.value,
   });
-
-  const reveal = useChartReveal(loading);
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
   const linePaths = useMultiSeriesLinePaths(engine, effectivePadding);
 
@@ -220,7 +240,7 @@ export function LiveChartSeries({
                 index={i}
                 paths={linePaths}
                 opacities={engine.seriesOpacities}
-                series={series}
+                series={effectiveSeries}
                 strokeWidth={strokeWidth}
               />
             ))}

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,13 +1,21 @@
 import {
   Group,
+  LinearGradient,
   Path,
+  Rect,
   RoundedRect,
   Skia,
   Text as SkiaText,
+  vec,
   type SkFont,
 } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import { BADGE_DOT_GAP } from "../constants";
+import {
+  BADGE_DOT_GAP,
+  EMPTY_GAP_FADE_WIDTH,
+  EMPTY_STATE_LABEL_ALPHA,
+  EMPTY_TEXT_GAP_PAD,
+} from "../constants";
 import {
   badgeTailAndCap,
   gutterCenteredTextLeftX,
@@ -53,7 +61,8 @@ export function LoadingOverlay({
   font: SkFont;
   morphT: SharedValue<number>;
   isLoading: SharedValue<boolean>;
-  isEmpty: SharedValue<boolean>;
+  /** Derived or shared; only `.value` is read on the UI thread. */
+  isEmpty: SharedValue<boolean> | { value: boolean };
   emptyText: string;
   strokeWidth: number;
   /** Mirror the badge prop so labels align with GridOverlay's label positions. */
@@ -113,26 +122,81 @@ export function LoadingOverlay({
   const ly2 = useDerivedValue(() => labelLayout.value.ys[2]);
   const ly3 = useDerivedValue(() => labelLayout.value.ys[3]);
 
-  // Empty-state text: centered in the chart area
-  const emptyLayout = useDerivedValue(() => {
+  // Empty-state text + gradient gap
+  const emptyGapLayout = useDerivedValue(() => {
     const w = engine.canvasWidth.value;
     const h = engine.canvasHeight.value;
-    if (w === 0 || h === 0) return { x: 0, y: 0 };
-    const fm = font.getMetrics();
-    const textW = font.measureText(emptyText).width;
+    if (w === 0 || h === 0) {
+      return {
+        gapLeft: 0,
+        gapRight: 0,
+        centerY: 0,
+        eraseH: 0,
+        fadeW: EMPTY_GAP_FADE_WIDTH,
+        textX: 0,
+        textY: 0,
+        textW: 0,
+        showGap: 0,
+      };
+    }
+    const chartH = h - padding.top - padding.bottom;
+    const centerY = padding.top + chartH / 2;
     const chartCentreX = (padding.left + w - padding.right) / 2;
-    const chartCentreY = (padding.top + h - padding.bottom) / 2;
+    const textW = font.measureText(emptyText).width;
+    const gapHalf = textW / 2 + EMPTY_TEXT_GAP_PAD;
+    const fadeW = EMPTY_GAP_FADE_WIDTH;
+    const gapLeft = chartCentreX - gapHalf - fadeW;
+    const gapRight = chartCentreX + gapHalf + fadeW;
+    const eraseH = Math.max(56, chartH * 0.28) + strokeWidth;
+    const fm = font.getMetrics();
+    const textX = chartCentreX - textW / 2;
+    const textY = centerY - (fm.ascent + fm.descent) / 2;
     return {
-      x: chartCentreX - textW / 2,
-      y: chartCentreY - (fm.ascent + fm.descent) / 2,
+      gapLeft,
+      gapRight,
+      centerY,
+      eraseH,
+      fadeW,
+      textX,
+      textY,
+      textW,
+      showGap: isEmpty.value ? 1 : 0,
     };
   });
 
-  const emptyTextX = useDerivedValue(() => emptyLayout.value.x);
-  const emptyTextY = useDerivedValue(() => emptyLayout.value.y);
-  const showText = useDerivedValue(() => (isEmpty.value ? 1 : 0));
+  const gapLeft = useDerivedValue(() => emptyGapLayout.value.gapLeft);
+  const gapTop = useDerivedValue(
+    () => emptyGapLayout.value.centerY - emptyGapLayout.value.eraseH / 2,
+  );
+  const gapWidth = useDerivedValue(
+    () => emptyGapLayout.value.gapRight - emptyGapLayout.value.gapLeft,
+  );
+  const gapHeight = useDerivedValue(() => emptyGapLayout.value.eraseH);
+  const emptyTextX = useDerivedValue(() => emptyGapLayout.value.textX);
+  const emptyTextY = useDerivedValue(() => emptyGapLayout.value.textY);
+  const showGapGroup = useDerivedValue(() => emptyGapLayout.value.showGap);
+
+  const gapGradientPositions = useDerivedValue(() => {
+    const L = emptyGapLayout.value.gapRight - emptyGapLayout.value.gapLeft;
+    const fw = emptyGapLayout.value.fadeW;
+    if (L <= 0) return [0, 0, 1, 1] as number[];
+    const t1 = Math.min(fw / L, 0.49);
+    const t2 = Math.max(1 - fw / L, 0.51);
+    return [0, t1, t2, 1];
+  });
+
+  const gapGradEnd = useDerivedValue(() =>
+    vec(
+      Math.max(1, emptyGapLayout.value.gapRight - emptyGapLayout.value.gapLeft),
+      0,
+    ),
+  );
+
   const emptyLabelText = useDerivedValue(() =>
     isEmpty.value ? emptyText : "",
+  );
+  const emptyLabelOpacity = useDerivedValue(() =>
+    isEmpty.value ? EMPTY_STATE_LABEL_ALPHA : 0,
   );
 
   return (
@@ -146,6 +210,23 @@ export function LoadingOverlay({
         strokeCap="round"
         strokeJoin="round"
       />
+
+      {/* Erase a soft horizontal band through the squiggle for the label (dstOut) */}
+      <Group opacity={showGapGroup} blendMode="dstOut">
+        <Rect x={gapLeft} y={gapTop} width={gapWidth} height={gapHeight}>
+          <LinearGradient
+            start={vec(0, 0)}
+            end={gapGradEnd}
+            colors={[
+              "rgba(0,0,0,0)",
+              "rgba(0,0,0,1)",
+              "rgba(0,0,0,1)",
+              "rgba(0,0,0,0)",
+            ]}
+            positions={gapGradientPositions}
+          />
+        </Rect>
+      </Group>
 
       {/* Skeleton Y-axis label placeholders */}
       <RoundedRect
@@ -188,7 +269,7 @@ export function LoadingOverlay({
         text={emptyLabelText}
         font={font}
         color={palette.gridLabel}
-        opacity={showText}
+        opacity={emptyLabelOpacity}
       />
     </Group>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,13 @@ export const MAX_MULTI_SERIES = 12;
 /** Default width (px) of the left-edge fade band */
 export const FADE_EDGE_WIDTH = 40;
 
+/** Empty-state label opacity. */
+export const EMPTY_STATE_LABEL_ALPHA = 0.35;
+/** Half-padding (px) around empty text for the squiggle “gap” erase band. */
+export const EMPTY_TEXT_GAP_PAD = 20;
+/** Horizontal fade width (px) on each side of the empty-text gap. */
+export const EMPTY_GAP_FADE_WIDTH = 30;
+
 /**
  * Floats per degen particle slot: `x, y, vx, vy, t0, active, size`.
  * Layout is fixed; not on `DegenOptions` because changing it needs matching renderer changes.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,11 +8,16 @@ export { useChartReveal } from "./useChartReveal";
 export { useCrosshair } from "./useCrosshair";
 export { useCrosshairMulti } from "./useCrosshairMulti";
 export { useDegen } from "./useDegen";
+export { useLiveChartHasData } from "./useLiveChartHasData";
 export { useLiveDot } from "./useLiveDot";
 export { useModeBlend } from "./useModeBlend";
 export { useMomentum } from "./useMomentum";
 export { useMultiSeriesLinePaths } from "./useMultiSeriesLinePaths";
 export { useReferenceLine } from "./useReferenceLine";
+export {
+  useMultiSeriesReverseMorphInputs,
+  useSingleChartReverseMorphInputs
+} from "./useReverseMorphEngineInputs";
 export { useTradeStream } from "./useTradeStream";
 export { useXAxis } from "./useXAxis";
 export { useYAxis } from "./useYAxis";

--- a/src/hooks/useChartReveal.test.ts
+++ b/src/hooks/useChartReveal.test.ts
@@ -1,6 +1,7 @@
 import { revealRamp, useChartReveal } from "./useChartReveal";
 
 import { renderHook } from "@testing-library/react-native";
+import { useSharedValue } from "react-native-reanimated";
 
 // ─── revealRamp ───────────────────────────────────────────────────────────────
 
@@ -63,74 +64,121 @@ describe("revealRamp", () => {
   });
 });
 
-// ─── useChartReveal (hook smoke tests) ───────────────────────────────────────
+// ─── useChartReveal (hook) ───────────────────────────────────────────────────
+
+function useChartRevealTestSetup(
+  loading: boolean,
+  has: boolean,
+  initialMorphT: number,
+): ReturnType<typeof useChartReveal> {
+  const hasData = useSharedValue(has);
+  return useChartReveal(loading, hasData, initialMorphT);
+}
 
 describe("useChartReveal (hook)", () => {
   it("morphT starts at 0 when loading=true", () => {
-    const { result } = renderHook(() => useChartReveal(true));
+    const { result } = renderHook(() => useChartRevealTestSetup(true, true, 0));
     expect(result.current.morphT.value).toBe(0);
   });
 
-  it("morphT starts at 1 when loading=false", () => {
-    const { result } = renderHook(() => useChartReveal(false));
+  it("morphT starts at 1 when loading=false and hasData", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, true, 1),
+    );
     expect(result.current.morphT.value).toBe(1);
   });
 
+  it("morphT starts at 0 when loading=false and no hasData", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, false, 0),
+    );
+    expect(result.current.morphT.value).toBe(0);
+  });
+
   it("isLoading is true when loading=true", () => {
-    const { result } = renderHook(() => useChartReveal(true));
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(true, false, 0),
+    );
     expect(result.current.isLoading.value).toBe(true);
   });
 
   it("isLoading is false when loading=false", () => {
-    const { result } = renderHook(() => useChartReveal(false));
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, true, 1),
+    );
     expect(result.current.isLoading.value).toBe(false);
   });
 
-  it("isEmpty starts false (controlled externally)", () => {
-    const { result } = renderHook(() => useChartReveal(false));
+  it("isEmpty when not loading and no hasData", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, false, 0),
+    );
+    expect(result.current.isEmpty.value).toBe(true);
+  });
+
+  it("isEmpty false when loading even if no hasData", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(true, false, 0),
+    );
     expect(result.current.isEmpty.value).toBe(false);
   });
 
-  it("all stagger opacities are 0 when morphT=0 (loading=true)", () => {
-    const { result } = renderHook(() => useChartReveal(true));
+  it("isEmpty false when hasData", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, true, 1),
+    );
+    expect(result.current.isEmpty.value).toBe(false);
+  });
+
+  it("all stagger opacities are 0 when morphT=0", () => {
+    const { result } = renderHook(() => useChartRevealTestSetup(true, true, 0));
     expect(result.current.yAxisOpacity.value).toBe(0);
     expect(result.current.fillOpacity.value).toBe(0);
     expect(result.current.dotOpacity.value).toBe(0);
     expect(result.current.badgeOpacity.value).toBe(0);
   });
 
-  it("all stagger opacities are 1 when morphT=1 (loading=false)", () => {
-    const { result } = renderHook(() => useChartReveal(false));
+  it("all stagger opacities are 1 when morphT=1", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, true, 1),
+    );
     expect(result.current.yAxisOpacity.value).toBeCloseTo(1);
     expect(result.current.fillOpacity.value).toBeCloseTo(1);
     expect(result.current.dotOpacity.value).toBeCloseTo(1);
     expect(result.current.badgeOpacity.value).toBeCloseTo(1);
   });
 
-  it("triggers reveal animation when loading transitions from true to false", () => {
-    const { result, rerender } = renderHook(
-      (props: { loading: boolean }) => useChartReveal(props.loading),
-      { initialProps: { loading: true } },
+  it("opacities stay 0 when loading=false but no hasData", () => {
+    const { result } = renderHook(() =>
+      useChartRevealTestSetup(false, false, 0),
     );
-    expect(result.current.morphT.value).toBe(0);
-    expect(result.current.isLoading.value).toBe(true);
-
-    rerender({ loading: false });
-
-    expect(result.current.isLoading.value).toBe(false);
-    // morphT has been handed to withTiming — value is either still animating
-    // or resolved to 1 depending on the test mock; either way it's >= 0.
-    expect(result.current.morphT.value).toBeGreaterThanOrEqual(0);
+    expect(result.current.yAxisOpacity.value).toBe(0);
+    expect(result.current.fillOpacity.value).toBe(0);
   });
 
-  it("resets to loading state when loading becomes true again", () => {
+  it("updates isLoading when loading prop changes", () => {
     const { result, rerender } = renderHook(
-      (props: { loading: boolean }) => useChartReveal(props.loading),
+      (props: { loading: boolean }) => {
+        const hasData = useSharedValue(true);
+        return useChartReveal(props.loading, hasData, 0);
+      },
+      { initialProps: { loading: true } },
+    );
+    expect(result.current.isLoading.value).toBe(true);
+    rerender({ loading: false });
+    expect(result.current.isLoading.value).toBe(false);
+  });
+
+  it("resets to loading shell when loading becomes true again", () => {
+    const { result, rerender } = renderHook(
+      (props: { loading: boolean }) => {
+        const hasData = useSharedValue(true);
+        return useChartReveal(props.loading, hasData, props.loading ? 0 : 1);
+      },
       { initialProps: { loading: false } },
     );
     expect(result.current.morphT.value).toBe(1);
     rerender({ loading: true });
-    expect(result.current.morphT.value).toBe(0);
     expect(result.current.isLoading.value).toBe(true);
     expect(result.current.isEmpty.value).toBe(false);
   });

--- a/src/hooks/useChartReveal.ts
+++ b/src/hooks/useChartReveal.ts
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import {
   Easing,
+  useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
   withTiming,
@@ -8,7 +9,8 @@ import {
 } from "react-native-reanimated";
 import { smoothstep } from "../math/squiggly";
 
-const REVEAL_DURATION_MS = 600;
+/** Duration for chart reveal (loading/empty → live) and collapse (live → empty). */
+export const CHART_REVEAL_DURATION_MS = 600;
 
 /**
  * Per-overlay reveal delay (fraction of morphT at which the overlay starts
@@ -33,11 +35,11 @@ export function revealRamp(morphT: number, delay: number): number {
 }
 
 export interface ChartRevealState {
-  /** 0 = fully squiggly (loading), 1 = fully live chart */
+  /** 0 = loading/empty shell, 1 = fully live chart (matches web chartReveal). */
   morphT: SharedValue<number>;
   /** True while loading=true */
   isLoading: SharedValue<boolean>;
-  /** True when loading=false but no data (set externally via isEmpty.value) */
+  /** True when not loading and fewer than two samples. */
   isEmpty: SharedValue<boolean>;
   yAxisOpacity: SharedValue<number>;
   fillOpacity: SharedValue<number>;
@@ -47,40 +49,42 @@ export interface ChartRevealState {
 }
 
 /**
- * Drives the loading → reveal → live state machine.
+ * Drives loading / empty / live visibility.
  *
- * - When `loading` is true: morphT=0, overlays hidden, LoadingOverlay visible.
- * - When `loading` becomes false: animate morphT 0→1 over 600ms; each overlay
- *   fades in staggered via revealRamp.
- * - When `loading` was never true (default): morphT starts at 1, no animation.
- *
- * NOTE: The empty state (isEmpty) is NOT auto-detected from data length here,
- * because SharedValue changes do not trigger React re-renders. Instead, set
- * isEmpty.value directly from a useAnimatedReaction in the parent, or simply
- * pass loading=true until data is ready.
+ * Chart is fully revealed only when `!loading && hasData`. `morphT` animates
+ * between 0 and 1 when that condition changes. `isEmpty` is derived as
+ * `!loading && !hasData` for the empty overlay label.
  */
-export function useChartReveal(loading: boolean): ChartRevealState {
-  // Start fully revealed if loading was never requested
-  const morphT = useSharedValue(loading ? 0 : 1);
+export function useChartReveal(
+  loading: boolean,
+  hasData: SharedValue<boolean>,
+  initialMorphT: number,
+): ChartRevealState {
+  const morphT = useSharedValue(initialMorphT);
   const isLoading = useSharedValue(loading);
-  const isEmpty = useSharedValue(false);
 
-  useEffect(() => {
-    if (loading) {
-      morphT.value = 0;
-      isLoading.value = true;
-      isEmpty.value = false;
-    } else {
-      isLoading.value = false;
-      // Animate reveal only if we were in loading state (morphT < 1)
-      if (morphT.value < 1) {
-        morphT.value = withTiming(1, {
-          duration: REVEAL_DURATION_MS,
+  useLayoutEffect(() => {
+    isLoading.value = loading;
+  }, [loading, isLoading]);
+
+  useAnimatedReaction(
+    () => !isLoading.value && hasData.value,
+    (chartVisible, prev) => {
+      "worklet";
+      if (prev === undefined) {
+        return;
+      }
+      if (prev !== chartVisible) {
+        morphT.value = withTiming(chartVisible ? 1 : 0, {
+          duration: CHART_REVEAL_DURATION_MS,
           easing: Easing.out(Easing.cubic),
         });
       }
-    }
-  }, [loading]); // eslint-disable-line react-hooks/exhaustive-deps
+    },
+    [hasData],
+  );
+
+  const isEmpty = useDerivedValue(() => !isLoading.value && !hasData.value);
 
   const yAxisOpacity = useDerivedValue(() =>
     revealRamp(morphT.value, DELAY.yAxis),
@@ -99,7 +103,8 @@ export function useChartReveal(loading: boolean): ChartRevealState {
   return {
     morphT,
     isLoading,
-    isEmpty,
+    // useDerivedValue is SharedValue-compatible for `.value` reads in Skia.
+    isEmpty: isEmpty as unknown as SharedValue<boolean>,
     yAxisOpacity,
     fillOpacity,
     lineOpacity,

--- a/src/hooks/useLiveChartHasData.ts
+++ b/src/hooks/useLiveChartHasData.ts
@@ -1,0 +1,43 @@
+import { useRef } from "react";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import type { CandlePoint, LiveChartPoint } from "../types";
+
+/**
+ * Data presence for {@link LiveChart}: line mode needs ≥2 points;
+ * candle mode needs ≥2 committed candles (`liveCandle` alone does not count).
+ *
+ * Also returns a one-shot `initialMorphT` for {@link useChartReveal} first paint
+ * (reads shared values once on mount — same tradeoff as inline LiveChart).
+ */
+export function useLiveChartHasData({
+  isCandle,
+  data,
+  candles,
+  loading,
+}: {
+  isCandle: boolean;
+  data: SharedValue<LiveChartPoint[]>;
+  candles: SharedValue<CandlePoint[]> | undefined;
+  loading: boolean;
+}): {
+  hasData: SharedValue<boolean>;
+  initialMorphT: number;
+} {
+  const hasData = useDerivedValue(() => {
+    "worklet";
+    if (isCandle) {
+      return (candles?.value.length ?? 0) >= 2;
+    }
+    return data.value.length >= 2;
+  });
+
+  const morphInitRef = useRef<number | null>(null);
+  if (morphInitRef.current === null) {
+    const initialHas = isCandle
+      ? (candles?.value.length ?? 0) >= 2
+      : data.value.length >= 2;
+    morphInitRef.current = loading ? 0 : initialHas ? 1 : 0;
+  }
+
+  return { hasData, initialMorphT: morphInitRef.current };
+}

--- a/src/hooks/useReverseMorphEngineInputs.ts
+++ b/src/hooks/useReverseMorphEngineInputs.ts
@@ -1,0 +1,140 @@
+import {
+  useAnimatedReaction,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
+
+const STASH_MORPH_EPS = 0.01;
+
+/**
+ * While `morphT` animates down after data clears, keep feeding the engine the
+ * last stashed line/candle snapshot.
+ */
+export function useSingleChartReverseMorphInputs({
+  isCandle,
+  data,
+  candles,
+  liveCandle,
+  hasData,
+  morphT,
+}: {
+  isCandle: boolean;
+  data: SharedValue<LiveChartPoint[]>;
+  candles: SharedValue<CandlePoint[]> | undefined;
+  liveCandle: SharedValue<CandlePoint | null> | undefined;
+  hasData: SharedValue<boolean>;
+  morphT: SharedValue<number>;
+}): {
+  lineEngineData: SharedValue<LiveChartPoint[]>;
+  candlesEngine: SharedValue<CandlePoint[]>;
+  liveEngine: SharedValue<CandlePoint | null>;
+} {
+  const lineStash = useSharedValue<LiveChartPoint[]>([]);
+  const candleStash = useSharedValue<CandlePoint[]>([]);
+  const lineEngineData = useSharedValue<LiveChartPoint[]>([]);
+  const candlesEngine = useSharedValue<CandlePoint[]>([]);
+  const liveEngine = useSharedValue<CandlePoint | null>(null);
+
+  useAnimatedReaction(
+    () => ({
+      candle: isCandle,
+      has: hasData.value,
+      m: morphT.value,
+      d: data.value,
+      cLen: candles?.value.length ?? 0,
+      c: candles?.value,
+      lc: liveCandle?.value ?? null,
+    }),
+    (curr) => {
+      "worklet";
+      if (!curr.candle) {
+        if (curr.has && curr.d.length >= 2) {
+          lineStash.value = curr.d.slice();
+          lineEngineData.value = curr.d;
+        } else if (
+          !curr.has &&
+          curr.m > STASH_MORPH_EPS &&
+          lineStash.value.length >= 2
+        ) {
+          lineEngineData.value = lineStash.value;
+        } else {
+          lineEngineData.value = curr.d;
+        }
+        return;
+      }
+
+      const cArr = curr.c;
+      if (curr.has && curr.cLen >= 2 && cArr) {
+        candleStash.value = cArr.slice();
+        candlesEngine.value = cArr;
+        liveEngine.value = curr.lc;
+      } else if (
+        !curr.has &&
+        curr.m > STASH_MORPH_EPS &&
+        candleStash.value.length >= 2
+      ) {
+        candlesEngine.value = candleStash.value;
+        liveEngine.value = null;
+      } else {
+        candlesEngine.value = cArr ?? [];
+        liveEngine.value = curr.lc;
+      }
+    },
+    [isCandle, data, candles, liveCandle, hasData, morphT],
+  );
+
+  return { lineEngineData, candlesEngine, liveEngine };
+}
+
+function snapshotSeriesWorklet(s: SeriesConfig[]): SeriesConfig[] {
+  "worklet";
+  const out: SeriesConfig[] = [];
+  for (let i = 0; i < s.length; i++) {
+    const x = s[i];
+    out.push({ ...x, data: x.data.slice() });
+  }
+  return out;
+}
+
+export function useMultiSeriesReverseMorphInputs({
+  series,
+  hasData,
+  morphT,
+}: {
+  series: SharedValue<SeriesConfig[]>;
+  hasData: SharedValue<boolean>;
+  morphT: SharedValue<number>;
+}): SharedValue<SeriesConfig[]> {
+  const seriesStash = useSharedValue<SeriesConfig[]>([]);
+  const effectiveSeries = useSharedValue<SeriesConfig[]>([]);
+
+  useAnimatedReaction(
+    () => ({
+      has: hasData.value,
+      m: morphT.value,
+      live: series.value,
+    }),
+    (curr) => {
+      "worklet";
+      const live = curr.live;
+      const anyReady = live.some((x) => x.data.length >= 2);
+
+      if (curr.has && anyReady) {
+        seriesStash.value = snapshotSeriesWorklet(live);
+        effectiveSeries.value = live;
+      } else if (
+        !curr.has &&
+        curr.m > STASH_MORPH_EPS &&
+        seriesStash.value.some((x) => x.data.length >= 2)
+      ) {
+        effectiveSeries.value = seriesStash.value;
+      } else {
+        effectiveSeries.value = live;
+      }
+    },
+    [series, hasData, morphT],
+  );
+
+  return effectiveSeries;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,13 +308,19 @@ export interface LiveChartCoreProps {
   timeWindow?: number;
   /** Freeze chart scrolling. Resume catches up to real time. Default `false`. */
   paused?: boolean;
-  /** Show breathing line loading animation. Default `false`. */
+  /**
+   * Breathing-line loading shell. When this becomes `false`, the chart reveals
+   * only if there is data (≥2 line points or ≥2 committed candles).
+   */
   loading?: boolean;
   /** Spline smoothing factor (0 = sharp, 1 = maximum). Default `0.5`. */
   smoothing?: number;
   /** Tight Y-axis — small value moves fill the full chart height. Default `false`. */
   exaggerate?: boolean;
-  /** Text shown in the empty state when data is empty and not loading. Default `"No data to display"`. */
+  /**
+   * Label in the empty state when `loading` is false and there are fewer than
+   * two samples (line points or committed candles). Default `"No data"`.
+   */
   emptyText?: string;
   /** Custom formatter for value labels (axes, badge, tooltips). Default `v => v.toFixed(2)`. */
   formatValue?: (v: number) => string;


### PR DESCRIPTION
### TL;DR

Enhanced chart empty state handling with proper data validation, reverse morphing animations, and improved loading/empty state transitions.

### What changed?

- **Data validation**: Charts now require ≥2 line points or ≥2 committed candles to display content
- **Empty state detection**: Added `useLiveChartHasData` hook to determine when charts have sufficient data
- **Reverse morphing**: Implemented data stashing during collapse animations to maintain visual continuity when transitioning from live chart back to empty state
- **Loading overlay improvements**: Enhanced empty state with gradient gap around text label and better visual hierarchy
- **Demo enhancements**: Added controls to test empty states, single data points, and edge cases across all demo screens
- **Chart reveal logic**: Refactored `useChartReveal` to handle loading/empty/live state transitions more robustly

### How to test?

1. Run the demo app and navigate to different chart screens
2. Use the new "Empty data", "No points", "1 point only" toggles to test empty states
3. Toggle loading states to verify smooth transitions
4. Test candlestick charts with "No committed candles" option
5. Verify multi-series charts handle empty series correctly
6. Check that charts remain in loading/empty shell until sufficient data is available

### Why make this change?

This change addresses several UX issues where charts would display incorrectly with insufficient data or during state transitions. The improvements ensure charts only reveal when they have meaningful content to display, provide better visual feedback during loading states, and maintain smooth animations when transitioning between different chart states. This creates a more polished and predictable user experience.