### PR TITLE
feat(chart): reference lines/bands, y-axis bounds, grid & palette config

### DIFF
--- a/app/demo/appearance.tsx
+++ b/app/demo/appearance.tsx
@@ -45,6 +45,8 @@ export default function AppearanceScreen() {
   const [skiaFontFamily, setSkiaFontFamily] =
     useState<SkiaFontFamilyDemo>("platformMono");
   const [roundedStyle, setRoundedStyle] = useState(false);
+  const [gridDashed, setGridDashed] = useState(false);
+  const [paletteOverride, setPaletteOverride] = useState(false);
 
   const { data, value } = useSimulatedChartData({
     multiSeries: false,
@@ -82,6 +84,14 @@ export default function AppearanceScreen() {
                 ? { typeface: googleSansCodeRegular }
                 : {}),
           }}
+          gridStyle={
+            gridDashed ? { intervals: [1, 3], opacity: 0.8 } : undefined
+          }
+          palette={
+            paletteOverride
+              ? { gridLine: "rgba(96,165,250,0.35)", gridLabel: "#60a5fa" }
+              : undefined
+          }
           style={
             roundedStyle
               ? {
@@ -321,6 +331,36 @@ export default function AppearanceScreen() {
             </Text>
           </Pressable>
         ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Grid & palette</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, gridDashed && demoStyles.chipActive]}
+          onPress={() => setGridDashed((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              gridDashed && demoStyles.chipTextActive,
+            ]}
+          >
+            Dotted grid
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, paletteOverride && demoStyles.chipActive]}
+          onPress={() => setPaletteOverride((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              paletteOverride && demoStyles.chipTextActive,
+            ]}
+          >
+            Palette override
+          </Text>
+        </Pressable>
       </View>
 
       <Text style={demoStyles.sectionLabel}>Container style</Text>

--- a/app/demo/horizontal-lines.tsx
+++ b/app/demo/horizontal-lines.tsx
@@ -1,118 +1,152 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import { LiveChart } from "react-native-livechart";
+import { LiveChart, type ReferenceLine } from "react-native-livechart";
 
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 import { DemoScreen } from "./lib/DemoScreen";
 import { ACCENT } from "./lib/shared";
 import { demoStyles } from "./lib/styles";
 
-export const options = { title: "Reference & value lines" };
+export const options = { title: "Reference lines & bands" };
+
+const START = 100;
 
 export default function HorizontalLinesScreen() {
-  const [refOn, setRefOn] = useState(true);
-  const [refStyled, setRefStyled] = useState(false);
-  const [valOn, setValOn] = useState(true);
-  const [valStyled, setValStyled] = useState(false);
+  const [lines, setLines] = useState(true);
+  const [valueBand, setValueBand] = useState(false);
+  const [timeBand, setTimeBand] = useState(false);
+  const [offAxis, setOffAxis] = useState(false);
+  const [valueLine, setValueLine] = useState(true);
 
-  const startValue = 100;
   const { data, value } = useSimulatedChartData({
     multiSeries: false,
     candleAggregation: false,
     tradeStream: false,
-    startValue,
+    startValue: START,
   });
+
+  // Pin the time band ONCE when it's enabled (the band lives in absolute
+  // unix-seconds space, so it then scrolls smoothly leftward with the chart).
+  // Re-pinning on an interval would make it jump back to the right each tick.
+  const [timeWindow, setTimeWindow] = useState<{
+    from: number;
+    to: number;
+  } | null>(null);
+  useEffect(() => {
+    if (!timeBand) return;
+    const now = Date.now() / 1000;
+    setTimeWindow({ from: now - 20, to: now - 8 });
+  }, [timeBand]);
+
+  const referenceLines: ReferenceLine[] = [];
+  if (lines) {
+    referenceLines.push({ value: START * 1.05, label: "+5%", color: "#34d399" });
+    referenceLines.push({
+      value: START * 0.95,
+      label: "-5%",
+      color: "#f87171",
+      strokeWidth: 2,
+      intervals: [6, 4],
+    });
+  }
+  if (valueBand) {
+    referenceLines.push({
+      valueFrom: START * 0.98,
+      valueTo: START * 1.02,
+      color: "#fbbf24",
+      label: "±2% band",
+      // strokeWidth adds a dashed border; fillOpacity tunes the fill alpha.
+      strokeWidth: 1,
+      intervals: [4, 3],
+      fillOpacity: 0.18,
+    });
+  }
+  if (timeBand && timeWindow) {
+    referenceLines.push({
+      from: timeWindow.from,
+      to: timeWindow.to,
+      color: "#60a5fa",
+      label: "event",
+      strokeWidth: 1,
+      intervals: [4, 3],
+    });
+  }
+  if (offAxis) {
+    referenceLines.push({
+      value: START * 1.5,
+      offAxisBadge: true,
+      offAxisBadgeLabel: "Target",
+      excludeFromRange: true,
+      color: "#a855f7",
+      // Target panel styling: background / border / radius.
+      badgeBackground: "rgba(168,85,247,0.18)",
+      badgeBorderColor: "#a855f7",
+      badgeRadius: 8,
+    });
+  }
 
   return (
     <DemoScreen
-      description="referenceLine and valueLine (+ config objects)"
+      description="referenceLines array — lines, value bands, time bands, off-axis badge"
       chart={
         <LiveChart
           data={data}
           value={value}
           accentColor={ACCENT}
           theme="dark"
-          referenceLine={
-            refOn
-              ? refStyled
-                ? {
-                    value: startValue * 1.05,
-                    label: "+5%",
-                    strokeWidth: 2,
-                    intervals: [6, 4],
-                    color: "#fbbf24",
-                  }
-                : { value: startValue * 1.05, label: "+5%" }
-              : undefined
-          }
-          valueLine={
-            valOn
-              ? valStyled
-                ? {
-                    strokeWidth: 2,
-                    intervals: [4, 6],
-                    color: "#34d399",
-                  }
-                : true
-              : false
-          }
+          referenceLines={referenceLines}
+          valueLine={valueLine}
           scrub={false}
         />
       }
     >
-      <Text style={demoStyles.sectionLabel}>Reference line</Text>
+      <Text style={demoStyles.sectionLabel}>Reference forms</Text>
       <View style={demoStyles.buttonRow}>
-        <Pressable
-          style={[demoStyles.chip, refOn && demoStyles.chipActive]}
-          onPress={() => setRefOn((v) => !v)}
-        >
-          <Text
-            style={[demoStyles.chipText, refOn && demoStyles.chipTextActive]}
-          >
-            {refOn ? "On" : "Off"}
-          </Text>
-        </Pressable>
-        <Pressable
-          style={[demoStyles.chip, refStyled && demoStyles.chipActive]}
-          onPress={() => setRefStyled((v) => !v)}
-        >
-          <Text
-            style={[
-              demoStyles.chipText,
-              refStyled && demoStyles.chipTextActive,
-            ]}
-          >
-            Dashed + color
-          </Text>
-        </Pressable>
+        <Toggle label="Lines (±5%)" on={lines} onPress={() => setLines((v) => !v)} />
+        <Toggle
+          label="Value band"
+          on={valueBand}
+          onPress={() => setValueBand((v) => !v)}
+        />
+        <Toggle
+          label="Time band"
+          on={timeBand}
+          onPress={() => setTimeBand((v) => !v)}
+        />
       </View>
-
-      <Text style={demoStyles.sectionLabel}>Value line</Text>
       <View style={demoStyles.buttonRow}>
-        <Pressable
-          style={[demoStyles.chip, valOn && demoStyles.chipActive]}
-          onPress={() => setValOn((v) => !v)}
-        >
-          <Text
-            style={[demoStyles.chipText, valOn && demoStyles.chipTextActive]}
-          >
-            {valOn ? "On" : "Off"}
-          </Text>
-        </Pressable>
-        <Pressable
-          style={[demoStyles.chip, valStyled && demoStyles.chipActive]}
-          onPress={() => setValStyled((v) => !v)}
-        >
-          <Text
-            style={[
-              demoStyles.chipText,
-              valStyled && demoStyles.chipTextActive,
-            ]}
-          >
-            Styled dash
-          </Text>
-        </Pressable>
+        <Toggle
+          label="Off-axis target"
+          on={offAxis}
+          onPress={() => setOffAxis((v) => !v)}
+        />
+        <Toggle
+          label="Value line"
+          on={valueLine}
+          onPress={() => setValueLine((v) => !v)}
+        />
       </View>
     </DemoScreen>
+  );
+}
+
+function Toggle({
+  label,
+  on,
+  onPress,
+}: {
+  label: string;
+  on: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      style={[demoStyles.chip, on && demoStyles.chipActive]}
+      onPress={onPress}
+    >
+      <Text style={[demoStyles.chipText, on && demoStyles.chipTextActive]}>
+        {label}
+      </Text>
+    </Pressable>
   );
 }

--- a/app/demo/line-playback.tsx
+++ b/app/demo/line-playback.tsx
@@ -1,30 +1,61 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import { LiveChart } from "react-native-livechart";
+import { LiveChart, type LiveChartPoint } from "react-native-livechart";
+import { useSharedValue } from "react-native-reanimated";
 
-import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 import { DemoScreen } from "./lib/DemoScreen";
 import { ACCENT, SMOOTHING_PRESETS, TIME_WINDOWS } from "./lib/shared";
 import { demoStyles } from "./lib/styles";
 
 export const options = { title: "Line & playback" };
 
+/** Wide sine sweep (≈ -50…200) so the Y-axis clamps below are visibly testable. */
+const wave = (t: number) => 75 + 125 * Math.sin(t / 3);
+
 export default function LinePlaybackScreen() {
   const [windowSecs, setWindowSecs] = useState(30);
   const [paused, setPaused] = useState(false);
   const [smoothing, setSmoothing] = useState(0.08);
   const [exaggerate, setExaggerate] = useState(false);
+  const [nonNegative, setNonNegative] = useState(false);
+  const [maxValue, setMaxValue] = useState<number | undefined>(undefined);
 
-  const { data, value } = useSimulatedChartData({
-    multiSeries: false,
-    candleAggregation: false,
-    tradeStream: false,
-    paused,
-  });
+  const data = useSharedValue<LiveChartPoint[]>([]);
+  const value = useSharedValue(wave(Date.now() / 1000));
+
+  // Seed a little history once so the chart reveals immediately.
+  useEffect(() => {
+    const now = Date.now() / 1000;
+    const seed: LiveChartPoint[] = [];
+    for (let i = 80; i >= 0; i--) {
+      const t = now - i * 0.25;
+      seed.push({ time: t, value: wave(t) });
+    }
+    data.value = seed;
+    value.value = wave(now);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Live oscillator (paused freezes it, matching the chart's paused prop).
+  useEffect(() => {
+    if (paused) return;
+    const id = setInterval(() => {
+      const now = Date.now() / 1000;
+      const v = wave(now);
+      data.modify((arr) => {
+        "worklet";
+        arr.push({ time: now, value: v });
+        if (arr.length > 600) arr.shift();
+        return arr;
+      });
+      value.value = v;
+    }, 1000 / 30);
+    return () => clearInterval(id);
+  }, [paused, data, value]);
 
   return (
     <DemoScreen
-      description="timeWindow, paused, smoothing, exaggerate"
+      description="timeWindow, paused, smoothing, exaggerate, nonNegative, maxValue (data sweeps ≈ -50…200)"
       chart={
         <LiveChart
           data={data}
@@ -35,6 +66,8 @@ export default function LinePlaybackScreen() {
           paused={paused}
           smoothing={smoothing}
           exaggerate={exaggerate}
+          nonNegative={nonNegative}
+          maxValue={maxValue}
           scrub={false}
         />
       }
@@ -110,6 +143,42 @@ export default function LinePlaybackScreen() {
             Exaggerate
           </Text>
         </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Y-axis range</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, nonNegative && demoStyles.chipActive]}
+          onPress={() => setNonNegative((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              nonNegative && demoStyles.chipTextActive,
+            ]}
+          >
+            nonNegative
+          </Text>
+        </Pressable>
+        {[
+          { label: "max off", value: undefined },
+          { label: "max 150", value: 150 },
+        ].map((m) => (
+          <Pressable
+            key={m.label}
+            style={[demoStyles.chip, maxValue === m.value && demoStyles.chipActive]}
+            onPress={() => setMaxValue(m.value)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                maxValue === m.value && demoStyles.chipTextActive,
+              ]}
+            >
+              {m.label}
+            </Text>
+          </Pressable>
+        ))}
       </View>
     </DemoScreen>
   );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -51,8 +51,8 @@ const DEMOS: { href: Href; title: string; blurb: string }[] = [
   },
   {
     href: "/demo/horizontal-lines",
-    title: "Reference & value lines",
-    blurb: "referenceLine and valueLine styling.",
+    title: "Reference lines & bands",
+    blurb: "referenceLines array: lines, value/time bands, off-axis badge.",
   },
   {
     href: "/demo/trade-stream",

--- a/docs/feature-parity-plan.md
+++ b/docs/feature-parity-plan.md
@@ -1,0 +1,390 @@
+# Feature parity plan — `react-native-livechart` vs `@morfi/chart`
+
+Status: **proposed** · Last updated: 2026-06-02
+
+This plan captures every feature/config gap between our Skia/Reanimated chart and the
+React/canvas `@morfi/chart` fork (v0.6.0), and maps each one to concrete library
+changes **plus** a playground page (new or updated) to exercise it.
+
+Both libraries descend from upstream `benjitaylor/liveline` `0.0.7`. Morfi is the web
+fork; we are an independent RN reimplementation. Web-only surface (CSS `cursor`,
+`className`/`style: CSSProperties`, `resolveCssVar`, ARIA) is **out of scope** except
+where it has an RN equivalent (accessibility props).
+
+## Conventions when porting morfi APIs
+
+Adapt web naming to our existing idioms — do **not** copy morfi's prop names verbatim:
+
+| morfi (web)            | ours (RN)                          |
+| ---------------------- | ---------------------------------- |
+| `width` (line/ref)     | `strokeWidth`                      |
+| `dashPattern`          | `intervals`                        |
+| `color: var(--…)`      | literal color string only          |
+| `theme` + `color`      | `theme` + `accentColor`            |
+| `style: CSSProperties` | `style: ViewStyle`                 |
+| canvas `draw(ctx,…)`   | Skia `draw(canvas/path,…)` worklet |
+
+Keep all data on `SharedValue`s and all per-frame work in worklets / `useDerivedValue`,
+per `CLAUDE.md`. Reuse `SkPath` instances (`.rewind()`), never allocate per frame.
+
+## How playground pages work (for reference)
+
+- Pages live in `app/demo/*.tsx`, export `default` component + `export const options = { title }`.
+- Each wraps content in `<DemoScreen description chart={…}>{controls}</DemoScreen>`
+  ([DemoScreen.tsx](app/demo/lib/DemoScreen.tsx)).
+- **New pages must be registered** in the `DEMOS` array in [app/index.tsx](app/index.tsx:5).
+- Data comes from [useSimulatedChartData](sim/useSimulatedChartData.ts); shared constants
+  (`ACCENT`, `TIME_WINDOWS`, `VOLATILITY_MODES`, `TRADE_SOURCES`, …) from
+  [shared.ts](app/demo/lib/shared.ts); chips/toggles use `demoStyles`
+  ([styles.ts](app/demo/lib/styles.ts)).
+
+---
+
+## Phase 1 — Axis & reference (high value, low/medium effort)
+
+### 1.1 Multiple reference lines + bands + off-axis badge
+
+**What.** Today we expose a single `referenceLine?: ReferenceLine` with only a horizontal
+`value`. Morfi supports an **array** of three forms plus an off-axis indicator.
+
+**Library API** (extend [types.ts](packages/react-native-livechart/src/types.ts:49)):
+```ts
+export interface ReferenceLine {
+  // Form A — horizontal line
+  value?: number;
+  // Form B — horizontal band
+  valueFrom?: number;
+  valueTo?: number;
+  // Form C — vertical time band (unix seconds)
+  from?: number;
+  to?: number;
+  // Appearance
+  label?: string;
+  color?: string;
+  strokeWidth?: number;          // was morfi `width`
+  intervals?: [number, number];  // was morfi `dashPattern`
+  labelColor?: string;
+  labelPosition?: "left" | "center" | "right";
+  showValue?: boolean;
+  // Axis-range interaction
+  excludeFromRange?: boolean;    // skip in y-range computation
+  offAxisBadge?: boolean;        // pinned chevron pill when off-screen
+  offAxisBadgeLabel?: string;
+}
+// Add plural prop on LiveChartCoreProps (keep singular as deprecated alias):
+referenceLines?: ReferenceLine[];
+```
+
+**Implementation.**
+- Generalize [ReferenceLineOverlay.tsx](packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx)
+  to map over an array and render bands (filled `Rect`/path between two y's, or two x's
+  for time bands) in addition to lines.
+- Add `excludeFromRange` handling + a `classifyReferenceEdge(value, layout)` helper feeding
+  off-axis badge rendering. Wire reference values into y-range collection in
+  [math/range.ts](packages/react-native-livechart/src/math/range.ts).
+- Resolve in [resolveConfig.ts](packages/react-native-livechart/src/core/resolveConfig.ts).
+
+**Playground.** **Update** [horizontal-lines.tsx](app/demo/horizontal-lines.tsx)
+(title → "Reference lines & bands"). Add toggles: single line · multiple lines ·
+horizontal band · time band · off-axis badge (set a target above the visible range and
+confirm the chevron pill + dashed connector appear).
+
+**Tests.** Extend reference-line unit tests: precedence A>B>C, `excludeFromRange`,
+`classifyReferenceEdge` → `'in'|'above'|'below'`.
+
+### 1.2 Y-axis bounds: `nonNegative` + `maxValue`
+
+**What.** `nonNegative` clamps the y lower bound at 0 (prices/caps/volumes); `maxValue`
+caps the upper bound (e.g. market share ≤ 1). Symmetric clamps on the computed range.
+
+**Library API** (add to `LiveChartCoreProps`):
+```ts
+nonNegative?: boolean;  // default false
+maxValue?: number;      // default undefined (uncapped)
+```
+
+**Implementation.** Thread both into the range computation in
+[math/range.ts](packages/react-native-livechart/src/math/range.ts) and the engine tick
+([liveChartEngineTick.ts](packages/react-native-livechart/src/core/liveChartEngineTick.ts),
+[liveChartSeriesEngineTick.ts](packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts)).
+Also fix the morfi-noted edge case: a tick landing exactly on a clamped ceiling must still
+render (don't let the edge fade hide it).
+
+**Playground.** **Update** [line-playback.tsx](app/demo/line-playback.tsx) (or add a small
+"Y-axis range" section): toggles for `nonNegative` and `maxValue` presets (`1`, `100`,
+off). Drive value toward 0 and toward the cap to see clamping.
+
+**Tests.** Range computation with each clamp, and combined with `exaggerate`.
+
+### 1.3 Grid styling + palette override + lerp speed
+
+**What.** Three small appearance configs:
+- `gridStyle` — stroke color/width/dash/opacity for grid lines.
+- `palette` — partial override of individual palette keys on top of `accentColor`+`theme`.
+- `lerpSpeed` — value-lerp speed (currently hardcoded internally).
+
+**Library API:**
+```ts
+// LiveChartCoreProps
+gridStyle?: { color?: string; strokeWidth?: number; intervals?: number[]; opacity?: number };
+palette?: Partial<LiveChartPalette>;
+lerpSpeed?: number;  // default 0.08
+```
+
+**Implementation.**
+- `gridStyle` → [draw/grid.ts](packages/react-native-livechart/src/draw/grid.ts) +
+  [YAxisOverlay.tsx](packages/react-native-livechart/src/components/YAxisOverlay.tsx).
+- `palette` → merge in [theme.ts](packages/react-native-livechart/src/theme.ts) /
+  [useChartColors.ts](packages/react-native-livechart/src/hooks/useChartColors.ts) after
+  deriving from accent.
+- `lerpSpeed` → engine ticks (replace the hardcoded factor).
+
+**Playground.** **Update** [appearance.tsx](app/demo/appearance.tsx) (palette override +
+gridStyle) and [line-playback.tsx](app/demo/line-playback.tsx) (lerpSpeed slider/presets:
+Snappy / Default / Floaty).
+
+**Tests.** Palette merge precedence; grid resolve defaults; tick lerp at varied speeds.
+
+---
+
+## Phase 2 — Multi-series parity
+
+### 2.1 Per-series styling
+
+**What.** Morfi's series carry `style` (solid/dashed), `dashPattern`, `width`, `glow`,
+`kind` ('outcome'|'derived'), `valueLabel`. Our `SeriesConfig` has only
+`color`/`label`/`visible`.
+
+**Library API** (extend [SeriesConfig](packages/react-native-livechart/src/types.ts:279)):
+```ts
+style?: "solid" | "dashed";
+intervals?: [number, number];
+strokeWidth?: number;
+glow?: boolean;
+kind?: "outcome" | "derived";   // affects legend chip styling
+valueLabel?: string;            // shown next to label in chip + endpoint
+```
+
+**Implementation.** Per-series stroke in
+[MultiSeriesStroke.tsx](packages/react-native-livechart/src/components/MultiSeriesStroke.tsx)
+(dash via Skia `DashPathEffect`, glow via blur layer), endpoint labels in
+[MultiSeriesValueLabels.tsx](packages/react-native-livechart/src/components/MultiSeriesValueLabels.tsx),
+chip styling in [SeriesToggleChips.tsx](packages/react-native-livechart/src/components/SeriesToggleChips.tsx).
+
+**Playground.** **Update** [multi-series.tsx](app/demo/multi-series.tsx): per-series
+dashed/solid, width, glow on/off, a 'derived' trajectory series styled differently.
+
+### 2.2 Multi-series degen
+
+**What.** Run particles + shake in multi-series mode (each series sparks off its own dot
+in its own color; one shared shake from the largest swing). Today `degen` only exists on
+single-series `LiveChartProps`.
+
+**Library API.** Add `degen?: boolean | DegenOptions` to
+[LiveChartSeriesProps](packages/react-native-livechart/src/types.ts:446).
+
+**Implementation.** Per-series particle pools keyed by series id in
+[useLiveChartSeriesEngine.ts](packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts)
++ [liveChartSeriesEngineTick.ts](packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts);
+reuse [DegenParticlesOverlay.tsx](packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx)
+and the [degenTick.ts](packages/react-native-livechart/src/math/degenTick.ts) math. Re-arm
+one shared shake from the largest per-series burst. Honor reduced-motion.
+
+**Playground.** **Update** [degen.tsx](app/demo/degen.tsx): add a single ↔ multi toggle;
+confirm independent per-series bursts and a shared shake.
+
+### 2.3 Legend / series-toggle styling + series-color dash lines
+
+**What.** Morfi's `SeriesToggleStyle` is a full styling surface; `seriesEndpoints`
+supports `showDashLines: 'series-color'` (tint each endpoint dash to its stroke).
+
+**Library API** (extend [LegendConfig](packages/react-native-livechart/src/types.ts:269)
+and [MultiSeriesDotConfig](packages/react-native-livechart/src/types.ts:257)):
+```ts
+// LegendConfig
+style?: {
+  fontSize?: number; fontWeight?: FontWeight;
+  gap?: number; borderRadius?: number; paddingX?: number; paddingY?: number;
+  dotSize?: number; dotGap?: number;
+  containerBackground?: string;
+  defaultBackground?: string; defaultColor?: string;
+  hiddenBackground?: string; hiddenColor?: string;
+  valueColor?: string; valueFontWeight?: FontWeight;
+};
+// MultiSeriesDotConfig
+valueLine?: boolean | ValueLineConfig | "series-color";
+```
+
+**Implementation.** [SeriesToggleChips.tsx](packages/react-native-livechart/src/components/SeriesToggleChips.tsx)
+and [MultiSeriesValueLines.tsx](packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx).
+
+**Playground.** **Update** [multi-series.tsx](app/demo/multi-series.tsx): a "Legend style"
+section (pill radius, compact, colors) + series-color dash toggle.
+
+---
+
+## Phase 3 — Marker & data overlays (larger lifts)
+
+### 3.1 General marker system
+
+**What.** Morfi's headline addition over upstream: `markers?: Marker[]` with 5 built-in
+kinds (`trade`, `boost`, `graduation`, `winner`, `clawback`), per-marker `draw` override,
+`onMarkerHover` + `markerHitRadius` hit-testing with kind-precedence tie-break. We only
+have single-series `tradeStream`.
+
+**Library API:**
+```ts
+export type MarkerKind = "trade" | "boost" | "graduation" | "winner" | "clawback";
+export interface Marker {
+  id: string;
+  time: number;            // unix seconds
+  kind: MarkerKind;
+  seriesId?: string;       // anchor y to a series line… (multi)
+  value?: number;          // …or absolute y
+  color?: string;
+  data?: unknown;          // pass-through for hover
+  draw?: (canvas, x, y, state) => void;   // Skia worklet override
+}
+// Props (both components):
+markers?: SharedValue<Marker[]>;
+onMarkerHover?: (event: { marker: Marker; point: { x: number; y: number } } | null) => void;
+markerHitRadius?: number;  // default 8; ~22 for touch
+```
+
+**Implementation.**
+- New `src/draw/markers/` (one file per kind) mirroring morfi's renderers, in Skia:
+  graduation (stem + flag), winner (pulsing star), boost (starburst), clawback (axis
+  square), trade (reuse [draw/trade.ts](packages/react-native-livechart/src/draw/trade.ts)).
+- `MARKER_KIND_PRECEDENCE` + `drawMarkerDefault` dispatcher.
+- New `MarkerOverlay.tsx` reading the `SharedValue`; new `useMarkers` hook for layout +
+  hit-test (touch via gesture handler → `onMarkerHover` on JS thread).
+- Anchor y by `seriesId` (interpolate the series line) or absolute `value`.
+
+**Playground.** **New page** `app/demo/markers.tsx` (register in `DEMOS`): toggles to seed
+each kind, a hit-radius slider, and an `onMarkerHover` readout. Drive markers from a
+`SharedValue` updated by `useSimulatedChartData`-style timers.
+
+### 3.2 Orderbook overlay
+
+**What.** `orderbook?: OrderbookData` (`bids`/`asks`). Streaming size-weighted labels that
+fade in/out, green/red mixed toward the background by intensity, with per-entry
+`label`/`color`/`id` overrides for trade-tape style. We have nothing.
+
+**Library API:**
+```ts
+export interface OrderbookEntryOptions { label?: string; color?: string; id?: string }
+export type OrderbookEntry =
+  | readonly [number, number]                                  // [price, size]
+  | (OrderbookEntryOptions & { size: number; price?: number });
+export interface OrderbookData { bids: OrderbookEntry[]; asks: OrderbookEntry[] }
+// Prop (single-series): orderbook?: SharedValue<OrderbookData>;
+```
+
+**Implementation.** Port morfi `draw/orderbook.ts` to Skia: a ring-buffer label state
+(`OrderbookState`) advanced in the engine tick, size→intensity→alpha mixing toward
+`palette.bgRgb`, per-entry `id` ⇒ spawn-once semantics. New `OrderbookOverlay.tsx`.
+
+**Playground.** **Update** [trade-stream.tsx](app/demo/trade-stream.tsx) (already blurbs
+"orderbook vs bonding-curve") or **new** `app/demo/orderbook.tsx`: drive bids/asks from the
+sim's `orderbook` `TradeSource` and show intensity-weighted labels.
+
+---
+
+## Phase 4 — Crosshair & value display
+
+### 4.1 Crosshair tooltip layouts
+
+**What.** Morfi: `layout: 'multi-text' | 'per-series-pill' | 'none'` with a deep style
+surface (time pill + per-series pills, `formatTimeRange`, `formatSeriesValue`, dot sizing,
+label truncation). Our scrub tooltip is a single layout.
+
+**Library API** (extend [ScrubConfig](packages/react-native-livechart/src/types.ts:113)):
+```ts
+layout?: "single" | "per-series-pill" | "none";   // "single" = current behavior
+timePill?: { background?: string; color?: string; borderColor?: string; radius?: number };
+seriesPill?: { background?: string; color?: string; radius?: number; dotSize?: number };
+formatTimeRange?: (from: number, to: number) => string;
+maxLabelChars?: number;
+```
+
+**Implementation.** [CrosshairOverlay.tsx](packages/react-native-livechart/src/components/CrosshairOverlay.tsx)
++ [MultiSeriesTooltipStack.tsx](packages/react-native-livechart/src/components/MultiSeriesTooltipStack.tsx)
+(per-series-pill: a time pill at top-center + one pill at each series intersection).
+
+**Playground.** **Update** [scrub.tsx](app/demo/scrub.tsx) (layout switch) and
+[multi-series.tsx](app/demo/multi-series.tsx) (per-series-pill demo).
+
+### 4.2 Live value text overlay: `showValue` + `valueMomentumColor`
+
+**What.** `showValue` renders the live value as a large text overlay; `valueMomentumColor`
+tints it green/red by momentum.
+
+**Library API** (single-series `LiveChartProps`):
+```ts
+showValue?: boolean;            // default false
+valueMomentumColor?: boolean;   // default false
+```
+
+**Implementation.** Reuse [AnimatedLabel.tsx](packages/react-native-livechart/src/components/AnimatedLabel.tsx)
+driven by the engine's smoothed value + momentum `SharedValue`s; format via `formatValue`.
+
+**Playground.** **Update** [badge-pulse.tsx](app/demo/badge-pulse.tsx) or
+[momentum.tsx](app/demo/momentum.tsx): toggle the value overlay and momentum coloring.
+
+---
+
+## Phase 5 — Optional / host-owned (decide per use case)
+
+These are lower priority — several are arguably better owned by the host app in RN.
+
+### 5.1 Historical data fill: `windowBuffer` + `nowOverride`
+Right-edge buffer fraction (0 ⇒ latest point hits the edge) and an engine "now" override
+so historical data fills edge-to-edge. Thread into the engine ticks + layout.
+**Playground:** new `app/demo/historical-data.tsx` — replay a fixed historical span filling
+the full width (`windowBuffer=0`, `nowOverride=maxT`).
+
+### 5.2 Built-in time-range selector: `windows` / `onWindowChange` / `windowStyle`
+A built-in row of 1m/5m/1h… buttons. We already have `TIME_WINDOWS` in
+[shared.ts](app/demo/lib/shared.ts:33); decide whether to ship the selector UI in the
+library or leave it host-owned. **Playground:** new `app/demo/time-windows.tsx`.
+
+### 5.3 Built-in mode toggle: `onModeChange`
+A built-in candle↔line toggle row (we already have the `mode` prop + internal
+`useModeBlend`). **Playground:** update [candlestick.tsx](app/demo/candlestick.tsx).
+
+### 5.4 Chart transition wrapper (`LivelineTransition` equivalent)
+A cross-fade wrapper between two chart instances. RN version via Reanimated opacity.
+**Playground:** new `app/demo/transitions.tsx` (line ↔ candle cross-fade).
+
+### 5.5 Accessibility props
+RN equivalents of morfi's ARIA: `accessibilityLabel` / `accessibilityRole` on the chart
+container (add to `LiveChartCoreProps`). No dedicated page — fold into existing screens.
+
+---
+
+## Suggested order & sizing
+
+| Phase | Items | Rough size |
+| ----- | ----- | ---------- |
+| 1 | reference lines/bands, y-bounds, grid/palette/lerp | M |
+| 2 | per-series style, multi degen, legend style | M |
+| 3 | markers, orderbook | L |
+| 4 | crosshair layouts, value overlay | M |
+| 5 | windowBuffer/nowOverride, window selector, mode toggle, transition, a11y | S–M each |
+
+Each item is additive and independently shippable. Recommended first cut: **1.1, 1.2,
+2.1** (broadest utility), then the **marker system (3.1)** since it builds on the existing
+`tradeStream` plumbing.
+
+## Definition of done (per item)
+
+- [ ] Library types + `resolveConfig` updated; defaults documented.
+- [ ] Worklet-safe rendering; `SkPath` reuse; no per-frame allocation.
+- [ ] Unit tests for pure logic (ticks, range, resolve, hit-test) ≥ existing coverage
+      thresholds (branches 90 / funcs 95 / lines 95 / stmts 95).
+- [ ] Playground page added/updated **and registered** in
+      [app/index.tsx](app/index.tsx:5) `DEMOS`.
+- [ ] `npm run verify` (typecheck + lint + test) green.
+- [ ] README/CHANGELOG note for the new prop(s).
+</content>
+</invoke>

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import { useSharedValue } from "react-native-reanimated";
@@ -20,9 +21,9 @@ import {
   resolveBadge,
   resolveDegen,
   resolveGradient,
+  resolveGridStyle,
   resolveLeftEdgeFade,
   resolvePulse,
-  resolveReferenceLineConfig,
   resolveScrub,
   resolveTradeStream,
   resolveValueLine,
@@ -45,7 +46,6 @@ import {
   useLiveDot,
   useModeBlend,
   useMomentum,
-  useReferenceLine,
   useSingleChartReverseMorphInputs,
   useTradeStream,
   useXAxis,
@@ -56,7 +56,12 @@ import {
   formatValue as defaultFormatValue,
 } from "../lib/format";
 import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
-import { leftEdgeFadeColorsFromBgRgb, resolveTheme } from "../theme";
+import { collectReferenceValues } from "../math/referenceLines";
+import {
+  applyPaletteOverride,
+  leftEdgeFadeColorsFromBgRgb,
+  resolveTheme,
+} from "../theme";
 import type { LiveChartProps, TradeEvent } from "../types";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
@@ -97,6 +102,8 @@ export function LiveChart({
   loading = false,
   smoothing = 0.08,
   exaggerate = false,
+  nonNegative = false,
+  maxValue,
   emptyText = "No data",
   formatValue = defaultFormatValue,
   formatTime = defaultFormatTime,
@@ -109,6 +116,9 @@ export function LiveChart({
   pulse = true,
   valueLine = true,
   referenceLine,
+  referenceLines,
+  gridStyle,
+  palette: paletteOverride,
   scrub = true,
   tradeStream,
   degen,
@@ -130,15 +140,31 @@ export function LiveChart({
   const gradientCfg = isCandle ? null : resolveGradient(gradient);
   const valueLineCfg = resolveValueLine(valueLine);
   const pulseCfg = resolvePulse(pulse);
-  const refLineCfg = resolveReferenceLineConfig(referenceLine);
+  const gridStyleCfg = resolveGridStyle(gridStyle);
   const degenCfg = resolveDegen(degen);
   const tradeStreamResolved = resolveTradeStream(tradeStream);
+
+  // Merge the legacy singular `referenceLine` into the `referenceLines` array.
+  const allRefLines = useMemo(
+    () => [
+      ...(referenceLine ? [referenceLine] : []),
+      ...(referenceLines ?? []),
+    ],
+    [referenceLine, referenceLines],
+  );
+  const refValues = useMemo(
+    () => collectReferenceValues(allRefLines),
+    [allRefLines],
+  );
 
   const badgeUsesRightGutter =
     badgeCfg !== null && (badgeCfg.position ?? "right") === "right";
 
   // ── Theme, font and layout ─────────────────────────────────────────────
-  const palette = resolveTheme(accentColor, theme);
+  const palette = applyPaletteOverride(
+    resolveTheme(accentColor, theme),
+    paletteOverride,
+  );
 
   const leftEdgeFadeCfg = resolveLeftEdgeFade(
     leftEdgeFade,
@@ -205,7 +231,9 @@ export function LiveChart({
     paused,
     smoothing,
     exaggerate,
-    referenceValue: referenceLine?.value,
+    referenceValues: refValues,
+    nonNegative,
+    maxValue,
     mode,
     candles: isCandle ? candlesEngine : candles,
     liveCandle: isCandle ? liveEngine : liveCandle,
@@ -253,14 +281,6 @@ export function LiveChart({
   } = useDegen(engine, dotX, dotY, momentumSV, degenCfg, onDegenShake);
 
   // ── Overlay hooks ─────────────────────────────────────────────────────
-  const referenceLineLayout = useReferenceLine(
-    engine,
-    effectivePadding,
-    referenceLine,
-    formatValue,
-    skiaFont,
-  );
-
   const { yAxisEntries } = useYAxis(
     engine,
     effectivePadding,
@@ -343,6 +363,7 @@ export function LiveChart({
                   font={skiaFont}
                   badge={badgeUsesRightGutter}
                   badgeTail={badgeCfg?.tail ?? true}
+                  gridStyle={gridStyleCfg}
                 />
               </Group>
             )}
@@ -374,16 +395,18 @@ export function LiveChart({
               </Group>
             )}
 
-            {refLineCfg && (
+            {allRefLines.map((rl, i) => (
               <ReferenceLineOverlay
-                layout={referenceLineLayout}
-                strokeWidth={refLineCfg.strokeWidth}
-                intervals={refLineCfg.intervals}
-                color={refLineCfg.color ?? palette.refLine}
-                labelColor={palette.refLabel}
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                engine={engine}
+                padding={effectivePadding}
+                line={rl}
+                palette={palette}
+                formatValue={formatValue}
                 font={skiaFont}
               />
-            )}
+            ))}
 
             {/* Chart line (fades out in candle mode) */}
             <Group opacity={lineGroupOpacity}>

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -5,7 +5,7 @@
  * @see https://github.com/benjitaylor/liveline
  */
 import { Canvas, Group } from "@shopify/react-native-skia";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import {
@@ -20,10 +20,10 @@ import {
   resolveMultiSeriesLineColorsSnapshot,
 } from "../core/multiSeriesLayout";
 import {
+  resolveGridStyle,
   resolveLeftEdgeFade,
   resolveLegend,
   resolveMultiSeriesDot,
-  resolveReferenceLineConfig,
   resolveScrub,
   resolveXAxis,
   resolveYAxis,
@@ -37,7 +37,6 @@ import {
   useCrosshairSeries,
   useMultiSeriesLinePaths,
   useMultiSeriesReverseMorphInputs,
-  useReferenceLine,
   useXAxis,
   useYAxis,
 } from "../hooks";
@@ -47,7 +46,12 @@ import {
 } from "../lib/format";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
-import { leftEdgeFadeColorsFromBgRgb, resolveTheme } from "../theme";
+import { collectReferenceValues } from "../math/referenceLines";
+import {
+  applyPaletteOverride,
+  leftEdgeFadeColorsFromBgRgb,
+  resolveTheme,
+} from "../theme";
 import type { LiveChartSeriesProps, SeriesConfig } from "../types";
 import { CrosshairLine } from "./CrosshairLine";
 import { LeftEdgeFade } from "./LeftEdgeFade";
@@ -79,12 +83,17 @@ export function LiveChartSeries({
   loading = false,
   smoothing = 0.08,
   exaggerate = false,
+  nonNegative = false,
+  maxValue,
   emptyText = "No data",
   formatValue = defaultFormatValue,
   formatTime = defaultFormatTime,
   yAxis = true,
   xAxis = true,
   referenceLine,
+  referenceLines,
+  gridStyle,
+  palette: paletteOverride,
   scrub = false,
   onScrub,
   onSeriesToggle,
@@ -97,11 +106,26 @@ export function LiveChartSeries({
   const xAxisCfg = resolveXAxis(xAxis);
   const scrubCfg = resolveScrub(scrub);
   const scrubEnabled = scrubCfg !== null;
-  const refLineCfg = resolveReferenceLineConfig(referenceLine);
+  const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
   const legendCfg = resolveLegend(legendProp, seriesToggleCompact);
 
-  const palette = resolveTheme(accentColor, theme);
+  const allRefLines = useMemo(
+    () => [
+      ...(referenceLine ? [referenceLine] : []),
+      ...(referenceLines ?? []),
+    ],
+    [referenceLine, referenceLines],
+  );
+  const refValues = useMemo(
+    () => collectReferenceValues(allRefLines),
+    [allRefLines],
+  );
+
+  const palette = applyPaletteOverride(
+    resolveTheme(accentColor, theme),
+    paletteOverride,
+  );
 
   const leftEdgeFadeCfg = resolveLeftEdgeFade(
     leftEdgeFade,
@@ -178,7 +202,9 @@ export function LiveChartSeries({
     paused,
     smoothing,
     exaggerate,
-    referenceValue: referenceLine?.value,
+    referenceValues: refValues,
+    nonNegative,
+    maxValue,
   });
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
   const linePaths = useMultiSeriesLinePaths(engine, effectivePadding);
@@ -203,14 +229,6 @@ export function LiveChartSeries({
   useEffect(() => {
     syncColors(series);
   }, [series, syncColors]);
-
-  const referenceLineLayout = useReferenceLine(
-    engine,
-    effectivePadding,
-    referenceLine,
-    formatValue,
-    skiaFont,
-  );
 
   const { yAxisEntries } = useYAxis(
     engine,
@@ -269,20 +287,23 @@ export function LiveChartSeries({
                 font={skiaFont}
                 badge={false}
                 seriesLabelInset={seriesLabelInset}
+                gridStyle={gridStyleCfg}
               />
             </Group>
           )}
 
-          {refLineCfg && (
+          {allRefLines.map((rl, i) => (
             <ReferenceLineOverlay
-              layout={referenceLineLayout}
-              strokeWidth={refLineCfg.strokeWidth}
-              intervals={refLineCfg.intervals}
-              color={refLineCfg.color ?? palette.refLine}
-              labelColor={palette.refLabel}
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              engine={engine}
+              padding={effectivePadding}
+              line={rl}
+              palette={palette}
+              formatValue={formatValue}
               font={skiaFont}
             />
-          )}
+          ))}
 
           {dotCfg.valueLine && (
             <Group opacity={reveal.lineOpacity}>

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -1,78 +1,289 @@
 import {
-    DashPathEffect,
-    Group,
-    Path,
-    Skia,
-    Text as SkiaText,
-    type SkFont,
+  DashPathEffect,
+  Group,
+  Path,
+  RoundedRect,
+  Skia,
+  Text as SkiaText,
+  type SkFont,
 } from "@shopify/react-native-skia";
 import { useMemo } from "react";
-import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import { useDerivedValue } from "react-native-reanimated";
 
-import type { ReferenceLineLayout } from "../hooks/useReferenceLine";
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { useReferenceLine } from "../hooks/useReferenceLine";
+import { measureFontTextWidth } from "../lib/measureFontTextWidth";
+import { referenceLineForm } from "../math/referenceLines";
+import type { LiveChartPalette, ReferenceLine } from "../types";
+
+/** Translucent fill alpha for value / time bands. */
+const BAND_FILL_OPACITY = 0.16;
+
+/** Padding inside the off-axis badge pill, in px. */
+const OFF_AXIS_PILL_PAD_X = 6;
+const OFF_AXIS_PILL_PAD_Y = 3;
+const OFF_AXIS_PILL_RADIUS = 5;
 
 /**
- * Renders a dashed horizontal reference line with an optional right-gutter label.
- * Placed inside the Skia <Canvas>, after the fill and before the chart line.
+ * Renders one reference line or band into the chart canvas. Handles all three
+ * `ReferenceLine` forms (horizontal line, horizontal value band, vertical time
+ * band) plus the off-axis badge for an off-screen Form-A value. Self-contained
+ * so callers can `.map()` over a variable-length `referenceLines` array.
  */
 export function ReferenceLineOverlay({
-  layout,
-  strokeWidth,
-  intervals,
-  color,
-  labelColor,
+  engine,
+  padding,
+  line,
+  palette,
+  formatValue,
   font,
 }: {
-  layout: SharedValue<ReferenceLineLayout>;
-  strokeWidth: number;
-  intervals: [number, number];
-  color: string;
-  labelColor: string;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  line: ReferenceLine;
+  palette: LiveChartPalette;
+  formatValue: (v: number) => string;
   font: SkFont;
 }) {
-  const opacity = useDerivedValue(() => (layout.value.visible ? 1 : 0));
+  const form = referenceLineForm(line);
+  const isBand = form === "value-band" || form === "time-band";
+  const layout = useReferenceLine(engine, padding, line, formatValue, font);
+
+  const color = line.color ?? palette.refLine;
+  const labelColor = line.labelColor ?? line.color ?? palette.refLabel;
+  const strokeWidth = line.strokeWidth ?? 1;
+  const intervals = line.intervals ?? [4, 4];
+
+  // Band fill + optional dashed border (border only when strokeWidth is set).
+  const bandFillOpacity = line.fillOpacity ?? BAND_FILL_OPACITY;
+  const hasBandBorder = isBand && line.strokeWidth !== undefined;
+
+  // Off-axis target pill styling.
+  const badgeBackground = line.badgeBackground ?? palette.tooltipBg;
+  const badgeBorderColor = line.badgeBorderColor ?? color;
+  const badgeRadius = line.badgeRadius ?? OFF_AXIS_PILL_RADIUS;
 
   const cache = useMemo(
     () => ({
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
+      lineA: Skia.Path.Make(),
+      lineB: Skia.Path.Make(),
+      lineT: false,
+      bandA: Skia.Path.Make(),
+      bandB: Skia.Path.Make(),
+      bandT: false,
+      borderA: Skia.Path.Make(),
+      borderB: Skia.Path.Make(),
+      borderT: false,
+      offA: Skia.Path.Make(),
+      offB: Skia.Path.Make(),
+      offT: false,
+      chevA: Skia.Path.Make(),
+      chevB: Skia.Path.Make(),
+      chevT: false,
     }),
     [],
   );
 
   const linePath = useDerivedValue(() => {
-    cache.tick = !cache.tick;
-    const path = cache.tick ? cache.a : cache.b;
-    path.reset();
+    cache.lineT = !cache.lineT;
+    const p = cache.lineT ? cache.lineA : cache.lineB;
+    p.reset();
     const l = layout.value;
-    if (!l.visible) return path;
-    path.moveTo(l.x1, l.y);
-    path.lineTo(l.x2, l.y);
-    return path;
+    if (!l.visible || l.offAxis || isBand) return p;
+    p.moveTo(l.x1, l.y);
+    p.lineTo(l.x2, l.y);
+    return p;
   });
+
+  const bandPath = useDerivedValue(() => {
+    cache.bandT = !cache.bandT;
+    const p = cache.bandT ? cache.bandA : cache.bandB;
+    p.reset();
+    const l = layout.value;
+    if (!l.visible || !isBand) return p;
+    p.moveTo(l.x1, l.y);
+    p.lineTo(l.x2, l.y);
+    p.lineTo(l.x2, l.yBottom);
+    p.lineTo(l.x1, l.yBottom);
+    p.close();
+    return p;
+  });
+
+  const bandBorderPath = useDerivedValue(() => {
+    cache.borderT = !cache.borderT;
+    const p = cache.borderT ? cache.borderA : cache.borderB;
+    p.reset();
+    const l = layout.value;
+    if (!l.visible || !hasBandBorder) return p;
+    if (form === "time-band") {
+      // Vertical edges at the band's left / right.
+      p.moveTo(l.x1, l.y);
+      p.lineTo(l.x1, l.yBottom);
+      p.moveTo(l.x2, l.y);
+      p.lineTo(l.x2, l.yBottom);
+    } else {
+      // Horizontal edges at the band's top / bottom.
+      p.moveTo(l.x1, l.y);
+      p.lineTo(l.x2, l.y);
+      p.moveTo(l.x1, l.yBottom);
+      p.lineTo(l.x2, l.yBottom);
+    }
+    return p;
+  });
+
+  const offLinePath = useDerivedValue(() => {
+    cache.offT = !cache.offT;
+    const p = cache.offT ? cache.offA : cache.offB;
+    p.reset();
+    const l = layout.value;
+    if (!l.visible || !l.offAxis) return p;
+    // Start the connector just past the badge pill's right edge so the dashed
+    // line runs out to the chart edge rather than behind the badge.
+    const pillRight =
+      l.labelX + measureFontTextWidth(font, l.label) + OFF_AXIS_PILL_PAD_X;
+    const start = pillRight + 4;
+    if (start >= l.x2) return p;
+    p.moveTo(start, l.y);
+    p.lineTo(l.x2, l.y);
+    return p;
+  });
+
+  const chevronPath = useDerivedValue(() => {
+    cache.chevT = !cache.chevT;
+    const p = cache.chevT ? cache.chevA : cache.chevB;
+    p.reset();
+    const l = layout.value;
+    if (!l.visible || !l.offAxis) return p;
+    const cx = l.x1 + 6;
+    const cy = l.y;
+    const s = 4;
+    if (l.chevronUp) {
+      p.moveTo(cx - s, cy + s);
+      p.lineTo(cx, cy - s);
+      p.lineTo(cx + s, cy + s);
+    } else {
+      p.moveTo(cx - s, cy - s);
+      p.lineTo(cx, cy + s);
+      p.lineTo(cx + s, cy - s);
+    }
+    return p;
+  });
+
+  const lineOpacity = useDerivedValue(() =>
+    layout.value.visible && !layout.value.offAxis && !isBand ? 1 : 0,
+  );
+  const bandOpacity = useDerivedValue(() =>
+    layout.value.visible && isBand ? bandFillOpacity : 0,
+  );
+  const bandBorderOpacity = useDerivedValue(() =>
+    layout.value.visible && hasBandBorder ? 1 : 0,
+  );
+  const offOpacity = useDerivedValue(() =>
+    layout.value.visible && layout.value.offAxis ? 1 : 0,
+  );
+  const labelOpacity = useDerivedValue(() => (layout.value.visible ? 1 : 0));
 
   const labelX = useDerivedValue(() => layout.value.labelX);
   const labelY = useDerivedValue(() => layout.value.labelY);
   const labelText = useDerivedValue(() => layout.value.label);
 
+  // Off-axis badge pill — a rounded background behind the chevron + label.
+  const pillX = useDerivedValue(() => layout.value.x1 + 2);
+  const pillY = useDerivedValue(() => {
+    const fm = font.getMetrics();
+    return layout.value.labelY + fm.ascent - OFF_AXIS_PILL_PAD_Y;
+  });
+  const pillW = useDerivedValue(() => {
+    const l = layout.value;
+    const textW = measureFontTextWidth(font, l.label);
+    return l.labelX + textW + OFF_AXIS_PILL_PAD_X - (l.x1 + 2);
+  });
+  const pillH = useDerivedValue(() => {
+    const fm = font.getMetrics();
+    return fm.descent - fm.ascent + OFF_AXIS_PILL_PAD_Y * 2;
+  });
+
   return (
-    <Group opacity={opacity}>
-      <Path
-        path={linePath}
-        style="stroke"
-        strokeWidth={strokeWidth}
-        color={color}
-      >
-        <DashPathEffect intervals={intervals} />
-      </Path>
-      <SkiaText
-        x={labelX}
-        y={labelY}
-        text={labelText}
-        font={font}
-        color={labelColor}
-      />
+    <Group>
+      {isBand && (
+        <Group opacity={bandOpacity}>
+          <Path path={bandPath} style="fill" color={color} />
+        </Group>
+      )}
+
+      {hasBandBorder && (
+        <Group opacity={bandBorderOpacity}>
+          <Path
+            path={bandBorderPath}
+            style="stroke"
+            strokeWidth={strokeWidth}
+            color={color}
+          >
+            <DashPathEffect intervals={intervals} />
+          </Path>
+        </Group>
+      )}
+
+      {!isBand && (
+        <Group opacity={lineOpacity}>
+          <Path
+            path={linePath}
+            style="stroke"
+            strokeWidth={strokeWidth}
+            color={color}
+          >
+            <DashPathEffect intervals={intervals} />
+          </Path>
+        </Group>
+      )}
+
+      <Group opacity={offOpacity}>
+        <Path
+          path={offLinePath}
+          style="stroke"
+          strokeWidth={strokeWidth}
+          color={color}
+        >
+          <DashPathEffect intervals={intervals} />
+        </Path>
+        <RoundedRect
+          x={pillX}
+          y={pillY}
+          width={pillW}
+          height={pillH}
+          r={badgeRadius}
+          color={badgeBackground}
+        />
+        <RoundedRect
+          x={pillX}
+          y={pillY}
+          width={pillW}
+          height={pillH}
+          r={badgeRadius}
+          color={badgeBorderColor}
+          style="stroke"
+          strokeWidth={1}
+        />
+        <Path
+          path={chevronPath}
+          style="stroke"
+          strokeWidth={1.5}
+          color={color}
+          strokeCap="round"
+          strokeJoin="round"
+        />
+      </Group>
+
+      <Group opacity={labelOpacity}>
+        <SkiaText
+          x={labelX}
+          y={labelY}
+          text={labelText}
+          font={font}
+          color={labelColor}
+        />
+      </Group>
     </Group>
   );
 }

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -1,7 +1,14 @@
-import { Group, Path, Skia, type SkFont } from "@shopify/react-native-skia";
+import {
+  DashPathEffect,
+  Group,
+  Path,
+  Skia,
+  type SkFont,
+} from "@shopify/react-native-skia";
 import { useMemo } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { BADGE_DOT_GAP } from "../constants";
+import type { ResolvedGridStyleConfig } from "../core/resolveConfig";
 import type { YAxisEntry } from "../draw/grid";
 import {
   badgeTailAndCap,
@@ -26,6 +33,7 @@ export function YAxisOverlay({
   badge = false,
   badgeTail = true,
   seriesLabelInset = 0,
+  gridStyle,
 }: {
   entries: SharedValue<YAxisEntry[]>;
   engine: ChartEngineLayout;
@@ -38,7 +46,13 @@ export function YAxisOverlay({
   badgeTail?: boolean;
   /** When > 0, series labels occupy the left portion of the gutter; Y-axis labels right-align. */
   seriesLabelInset?: number;
+  /** Grid-line styling overrides. Omit for the legacy solid 1px line. */
+  gridStyle?: ResolvedGridStyleConfig;
 }) {
+  const gridColor = gridStyle?.color ?? palette.gridLine;
+  const gridWidth = gridStyle?.strokeWidth ?? 1;
+  const gridIntervals = gridStyle?.intervals ?? [];
+  const gridOpacity = gridStyle?.opacity ?? 1;
   const gridCache = useMemo(
     () => ({
       a: Skia.Path.Make(),
@@ -89,12 +103,18 @@ export function YAxisOverlay({
 
   return (
     <Group>
-      <Path
-        path={gridLinesPath}
-        style="stroke"
-        strokeWidth={1}
-        color={palette.gridLine}
-      />
+      <Group opacity={gridOpacity}>
+        <Path
+          path={gridLinesPath}
+          style="stroke"
+          strokeWidth={gridWidth}
+          color={gridColor}
+        >
+          {gridIntervals.length > 0 && (
+            <DashPathEffect intervals={gridIntervals} />
+          )}
+        </Path>
+      </Group>
       {Array.from({ length: MAX_Y_LABELS }, (_, i) => (
         <AnimatedLabel
           key={i}

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -19,6 +19,12 @@ export interface EngineTickInput {
   smoothing: number;
   exaggerate: boolean;
   referenceValue: number | undefined;
+  /** Additional reference values (lines + bands) folded into the Y range. */
+  referenceValues?: number[];
+  /** Clamp the computed lower bound at 0. */
+  nonNegative?: boolean;
+  /** Hard cap for the computed upper bound. */
+  maxValue?: number;
   targetValue: number;
   points: LiveChartPoint[];
   /** Seconds since Unix epoch; defaults to `Date.now() / 1000` */
@@ -130,6 +136,15 @@ export function tickLiveChartEngineFrame(
     if (ref > tMax) tMax = ref;
   }
 
+  const refs = input.referenceValues;
+  if (refs !== undefined) {
+    for (let i = 0; i < refs.length; i++) {
+      const rv = refs[i];
+      if (rv < tMin) tMin = rv;
+      if (rv > tMax) tMax = rv;
+    }
+  }
+
   const isExaggerate = input.exaggerate;
   if (tMin !== Infinity && tMax !== -Infinity) {
     const rawRange = tMax - tMin;
@@ -146,6 +161,10 @@ export function tickLiveChartEngineFrame(
       tMin -= margin;
       tMax += margin;
     }
+
+    if (input.nonNegative && tMin < 0) tMin = 0;
+    const maxV = input.maxValue;
+    if (maxV !== undefined && tMax > maxV) tMax = maxV;
 
     if (tMin < state.displayMin) {
       state.displayMin = tMin;

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -19,6 +19,12 @@ export interface MultiEngineTickInput {
   smoothing: number;
   exaggerate: boolean;
   referenceValue: number | undefined;
+  /** Additional reference values (lines + bands) folded into the Y range. */
+  referenceValues?: number[];
+  /** Clamp the computed lower bound at 0. */
+  nonNegative?: boolean;
+  /** Hard cap for the computed upper bound. */
+  maxValue?: number;
   series: SeriesConfig[];
   nowSeconds?: number;
   paused?: boolean;
@@ -108,6 +114,15 @@ export function tickLiveChartSeriesEngineFrame(
     if (ref > tMax) tMax = ref;
   }
 
+  const refs = input.referenceValues;
+  if (refs !== undefined) {
+    for (let i = 0; i < refs.length; i++) {
+      const rv = refs[i];
+      if (rv < tMin) tMin = rv;
+      if (rv > tMax) tMax = rv;
+    }
+  }
+
   const isExaggerate = input.exaggerate;
   if (tMin !== Infinity && tMax !== -Infinity) {
     const rawRange = tMax - tMin;
@@ -124,6 +139,10 @@ export function tickLiveChartSeriesEngineFrame(
       tMin -= margin;
       tMax += margin;
     }
+
+    if (input.nonNegative && tMin < 0) tMin = 0;
+    const maxV = input.maxValue;
+    if (maxV !== undefined && tMax > maxV) tMax = maxV;
 
     if (tMin < state.displayMin) {
       state.displayMin = tMin;

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -5,6 +5,7 @@ import type {
   FontConfig,
   FontWeight,
   GradientConfig,
+  GridStyleConfig,
   LeftEdgeFadeConfig,
   LegendConfig,
   MultiSeriesDotConfig,
@@ -72,6 +73,15 @@ export interface ResolvedReferenceLineConfig {
   intervals: [number, number];
   /** undefined → use palette.refLine at render time */
   color: string | undefined;
+}
+
+export interface ResolvedGridStyleConfig {
+  /** undefined → use palette.gridLine at render time */
+  color: string | undefined;
+  strokeWidth: number;
+  /** Empty array → solid stroke (no dash effect). */
+  intervals: number[];
+  opacity: number;
 }
 
 export interface ResolvedFontConfig {
@@ -306,6 +316,30 @@ export function resolveReferenceLineConfig(
     strokeWidth: rl.strokeWidth ?? REFERENCE_LINE_VISUAL_DEFAULTS.strokeWidth,
     intervals: rl.intervals ?? REFERENCE_LINE_VISUAL_DEFAULTS.intervals,
     color: rl.color,
+  };
+}
+
+const GRID_STYLE_DEFAULTS: ResolvedGridStyleConfig = {
+  color: undefined,
+  strokeWidth: 1,
+  intervals: [],
+  opacity: 1,
+};
+
+/**
+ * Resolves the `gridStyle` prop into a fully-typed config. Always returns a
+ * config (the grid always needs concrete defaults); omitted fields fall back to
+ * the legacy solid 1px grid line.
+ */
+export function resolveGridStyle(
+  prop: GridStyleConfig | undefined,
+): ResolvedGridStyleConfig {
+  if (!prop) return GRID_STYLE_DEFAULTS;
+  return {
+    color: prop.color,
+    strokeWidth: prop.strokeWidth ?? GRID_STYLE_DEFAULTS.strokeWidth,
+    intervals: prop.intervals ?? GRID_STYLE_DEFAULTS.intervals,
+    opacity: prop.opacity ?? GRID_STYLE_DEFAULTS.opacity,
   };
 }
 

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -22,6 +22,9 @@ export interface EngineConfig {
   smoothing: number;
   exaggerate?: boolean;
   referenceValue?: number;
+  referenceValues?: number[];
+  nonNegative?: boolean;
+  maxValue?: number;
   paused?: boolean;
   mode?: "line" | "candle";
   candles?: SharedValue<CandlePoint[]>;
@@ -74,6 +77,9 @@ export interface EngineFrameRefs {
   smoothing: SharedValue<number>;
   exaggerateSV: SharedValue<boolean>;
   referenceValue: SharedValue<number | undefined>;
+  referenceValues?: SharedValue<number[] | undefined>;
+  nonNegativeSV?: SharedValue<boolean>;
+  maxValueSV?: SharedValue<number | undefined>;
   pausedSV: SharedValue<boolean>;
   modeSV: SharedValue<"line" | "candle">;
   candles?: SharedValue<CandlePoint[]>;
@@ -105,6 +111,9 @@ export function applyLiveChartEngineFrame(
     smoothing: sv.smoothing.value,
     exaggerate: sv.exaggerateSV.value,
     referenceValue: sv.referenceValue.value,
+    referenceValues: sv.referenceValues?.value,
+    nonNegative: sv.nonNegativeSV?.value ?? false,
+    maxValue: sv.maxValueSV?.value,
     targetValue: sv.value.value,
     points: sv.data.value,
     nowSeconds: Date.now() / 1000,
@@ -126,6 +135,9 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   const smoothing = useDerivedValue(() => config.smoothing);
   const exaggerateSV = useDerivedValue(() => config.exaggerate ?? false);
   const referenceValue = useDerivedValue(() => config.referenceValue);
+  const referenceValues = useDerivedValue(() => config.referenceValues);
+  const nonNegativeSV = useDerivedValue(() => config.nonNegative ?? false);
+  const maxValueSV = useDerivedValue(() => config.maxValue);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
   const modeSV = useDerivedValue(() => config.mode ?? "line");
 
@@ -158,6 +170,9 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
       smoothing,
       exaggerateSV,
       referenceValue,
+      referenceValues,
+      nonNegativeSV,
+      maxValueSV,
       pausedSV,
       modeSV,
       candles,

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -16,6 +16,9 @@ export interface MultiSeriesEngineConfig {
   smoothing: number;
   exaggerate?: boolean;
   referenceValue?: number;
+  referenceValues?: number[];
+  nonNegative?: boolean;
+  maxValue?: number;
   paused?: boolean;
 }
 
@@ -33,6 +36,9 @@ export interface MultiEngineFrameRefs {
   smoothing: SharedValue<number>;
   exaggerateSV: SharedValue<boolean>;
   referenceValue: SharedValue<number | undefined>;
+  referenceValues?: SharedValue<number[] | undefined>;
+  nonNegativeSV?: SharedValue<boolean>;
+  maxValueSV?: SharedValue<number | undefined>;
   pausedSV: SharedValue<boolean>;
 }
 
@@ -99,6 +105,9 @@ export function applyLiveChartSeriesEngineFrame(
     smoothing: sv.smoothing.value,
     exaggerate: sv.exaggerateSV.value,
     referenceValue: sv.referenceValue.value,
+    referenceValues: sv.referenceValues?.value,
+    nonNegative: sv.nonNegativeSV?.value ?? false,
+    maxValue: sv.maxValueSV?.value,
     series: seriesSnap,
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
@@ -122,6 +131,9 @@ export function useLiveChartSeriesEngine(
   const smoothing = useDerivedValue(() => config.smoothing);
   const exaggerateSV = useDerivedValue(() => config.exaggerate ?? false);
   const referenceValue = useDerivedValue(() => config.referenceValue);
+  const referenceValues = useDerivedValue(() => config.referenceValues);
+  const nonNegativeSV = useDerivedValue(() => config.nonNegative ?? false);
+  const maxValueSV = useDerivedValue(() => config.maxValue);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
 
   const displayMin = useSharedValue(0);
@@ -164,6 +176,9 @@ export function useLiveChartSeriesEngine(
         smoothing,
         exaggerateSV,
         referenceValue,
+        referenceValues,
+        nonNegativeSV,
+        maxValueSV,
         pausedSV,
       },
       scratch,

--- a/packages/react-native-livechart/src/hooks/useReferenceLine.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLine.ts
@@ -3,68 +3,210 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { SkFont } from "@shopify/react-native-skia";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
+import { measureFontTextWidth } from "../lib/measureFontTextWidth";
+import {
+  classifyReferenceEdge,
+  referenceLineForm,
+} from "../math/referenceLines";
 import type { ReferenceLine } from "../types";
 
+/** Screen-space geometry for one reference line / band, recomputed each frame. */
 export interface ReferenceLineLayout {
+  visible: boolean;
+  /** Line y, or band top-edge y. */
   y: number;
+  /** Band bottom-edge y (value/time band); equals `y` for a plain line. */
+  yBottom: number;
+  /** Left x extent. */
   x1: number;
+  /** Right x extent. */
   x2: number;
+  /** Resolved label text (with appended value when `showValue`). */
   label: string;
   labelX: number;
   labelY: number;
-  visible: boolean;
+  /** True when a Form-A line is off-screen and its off-axis badge is showing. */
+  offAxis: boolean;
+  /** Off-axis chevron points up (target above range) vs down (below). */
+  chevronUp: boolean;
 }
 
+const INVISIBLE: ReferenceLineLayout = {
+  visible: false,
+  y: -1,
+  yBottom: -1,
+  x1: 0,
+  x2: 0,
+  label: "",
+  labelX: 0,
+  labelY: -1,
+  offAxis: false,
+  chevronUp: false,
+};
+
+/** Off-axis indicator inset from the nearest plot edge, in px. */
+const OFF_AXIS_EDGE_INSET = 12;
+
 /**
- * Derives the screen-space layout for a horizontal reference line.
- * Returns a shared value that updates each frame as displayMin/Max animate.
+ * Derives screen-space layout for a single reference line or band. Supports all
+ * three `ReferenceLine` forms (horizontal line, horizontal value band, vertical
+ * time band) plus the off-axis badge for an off-screen Form-A value.
  */
 export function useReferenceLine(
   engine: ChartEngineLayout,
   padding: ChartPadding,
-  referenceLine: ReferenceLine | undefined,
+  line: ReferenceLine | undefined,
   formatValue: (v: number) => string,
   font: SkFont,
 ): SharedValue<ReferenceLineLayout> {
-  return useDerivedValue<ReferenceLineLayout>(() => {
-    const invisible: ReferenceLineLayout = {
-      y: -1,
-      x1: 0,
-      x2: 0,
-      label: "",
-      labelX: 0,
-      labelY: -1,
-      visible: false,
-    };
+  const form = line ? referenceLineForm(line) : "none";
 
-    if (!referenceLine) return invisible;
+  return useDerivedValue<ReferenceLineLayout>(() => {
+    if (!line || form === "none") return INVISIBLE;
 
     const w = engine.canvasWidth.value;
     const h = engine.canvasHeight.value;
-    const dMin = engine.displayMin.value;
-    const dMax = engine.displayMax.value;
-    const valRange = dMax - dMin;
+    if (w === 0 || h === 0) return INVISIBLE;
 
-    if (valRange <= 0 || w === 0 || h === 0) return invisible;
-
-    const chartH = h - padding.top - padding.bottom;
-    const y =
-      padding.top + chartH * (1 - (referenceLine.value - dMin) / valRange);
-
-    // Keep the line within the visible chart area
-    if (y < padding.top || y > h - padding.bottom) return invisible;
-
+    const chartTop = padding.top;
+    const chartBottom = h - padding.bottom;
+    const chartH = chartBottom - chartTop;
     const x1 = padding.left;
     const x2 = w - padding.right;
 
-    const label = referenceLine.label ?? formatValue(referenceLine.value);
-
-    // Place label in right gutter, vertically centered on the line
     const fm = font.getMetrics();
     const baselineOffset = (fm.ascent + fm.descent) / 2;
-    const labelX = x2 + 4;
-    const labelY = y - baselineOffset;
 
-    return { y, x1, x2, label, labelX, labelY, visible: true };
+    // ── Form C — vertical time band (independent of the value range) ─────────
+    if (form === "time-band") {
+      if (line.from === undefined || line.to === undefined) return INVISIBLE;
+      const now = engine.timestamp.value;
+      const win = engine.displayWindow.value;
+      const winStart = now - win;
+      const chartW = x2 - x1;
+      if (win <= 0 || chartW <= 0) return INVISIBLE;
+
+      let bx1 = x1 + ((line.from - winStart) / win) * chartW;
+      let bx2 = x1 + ((line.to - winStart) / win) * chartW;
+      if (bx2 < bx1) {
+        const t = bx1;
+        bx1 = bx2;
+        bx2 = t;
+      }
+      if (bx2 < x1 || bx1 > x2) return INVISIBLE;
+      if (bx1 < x1) bx1 = x1;
+      if (bx2 > x2) bx2 = x2;
+
+      const label = line.label ?? "";
+      const labelX =
+        line.labelPosition === "right"
+          ? bx2 - 4 - measureFontTextWidth(font, label)
+          : bx1 + 4;
+      return {
+        visible: true,
+        y: chartTop,
+        yBottom: chartBottom,
+        x1: bx1,
+        x2: bx2,
+        label,
+        labelX,
+        labelY: chartTop - fm.ascent + 2,
+        offAxis: false,
+        chevronUp: false,
+      };
+    }
+
+    // Forms A / B project values onto y, so they need a non-degenerate range.
+    const dMin = engine.displayMin.value;
+    const dMax = engine.displayMax.value;
+    const valRange = dMax - dMin;
+    if (valRange <= 0) return INVISIBLE;
+    const toY = (v: number) => chartTop + ((dMax - v) / valRange) * chartH;
+
+    // ── Form B — horizontal value band ───────────────────────────────────────
+    if (form === "value-band") {
+      if (line.valueFrom === undefined || line.valueTo === undefined) {
+        return INVISIBLE;
+      }
+      let yTop = toY(line.valueTo);
+      let yBot = toY(line.valueFrom);
+      if (yBot < yTop) {
+        const t = yTop;
+        yTop = yBot;
+        yBot = t;
+      }
+      if (yBot < chartTop || yTop > chartBottom) return INVISIBLE;
+      if (yTop < chartTop) yTop = chartTop;
+      if (yBot > chartBottom) yBot = chartBottom;
+
+      const label = line.label ?? "";
+      const labelX =
+        line.labelPosition === "right"
+          ? x2 - 4 - measureFontTextWidth(font, label)
+          : x1 + 4;
+      return {
+        visible: true,
+        y: yTop,
+        yBottom: yBot,
+        x1,
+        x2,
+        label,
+        labelX,
+        labelY: yTop - fm.ascent + 2,
+        offAxis: false,
+        chevronUp: false,
+      };
+    }
+
+    // ── Form A — horizontal line (with optional off-axis badge) ──────────────
+    if (line.value === undefined) return INVISIBLE;
+    const v = line.value;
+    const edge = classifyReferenceEdge(v, dMin, dMax);
+
+    if (edge !== "in") {
+      if (!line.offAxisBadge) return INVISIBLE; // legacy: cull off-screen line
+      const above = edge === "above";
+      const clampedY = above
+        ? chartTop + OFF_AXIS_EDGE_INSET
+        : chartBottom - OFF_AXIS_EDGE_INSET;
+      const word = line.offAxisBadgeLabel ?? line.label;
+      const text = word ? `${word}: ${formatValue(v)}` : formatValue(v);
+      return {
+        visible: true,
+        y: clampedY,
+        yBottom: clampedY,
+        x1,
+        x2,
+        label: text,
+        labelX: x1 + 16,
+        labelY: clampedY - baselineOffset,
+        offAxis: true,
+        chevronUp: above,
+      };
+    }
+
+    const y = toY(v);
+    let label = line.label ?? formatValue(v);
+    if (line.showValue && line.label) label = `${line.label} ${formatValue(v)}`;
+
+    const pos = line.labelPosition ?? "right";
+    let labelX: number;
+    if (pos === "left") labelX = x1 + 4;
+    else if (pos === "center")
+      labelX = (x1 + x2) / 2 - measureFontTextWidth(font, label) / 2;
+    else labelX = x2 + 4; // "right" — legacy gutter position
+
+    return {
+      visible: true,
+      y,
+      yBottom: y,
+      x1,
+      x2,
+      label,
+      labelX,
+      labelY: y - baselineOffset,
+      offAxis: false,
+      chevronUp: false,
+    };
   });
 }

--- a/packages/react-native-livechart/src/math/range.ts
+++ b/packages/react-native-livechart/src/math/range.ts
@@ -9,6 +9,8 @@ export function computeRange(
   currentValue: number,
   referenceValue?: number,
   exaggerate?: boolean,
+  nonNegative?: boolean,
+  maxValue?: number,
 ): { min: number; max: number } {
   "worklet";
   let targetMin = Infinity;
@@ -44,6 +46,9 @@ export function computeRange(
     targetMin -= margin;
     targetMax += margin;
   }
+
+  if (nonNegative && targetMin < 0) targetMin = 0;
+  if (maxValue !== undefined && targetMax > maxValue) targetMax = maxValue;
 
   return { min: targetMin, max: targetMax };
 }

--- a/packages/react-native-livechart/src/math/referenceLines.ts
+++ b/packages/react-native-livechart/src/math/referenceLines.ts
@@ -1,0 +1,56 @@
+import type { ReferenceLine } from "../types";
+
+/** Which of the three reference-line forms a `ReferenceLine` resolves to. */
+export type ReferenceLineForm = "line" | "value-band" | "time-band" | "none";
+
+/**
+ * Classify a `ReferenceLine` into one of its three forms, applying the
+ * documented precedence A (line) > B (value band) > C (time band).
+ */
+export function referenceLineForm(rl: ReferenceLine): ReferenceLineForm {
+  "worklet";
+  if (rl.value !== undefined) return "line";
+  if (rl.valueFrom !== undefined && rl.valueTo !== undefined) {
+    return "value-band";
+  }
+  if (rl.from !== undefined && rl.to !== undefined) return "time-band";
+  return "none";
+}
+
+/**
+ * Gather every Y value a set of reference lines should contribute to the
+ * axis-range computation. Lines flagged `excludeFromRange` are skipped, as are
+ * time bands (Form C) which constrain time, not value.
+ */
+export function collectReferenceValues(lines: ReferenceLine[]): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const rl = lines[i];
+    if (rl.excludeFromRange) continue;
+    switch (referenceLineForm(rl)) {
+      case "line":
+        out.push(rl.value as number);
+        break;
+      case "value-band":
+        out.push(rl.valueFrom as number, rl.valueTo as number);
+        break;
+      // time-band / none contribute no Y values
+    }
+  }
+  return out;
+}
+
+/**
+ * Where a Y value sits relative to the visible plot range:
+ * `"in"` (within [min, max]), `"above"` (greater than max), or `"below"`.
+ */
+export function classifyReferenceEdge(
+  value: number,
+  min: number,
+  max: number,
+): "in" | "above" | "below" {
+  "worklet";
+  if (value > max) return "above";
+  if (value < min) return "below";
+  return "in";
+}

--- a/packages/react-native-livechart/src/theme.ts
+++ b/packages/react-native-livechart/src/theme.ts
@@ -173,6 +173,19 @@ export function resolveTheme(color: string, mode: ThemeMode): LiveChartPalette {
 }
 
 /**
+ * Merge caller palette overrides on top of a derived palette. Only the keys
+ * present on `override` are replaced; everything else keeps the derived value.
+ * Returns the original palette unchanged when no override is supplied.
+ */
+export function applyPaletteOverride(
+  palette: LiveChartPalette,
+  override: Partial<LiveChartPalette> | undefined,
+): LiveChartPalette {
+  if (!override) return palette;
+  return { ...palette, ...override };
+}
+
+/**
  * Default multi-series line colors — Tailwind 500 scale, order: blue, red, green,
  * amber, violet, pink, cyan, orange.
  */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -46,18 +46,80 @@ export type ThemeMode = "light" | "dark";
  */
 export type BadgeVariant = "default" | "minimal";
 
-/** A horizontal reference line drawn at a fixed value (e.g. an entry price or target). */
+/**
+ * A reference line or band drawn into the chart. Three mutually-exclusive forms,
+ * with precedence A > B > C when fields from more than one are present:
+ * - **Form A** — horizontal line at `value`.
+ * - **Form B** — horizontal band between `valueFrom` and `valueTo`.
+ * - **Form C** — vertical time band between `from` and `to` (unix seconds).
+ */
 export interface ReferenceLine {
-  /** The Y-axis value where the line is drawn. */
-  value: number;
+  /** Form A — the Y-axis value where the horizontal line is drawn. */
+  value?: number;
+  /** Form B — horizontal band lower Y bound (paired with `valueTo`). */
+  valueFrom?: number;
+  /** Form B — horizontal band upper Y bound (paired with `valueFrom`). */
+  valueTo?: number;
+  /** Form C — vertical time-band start, unix seconds (paired with `to`). */
+  from?: number;
+  /** Form C — vertical time-band end, unix seconds (paired with `from`). */
+  to?: number;
   /** Optional right-gutter label (e.g. `"Entry"`). */
   label?: string;
-  /** Line thickness in pixels. Default `1`. */
+  /**
+   * Stroke thickness in pixels. For a line it's the line width (default `1`).
+   * For a band, setting this also renders a dashed border along the band edges
+   * (top/bottom for value bands, left/right for time bands); omit for no border.
+   */
   strokeWidth?: number;
-  /** Dash pattern as `[dashLength, gapLength]` in pixels. */
+  /** Dash pattern as `[dashLength, gapLength]` in pixels (line stroke + band border). */
   intervals?: [number, number];
-  /** Line color override. Defaults to palette `refLine`. */
+  /** Line / band color override. Defaults to palette `refLine`. */
   color?: string;
+  /** Fill opacity for a value / time band (0–1). Default `0.16`. */
+  fillOpacity?: number;
+  /** Label text color. Defaults to `color`, then palette `refLabel`. */
+  labelColor?: string;
+  /**
+   * Horizontal label placement. For a Form-A line: `"left" | "center" | "right"`
+   * (default `"right"`, the legacy gutter position). For a band: `"left" | "right"`
+   * (default `"left"`).
+   */
+  labelPosition?: "left" | "center" | "right";
+  /** Append the formatted `value` to the label (Form A only). Default `false`. */
+  showValue?: boolean;
+  /**
+   * Exclude this line's value(s) from the Y-axis range computation, so it may sit
+   * off-axis instead of forcing the axis to expand. Per-line; other lines are
+   * unaffected. Default `false`.
+   */
+  excludeFromRange?: boolean;
+  /**
+   * When a Form-A `value` falls outside the visible plot, render a pinned edge
+   * badge with a directional chevron instead of culling the off-screen line.
+   * Typically paired with `excludeFromRange`. Default `false`.
+   */
+  offAxisBadge?: boolean;
+  /** Localized word shown in the off-axis badge (e.g. "Target"). Falls back to `label`. */
+  offAxisBadgeLabel?: string;
+  /** Off-axis badge pill background. Default: theme `tooltipBg`. */
+  badgeBackground?: string;
+  /** Off-axis badge pill border color. Default: the line `color`. */
+  badgeBorderColor?: string;
+  /** Off-axis badge pill corner radius in pixels. Default `5`. */
+  badgeRadius?: number;
+}
+
+/** Per-instance grid-line styling for the horizontal value-axis grid. */
+export interface GridStyleConfig {
+  /** Stroke color. Defaults to palette `gridLine`. */
+  color?: string;
+  /** Stroke width in pixels. Default `1`. */
+  strokeWidth?: number;
+  /** Dash pattern as `[dash, gap, …]`. Default `[1, 3]` (dotted). Pass `[]` for solid. */
+  intervals?: number[];
+  /** Global alpha multiplier (0–1). Default `1`. */
+  opacity?: number;
 }
 
 /** Configuration for the horizontal dashed line at the current live value. */
@@ -362,10 +424,25 @@ export interface LiveChartCoreProps {
    * only if there is data (≥2 line points or ≥2 committed candles).
    */
   loading?: boolean;
-  /** Spline smoothing factor (0 = sharp, 1 = maximum). Default `0.5`. */
+  /**
+   * Value-lerp speed — how quickly the drawn value, time window, and Y-range chase
+   * their targets each frame (0 = frozen, 1 = instant). Equivalent to liveline's
+   * `lerpSpeed`. Default `0.08`.
+   */
   smoothing?: number;
   /** Tight Y-axis — small value moves fill the full chart height. Default `false`. */
   exaggerate?: boolean;
+  /**
+   * Clamp the Y-axis lower bound at 0 (prices, market caps, volumes) so the axis
+   * never shows negative ticks when data collapses toward zero. Default `false`.
+   */
+  nonNegative?: boolean;
+  /**
+   * Hard upper bound for the Y-axis range. Use for axes with a ceiling (e.g. market
+   * share ≤ `1`); the margin added above the data is capped here. Omit for unbounded
+   * axes (prices, market caps).
+   */
+  maxValue?: number;
   /**
    * Label in the empty state when `loading` is false and there are fewer than
    * two samples (line points or committed candles). Default `"No data"`.
@@ -379,8 +456,21 @@ export interface LiveChartCoreProps {
   yAxis?: boolean | YAxisConfig;
   /** X-axis time labels. `true` = defaults, `false` = hidden, or pass `XAxisConfig`. Default `true`. */
   xAxis?: boolean | XAxisConfig;
-  /** Horizontal reference line at a fixed value. */
+  /**
+   * Single horizontal reference line at a fixed value.
+   * @deprecated Use `referenceLines` (supports multiple lines and bands). When both
+   * are set, this line is merged into the `referenceLines` array.
+   */
   referenceLine?: ReferenceLine;
+  /** Reference lines / bands drawn into the chart. Supports all three `ReferenceLine` forms. */
+  referenceLines?: ReferenceLine[];
+  /** Per-instance grid-line styling. Pass an object to override color / width / dash / opacity. */
+  gridStyle?: GridStyleConfig;
+  /**
+   * Override individual resolved-palette keys on top of the palette derived from
+   * `accentColor` + `theme`. Only the keys you set are replaced.
+   */
+  palette?: Partial<LiveChartPalette>;
   /** Crosshair scrubbing on hover/drag. `true` = defaults, `false` = disabled, or pass `ScrubConfig`. Default `true`. */
   scrub?: boolean | ScrubConfig;
   /**

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -7,7 +7,7 @@ import type { EngineState } from "../../src/core/useLiveChartEngine";
 import { LoadingOverlay } from "../../src/components/LoadingOverlay";
 import { MultiSeriesTooltipStack } from "../../src/components/MultiSeriesTooltipStack";
 import React from "react";
-import type { ReferenceLineLayout } from "../../src/hooks/useReferenceLine";
+import type { ReferenceLine } from "../../src/types";
 import { ReferenceLineOverlay } from "../../src/components/ReferenceLineOverlay";
 import { Skia } from "@shopify/react-native-skia";
 import type { TooltipLayout } from "../../src/hooks/crosshairShared";
@@ -468,58 +468,77 @@ describe("XAxisOverlay", () => {
 });
 
 describe("ReferenceLineOverlay", () => {
-  const visibleLayout: ReferenceLineLayout = {
-    y: 142,
-    x1: 12,
-    x2: 320,
-    label: "50.00",
-    labelX: 324,
-    labelY: 139,
-    visible: true,
-  };
+  const fmt = (v: number) => v.toFixed(2);
 
-  const invisibleLayout: ReferenceLineLayout = {
-    y: -1,
-    x1: 0,
-    x2: 0,
-    label: "",
-    labelX: 0,
-    labelY: -1,
-    visible: false,
-  };
-
-  it("renders dashed line and label when visible", () => {
+  function renderLine(line: ReferenceLine) {
     function Fixture() {
-      const layout = useSharedValue(visibleLayout);
       return (
         <ReferenceLineOverlay
-          layout={layout}
-          strokeWidth={1}
-          intervals={[4, 4]}
-          color={palette.refLine}
-          labelColor={palette.refLabel}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          line={line}
+          palette={palette}
+          formatValue={fmt}
           font={font}
         />
       );
     }
     render(<Fixture />);
+  }
+
+  it("renders a horizontal line (Form A) in range", () => {
+    renderLine({ value: 5, label: "mid" });
   });
 
-  it("renders with zero opacity when not visible", () => {
-    function Fixture() {
-      const layout = useSharedValue(invisibleLayout);
-      return (
-        <ReferenceLineOverlay
-          layout={layout}
-          strokeWidth={1}
-          intervals={[4, 4]}
-          color={palette.refLine}
-          labelColor={palette.refLabel}
-          font={font}
-        />
-      );
-    }
-    render(<Fixture />);
+  it("renders a horizontal value band (Form B)", () => {
+    renderLine({ valueFrom: 2, valueTo: 8, color: "#fbbf24", label: "band" });
+  });
+
+  it("renders a vertical time band (Form C)", () => {
+    renderLine({
+      from: 1700000000 - 20,
+      to: 1700000000 - 5,
+      label: "window",
+      labelPosition: "right",
+    });
+  });
+
+  it("renders an off-axis badge when the value is above range", () => {
+    renderLine({ value: 99, offAxisBadge: true, offAxisBadgeLabel: "Target" });
+  });
+
+  it("renders a styled off-axis badge (background / border / radius)", () => {
+    renderLine({
+      value: 99,
+      offAxisBadge: true,
+      offAxisBadgeLabel: "Target",
+      badgeBackground: "#111827",
+      badgeBorderColor: "#ffffff",
+      badgeRadius: 12,
+    });
+  });
+
+  it("renders a value band with a dashed border + custom fill opacity", () => {
+    renderLine({
+      valueFrom: 2,
+      valueTo: 8,
+      color: "#fbbf24",
+      strokeWidth: 1.5,
+      intervals: [4, 2],
+      fillOpacity: 0.3,
+    });
+  });
+
+  it("renders a time band with a dashed border", () => {
+    renderLine({
+      from: 1700000000 - 20,
+      to: 1700000000 - 5,
+      strokeWidth: 2,
+    });
+  });
+
+  it("culls an off-screen line without offAxisBadge", () => {
+    renderLine({ value: 99 });
   });
 });
 

--- a/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
@@ -148,4 +148,159 @@ describe("useReferenceLine", () => {
     expect(result.current.value.visible).toBe(true);
     expect(result.current.value.x1).toBe(DEFAULT_PADDING.left);
   });
+
+  // ── Form B — value band ─────────────────────────────────────────────────────
+
+  it("renders a value band with top above bottom", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { valueFrom: 20, valueTo: 60 }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.visible).toBe(true);
+    expect(l.yBottom).toBeGreaterThan(l.y);
+  });
+
+  it("returns invisible for a value band fully outside the range", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine({ displayMin: 0, displayMax: 10 }),
+        PADDING,
+        { valueFrom: 50, valueTo: 80 },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("normalizes a reversed value band (valueFrom > valueTo)", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { valueFrom: 60, valueTo: 20 }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.visible).toBe(true);
+    expect(l.yBottom).toBeGreaterThan(l.y);
+  });
+
+  it("clamps a value band that overflows both edges to the plot area", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { valueFrom: -50, valueTo: 150 },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.visible).toBe(true);
+    expect(l.y).toBe(PADDING.top);
+    expect(l.yBottom).toBe(300 - PADDING.bottom);
+  });
+
+  it("returns invisible for a value band when the range is degenerate", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine({ displayMin: 50, displayMax: 50 }),
+        PADDING,
+        { valueFrom: 20, valueTo: 60 },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  // ── Form C — time band ──────────────────────────────────────────────────────
+
+  it("renders a time band spanning part of the window", () => {
+    // timestamp=0, window=30 → winStart=-30
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { from: -20, to: -5 }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.visible).toBe(true);
+    expect(l.x2).toBeGreaterThan(l.x1);
+  });
+
+  it("returns invisible for a time band entirely before the window", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { from: -100, to: -60 }, fmt, font),
+    );
+    expect(result.current.value.visible).toBe(false);
+  });
+
+  it("normalizes a reversed time band and clamps to the chart edges", () => {
+    // from later than to → swapped; spans beyond both window edges → clamped.
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { from: 50, to: -50 }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.visible).toBe(true);
+    expect(l.x1).toBe(PADDING.left);
+    expect(l.x2).toBe(400 - PADDING.right);
+  });
+
+  // ── Off-axis badge ──────────────────────────────────────────────────────────
+
+  it("shows an off-axis badge with an up chevron when above the range", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 150, offAxisBadge: true, offAxisBadgeLabel: "Target" },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.visible).toBe(true);
+    expect(l.offAxis).toBe(true);
+    expect(l.chevronUp).toBe(true);
+    expect(l.label).toContain("Target");
+  });
+
+  it("shows an off-axis badge with a down chevron when below the range", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: -50, offAxisBadge: true },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.offAxis).toBe(true);
+    expect(l.chevronUp).toBe(false);
+  });
+
+  // ── Label placement + showValue ─────────────────────────────────────────────
+
+  it("appends the value when showValue and a label are set", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, label: "Tgt", showValue: true },
+        fmt,
+        font,
+      ),
+    );
+    expect(result.current.value.label).toBe("Tgt 50.00");
+  });
+
+  it("center-aligns the label when labelPosition is 'center'", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, labelPosition: "center" },
+        fmt,
+        font,
+      ),
+    );
+    // center is left of the right-gutter default (x2 + 4 = 324)
+    expect(result.current.value.labelX).toBeLessThan(324);
+  });
 });

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -386,6 +386,64 @@ describe("tickLiveChartEngineFrame", () => {
     expect(s.displayMin).toBeLessThanOrEqual(-100);
   });
 
+  it("includes referenceValues array in range", () => {
+    const s = baseState();
+    tickLiveChartEngineFrame(s, {
+      dt: 16.67,
+      canvasWidth: 200,
+      canvasHeight: 100,
+      timeWindow: 30,
+      smoothing: 0.2,
+      exaggerate: false,
+      referenceValue: undefined,
+      referenceValues: [500, -100],
+      targetValue: 10,
+      points: [{ time: 1000, value: 10 }],
+      nowSeconds: 1000,
+    });
+    expect(s.displayMax).toBeGreaterThan(100);
+    expect(s.displayMin).toBeLessThan(0);
+  });
+
+  it("clamps the lower bound to 0 when nonNegative", () => {
+    const s = baseState();
+    tickLiveChartEngineFrame(s, {
+      dt: 16.67,
+      canvasWidth: 200,
+      canvasHeight: 100,
+      timeWindow: 30,
+      smoothing: 0.5,
+      exaggerate: false,
+      referenceValue: undefined,
+      nonNegative: true,
+      targetValue: 0,
+      points: [
+        { time: 1000, value: 0 },
+        { time: 1001, value: 0 },
+      ],
+      nowSeconds: 1000,
+    });
+    expect(s.displayMin).toBe(0);
+  });
+
+  it("caps the upper bound at maxValue", () => {
+    const s = baseState();
+    tickLiveChartEngineFrame(s, {
+      dt: 16.67,
+      canvasWidth: 200,
+      canvasHeight: 100,
+      timeWindow: 30,
+      smoothing: 0.5,
+      exaggerate: false,
+      referenceValue: undefined,
+      maxValue: 100,
+      targetValue: 50,
+      points: [{ time: 1000, value: 200 }],
+      nowSeconds: 1000,
+    });
+    expect(s.displayMax).toBeLessThanOrEqual(100);
+  });
+
   it("freezes timestamp when paused=true", () => {
     const s = { ...baseState(), timestamp: 999 };
     tickLiveChartEngineFrame(s, {

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -56,6 +56,33 @@ describe("tickLiveChartSeriesEngineFrame", () => {
     expect(s.displayMax).toBeGreaterThanOrEqual(55);
   });
 
+  it("includes referenceValues array, clamps with nonNegative + maxValue", () => {
+    const s = baseMulti();
+    tickLiveChartSeriesEngineFrame(s, {
+      dt: 16.67,
+      canvasWidth: 200,
+      canvasHeight: 100,
+      timeWindow: 30,
+      smoothing: 0.5,
+      exaggerate: false,
+      referenceValue: undefined,
+      referenceValues: [-50, 500],
+      nonNegative: true,
+      maxValue: 120,
+      series: [
+        {
+          id: "a",
+          data: [{ time: 1000, value: 10 }],
+          value: 10,
+          color: "#00f",
+        },
+      ],
+      nowSeconds: 1000,
+    });
+    expect(s.displayMin).toBe(0);
+    expect(s.displayMax).toBeLessThanOrEqual(120);
+  });
+
   it("excludes hidden series from Y-range", () => {
     const s = baseMulti();
     tickLiveChartSeriesEngineFrame(s, {

--- a/packages/react-native-livechart/tests/math/range.test.ts
+++ b/packages/react-native-livechart/tests/math/range.test.ts
@@ -100,4 +100,40 @@ describe("computeRange", () => {
     );
     expect(r.max - r.min).toBeGreaterThan(100);
   });
+
+  it("clamps the lower bound at 0 when nonNegative", () => {
+    const r = computeRange([{ time: 0, value: 0 }], 0, undefined, false, true);
+    expect(r.min).toBe(0);
+  });
+
+  it("leaves the lower bound alone when nonNegative but min is already ≥ 0", () => {
+    const r = computeRange(
+      [
+        { time: 0, value: 40 },
+        { time: 1, value: 100 },
+      ],
+      70,
+      undefined,
+      false,
+      true,
+    );
+    expect(r.min).toBeGreaterThanOrEqual(0);
+  });
+
+  it("caps the upper bound at maxValue", () => {
+    const r = computeRange(
+      [{ time: 0, value: 100 }],
+      100,
+      undefined,
+      false,
+      false,
+      100,
+    );
+    expect(r.max).toBe(100);
+  });
+
+  it("leaves the upper bound alone when below maxValue", () => {
+    const r = computeRange([{ time: 0, value: 10 }], 10, undefined, false, false, 1000);
+    expect(r.max).toBeLessThan(1000);
+  });
 });

--- a/packages/react-native-livechart/tests/math/referenceLines.test.ts
+++ b/packages/react-native-livechart/tests/math/referenceLines.test.ts
@@ -1,0 +1,85 @@
+import {
+  classifyReferenceEdge,
+  collectReferenceValues,
+  referenceLineForm,
+} from "../../src/math/referenceLines";
+
+describe("referenceLineForm", () => {
+  it("classifies a Form-A line", () => {
+    expect(referenceLineForm({ value: 5 })).toBe("line");
+  });
+
+  it("classifies a Form-B value band", () => {
+    expect(referenceLineForm({ valueFrom: 1, valueTo: 2 })).toBe("value-band");
+  });
+
+  it("classifies a Form-C time band", () => {
+    expect(referenceLineForm({ from: 100, to: 200 })).toBe("time-band");
+  });
+
+  it("returns none for an empty line", () => {
+    expect(referenceLineForm({})).toBe("none");
+  });
+
+  it("returns none for a half-specified band", () => {
+    expect(referenceLineForm({ valueFrom: 1 })).toBe("none");
+    expect(referenceLineForm({ from: 1 })).toBe("none");
+  });
+
+  it("applies precedence A > B > C", () => {
+    expect(
+      referenceLineForm({ value: 5, valueFrom: 1, valueTo: 2, from: 3, to: 4 }),
+    ).toBe("line");
+    expect(referenceLineForm({ valueFrom: 1, valueTo: 2, from: 3, to: 4 })).toBe(
+      "value-band",
+    );
+  });
+});
+
+describe("collectReferenceValues", () => {
+  it("gathers line + band values, excludes time bands", () => {
+    expect(
+      collectReferenceValues([
+        { value: 5 },
+        { valueFrom: 1, valueTo: 9 },
+        { from: 100, to: 200 },
+      ]),
+    ).toEqual([5, 1, 9]);
+  });
+
+  it("skips lines flagged excludeFromRange", () => {
+    expect(
+      collectReferenceValues([
+        { value: 5, excludeFromRange: true },
+        { value: 7 },
+      ]),
+    ).toEqual([7]);
+  });
+
+  it("ignores form-less entries", () => {
+    expect(collectReferenceValues([{}, { valueFrom: 1 }])).toEqual([]);
+  });
+
+  it("returns an empty array for no lines", () => {
+    expect(collectReferenceValues([])).toEqual([]);
+  });
+});
+
+describe("classifyReferenceEdge", () => {
+  it("returns 'in' when inside the range", () => {
+    expect(classifyReferenceEdge(5, 0, 10)).toBe("in");
+  });
+
+  it("returns 'above' when greater than max", () => {
+    expect(classifyReferenceEdge(11, 0, 10)).toBe("above");
+  });
+
+  it("returns 'below' when less than min", () => {
+    expect(classifyReferenceEdge(-1, 0, 10)).toBe("below");
+  });
+
+  it("treats the exact bounds as in-range", () => {
+    expect(classifyReferenceEdge(0, 0, 10)).toBe("in");
+    expect(classifyReferenceEdge(10, 0, 10)).toBe("in");
+  });
+});

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -3,6 +3,7 @@ import {
   resolveDegen,
   resolveFontConfig,
   resolveGradient,
+  resolveGridStyle,
   resolveLeftEdgeFade,
   resolvePulse,
   resolveReferenceLineConfig,
@@ -545,6 +546,37 @@ describe("resolveTradeStream", () => {
     expect(resolveTradeStream(mockStream, { labelOffsetX: 16 })).toEqual({
       maxCount: 50,
       labelOffsetX: 16,
+    });
+  });
+});
+
+describe("resolveGridStyle", () => {
+  it("returns the solid 1px default when omitted", () => {
+    expect(resolveGridStyle(undefined)).toEqual({
+      color: undefined,
+      strokeWidth: 1,
+      intervals: [],
+      opacity: 1,
+    });
+  });
+
+  it("merges provided fields over the defaults", () => {
+    expect(
+      resolveGridStyle({ color: "#fff", intervals: [1, 3], opacity: 0.5 }),
+    ).toEqual({
+      color: "#fff",
+      strokeWidth: 1,
+      intervals: [1, 3],
+      opacity: 0.5,
+    });
+  });
+
+  it("keeps default strokeWidth/opacity when only some fields are set", () => {
+    expect(resolveGridStyle({ strokeWidth: 2 })).toEqual({
+      color: undefined,
+      strokeWidth: 2,
+      intervals: [],
+      opacity: 1,
     });
   });
 });

--- a/packages/react-native-livechart/tests/theme.test.ts
+++ b/packages/react-native-livechart/tests/theme.test.ts
@@ -1,10 +1,29 @@
 import {
   SERIES_COLORS,
+  applyPaletteOverride,
   leftEdgeFadeColorsFromBgRgb,
   parseColorRgb,
   resolveSeriesPalettes,
   resolveTheme,
 } from "../src/theme";
+
+describe("applyPaletteOverride", () => {
+  it("returns the original palette when no override is given", () => {
+    const base = resolveTheme("#3b82f6", "dark");
+    expect(applyPaletteOverride(base, undefined)).toBe(base);
+  });
+
+  it("replaces only the overridden keys", () => {
+    const base = resolveTheme("#3b82f6", "dark");
+    const merged = applyPaletteOverride(base, {
+      gridLine: "#123456",
+      refLine: "#abcdef",
+    });
+    expect(merged.gridLine).toBe("#123456");
+    expect(merged.refLine).toBe("#abcdef");
+    expect(merged.line).toBe(base.line);
+  });
+});
 
 describe("parseColorRgb", () => {
   it("parses 6-digit hex", () => {


### PR DESCRIPTION
Phase 1 of the @morfi/chart feature-parity work.

- referenceLines[]: multiple lines + horizontal value bands + vertical
  time bands; per-line color/strokeWidth/intervals/label/labelPosition/
  showValue; off-axis target badge (offAxisBadge/offAxisBadgeLabel) and
  per-line excludeFromRange. Legacy singular referenceLine still works
  (merged into the array).
- nonNegative + maxValue: clamp the y-axis lower / upper bounds (single
  and multi-series engines + computeRange).
- gridStyle: color/strokeWidth/intervals/opacity for the value-axis grid.
- palette: partial override of resolved palette keys.
- Clarify that smoothing is the value-lerp speed (liveline lerpSpeed).

Playground: reference lines & bands page rewritten; y-axis range controls
added to line-playback; grid/palette toggles added to appearance.

Adds docs/feature-parity-plan.md (full 5-phase plan).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>