### PR TITLE
feat: add per-series value lines support

### DIFF
--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -1,10 +1,11 @@
+import React from "react";
+import { View } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
 import type { SeriesConfig } from "../src/types";
-import React from "react";
-import { View } from "react-native";
-import { useSharedValue } from "react-native-reanimated";
 
 describe("LiveChartSeries", () => {
   it("renders with default scrub when scrub prop is omitted", async () => {
@@ -52,6 +53,31 @@ describe("LiveChartSeries", () => {
           onSeriesToggle={jest.fn()}
         />
       );
+    }
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+  });
+
+  it("renders with per-series value lines", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return <LiveChartSeries series={series} dot={{ valueLine: true }} />;
     }
     const screen = render(<H />);
     await waitFor(() => expect(screen.getByText("A")).toBeTruthy());

--- a/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { useSharedValue } from "react-native-reanimated";
+
+import { Canvas } from "@shopify/react-native-skia";
+import { render } from "@testing-library/react-native";
+
+import { MultiSeriesValueLines } from "../../src/components/MultiSeriesValueLines";
+import type { ResolvedValueLineConfig } from "../../src/core/resolveConfig";
+import type { MultiEngineState } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import type { SeriesConfig } from "../../src/types";
+
+const VALUE_LINE_CFG: ResolvedValueLineConfig = {
+  strokeWidth: 1,
+  intervals: [4, 4],
+  color: undefined,
+};
+
+function EngineHarness({
+  series,
+  displaySeriesValues,
+  seriesOpacities,
+  canvasHeight = 300,
+  canvasWidth = 400,
+  displayMin = 0,
+  displayMax = 100,
+  colors,
+  config = VALUE_LINE_CFG,
+}: {
+  series: SeriesConfig[];
+  displaySeriesValues?: number[];
+  seriesOpacities?: number[];
+  canvasHeight?: number;
+  canvasWidth?: number;
+  displayMin?: number;
+  displayMax?: number;
+  colors?: string[];
+  config?: ResolvedValueLineConfig;
+}) {
+  const data = useSharedValue([{ time: 1, value: 1 }]);
+  const value = useSharedValue(1);
+  const displayValue = useSharedValue(1);
+  const seriesSV = useSharedValue(series);
+  const displaysSV = useSharedValue(
+    displaySeriesValues ?? series.map((s) => s.value),
+  );
+  const opacitiesSV = useSharedValue(seriesOpacities ?? series.map(() => 1));
+  const displayMinSV = useSharedValue(displayMin);
+  const displayMaxSV = useSharedValue(displayMax);
+  const displayWindowSV = useSharedValue(30);
+  const canvasWidthSV = useSharedValue(canvasWidth);
+  const canvasHeightSV = useSharedValue(canvasHeight);
+  const timestampSV = useSharedValue(1_700_000_000);
+
+  const engine: MultiEngineState = {
+    data,
+    value,
+    displayValue,
+    series: seriesSV,
+    displaySeriesValues: displaysSV,
+    seriesOpacities: opacitiesSV,
+    displayMin: displayMinSV,
+    displayMax: displayMaxSV,
+    displayWindow: displayWindowSV,
+    canvasWidth: canvasWidthSV,
+    canvasHeight: canvasHeightSV,
+    timestamp: timestampSV,
+  };
+
+  const lineColors = colors ?? series.map((s) => s.color ?? "#888888");
+
+  return (
+    <Canvas style={{ width: canvasWidth, height: canvasHeight }}>
+      <MultiSeriesValueLines
+        engine={engine}
+        padding={DEFAULT_PADDING}
+        colors={lineColors}
+        config={config}
+      />
+    </Canvas>
+  );
+}
+
+describe("MultiSeriesValueLines", () => {
+  const oneSeries: SeriesConfig[] = [
+    {
+      id: "a",
+      data: [
+        { time: 1_700_000_000, value: 10 },
+        { time: 1_700_000_030, value: 20 },
+      ],
+      value: 50,
+      color: "#3b82f6",
+    },
+  ];
+
+  it("renders horizontal value lines for each slot with valid canvas size", () => {
+    render(
+      <EngineHarness
+        series={oneSeries}
+        config={{ strokeWidth: 2, intervals: [6, 2], color: "#ff0000" }}
+      />,
+    );
+  });
+
+  it("returns empty paths when canvas height is zero", () => {
+    render(<EngineHarness series={oneSeries} canvasHeight={0} />);
+  });
+
+  it("centers the line when display range is zero", () => {
+    render(
+      <EngineHarness series={oneSeries} displayMin={10} displayMax={10} />,
+    );
+  });
+
+  it("skips drawing when computed y is negative", () => {
+    render(
+      <EngineHarness
+        series={oneSeries}
+        displayMin={0}
+        displayMax={1}
+        displaySeriesValues={[1e6]}
+      />,
+    );
+  });
+
+  it("uses series value when displaySeriesValues entry is missing", () => {
+    render(<EngineHarness series={oneSeries} displaySeriesValues={[]} />);
+  });
+
+  it("uses palette color from config when provided", () => {
+    render(
+      <EngineHarness
+        series={oneSeries}
+        config={{
+          strokeWidth: 1,
+          intervals: [2, 2],
+          color: "#00ff00",
+        }}
+      />,
+    );
+  });
+
+  it("falls back to colors[i] when config color is undefined", () => {
+    render(
+      <EngineHarness
+        series={oneSeries}
+        colors={["#abcdef"]}
+        config={{ strokeWidth: 1, intervals: [1, 1], color: undefined }}
+      />,
+    );
+  });
+
+  it("uses zero opacity when series opacities are shorter than index", () => {
+    render(<EngineHarness series={oneSeries} seriesOpacities={[]} />);
+  });
+});

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -1,12 +1,18 @@
 import {
+  BADGE_DOT_GAP,
+  BADGE_MARGIN_RIGHT,
+  BADGE_PILL_PAD_X,
   BADGE_TAIL_LEN,
   DEFAULT_PADDING,
   badgeTailAndCap,
   buildLinePoints,
   gutterCenteredTextLeftX,
+  gutterRightAlignedTextLeftX,
+  minPaddingLeftForBadge,
   minPaddingRightForBadgeYAxisAlign,
   minPaddingRightForYAxisWithPulse,
   pulseRadialOutset,
+  resolveAutoLeft,
   resolveAutoRight,
   resolvePadding,
 } from "../../src/draw/line";
@@ -14,6 +20,28 @@ import {
 describe("gutterCenteredTextLeftX", () => {
   it("matches grid label placement", () => {
     expect(gutterCenteredTextLeftX(400, 130, 35)).toBe(317.5);
+  });
+});
+
+describe("gutterRightAlignedTextLeftX", () => {
+  it("places text flush to the right with margin", () => {
+    expect(gutterRightAlignedTextLeftX(400, 100, 8)).toBe(292);
+    expect(gutterRightAlignedTextLeftX(400, 100)).toBe(296);
+  });
+});
+
+describe("minPaddingLeftForBadge", () => {
+  it("includes margin, pill padding, text width, and dot gap", () => {
+    expect(minPaddingLeftForBadge(40)).toBe(
+      Math.ceil(BADGE_MARGIN_RIGHT + 2 * BADGE_PILL_PAD_X + 40 + BADGE_DOT_GAP),
+    );
+  });
+});
+
+describe("resolveAutoLeft", () => {
+  it("widens left inset for left badge", () => {
+    expect(resolveAutoLeft(true)).toBe(minPaddingLeftForBadge(49));
+    expect(resolveAutoLeft(false)).toBe(DEFAULT_PADDING.left);
   });
 });
 
@@ -126,6 +154,11 @@ describe("resolvePadding", () => {
     const r = resolvePadding({ left: 40 });
     expect(r.left).toBe(40);
     expect(r.right).toBe(DEFAULT_PADDING.right);
+  });
+
+  it("widens left padding when badgeOnLeft is true", () => {
+    const r = resolvePadding(undefined, false, false, true);
+    expect(r.left).toBe(resolveAutoLeft(true));
   });
 });
 


### PR DESCRIPTION
### TL;DR

Added support for per-series value lines with left-aligned badges and comprehensive test coverage.

### What changed?

- Created `MultiSeriesValueLines` component to render horizontal value lines for each data series
- Added badge positioning functions for left-aligned badges including `gutterRightAlignedTextLeftX`, `minPaddingLeftForBadge`, and `resolveAutoLeft`
- Enhanced `resolvePadding` function to handle `badgeOnLeft` parameter for proper spacing
- Added test for per-series value lines in `LiveChartSeries` component
- Reorganized imports in test files to follow consistent ordering

### How to test?

Run the test suite to verify:
- `LiveChartSeries` renders correctly with `dot={{ valueLine: true }}` prop
- `MultiSeriesValueLines` component handles various edge cases including zero canvas height, zero display range, and missing values
- Badge positioning functions calculate correct coordinates for left-aligned badges
- Padding resolution accounts for left badge positioning

### Why make this change?

This enhancement allows charts to display individual value lines for each data series, improving data visualization capabilities. The left-aligned badge support provides more flexible positioning options for chart annotations and labels.