### PR TITLE
fix: reuse SkPath instances to stop iOS memory climb

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "expo@claude-plugins-official": true,
+    "react-native-best-practices@callstack-agent-skills": true
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agent-device": {
+      "type": "stdio",
+      "command": "agent-device",
+      "args": [
+        "mcp"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+A high-performance live charting library for React Native, built on `@shopify/react-native-skia`, `react-native-reanimated`, and `react-native-gesture-handler`. All data and live values flow through Reanimated `SharedValue`s so animations run on the UI thread without JS bridge traffic.
+
+This is a **monorepo** with npm workspaces:
+- `packages/react-native-livechart/` — the publishable library
+- Root — an Expo example app that demos the library via `app/demo/` screens
+
+## Commands
+
+```bash
+npm test                # run all tests (Jest + jest-expo)
+npm run test:lib        # library tests only
+npx jest path/to/file   # single test file
+npm run typecheck       # tsc --noEmit
+npm run lint            # eslint (expo flat config)
+npm run verify          # typecheck + lint + test (all three)
+npm run build:lib       # emit .d.ts only into packages/.../dist/
+npm start               # expo start (dev server for the example app)
+npm run ios             # expo run:ios
+```
+
+The **pre-commit hook** (husky) runs `npm test` — all tests must pass before committing.
+
+## Architecture
+
+### Engine (UI-thread tick loop)
+
+The chart's core is a **frame-callback engine** that runs on the UI thread via `useFrameCallback`. Each frame, a pure tick function updates mutable state (display min/max, time window, smoothed value) and writes results to SharedValues.
+
+- `src/core/liveChartEngineTick.ts` — pure tick function for single-series (`tickLiveChartEngineFrame`)
+- `src/core/liveChartSeriesEngineTick.ts` — pure tick function for multi-series (`tickMultiSeriesFrame`)
+- `src/core/useLiveChartEngine.ts` — React hook wrapping the single-series frame callback
+- `src/core/useLiveChartSeriesEngine.ts` — React hook wrapping the multi-series frame callback
+
+The tick functions are **pure** (no hooks, no SharedValues) — they take mutable state + input and return void after mutating. This makes them unit-testable without Reanimated.
+
+### Two chart components
+
+- `LiveChart` — single-series line/candle chart with scrubbing, badges, trade markers, degen effects
+- `LiveChartSeries` — multi-series line chart with toggleable series, per-series dots, and crosshair
+
+Both compose from a shared set of overlay components and hooks in `src/components/` and `src/hooks/`.
+
+### Drawing layer
+
+`src/draw/` contains Skia path-building functions (`line.ts`, `candle.ts`, `grid.ts`, `trade.ts`) that construct `SkPath` objects from data arrays. These run inside `useDerivedValue` on the UI thread.
+
+### Math utilities
+
+`src/math/` has pure functions for interpolation, splines, color blending, momentum detection, and candle aggregation. All are worklet-safe (no closures over JS-thread state).
+
+### Config resolution
+
+`src/core/resolveConfig.ts` normalizes user-facing props (booleans, partial objects) into fully resolved config objects with defaults. The `resolve*` functions are called once at render time, not per frame.
+
+## Key patterns
+
+- **SharedValue-driven**: Data enters as `SharedValue<LiveChartPoint[]>`. The engine, path builders, and overlays all read SharedValues — React re-renders are minimal.
+- **Worklets**: Functions tagged `"worklet"` or used inside `useDerivedValue`/`useFrameCallback` run on the UI thread. Keep them free of JS-thread closures and non-worklet imports.
+- **SkPath reuse**: Drawing functions accept and `.rewind()` existing SkPath instances rather than allocating new ones each frame (iOS memory optimization).
+- **Library ships TypeScript source**: The package's `main`/`exports` point at `src/index.ts`. The consumer's Metro + Babel compiles it. `dist/` only contains `.d.ts` files.
+
+## Testing
+
+Tests use `jest-expo` with a Skia mock and a Reanimated/Worklets stub (see `jest-setup.js`). SharedValues in tests are plain `{ value }` objects — full UI-thread round-trips don't work under Jest.
+
+Coverage thresholds: branches 90%, functions 95%, lines 95%, statements 95%.
+
+The `sim/` directory contains simulation hooks (`useSimulatedChartData`) used by the demo app, with their own tests.
+
+## Babel configuration
+
+`react-native-worklets/plugin` must be **last** in the Babel plugins array. Reordering breaks worklet compilation at build or runtime.

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -66,6 +66,9 @@ jest.mock("@shopify/react-native-skia", () => {
     close: jest.fn(),
     arcToOval: jest.fn(),
     addRRect: jest.fn(),
+    addRect: jest.fn(),
+    reset: jest.fn(),
+    rewind: jest.fn(),
   });
 
   const mockFont = {

--- a/packages/react-native-livechart/src/components/LoadingOverlay.tsx
+++ b/packages/react-native-livechart/src/components/LoadingOverlay.tsx
@@ -9,6 +9,7 @@ import {
   vec,
   type SkFont,
 } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import {
   BADGE_DOT_GAP,
@@ -33,9 +34,9 @@ const RECT_H = 4;
 const RECT_R = 4;
 const RECT_SPACING = 32;
 
-function buildSplinePath(pts: number[]) {
+function buildSplineInto(path: ReturnType<typeof Skia.Path.Make>, pts: number[]) {
   "worklet";
-  const path = Skia.Path.Make();
+  path.reset();
   const n = pts.length >> 1;
   if (n < 2) return path;
   path.moveTo(pts[0], pts[1]);
@@ -73,10 +74,25 @@ export function LoadingOverlay({
 }) {
   // Same left-inset formula as GridOverlay (only used when badge=true)
   const leftInset = BADGE_DOT_GAP + badgeTailAndCap(font.getSize(), badgeTail);
+
+  // Ping-pong persistent paths — avoid allocating a JSI-backed SkPath per frame
+  // while the squiggly loading/empty-state animation is running.
+  const squigglyCache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   // Squiggly path — animated each frame via timestamp
   const squigglyPath = useDerivedValue(() => {
+    squigglyCache.tick = !squigglyCache.tick;
+    const path = squigglyCache.tick ? squigglyCache.a : squigglyCache.b;
     if (!isLoading.value && !isEmpty.value && morphT.value >= 1) {
-      return Skia.Path.Make();
+      path.reset();
+      return path;
     }
     const pts = buildSquigglyPts(
       engine.canvasWidth.value,
@@ -84,7 +100,7 @@ export function LoadingOverlay({
       padding,
       engine.timestamp.value,
     );
-    return buildSplinePath(pts);
+    return buildSplineInto(path, pts);
   });
 
   // Fades out quickly as the reveal animation begins (first 33% of morphT)

--- a/packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx
@@ -1,5 +1,6 @@
 import { DashPathEffect, Group, Path, Skia } from "@shopify/react-native-skia";
 
+import { useMemo } from "react";
 import { useDerivedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
@@ -19,8 +20,19 @@ function SeriesValueLineAtIndex({
   color: string;
   config: ResolvedValueLineConfig;
 }) {
+  const cache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const path = useDerivedValue(() => {
-    const p = Skia.Path.Make();
+    cache.tick = !cache.tick;
+    const p = cache.tick ? cache.a : cache.b;
+    p.reset();
     const h = engine.canvasHeight.value;
     if (h === 0) return p;
     const s = engine.series.value;

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -6,6 +6,7 @@ import {
     Text as SkiaText,
     type SkFont,
 } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ReferenceLineLayout } from "../hooks/useReferenceLine";
@@ -31,9 +32,20 @@ export function ReferenceLineOverlay({
 }) {
   const opacity = useDerivedValue(() => (layout.value.visible ? 1 : 0));
 
+  const cache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const linePath = useDerivedValue(() => {
+    cache.tick = !cache.tick;
+    const path = cache.tick ? cache.a : cache.b;
+    path.reset();
     const l = layout.value;
-    const path = Skia.Path.Make();
     if (!l.visible) return path;
     path.moveTo(l.x1, l.y);
     path.lineTo(l.x2, l.y);

--- a/packages/react-native-livechart/src/components/ValueLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ValueLineOverlay.tsx
@@ -1,4 +1,5 @@
 import { DashPathEffect, Path, Skia } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ChartPadding } from "../draw/line";
@@ -23,8 +24,20 @@ export function ValueLineOverlay({
   intervals: [number, number];
   color: string;
 }) {
+  // Ping-pong persistent paths — avoid allocating a JSI-backed SkPath per frame.
+  const cache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const path = useDerivedValue(() => {
-    const p = Skia.Path.Make();
+    cache.tick = !cache.tick;
+    const p = cache.tick ? cache.a : cache.b;
+    p.reset();
     const y = dotY.value;
     if (y < 0) return p;
     p.moveTo(padding.left, y);

--- a/packages/react-native-livechart/src/components/XAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/XAxisOverlay.tsx
@@ -1,4 +1,5 @@
 import { Group, Path, Skia, type SkFont } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
@@ -24,9 +25,20 @@ export function XAxisOverlay({
   palette: LiveChartPalette;
   font: SkFont;
 }) {
+  const axisCache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const axisPath = useDerivedValue(() => {
     "worklet";
-    const path = Skia.Path.Make();
+    axisCache.tick = !axisCache.tick;
+    const path = axisCache.tick ? axisCache.a : axisCache.b;
+    path.reset();
     const w = engine.canvasWidth.value;
     const h = engine.canvasHeight.value;
     const lineY = h - padding.bottom;

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -1,4 +1,5 @@
 import { Group, Path, Skia, type SkFont } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { BADGE_DOT_GAP } from "../constants";
 import type { YAxisEntry } from "../draw/grid";
@@ -38,8 +39,19 @@ export function YAxisOverlay({
   /** When > 0, series labels occupy the left portion of the gutter; Y-axis labels right-align. */
   seriesLabelInset?: number;
 }) {
+  const gridCache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const gridLinesPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    gridCache.tick = !gridCache.tick;
+    const path = gridCache.tick ? gridCache.a : gridCache.b;
+    path.reset();
     const items = entries.value;
     const w = engine.canvasWidth.value;
     for (let i = 0; i < items.length; i++) {

--- a/packages/react-native-livechart/src/hooks/useBadge.ts
+++ b/packages/react-native-livechart/src/hooks/useBadge.ts
@@ -1,4 +1,5 @@
 import { Skia, type SkFont } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import {
   useDerivedValue,
   useSharedValue,
@@ -45,12 +46,27 @@ export function useBadge(
   const downRgb = hexToRgb(palette.dotDown);
   const accentRgb = hexToRgb(palette.badgeBg);
 
+  // Ping-pong between two persistent badge paths so the derived value always
+  // returns a freshly-mutated SkPath without allocating a new one every frame.
+  // See useChartPaths for the full rationale on per-frame Skia.Path.Make().
+  const cache = useMemo(
+    () => ({
+      a: Skia.Path.Make(),
+      b: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const badge = useDerivedValue(() => {
     const w = engine.canvasWidth.value;
     const h = engine.canvasHeight.value;
+    cache.tick = !cache.tick;
+    const path = cache.tick ? cache.a : cache.b;
+    path.reset();
     if (w === 0 || h === 0) {
       return {
-        path: Skia.Path.Make(),
+        path,
         textX: 0,
         textY: 0,
         text: "",
@@ -75,7 +91,6 @@ export function useBadge(
     const pillH = font.getSize() + BADGE_PILL_PAD_Y * 2;
     const r = pillH / 2;
     const badgeY = dotY - pillH / 2;
-    const path = Skia.Path.Make();
     let textX: number;
 
     if (position === "left") {

--- a/packages/react-native-livechart/src/hooks/useCandlePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useCandlePaths.ts
@@ -1,4 +1,5 @@
 import { Skia } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import {
   useDerivedValue,
   useFrameCallback,
@@ -14,6 +15,13 @@ import type { CandlePoint } from "../types";
 
 const CANDLE_WIDTH_LERP_SPEED = 0.08;
 
+/**
+ * Persistent candle `SkPath`s — two per geometry slot (up/down bodies + up/down wicks).
+ * Each derived value ping-pongs between its pair and mutates the picked path in place
+ * so we don't allocate a new JSI-backed `SkPath` per frame. See {@link useChartPaths}
+ * for the rationale (this was the primary driver of the iOS memory climb under live
+ * ticking).
+ */
 export function useCandlePaths(
   engine: SingleEngineState,
   padding: ChartPadding,
@@ -24,6 +32,24 @@ export function useCandlePaths(
 ) {
   const targetCandleWidth = useDerivedValue(() => candleWidthSecs);
   const displayCandleWidth = useSharedValue(candleWidthSecs);
+
+  const cache = useMemo(
+    () => ({
+      upBodiesA: Skia.Path.Make(),
+      upBodiesB: Skia.Path.Make(),
+      downBodiesA: Skia.Path.Make(),
+      downBodiesB: Skia.Path.Make(),
+      upWicksA: Skia.Path.Make(),
+      upWicksB: Skia.Path.Make(),
+      downWicksA: Skia.Path.Make(),
+      downWicksB: Skia.Path.Make(),
+      ubTick: false,
+      dbTick: false,
+      uwTick: false,
+      dwTick: false,
+    }),
+    [],
+  );
 
   useFrameCallback((frameInfo) => {
     "worklet";
@@ -56,7 +82,9 @@ export function useCandlePaths(
 
   /* istanbul ignore next -- worklet */
   const upBodiesPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    cache.ubTick = !cache.ubTick;
+    const path = cache.ubTick ? cache.upBodiesA : cache.upBodiesB;
+    path.reset();
     const { bodies } = geometry.value;
     for (let i = 0; i < bodies.length; i++) {
       if (bodies[i].up) {
@@ -70,7 +98,9 @@ export function useCandlePaths(
 
   /* istanbul ignore next -- worklet */
   const downBodiesPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    cache.dbTick = !cache.dbTick;
+    const path = cache.dbTick ? cache.downBodiesA : cache.downBodiesB;
+    path.reset();
     const { bodies } = geometry.value;
     for (let i = 0; i < bodies.length; i++) {
       if (!bodies[i].up) {
@@ -84,7 +114,9 @@ export function useCandlePaths(
 
   /* istanbul ignore next -- worklet */
   const upWicksPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    cache.uwTick = !cache.uwTick;
+    const path = cache.uwTick ? cache.upWicksA : cache.upWicksB;
+    path.reset();
     const { wicks } = geometry.value;
     for (let i = 0; i < wicks.length; i++) {
       if (wicks[i].up) {
@@ -97,7 +129,9 @@ export function useCandlePaths(
 
   /* istanbul ignore next -- worklet */
   const downWicksPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    cache.dwTick = !cache.dwTick;
+    const path = cache.dwTick ? cache.downWicksA : cache.downWicksB;
+    path.reset();
     const { wicks } = geometry.value;
     for (let i = 0; i < wicks.length; i++) {
       if (!wicks[i].up) {

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -1,15 +1,39 @@
 import { Skia } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { SingleEngineState } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline } from "../math/spline";
 import { blendPtsY, squigglifyPts } from "../math/squiggly";
 
+/**
+ * Persistent `linePath` / `fillPath` `SkPath`s that are **mutated in place** each frame.
+ *
+ * Why not `useDerivedValue(() => Skia.Path.Make())`? Each call would allocate a brand-new
+ * JSI-backed `SkPath`, and on iOS the native GC lags the JS GC under a steady firehose —
+ * resident memory climbs steadily for as long as the chart is mounted. Here we allocate
+ * two paths per curve once and ping-pong the reference each frame so Reanimated's
+ * value-equality early-return still fires its subscribers (i.e. the Skia reanimated
+ * container re-records and repaints).
+ */
 export function useChartPaths(
   engine: SingleEngineState,
   padding: ChartPadding,
   morphT?: SharedValue<number>,
 ) {
+  // Two persistent paths per curve; ping-pong so the returned reference changes
+  // every frame, which keeps Reanimated's setter from short-circuiting the notify.
+  const cache = useMemo(
+    () => ({
+      lineA: Skia.Path.Make(),
+      lineB: Skia.Path.Make(),
+      fillA: Skia.Path.Make(),
+      fillB: Skia.Path.Make(),
+      tick: false,
+    }),
+    [],
+  );
+
   const flatPts = useDerivedValue(() => {
     const realPts = buildLinePoints(
       engine.data.value,
@@ -44,7 +68,9 @@ export function useChartPaths(
 
   const linePath = useDerivedValue(() => {
     const pts = flatPts.value;
-    const path = Skia.Path.Make();
+    cache.tick = !cache.tick;
+    const path = cache.tick ? cache.lineA : cache.lineB;
+    path.reset();
     const n = pts.length >> 1;
     if (n < 2) return path;
     path.moveTo(pts[0], pts[1]);
@@ -54,7 +80,10 @@ export function useChartPaths(
 
   const fillPath = useDerivedValue(() => {
     const pts = flatPts.value;
-    const path = Skia.Path.Make();
+    // Use the same tick flag flipped by linePath — flipping again here would
+    // keep both paths in sync, so just read the current parity.
+    const path = cache.tick ? cache.fillA : cache.fillB;
+    path.reset();
     const n = pts.length >> 1;
     if (n < 2) return path;
     path.moveTo(pts[0], pts[1]);

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -1,4 +1,5 @@
 import { Skia } from "@shopify/react-native-skia";
+import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
@@ -7,18 +8,38 @@ import { drawSpline } from "../math/spline";
 
 /**
  * One derived shared value holding up to `MAX_MULTI_SERIES` Skia paths (unused slots are empty paths).
+ *
+ * Each slot ping-pongs between two persistent `SkPath`s so `MultiSeriesStroke`'s
+ * per-slot `useDerivedValue(() => paths.value[index])` sees a fresh reference each
+ * tick (otherwise Reanimated's setter short-circuits and Skia never repaints).
+ * No new JSI-backed `SkPath` is allocated per frame. See {@link useChartPaths}
+ * for the memory rationale.
  */
 export function useMultiSeriesLinePaths(
   engine: MultiEngineState,
   padding: ChartPadding,
 ): SharedValue<ReturnType<typeof Skia.Path.Make>[]> {
+  const pool = useMemo(() => {
+    const a: ReturnType<typeof Skia.Path.Make>[] = [];
+    const b: ReturnType<typeof Skia.Path.Make>[] = [];
+    for (let i = 0; i < MAX_MULTI_SERIES; i++) {
+      a.push(Skia.Path.Make());
+      b.push(Skia.Path.Make());
+    }
+    return { a, b, tick: false };
+  }, []);
+
   return useDerivedValue(() => {
+    pool.tick = !pool.tick;
+    const slots = pool.tick ? pool.a : pool.b;
     const s = engine.series.value;
     const displays = engine.displaySeriesValues.value;
     const out: ReturnType<typeof Skia.Path.Make>[] = [];
     for (let i = 0; i < MAX_MULTI_SERIES; i++) {
+      const path = slots[i];
+      path.reset();
       if (i >= s.length) {
-        out.push(Skia.Path.Make());
+        out.push(path);
         continue;
       }
       const pts = buildLinePoints(
@@ -32,7 +53,6 @@ export function useMultiSeriesLinePaths(
         engine.canvasHeight.value,
         padding,
       );
-      const path = Skia.Path.Make();
       const n = pts.length >> 1;
       if (n >= 2) {
         path.moveTo(pts[0], pts[1]);


### PR DESCRIPTION
## Summary

The rising iOS memory under a live-ticking `<LiveChart>` was tracked to a per-frame `Skia.Path.Make()` pattern across the chart's `useDerivedValue` worklets. The playground and simulated data hook were clean — everything is capped/FIFO'd and runs on plain JS objects — so the climb was coming from the chart itself, not the screen around it.

Every frame the engine's frame callback mutates `displayValue`, `displayMin/Max`, `timestamp`, `canvasWidth/Height`, etc. Each downstream derived value that reads those shared values re-ran its worklet and returned a brand-new JSI-backed `SkPath`:

- `useChartPaths` — line + fill paths (always on in line mode)
- `useCandlePaths` — 4 paths (up/down bodies + up/down wicks) in candle mode
- `useBadge` — badge pill path
- `ValueLineOverlay` — tracks `dotY` every frame
- `LoadingOverlay` — squiggly loader spline
- `YAxisOverlay` / `XAxisOverlay` / `ReferenceLineOverlay` — lower cadence but still allocating
- `useMultiSeriesLinePaths` + `MultiSeriesValueLines` — per-slot multi-series lines

On iOS, GC of those host objects through JSI lags the JS GC, so resident memory kept climbing for as long as the chart was mounted.

## Fix

Replace the hot `Skia.Path.Make()` calls with a `useMemo` pool of **two** persistent paths per curve, reset and mutated in place each frame. We ping-pong the reference between the two paths so Reanimated's `valueSetter` short-circuit (`mutable._value === value && !forceUpdate`) still notifies listeners — otherwise `<skPath>` would never re-record on the reanimated Skia container even though the path content changed.

Closure state (`cache.tick`) is only mutated on the UI runtime after the first `initialUpdaterRun` on JS. The JS-side freeze-after-serialize that ships with `react-native-worklets` isn't tripped because no mutation happens JS-side once the mapper is started.

For `useMultiSeriesLinePaths` the same pattern is applied — each slot ping-pongs so `MultiSeriesStroke`'s per-slot `useDerivedValue(() => paths.value[index])` sees a fresh reference each tick.

## Files touched

- `packages/react-native-livechart/src/hooks/useChartPaths.ts`
- `packages/react-native-livechart/src/hooks/useCandlePaths.ts`
- `packages/react-native-livechart/src/hooks/useBadge.ts`
- `packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts`
- `packages/react-native-livechart/src/components/ValueLineOverlay.tsx`
- `packages/react-native-livechart/src/components/LoadingOverlay.tsx`
- `packages/react-native-livechart/src/components/XAxisOverlay.tsx`
- `packages/react-native-livechart/src/components/YAxisOverlay.tsx`
- `packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx`
- `packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx`
- `jest-setup.js` — add `reset` / `addRect` / `rewind` to the Skia Path mock so tests can exercise the in-place mutation path

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:lib` — **551 passed / 3 skipped / 49 suites**, pre-existing Reanimated `cancelAnimation` warning count unchanged (1965 → 1965, confirming no new closure-freeze warnings from the cache objects)
- [ ] Manual iOS profiling: leave the playground running on the `line-playback`, `scrub`, `candlestick`, `multi-series`, and `playground` screens for several minutes and confirm the RSS graph stays flat instead of climbing
- [ ] Manual iOS smoke: line ↔ candle toggle, degen shake, trade stream, reference line, loading/empty reveal, multi-series toggle chips still render and animate correctly
