### PR TITLE
perf(chart): reuse per-frame buffers to cut UI-thread allocation

### DIFF
--- a/packages/react-native-livechart/src/draw/line.ts
+++ b/packages/react-native-livechart/src/draw/line.ts
@@ -197,6 +197,13 @@ export function resolvePadding(
  * and appends a live tip at (now, displayValue).
  *
  * Flat layout avoids ~150 tuple object allocations per frame.
+ *
+ * Pass `out` to reuse a persistent array instead of allocating a fresh one each
+ * frame (it is cleared and refilled). The per-frame allocation otherwise scales
+ * with the visible point count, so pooling it cuts UI-thread GC pressure on
+ * busy / wide-window charts. Callers that pool `out` must ping-pong two buffers
+ * so the returned reference still changes each frame (Reanimated's value-equality
+ * check skips notifying subscribers when the reference is unchanged).
  */
 export function buildLinePoints(
   data: LiveChartPoint[],
@@ -208,14 +215,17 @@ export function buildLinePoints(
   canvasWidth: number,
   canvasHeight: number,
   padding: ChartPadding,
+  out?: number[],
 ): number[] {
   "worklet";
+  const pts: number[] = out ?? [];
+  if (out) out.length = 0;
   const chartW = canvasWidth - padding.left - padding.right;
   const chartH = canvasHeight - padding.top - padding.bottom;
   const valRange = displayMax - displayMin;
 
   if (valRange === 0 || chartW <= 0 || chartH <= 0 || data.length === 0)
-    return [];
+    return pts;
 
   const winStart = now - windowSecs;
 
@@ -229,7 +239,6 @@ export function buildLinePoints(
   }
   const startIdx = Math.max(0, lo - 1);
 
-  const pts: number[] = [];
   for (let i = startIdx; i < data.length; i++) {
     if (data[i].time > now) break;
     pts.push(

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { SingleEngineState } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
-import { drawSpline } from "../math/spline";
+import { drawSpline, makeSplineScratch } from "../math/spline";
 import { blendPtsY, squigglifyPts } from "../math/squiggly";
 
 /**
@@ -30,11 +30,19 @@ export function useChartPaths(
       fillA: Skia.Path.Make(),
       fillB: Skia.Path.Make(),
       tick: false,
+      // Ping-pong point buffers: reused across frames but the returned reference
+      // still alternates, so Reanimated keeps notifying linePath/fillPath.
+      ptsA: [] as number[],
+      ptsB: [] as number[],
+      ptsTick: false,
+      scratch: makeSplineScratch(),
     }),
     [],
   );
 
   const flatPts = useDerivedValue(() => {
+    cache.ptsTick = !cache.ptsTick;
+    const buf = cache.ptsTick ? cache.ptsA : cache.ptsB;
     const realPts = buildLinePoints(
       engine.data.value,
       engine.displayValue.value,
@@ -45,6 +53,7 @@ export function useChartPaths(
       engine.canvasWidth.value,
       engine.canvasHeight.value,
       padding,
+      buf,
     );
 
     // Skip blending when fully revealed or no morphT provided
@@ -74,7 +83,7 @@ export function useChartPaths(
     const n = pts.length >> 1;
     if (n < 2) return path;
     path.moveTo(pts[0], pts[1]);
-    drawSpline(path, pts);
+    drawSpline(path, pts, cache.scratch);
     return path;
   });
 
@@ -87,7 +96,7 @@ export function useChartPaths(
     const n = pts.length >> 1;
     if (n < 2) return path;
     path.moveTo(pts[0], pts[1]);
-    drawSpline(path, pts);
+    drawSpline(path, pts, cache.scratch);
     const bottom = engine.canvasHeight.value - padding.bottom;
     path.lineTo(pts[(n - 1) * 2], bottom);
     path.lineTo(pts[0], bottom);

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -52,6 +52,7 @@ export function useDegen(
   const shakeY = useSharedValue(0);
   const shakeStart = useSharedValue(0);
   const prevTimestamp = useSharedValue(0);
+  const prevActiveCount = useSharedValue(0);
   const hasOnShakeListenerSV = useSharedValue(0);
 
   const onShakeRef = useRef(onShake);
@@ -147,6 +148,7 @@ export function useDegen(
       if (enabledSV.value < 0.5) {
         for (let i = 0; i < slots; i++) buf[i * 7 + 5] = 0;
         prevM.value = momentumSV.value;
+        prevActiveCount.value = 0;
         shakeStart.value = 0;
         shakeX.value = 0;
         shakeY.value = 0;
@@ -208,7 +210,7 @@ export function useDegen(
         shakeY.value = 0;
       }
 
-      tickParticles(
+      const activeCount = tickParticles(
         buf,
         slots,
         now,
@@ -217,7 +219,14 @@ export function useDegen(
         dtSec,
       );
 
-      packRevision.value = packRevision.value + 1;
+      // Repaint only while particles are alive (or on the frame they all expire,
+      // so the overlay clears). When the field is empty the 4 derived values per
+      // slot stay subscribed to `packRevision` alone and freeze — no per-frame
+      // worklet churn for an idle particle system.
+      if (activeCount > 0 || prevActiveCount.value > 0) {
+        packRevision.value = packRevision.value + 1;
+      }
+      prevActiveCount.value = activeCount;
     },
   );
 

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -4,7 +4,7 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
-import { drawSpline } from "../math/spline";
+import { drawSpline, makeSplineScratch } from "../math/spline";
 
 /**
  * One derived shared value holding up to `MAX_MULTI_SERIES` Skia paths (unused slots are empty paths).
@@ -26,7 +26,9 @@ export function useMultiSeriesLinePaths(
       a.push(Skia.Path.Make());
       b.push(Skia.Path.Make());
     }
-    return { a, b, tick: false };
+    // One point buffer + spline scratch, reused across slots (built sequentially)
+    // and across frames — no per-frame, per-series array allocation.
+    return { a, b, tick: false, ptsBuf: [] as number[], scratch: makeSplineScratch() };
   }, []);
 
   return useDerivedValue(() => {
@@ -52,11 +54,12 @@ export function useMultiSeriesLinePaths(
         engine.canvasWidth.value,
         engine.canvasHeight.value,
         padding,
+        pool.ptsBuf,
       );
       const n = pts.length >> 1;
       if (n >= 2) {
         path.moveTo(pts[0], pts[1]);
-        drawSpline(path, pts);
+        drawSpline(path, pts, pool.scratch);
       }
       out.push(path);
     }

--- a/packages/react-native-livechart/src/hooks/useTradeStream.ts
+++ b/packages/react-native-livechart/src/hooks/useTradeStream.ts
@@ -50,6 +50,11 @@ export function useTradeStream(
       const s = state.value;
       tickTradeStream(s, tradeStream.value, dt, chartTop, chartBottom);
 
+      // Idle tape: nothing to draw and nothing already drawn. Skip the projection
+      // and SharedValue write so the TapeLabel derived values don't re-run and we
+      // don't allocate a fresh marker array every frame.
+      if (s.labels.length === 0 && markers.value.length === 0) return;
+
       const chartH = chartBottom - chartTop;
       markers.value = projectLabels(s, chartTop, chartH);
     },

--- a/packages/react-native-livechart/src/hooks/useXAxis.ts
+++ b/packages/react-native-livechart/src/hooks/useXAxis.ts
@@ -87,14 +87,13 @@ export function useXAxis(
 
     const alphas = labelAlphas.value;
 
-    // Create/update labels
+    // Create labels for new keys only. A key encodes its time, so the formatted
+    // text never changes — re-formatting (and re-allocating the entry) every
+    // frame just churns strings/objects for the GC.
     for (let i = 0; i < targetKeys.length; i++) {
       const key = targetKeys[i];
-      const text = formatTime(key / 100);
       if (!alphas[key]) {
-        alphas[key] = { alpha: 0, text };
-      } else {
-        alphas[key] = { alpha: alphas[key].alpha, text };
+        alphas[key] = { alpha: 0, text: formatTime(key / 100) };
       }
     }
 
@@ -118,7 +117,8 @@ export function useXAxis(
       if (next < 0.01 && target === 0) {
         delete alphas[key];
       } else {
-        alphas[key] = { alpha: next, text: label.text };
+        // Mutate in place — text is stable, so no need to reallocate the entry.
+        label.alpha = next;
       }
     }
 

--- a/packages/react-native-livechart/src/math/degenTick.ts
+++ b/packages/react-native-livechart/src/math/degenTick.ts
@@ -106,7 +106,11 @@ export function computeShake(
   };
 }
 
-/** Advance all particles by `dtSec`: apply velocity, drag, and expire particles older than `burstDur`. */
+/**
+ * Advance all particles by `dtSec`: apply velocity, drag, and expire particles older than `burstDur`.
+ * Returns the number of particles still alive after the tick, so callers can skip per-frame
+ * repaint work (bumping `packRevision`) when the field is empty.
+ */
 export function tickParticles(
   buf: Float64Array,
   slots: number,
@@ -114,9 +118,10 @@ export function tickParticles(
   burstDur: number,
   drag: number,
   dtSec: number,
-): void {
+): number {
   "worklet";
   const stride = DEGEN_STRIDE;
+  let active = 0;
   for (let i = 0; i < slots; i++) {
     const b = i * stride;
     if (buf[b + 5] < 0.5) continue;
@@ -129,5 +134,7 @@ export function tickParticles(
     buf[b + 1] += buf[b + 3] * dtSec;
     buf[b + 2] *= drag;
     buf[b + 3] *= drag;
+    active++;
   }
+  return active;
 }

--- a/packages/react-native-livechart/src/math/spline.ts
+++ b/packages/react-native-livechart/src/math/spline.ts
@@ -1,6 +1,24 @@
 import type { SkPath } from "@shopify/react-native-skia";
 
 /**
+ * Reusable scratch buffers for {@link drawSpline}. Pass a persistent instance
+ * (created once per chart via `useMemo`) to avoid allocating three arrays sized
+ * to the point count on every frame — the per-frame garbage scales with the
+ * number of points (large `timeWindow`s push 1000+ points), so pooling these
+ * meaningfully cuts UI-thread GC pressure on live charts.
+ */
+export interface SplineScratch {
+  delta: number[];
+  h: number[];
+  m: number[];
+}
+
+/** Allocate an empty {@link SplineScratch} (arrays grow on demand). */
+export function makeSplineScratch(): SplineScratch {
+  return { delta: [], h: [], m: [] };
+}
+
+/**
  * Fritsch-Carlson monotone cubic interpolation.
  * Guarantees no overshoots — the curve never exceeds local min/max.
  * Same approach documented in liveline for smooth live line charts (adapted code; MIT).
@@ -8,9 +26,13 @@ import type { SkPath } from "@shopify/react-native-skia";
  * pts is a flat number array with stride 2: [x0, y0, x1, y1, ...].
  * Caller must moveTo the first point before calling.
  *
+ * Pass `scratch` (see {@link makeSplineScratch}) to reuse the tangent/interval
+ * buffers across frames instead of allocating them each call. Only indices
+ * `0..n-1` are read after being written, so stale tail entries are harmless.
+ *
  * @see https://github.com/benjitaylor/liveline
  */
-export function drawSpline(path: SkPath, pts: number[]) {
+export function drawSpline(path: SkPath, pts: number[], scratch?: SplineScratch) {
   "worklet";
   const n = pts.length >> 1;
   if (n < 2) return;
@@ -20,8 +42,8 @@ export function drawSpline(path: SkPath, pts: number[]) {
   }
 
   // 1. Secant slopes and x-intervals
-  const delta: number[] = new Array(n - 1);
-  const h: number[] = new Array(n - 1);
+  const delta: number[] = scratch ? scratch.delta : new Array(n - 1);
+  const h: number[] = scratch ? scratch.h : new Array(n - 1);
   for (let i = 0; i < n - 1; i++) {
     const i2 = i * 2;
     const j2 = i2 + 2;
@@ -30,7 +52,7 @@ export function drawSpline(path: SkPath, pts: number[]) {
   }
 
   // 2. Initial tangent estimates
-  const m: number[] = new Array(n);
+  const m: number[] = scratch ? scratch.m : new Array(n);
   m[0] = delta[0];
   m[n - 1] = delta[n - 2];
   for (let i = 1; i < n - 1; i++) {


### PR DESCRIPTION
Reduces per-frame allocation in the chart's UI-thread render path. The engine writes `timestamp` every frame, so every overlay's worklet re-runs each frame — these changes pool the allocations that scaled with that work.

- `buildLinePoints` / `drawSpline` accept reusable scratch buffers; `useChartPaths` and `useMultiSeriesLinePaths` ping-pong them so Reanimated still notifies subscribers each frame.
- **degen**: only bump `packRevision` while particles are alive — previously ~240 derived-value evaluations ran every frame even with no active burst.
- **trade-stream**: skip projection + SharedValue write on an empty tape.
- **x-axis**: cache formatted label strings and mutate alpha in place.

No behaviour change. `npm run verify` (typecheck + lint + 564 tests) passes; verified on the iOS 26 simulator that single- and multi-series charts still animate.

Profiling note: these are CPU/GC-pressure reductions. The single biggest *memory* climb in the example app turned out to be the demo header, fixed in the PR stacked on top of this one.

Stacked on #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)