### PR TITLE
feat: callback for shake animation

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -107,15 +107,16 @@ export function LiveChart({
   badge = true,
   momentum = true,
   pulse = true,
-  valueLine = false,
+  valueLine = true,
   referenceLine,
-  scrub = false,
+  scrub = true,
   tradeStream,
   degen,
   leftEdgeFade = true,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
+  onDegenShake,
 }: LiveChartProps) {
   const emptyTradeStream = useSharedValue<TradeEvent[]>([]);
   const tradeStreamSV = tradeStream ?? emptyTradeStream;
@@ -249,7 +250,7 @@ export function LiveChart({
     pack: degenPack,
     packRevision: degenPackRevision,
     shakeTransform: degenShakeTransform,
-  } = useDegen(engine, dotX, dotY, momentumSV, degenCfg);
+  } = useDegen(engine, dotX, dotY, momentumSV, degenCfg, onDegenShake);
 
   // ── Overlay hooks ─────────────────────────────────────────────────────
   const referenceLineLayout = useReferenceLine(

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
+  runOnJS,
   useDerivedValue,
   useFrameCallback,
   useSharedValue,
@@ -9,7 +10,7 @@ import {
 import type { ResolvedDegenConfig } from "../core/resolveConfig";
 import type { SingleEngineState } from "../core/useLiveChartEngine";
 import { computeShake, spawnBurst, tickParticles } from "../math/degenTick";
-import type { Momentum } from "../types";
+import type { DegenShakePayload, Momentum } from "../types";
 
 export function useDegen(
   engine: SingleEngineState,
@@ -17,6 +18,7 @@ export function useDegen(
   dotY: SharedValue<number>,
   momentumSV: SharedValue<Momentum>,
   cfg: ResolvedDegenConfig | null,
+  onShake?: (payload: DegenShakePayload) => void,
 ): {
   pack: SharedValue<Float64Array<ArrayBuffer>>;
   packRevision: SharedValue<number>;
@@ -50,6 +52,14 @@ export function useDegen(
   const shakeY = useSharedValue(0);
   const shakeStart = useSharedValue(0);
   const prevTimestamp = useSharedValue(0);
+  const hasOnShakeListenerSV = useSharedValue(0);
+
+  const onShakeRef = useRef(onShake);
+  onShakeRef.current = onShake;
+
+  const emitShake = useCallback((direction: "up" | "down") => {
+    onShakeRef.current?.({ direction });
+  }, []);
 
   const degenOff = cfg === null;
   const resolvedScale = cfg?.scale ?? 1;
@@ -73,11 +83,13 @@ export function useDegen(
     if (degenOff) {
       enabledSV.value = 0;
       shakeEnabledSV.value = 0;
+      hasOnShakeListenerSV.value = 0;
       shakeStart.value = 0;
       shakeX.value = 0;
       shakeY.value = 0;
       return;
     }
+    hasOnShakeListenerSV.value = onShake != null ? 1 : 0;
     enabledSV.value = 1;
     scaleSV.value = resolvedScale;
     downSV.value = resolvedDown ? 1 : 0;
@@ -103,6 +115,7 @@ export function useDegen(
     // eslint-disable-next-line react-hooks/exhaustive-deps -- shared value refs are stable; react only to cfg primitives
   }, [
     degenOff,
+    onShake,
     resolvedScale,
     resolvedDown,
     resolvedShake,
@@ -168,7 +181,12 @@ export function useDegen(
               baseRot: writeRot.value,
               slots,
             });
-            if (shakeEnabledSV.value > 0.5) shakeStart.value = now;
+            if (shakeEnabledSV.value > 0.5) {
+              shakeStart.value = now;
+              if (hasOnShakeListenerSV.value > 0.5) {
+                runOnJS(emitShake)(isUp ? "up" : "down");
+              }
+            }
           }
         }
       }

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -15,8 +15,8 @@ export { LiveChart, LiveChartSeries };
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
-  export { formatTime, formatValue } from "./lib/format";
-  export { MONO_FONT_FAMILY } from "./lib/monoFontFamily";
+export { formatTime, formatValue } from "./lib/format";
+export { MONO_FONT_FAMILY } from "./lib/monoFontFamily";
 
 // ── Optional hooks (degen / trade markers — see README) ───────────────────────
 
@@ -31,6 +31,7 @@ export type {
   CandlePoint,
   ChartInsets,
   DegenOptions,
+  DegenShakePayload,
   FontConfig,
   FontWeight,
   GradientConfig,
@@ -57,6 +58,5 @@ export type {
   TradeEvent,
   ValueLineConfig,
   XAxisConfig,
-  YAxisConfig
+  YAxisConfig,
 } from "./types";
-

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -248,6 +248,11 @@ export interface DegenOptions {
   colors?: string | string[];
 }
 
+/** Payload for {@link LiveChartProps.onDegenShake}. */
+export interface DegenShakePayload {
+  direction: "up" | "down";
+}
+
 /** Live dot configuration for multi-series charts. */
 export interface MultiSeriesDotConfig {
   /** Dot radius in pixels. Default `3.5`. */
@@ -430,6 +435,11 @@ export interface LiveChartProps extends LiveChartCoreProps {
   value: SharedValue<number>;
   /** Called when the user scrubs the crosshair. `null` when scrub ends. */
   onScrub?: (point: ScrubPoint | null) => void;
+  /**
+   * Called on the JS thread when degen chart shake starts (momentum swing with shake enabled).
+   * Not called when `degen` is off or `DegenOptions.shake` is `false`.
+   */
+  onDegenShake?: (payload: DegenShakePayload) => void;
 }
 
 /** Props for the multi-series `LiveChartSeries` component. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -173,4 +173,13 @@ describe("LiveChart", () => {
       nativeEvent: { layout: { width: 400, height: 300 } },
     });
   });
+
+  it("accepts onDegenShake with degen enabled", () => {
+    const onDegenShake = jest.fn();
+    const screen = render(<Harness degen onDegenShake={onDegenShake} />);
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+  });
 });

--- a/packages/react-native-livechart/tests/hooks/useDegen.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useDegen.test.tsx
@@ -1,5 +1,7 @@
-import { renderHook } from "@testing-library/react-native";
 import { useSharedValue } from "react-native-reanimated";
+
+import { renderHook } from "@testing-library/react-native";
+
 import { resolveDegen } from "../../src/core/resolveConfig";
 import { useLiveChartEngine } from "../../src/core/useLiveChartEngine";
 import { useDegen } from "../../src/hooks/useDegen";
@@ -71,5 +73,25 @@ describe("useDegen", () => {
     });
 
     expect(result.current.pack).toBeDefined();
+  });
+
+  it("accepts optional onShake callback", () => {
+    const onShake = jest.fn();
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      const dotX = useSharedValue(100);
+      const dotY = useSharedValue(80);
+      const momentum = useSharedValue<"flat" | "up" | "down">("flat");
+      return useDegen(
+        engine,
+        dotX,
+        dotY,
+        momentum,
+        resolveDegen(true),
+        onShake,
+      );
+    });
+
+    expect(result.current.shakeTransform).toBeDefined();
   });
 });


### PR DESCRIPTION
### TL;DR

Added `onDegenShake` callback to LiveChart that fires when degen chart shake animations start, and changed default values for `valueLine` and `scrub` props to `true`.

### What changed?

- Added new `onDegenShake` prop to `LiveChart` component that accepts a callback function
- Created `DegenShakePayload` type with direction property ("up" | "down") 
- Modified `useDegen` hook to emit shake events via `runOnJS` when momentum swings occur with shake enabled
- Changed default value of `valueLine` prop from `false` to `true`
- Changed default value of `scrub` prop from `false` to `true`
- Exported new `DegenShakePayload` type from the main index

### How to test?

- Enable degen mode with shake enabled on a LiveChart
- Trigger momentum swings that would cause shake animations
- Verify the `onDegenShake` callback fires with correct direction payload
- Test that charts now show value lines and enable scrubbing by default
- Ensure the callback only fires when degen mode and shake are both enabled

### Why make this change?

This enables developers to respond to degen chart shake events in their applications, allowing for custom behaviors like haptic feedback, sound effects, or UI updates when chart momentum triggers shake animations. The default value changes improve the out-of-box experience by enabling commonly used chart features.