### PR TITLE
perf(multi-series): cut per-tick allocations in the live feed and engine

### DIFF
--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   useDerivedValue,
   useFrameCallback,
@@ -36,20 +37,52 @@ export interface MultiEngineFrameRefs {
 }
 
 /**
+ * Reusable per-frame scratch for {@link applyLiveChartSeriesEngineFrame}. The two
+ * output arrays ping-pong so the assigned reference still changes each frame
+ * (Reanimated propagates on reference change) without allocating a fresh array
+ * per frame. Create one per engine via `useMemo`.
+ */
+export interface MultiSeriesEngineScratch {
+  dvA: number[];
+  dvB: number[];
+  opA: number[];
+  opB: number[];
+  tick: boolean;
+}
+
+/**
  * One frame of the multi-series chart engine.
  * Mirrors `applyLiveChartEngineFrame` but iterates over each series
  * to lerp per-series display values and opacities. Extracted as a
  * pure function so it can be called from both `useFrameCallback` and tests.
+ *
+ * Pass `scratch` to reuse the output arrays across frames instead of allocating
+ * two via `.slice()` each frame; omit it (tests) to fall back to allocation.
  */
 export function applyLiveChartSeriesEngineFrame(
   frameInfo: { timeSincePreviousFrame?: number | null },
   sv: MultiEngineFrameRefs,
+  scratch?: MultiSeriesEngineScratch,
 ): void {
   "worklet";
   const dt = frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
   const seriesSnap = sv.series.value;
-  const displayValues = sv.displaySeriesValues.value.slice();
-  const opacities = sv.seriesOpacities.value.slice();
+  const curDv = sv.displaySeriesValues.value;
+  const curOp = sv.seriesOpacities.value;
+  let displayValues: number[];
+  let opacities: number[];
+  if (scratch) {
+    scratch.tick = !scratch.tick;
+    displayValues = scratch.tick ? scratch.dvA : scratch.dvB;
+    opacities = scratch.tick ? scratch.opA : scratch.opB;
+    displayValues.length = curDv.length;
+    for (let i = 0; i < curDv.length; i++) displayValues[i] = curDv[i];
+    opacities.length = curOp.length;
+    for (let i = 0; i < curOp.length; i++) opacities[i] = curOp[i];
+  } else {
+    displayValues = curDv.slice();
+    opacities = curOp.slice();
+  }
   const state = {
     displayMin: sv.displayMin.value,
     displayMax: sv.displayMax.value,
@@ -107,24 +140,34 @@ export function useLiveChartSeriesEngine(
 
   const { series } = config;
 
+  // Reused per-frame output buffers (ping-ponged) — see applyLiveChartSeriesEngineFrame.
+  const scratch = useMemo<MultiSeriesEngineScratch>(
+    () => ({ dvA: [], dvB: [], opA: [], opB: [], tick: false }),
+    [],
+  );
+
   useFrameCallback((frameInfo) => {
     "worklet";
-    applyLiveChartSeriesEngineFrame(frameInfo, {
-      series,
-      displaySeriesValues,
-      seriesOpacities,
-      displayMin,
-      displayMax,
-      displayWindow,
-      timestamp,
-      canvasWidth,
-      canvasHeight,
-      timeWindow,
-      smoothing,
-      exaggerateSV,
-      referenceValue,
-      pausedSV,
-    });
+    applyLiveChartSeriesEngineFrame(
+      frameInfo,
+      {
+        series,
+        displaySeriesValues,
+        seriesOpacities,
+        displayMin,
+        displayMax,
+        displayWindow,
+        timestamp,
+        canvasWidth,
+        canvasHeight,
+        timeWindow,
+        smoothing,
+        exaggerateSV,
+        referenceValue,
+        pausedSV,
+      },
+      scratch,
+    );
   });
 
   return {

--- a/sim/generators.ts
+++ b/sim/generators.ts
@@ -334,6 +334,9 @@ export function stepMultiSeries(
 
   for (let i = 0; i < series.length; i++) {
     series[i].value = values[i];
-    series[i].data = [...series[i].data, { time: now, value: values[i] }];
+    // Append in place. The caller publishes a fresh top-level series array each
+    // tick so the SharedValue still notifies; copying each series' full (growing)
+    // history per tick was a needless allocation firehose under live ticking.
+    series[i].data.push({ time: now, value: values[i] });
   }
 }

--- a/sim/useSimulatedChartData.ts
+++ b/sim/useSimulatedChartData.ts
@@ -331,24 +331,22 @@ export function useSimulatedChartData(
       }
 
       if (multiSeries) {
-        b.series = b.series.map((s) => {
-          const vis = seriesVisibilityRef?.current[s.id];
-          return {
-            ...s,
-            data: [...s.data],
-            ...(vis !== undefined ? { visible: vis } : {}),
-          };
-        });
-        stepMultiSeries(b.series, true);
-        for (let i = 0; i < b.series.length; i++) {
-          if (b.series[i].data.length > maxPoints) {
-            b.series[i] = {
-              ...b.series[i],
-              data: b.series[i].data.slice(-maxPoints),
-            };
+        // Apply visibility overrides in place — no per-tick copy of each series'
+        // (growing) data array. stepMultiSeries appends in place and we trim in
+        // place; publishing a fresh top-level array reference is enough for the
+        // SharedValue to notify subscribers.
+        if (seriesVisibilityRef) {
+          for (let i = 0; i < b.series.length; i++) {
+            const vis = seriesVisibilityRef.current[b.series[i].id];
+            if (vis !== undefined) b.series[i].visible = vis;
           }
         }
-        series.value = b.series;
+        stepMultiSeries(b.series, true);
+        for (let i = 0; i < b.series.length; i++) {
+          const d = b.series[i].data;
+          if (d.length > maxPoints) d.splice(0, d.length - maxPoints);
+        }
+        series.value = b.series.slice();
       }
     };
 


### PR DESCRIPTION
Profiling the multi-series demo on iOS (Release) showed a sustained
memory climb (~0.33 MB/s) absent from single-series and candle charts.

- sim feed (useSimulatedChartData + stepMultiSeries): every tick copied
  each series' full (growing) data array twice — once in the visibility
  .map(), once in stepMultiSeries — before publishing. Now append in
  place and publish a fresh top-level array reference (Reanimated still
  notifies subscribers); visibility overrides are applied in place.
- series engine (applyLiveChartSeriesEngineFrame): allocated two arrays
  via .slice() every frame; now reuses ping-ponged buffers.

The chart's multi-series render path was already clean (fixed slots +
reused paths). The remaining growth is bounded heap warm-up from cloning
the series arrays through SharedValues each tick — it decelerates and
plateaus, not a leak. 564 tests pass; multi-series verified rendering
correctly after the change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>