### PR TITLE
feat(chart): multi-series per-series styling, degen, legend styling

### DIFF
--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
 import {
   formatTime,
@@ -51,6 +51,10 @@ export default function MultiSeriesScreen() {
   const [legendVisible, setLegendVisible] = useState(true);
   const [legendCompact, setLegendCompact] = useState(false);
   const [legendPosition, setLegendPosition] = useState<"top" | "bottom">("top");
+  const [styled, setStyled] = useState(false);
+  const [legendStyled, setLegendStyled] = useState(false);
+  const [degenOn, setDegenOn] = useState(false);
+  const [degenColors, setDegenColors] = useState(false);
 
   const sim = useSimulatedChartData({
     multiSeries: !empty,
@@ -65,6 +69,27 @@ export default function MultiSeriesScreen() {
 
   const seriesSource = empty ? emptySeries : sim.series;
 
+  // Inject per-series stroke style onto the sim's series objects (mutated in
+  // place, so style survives the sim's per-tick data appends).
+  useEffect(() => {
+    if (empty) return;
+    sim.series.modify((arr) => {
+      "worklet";
+      for (let i = 0; i < arr.length; i++) {
+        if (styled) {
+          arr[i].style = i % 2 === 1 ? "dashed" : "solid";
+          arr[i].glow = i === 0;
+          arr[i].strokeWidth = i === 0 ? 3 : 2;
+        } else {
+          arr[i].style = undefined;
+          arr[i].glow = undefined;
+          arr[i].strokeWidth = undefined;
+        }
+      }
+      return arr;
+    });
+  }, [styled, empty, sim.series]);
+
   const dotConfig: MultiSeriesDotConfig = {
     radius: dotRadius,
     pulse,
@@ -76,6 +101,16 @@ export default function MultiSeriesScreen() {
     visible: legendVisible,
     compact: legendCompact,
     position: legendPosition,
+    style: legendStyled
+      ? {
+          borderRadius: 20,
+          fontSize: 14,
+          dotSize: 10,
+          activeBackground: "rgba(96,165,250,0.18)",
+          activeColor: "#ffffff",
+          hiddenColor: "rgba(255,255,255,0.35)",
+        }
+      : undefined,
   };
 
   return (
@@ -107,6 +142,13 @@ export default function MultiSeriesScreen() {
             emptyText="No series"
             dot={dotConfig}
             legend={legendConfig}
+            degen={
+              degenOn
+                ? degenColors
+                  ? { colors: ["#f472b6", "#22d3ee", "#fde047"] }
+                  : true
+                : false
+            }
             scrub
             onSeriesToggle={
               empty
@@ -278,6 +320,56 @@ export default function MultiSeriesScreen() {
             ]}
           >
             Bottom
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Per-series style & degen</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, styled && demoStyles.chipActive]}
+          onPress={() => setStyled((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, styled && demoStyles.chipTextActive]}
+          >
+            Styled lines
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, legendStyled && demoStyles.chipActive]}
+          onPress={() => setLegendStyled((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              legendStyled && demoStyles.chipTextActive,
+            ]}
+          >
+            Legend style
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, degenOn && demoStyles.chipActive]}
+          onPress={() => setDegenOn((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, degenOn && demoStyles.chipTextActive]}
+          >
+            Degen
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[demoStyles.chip, degenColors && demoStyles.chipActive]}
+          onPress={() => setDegenColors((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              degenColors && demoStyles.chipTextActive,
+            ]}
+          >
+            Degen colors
           </Text>
         </Pressable>
       </View>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -72,7 +72,7 @@ const DEMOS: { href: Href; title: string; blurb: string }[] = [
   {
     href: "/demo/multi-series",
     title: "Multi-series",
-    blurb: "LiveChartSeries, toggles, scrub, shared core props.",
+    blurb: "Per-series style, degen, legend styling, toggles, scrub.",
   },
 ];
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -94,6 +94,7 @@ jest.mock("@shopify/react-native-skia", () => {
     Path: ({ children, ...props }) =>
       React.createElement(View, props, children),
     DashPathEffect: View,
+    Blur: View,
     LinearGradient: View,
     vec: (x, y) => ({ x, y }),
     matchFont: jest.fn(() => mockFont),

--- a/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
+++ b/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
@@ -2,15 +2,18 @@ import { Circle, Group } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { DEGEN_STRIDE } from "../constants";
 import type { LiveChartPalette } from "../types";
-import type { SingleEngineState } from "../core/useLiveChartEngine";
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 
 type DegenPack = SharedValue<Float64Array<ArrayBuffer>>;
 
 /**
  * Renders one particle slot from the packed ring buffer.
- * Buffer layout per slot (stride = DEGEN_STRIDE = 7):
- *   [0] x, [1] y, [2] vx, [3] vy, [4] t0, [5] active, [6] size
+ * Buffer layout per slot (stride = DEGEN_STRIDE = 8):
+ *   [0] x, [1] y, [2] vx, [3] vy, [4] t0, [5] active, [6] size, [7] colorIndex
  * See `math/degenTick.ts` for the authoritative layout documentation.
+ *
+ * Each particle stores a `colorIndex` (set at spawn) that selects its color
+ * from `colorList`, so multi-series bursts render in their own series' color.
  */
 function DegenSlot({
   index,
@@ -19,15 +22,15 @@ function DegenSlot({
   engine,
   particleBurstDurationSec,
   particleOpacity,
-  color,
+  colorList,
 }: {
   index: number;
   pack: DegenPack;
   packRevision: SharedValue<number>;
-  engine: SingleEngineState;
+  engine: ChartEngineLayout;
   particleBurstDurationSec: number;
   particleOpacity: number;
-  color: string;
+  colorList: string[];
 }) {
   const base = index * DEGEN_STRIDE;
 
@@ -76,6 +79,18 @@ function DegenSlot({
     return life * particleOpacity;
   });
 
+  /* istanbul ignore next -- worklet */
+  const color = useDerivedValue(() => {
+    // Read packRevision so this re-runs each frame — the pack buffer is mutated
+    // in place (stable reference), so without this the color would freeze at the
+    // mount-time colorIndex (0) for every particle.
+    const rev = packRevision.value;
+    const buf = pack.value;
+    if (!(rev >= 0)) return colorList[0];
+    const idx = Math.max(0, Math.floor(buf[base + 7]));
+    return colorList[idx % colorList.length];
+  });
+
   return <Circle cx={cx} cy={cy} r={r} color={color} opacity={opacity} />;
 }
 
@@ -91,7 +106,7 @@ export function DegenParticlesOverlay({
 }: {
   pack: DegenPack;
   packRevision: SharedValue<number>;
-  engine: SingleEngineState;
+  engine: ChartEngineLayout;
   palette: LiveChartPalette;
   particleSlotCount: number;
   particleBurstDurationSec: number;
@@ -111,7 +126,7 @@ export function DegenParticlesOverlay({
         engine={engine}
         particleBurstDurationSec={particleBurstDurationSec}
         particleOpacity={particleOpacity}
-        color={colorList[i % colorList.length]}
+        colorList={colorList}
       />,
     );
   }

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -17,9 +17,13 @@ import { scheduleOnRN } from "react-native-worklets";
 import { MAX_MULTI_SERIES } from "../constants";
 import {
   lineColorsSignatureFromArray,
+  lineStyleSignatureFromArray,
   resolveMultiSeriesLineColorsSnapshot,
+  resolveMultiSeriesLineStylesSnapshot,
+  type SeriesLineStyle,
 } from "../core/multiSeriesLayout";
 import {
+  resolveDegen,
   resolveGridStyle,
   resolveLeftEdgeFade,
   resolveLegend,
@@ -35,6 +39,7 @@ import {
   useChartReveal,
   useChartSkiaFont,
   useCrosshairSeries,
+  useMultiSeriesDegen,
   useMultiSeriesLinePaths,
   useMultiSeriesReverseMorphInputs,
   useXAxis,
@@ -54,6 +59,7 @@ import {
 } from "../theme";
 import type { LiveChartSeriesProps, SeriesConfig } from "../types";
 import { CrosshairLine } from "./CrosshairLine";
+import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
 import { LeftEdgeFade } from "./LeftEdgeFade";
 import { LoadingOverlay } from "./LoadingOverlay";
 import { MultiSeriesDots } from "./MultiSeriesDots";
@@ -100,6 +106,8 @@ export function LiveChartSeries({
   seriesToggleCompact,
   dot: dotProp,
   legend: legendProp,
+  degen,
+  onDegenShake,
   leftEdgeFade = true,
 }: LiveChartSeriesProps) {
   const yAxisCfg = resolveYAxis(yAxis);
@@ -109,6 +117,7 @@ export function LiveChartSeries({
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
   const legendCfg = resolveLegend(legendProp, seriesToggleCompact);
+  const degenCfg = resolveDegen(degen);
 
   const allRefLines = useMemo(
     () => [
@@ -230,6 +239,35 @@ export function LiveChartSeries({
     syncColors(series);
   }, [series, syncColors]);
 
+  // Per-series stroke style (dash / width / glow) — synced to React state when
+  // the style signature changes (not on every data tick), like the colors above.
+  const [lineStyles, setLineStyles] = useState<SeriesLineStyle[]>(() =>
+    resolveMultiSeriesLineStylesSnapshot([]),
+  );
+
+  const syncStyles = useCallback((sv: SharedValue<SeriesConfig[]>) => {
+    setLineStyles(resolveMultiSeriesLineStylesSnapshot(sv.value));
+  }, []);
+
+  useAnimatedReaction(
+    () => lineStyleSignatureFromArray(series.value),
+    /* istanbul ignore next -- scheduleOnRN from UI-thread reaction */
+    (sig, prev) => {
+      if (sig !== prev) scheduleOnRN(syncStyles, series);
+    },
+    [series, syncStyles],
+  );
+
+  useEffect(() => {
+    syncStyles(series);
+  }, [series, syncStyles]);
+
+  const {
+    pack: degenPack,
+    packRevision: degenPackRevision,
+    shakeTransform: degenShakeTransform,
+  } = useMultiSeriesDegen(engine, effectivePadding, degenCfg, onDegenShake);
+
   const { yAxisEntries } = useYAxis(
     engine,
     effectivePadding,
@@ -277,6 +315,7 @@ export function LiveChartSeries({
       <View style={[{ flex: 1, backgroundColor }, style]} onLayout={onLayout}>
         {legendTop}
         <Canvas style={{ flex: 1, minHeight: layoutHeight || 1 }}>
+          <Group transform={degenShakeTransform}>
           {yAxisCfg && (
             <Group opacity={reveal.yAxisOpacity}>
               <YAxisOverlay
@@ -325,6 +364,7 @@ export function LiveChartSeries({
                 opacities={engine.seriesOpacities}
                 series={effectiveSeries}
                 strokeWidth={strokeWidth}
+                lineStyle={lineStyles[i]}
               />
             ))}
           </Group>
@@ -361,6 +401,21 @@ export function LiveChartSeries({
             </Group>
           )}
 
+          {degenCfg && (
+            <Group opacity={reveal.dotOpacity}>
+              <DegenParticlesOverlay
+                pack={degenPack}
+                packRevision={degenPackRevision}
+                engine={engine}
+                palette={palette}
+                particleSlotCount={degenCfg.particleSlotCount}
+                particleBurstDurationSec={degenCfg.particleBurstDurationSec}
+                particleOpacity={degenCfg.particleOpacity}
+                colors={degenCfg.colors ?? lineColors}
+              />
+            </Group>
+          )}
+
           <LoadingOverlay
             engine={engine}
             padding={effectivePadding}
@@ -373,6 +428,7 @@ export function LiveChartSeries({
             strokeWidth={strokeWidth}
             badge={false}
           />
+          </Group>
 
           {leftEdgeFadeCfg && (
             <LeftEdgeFade

--- a/packages/react-native-livechart/src/components/MultiSeriesStroke.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesStroke.tsx
@@ -1,5 +1,7 @@
-import { Group, Path, Skia } from "@shopify/react-native-skia";
+import { Blur, Group, Path, Skia } from "@shopify/react-native-skia";
+import { DashPathEffect } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import type { SeriesLineStyle } from "../core/multiSeriesLayout";
 import { SERIES_COLORS } from "../theme";
 import type { SeriesConfig } from "../types";
 
@@ -9,12 +11,15 @@ export function MultiSeriesStroke({
   opacities,
   series,
   strokeWidth,
+  lineStyle,
 }: {
   index: number;
   paths: SharedValue<ReturnType<typeof Skia.Path.Make>[]>;
   opacities: SharedValue<number[]>;
   series: SharedValue<SeriesConfig[]>;
   strokeWidth: number;
+  /** Per-series static stroke style (dash / width / glow). */
+  lineStyle?: SeriesLineStyle;
 }) {
   const path = useDerivedValue(
     /* istanbul ignore next -- Skia path derived on UI thread */
@@ -37,16 +42,38 @@ export function MultiSeriesStroke({
         SERIES_COLORS[index % SERIES_COLORS.length]) as string;
     },
   );
+
+  const sw = lineStyle?.strokeWidth ?? strokeWidth;
+  const dashed = lineStyle?.dashed ?? false;
+  const intervals = lineStyle?.intervals ?? [6, 4];
+  const glow = lineStyle?.glow ?? false;
+
   return (
     <Group opacity={opacity}>
+      {glow && (
+        <Group opacity={0.35}>
+          <Path
+            path={path}
+            style="stroke"
+            strokeWidth={sw * 2.5}
+            color={color}
+            strokeCap="round"
+            strokeJoin="round"
+          >
+            <Blur blur={4} />
+          </Path>
+        </Group>
+      )}
       <Path
         path={path}
         style="stroke"
-        strokeWidth={strokeWidth}
+        strokeWidth={sw}
         color={color}
         strokeCap="round"
         strokeJoin="round"
-      />
+      >
+        {dashed && <DashPathEffect intervals={intervals} />}
+      </Path>
     </Group>
   );
 }

--- a/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
+++ b/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
@@ -71,12 +71,16 @@ export function SeriesToggleChips({
   };
 
   const compact = legend.compact;
+  const st = legend.style;
 
   return (
     <View style={[styles.row, compact && styles.rowCompact]}>
       {snapshot.map((s) => {
         const on = s.visible !== false;
         const label = s.label ?? s.id;
+        const swatchSize = st?.dotSize;
+        const chipBg = on ? st?.activeBackground : st?.hiddenBackground;
+        const textColor = on ? st?.activeColor : st?.hiddenColor;
         return (
           <Pressable
             key={s.id}
@@ -85,20 +89,36 @@ export function SeriesToggleChips({
               styles.chip,
               compact && styles.chipCompact,
               on && styles.chipOn,
+              st?.borderRadius !== undefined && { borderRadius: st.borderRadius },
+              chipBg !== undefined && { backgroundColor: chipBg },
             ]}
           >
             <View
-              style={[styles.swatch, { backgroundColor: s.color ?? "#888" }]}
+              style={[
+                styles.swatch,
+                { backgroundColor: s.color ?? "#888" },
+                swatchSize !== undefined && {
+                  width: swatchSize,
+                  height: swatchSize,
+                  borderRadius: swatchSize / 2,
+                },
+              ]}
             />
             <Text
               style={[
                 styles.chipText,
                 compact && styles.chipTextCompact,
                 on && styles.chipTextOn,
+                s.kind === "derived" && styles.chipTextDerived,
+                st?.fontSize !== undefined && { fontSize: st.fontSize },
+                textColor !== undefined && { color: textColor },
               ]}
               numberOfLines={1}
             >
               {label}
+              {s.valueLabel ? (
+                <Text style={styles.chipValue}> {s.valueLabel}</Text>
+              ) : null}
             </Text>
           </Pressable>
         );
@@ -155,5 +175,12 @@ const styles = StyleSheet.create({
   },
   chipTextOn: {
     color: "rgba(255,255,255,0.9)",
+  },
+  chipTextDerived: {
+    fontStyle: "italic",
+    opacity: 0.85,
+  },
+  chipValue: {
+    fontWeight: "700",
   },
 });

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -29,7 +29,9 @@ export const EMPTY_TEXT_GAP_PAD = 20;
 export const EMPTY_GAP_FADE_WIDTH = 30;
 
 /**
- * Floats per degen particle slot: `x, y, vx, vy, t0, active, size`.
+ * Floats per degen particle slot: `x, y, vx, vy, t0, active, size, colorIndex`.
+ * `colorIndex` selects which entry of the renderer's color list a particle uses
+ * (multi-series sets it per series; single-series cycles it per particle).
  * Layout is fixed; not on `DegenOptions` because changing it needs matching renderer changes.
  */
-export const DEGEN_STRIDE = 7;
+export const DEGEN_STRIDE = 8;

--- a/packages/react-native-livechart/src/core/multiSeriesLayout.ts
+++ b/packages/react-native-livechart/src/core/multiSeriesLayout.ts
@@ -28,3 +28,53 @@ export function resolveMultiSeriesLineColorsSnapshot(
       : "#ffffff",
   );
 }
+
+/** Per-series visual stroke style resolved for one render slot. */
+export interface SeriesLineStyle {
+  /** Per-series stroke width override, or `undefined` to use the chart default. */
+  strokeWidth: number | undefined;
+  dashed: boolean;
+  intervals: [number, number];
+  glow: boolean;
+}
+
+const DEFAULT_LINE_STYLE: SeriesLineStyle = {
+  strokeWidth: undefined,
+  dashed: false,
+  intervals: [6, 4],
+  glow: false,
+};
+
+/**
+ * Stable signature over the per-series style fields (style / intervals /
+ * strokeWidth / glow), so a snapshot re-sync fires when styling changes but not
+ * on every data tick.
+ */
+export function lineStyleSignatureFromArray(arr: SeriesConfig[]): string {
+  "worklet";
+  let out = "";
+  for (let i = 0; i < arr.length; i++) {
+    if (i > 0) out += "\x1e";
+    const x = arr[i];
+    const iv = x.intervals ? `${x.intervals[0]},${x.intervals[1]}` : "";
+    out += `${x.id}\x1f${x.style ?? ""}\x1f${x.strokeWidth ?? ""}\x1f${x.glow ? 1 : 0}\x1f${iv}`;
+  }
+  return out;
+}
+
+/** Per-slot resolved stroke style for Skia (empty slots → defaults). */
+export function resolveMultiSeriesLineStylesSnapshot(
+  arr: SeriesConfig[],
+  maxSlots = MAX_MULTI_SERIES,
+): SeriesLineStyle[] {
+  return Array.from({ length: maxSlots }, (_, i) => {
+    const s = arr[i];
+    if (!s) return DEFAULT_LINE_STYLE;
+    return {
+      strokeWidth: s.strokeWidth,
+      dashed: s.style === "dashed",
+      intervals: s.intervals ?? DEFAULT_LINE_STYLE.intervals,
+      glow: s.glow ?? false,
+    };
+  });
+}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -8,6 +8,7 @@ import type {
   GridStyleConfig,
   LeftEdgeFadeConfig,
   LegendConfig,
+  LegendStyle,
   MultiSeriesDotConfig,
   PulseConfig,
   ReferenceLine,
@@ -498,12 +499,15 @@ export interface ResolvedLegendConfig {
   visible: boolean;
   compact: boolean;
   position: "top" | "bottom";
+  /** Raw style overrides; the chip row applies its own fallbacks. */
+  style: LegendStyle | undefined;
 }
 
 const LEGEND_DEFAULTS: ResolvedLegendConfig = {
   visible: true,
   compact: false,
   position: "top",
+  style: undefined,
 };
 
 export function resolveLegend(
@@ -518,5 +522,6 @@ export function resolveLegend(
     visible: prop.visible ?? LEGEND_DEFAULTS.visible,
     compact: prop.compact ?? compactFallback ?? LEGEND_DEFAULTS.compact,
     position: prop.position ?? LEGEND_DEFAULTS.position,
+    style: prop.style,
   };
 }

--- a/packages/react-native-livechart/src/hooks/index.ts
+++ b/packages/react-native-livechart/src/hooks/index.ts
@@ -13,6 +13,7 @@ export { useLiveChartHasData } from "./useLiveChartHasData";
 export { useLiveDot } from "./useLiveDot";
 export { useModeBlend } from "./useModeBlend";
 export { useMomentum } from "./useMomentum";
+export { useMultiSeriesDegen } from "./useMultiSeriesDegen";
 export { useMultiSeriesLinePaths } from "./useMultiSeriesLinePaths";
 export { useReferenceLine } from "./useReferenceLine";
 export {

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -7,6 +7,7 @@ import {
   type DerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import { DEGEN_STRIDE } from "../constants";
 import type { ResolvedDegenConfig } from "../core/resolveConfig";
 import type { SingleEngineState } from "../core/useLiveChartEngine";
 import { computeShake, spawnBurst, tickParticles } from "../math/degenTick";
@@ -27,7 +28,7 @@ export function useDegen(
   >;
 } {
   const MAX_SLOTS = 80;
-  const pack = useSharedValue(new Float64Array(MAX_SLOTS * 7));
+  const pack = useSharedValue(new Float64Array(MAX_SLOTS * DEGEN_STRIDE));
   const packRevision = useSharedValue(0);
   const prevM = useSharedValue<Momentum>("flat");
   const writeRot = useSharedValue(0);
@@ -146,7 +147,7 @@ export function useDegen(
       prevTimestamp.value = now;
 
       if (enabledSV.value < 0.5) {
-        for (let i = 0; i < slots; i++) buf[i * 7 + 5] = 0;
+        for (let i = 0; i < slots; i++) buf[i * DEGEN_STRIDE + 5] = 0;
         prevM.value = momentumSV.value;
         prevActiveCount.value = 0;
         shakeStart.value = 0;
@@ -182,6 +183,7 @@ export function useDegen(
               now,
               baseRot: writeRot.value,
               slots,
+              colorIndex: -1, // cycle the color list per particle
             });
             if (shakeEnabledSV.value > 0.5) {
               shakeStart.value = now;

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  runOnJS,
+  useDerivedValue,
+  useFrameCallback,
+  useSharedValue,
+  type DerivedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import { DEGEN_STRIDE } from "../constants";
+import type { ResolvedDegenConfig } from "../core/resolveConfig";
+import type { MultiEngineState } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { computeShake, spawnBurst, tickParticles } from "../math/degenTick";
+import { detectMomentum } from "../math/momentum";
+import type { DegenShakePayload } from "../types";
+
+/**
+ * Multi-series degen: **every** visible series sparks a burst off its own
+ * endpoint dot on an up-momentum swing — in that series' color (its particles
+ * carry the series index as their `colorIndex`) — plus one shared chart shake
+ * re-armed from the strongest swing each frame. Reuses the single-series
+ * particle/shake math (`math/degenTick`).
+ */
+export function useMultiSeriesDegen(
+  engine: MultiEngineState,
+  padding: ChartPadding,
+  cfg: ResolvedDegenConfig | null,
+  onShake?: (payload: DegenShakePayload) => void,
+): {
+  pack: SharedValue<Float64Array<ArrayBuffer>>;
+  packRevision: SharedValue<number>;
+  shakeTransform: DerivedValue<
+    [{ translateX: number }, { translateY: number }]
+  >;
+} {
+  const MAX_SLOTS = 80;
+  const pack = useSharedValue(new Float64Array(MAX_SLOTS * DEGEN_STRIDE));
+  const packRevision = useSharedValue(0);
+  // Per-series previous momentum (0 = flat, 1 = up, 2 = down), index-aligned to series.
+  const prevMoms = useSharedValue<number[]>([]);
+  const writeRot = useSharedValue(0);
+  const enabledSV = useSharedValue(0);
+  const scaleSV = useSharedValue(1);
+  const downSV = useSharedValue(0);
+  const shakeEnabledSV = useSharedValue(0);
+  const shakeIntensitySV = useSharedValue(1);
+  const shakeDurationSecSV = useSharedValue(0.45);
+  const slotCountSV = useSharedValue(60);
+  const burstParticleCountSV = useSharedValue(20);
+  const particleBurstDurationSecSV = useSharedValue(1.0);
+  const dragSV = useSharedValue(0.95);
+  const sizeMinSV = useSharedValue(1);
+  const sizeMaxSV = useSharedValue(2.2);
+  const spreadAngleSV = useSharedValue(Math.PI * 1.2);
+  const jitterXSV = useSharedValue(24);
+  const jitterYSV = useSharedValue(8);
+  const speedMinSV = useSharedValue(60);
+  const speedMaxSV = useSharedValue(160);
+  const shakeX = useSharedValue(0);
+  const shakeY = useSharedValue(0);
+  const shakeStart = useSharedValue(0);
+  const prevTimestamp = useSharedValue(0);
+  const prevActiveCount = useSharedValue(0);
+  const hasOnShakeListenerSV = useSharedValue(0);
+
+  const onShakeRef = useRef(onShake);
+  onShakeRef.current = onShake;
+  const emitShake = useCallback(
+    /* istanbul ignore next -- invoked only from the UI-thread frame worklet */
+    (direction: "up" | "down") => {
+      onShakeRef.current?.({ direction });
+    },
+    [],
+  );
+
+  const degenOff = cfg === null;
+
+  useEffect(() => {
+    if (degenOff) {
+      enabledSV.value = 0;
+      shakeEnabledSV.value = 0;
+      hasOnShakeListenerSV.value = 0;
+      shakeStart.value = 0;
+      shakeX.value = 0;
+      shakeY.value = 0;
+      return;
+    }
+    hasOnShakeListenerSV.value = onShake != null ? 1 : 0;
+    enabledSV.value = 1;
+    scaleSV.value = cfg.scale;
+    downSV.value = cfg.downMomentum ? 1 : 0;
+    shakeEnabledSV.value = cfg.shake ? 1 : 0;
+    shakeIntensitySV.value = cfg.shakeIntensity;
+    shakeDurationSecSV.value = cfg.shakeDurationSec;
+    slotCountSV.value = cfg.particleSlotCount;
+    burstParticleCountSV.value = cfg.burstParticleCount;
+    particleBurstDurationSecSV.value = cfg.particleBurstDurationSec;
+    dragSV.value = cfg.drag;
+    sizeMinSV.value = cfg.particleSizeMin;
+    sizeMaxSV.value = cfg.particleSizeMax;
+    spreadAngleSV.value = cfg.spreadAngle;
+    jitterXSV.value = cfg.positionJitterX;
+    jitterYSV.value = cfg.positionJitterY;
+    speedMinSV.value = cfg.speedMin;
+    speedMaxSV.value = cfg.speedMax;
+    if (!cfg.shake) {
+      shakeStart.value = 0;
+      shakeX.value = 0;
+      shakeY.value = 0;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- shared value refs are stable; react to cfg only
+  }, [degenOff, onShake, cfg]);
+
+  useFrameCallback(
+    /* istanbul ignore next -- worklet runs on UI thread, not in Jest */ () => {
+      "worklet";
+      const now = engine.timestamp.value;
+      const buf = pack.value;
+      const slots = slotCountSV.value;
+
+      const dtSec = prevTimestamp.value > 0 ? now - prevTimestamp.value : 0.016;
+      prevTimestamp.value = now;
+
+      const moms = prevMoms.value;
+
+      if (enabledSV.value < 0.5) {
+        for (let i = 0; i < slots; i++) buf[i * DEGEN_STRIDE + 5] = 0;
+        moms.length = 0;
+        prevActiveCount.value = 0;
+        shakeStart.value = 0;
+        shakeX.value = 0;
+        shakeY.value = 0;
+        return;
+      }
+
+      const s = engine.series.value;
+      const displays = engine.displaySeriesValues.value;
+      const ops = engine.seriesOpacities.value;
+      const n = s.length;
+      while (moms.length < n) moms.push(0);
+      if (moms.length > n) moms.length = n;
+
+      const cw = engine.canvasWidth.value;
+      const ch = engine.canvasHeight.value;
+      const canSpawn = cw >= 1 && ch >= 1;
+      const dMin = engine.displayMin.value;
+      const dMax = engine.displayMax.value;
+      const valRange = dMax - dMin;
+      const chartH = ch - padding.top - padding.bottom;
+      const ox = cw - padding.right;
+      const allowDown = downSV.value > 0.5;
+
+      // Each visible series fires a burst off its own dot on a fresh swing.
+      let firedDir = 0; // 0 none, 1 up, 2 down
+      for (let i = 0; i < n; i++) {
+        const visible = (ops[i] ?? 0) >= 0.5;
+        const m = visible ? detectMomentum(s[i].data) : "flat";
+        const code = m === "up" ? 1 : m === "down" ? 2 : 0;
+        const prev = moms[i];
+        moms[i] = code;
+        if (!canSpawn || code === 0 || code === prev) continue;
+        const isUp = code === 1;
+        if (!isUp && !allowDown) continue;
+        const v = displays[i] ?? s[i].value;
+        const oy =
+          valRange === 0
+            ? padding.top + chartH / 2
+            : padding.top + ((dMax - v) / valRange) * chartH;
+        writeRot.value = spawnBurst(buf, {
+          ox,
+          oy,
+          sc: scaleSV.value,
+          burst: burstParticleCountSV.value,
+          baseAngle: isUp ? -Math.PI / 2 : Math.PI / 2,
+          spread: spreadAngleSV.value,
+          jx: jitterXSV.value,
+          jy: jitterYSV.value,
+          sMin: speedMinSV.value,
+          sMax: speedMaxSV.value,
+          szMin: sizeMinSV.value,
+          szMax: sizeMaxSV.value,
+          now,
+          baseRot: writeRot.value,
+          slots,
+          colorIndex: i, // color this burst with series i's color
+        });
+        // Up swings win the shared shake; otherwise a down swing arms it.
+        if (firedDir !== 1) firedDir = isUp ? 1 : 2;
+      }
+
+      if (firedDir !== 0 && shakeEnabledSV.value > 0.5) {
+        shakeStart.value = now;
+        if (hasOnShakeListenerSV.value > 0.5) {
+          runOnJS(emitShake)(firedDir === 1 ? "up" : "down");
+        }
+      }
+
+      if (shakeStart.value > 0 && shakeEnabledSV.value > 0.5) {
+        const r = computeShake(
+          now - shakeStart.value,
+          shakeDurationSecSV.value,
+          scaleSV.value,
+          shakeIntensitySV.value,
+        );
+        shakeX.value = r.x;
+        shakeY.value = r.y;
+        if (!r.active) shakeStart.value = 0;
+      } else if (shakeEnabledSV.value < 0.5) {
+        shakeStart.value = 0;
+        shakeX.value = 0;
+        shakeY.value = 0;
+      }
+
+      const activeCount = tickParticles(
+        buf,
+        slots,
+        now,
+        particleBurstDurationSecSV.value,
+        dragSV.value,
+        dtSec,
+      );
+
+      if (activeCount > 0 || prevActiveCount.value > 0) {
+        packRevision.value = packRevision.value + 1;
+      }
+      prevActiveCount.value = activeCount;
+    },
+  );
+
+  const shakeTransform = useDerivedValue(() => {
+    "worklet";
+    return [{ translateX: shakeX.value }, { translateY: shakeY.value }] as [
+      { translateX: number },
+      { translateY: number },
+    ];
+  });
+
+  return { pack, packRevision, shakeTransform };
+}

--- a/packages/react-native-livechart/src/math/degenTick.ts
+++ b/packages/react-native-livechart/src/math/degenTick.ts
@@ -4,15 +4,16 @@
  * Particles live in a packed `Float64Array` ring buffer.  Each slot occupies
  * `DEGEN_STRIDE` (7) contiguous floats:
  *
- * | offset | field    | description                          |
- * | ------ | -------- | ------------------------------------ |
- * |   0    | x        | current x position (px)              |
- * |   1    | y        | current y position (px)              |
- * |   2    | vx       | velocity x (px/s)                    |
- * |   3    | vy       | velocity y (px/s)                    |
- * |   4    | t0       | spawn timestamp (seconds)            |
- * |   5    | active   | 1 = alive, 0 = expired               |
- * |   6    | size     | particle radius (px, pre-scaled)      |
+ * | offset | field      | description                          |
+ * | ------ | ---------- | ------------------------------------ |
+ * |   0    | x          | current x position (px)              |
+ * |   1    | y          | current y position (px)              |
+ * |   2    | vx         | velocity x (px/s)                    |
+ * |   3    | vy         | velocity y (px/s)                    |
+ * |   4    | t0         | spawn timestamp (seconds)            |
+ * |   5    | active     | 1 = alive, 0 = expired               |
+ * |   6    | size       | particle radius (px, pre-scaled)     |
+ * |   7    | colorIndex | index into the renderer's color list |
  *
  * All functions are worklet-safe for UI-thread execution.
  */
@@ -56,6 +57,13 @@ export interface SpawnParams {
   baseRot: number;
   /** Total number of slots in the ring buffer. */
   slots: number;
+  /**
+   * Color list index written to every particle in this burst. Use a fixed value
+   * (e.g. a series index) to color the whole burst uniformly, or `-1` to cycle
+   * the renderer's color list per particle (the particle's loop index is stored).
+   * Defaults to `-1`.
+   */
+  colorIndex?: number;
 }
 
 /** Write `p.burst` particles into the ring buffer starting at `p.baseRot`. Returns the next rotation index. */
@@ -63,6 +71,7 @@ export function spawnBurst(buf: Float64Array, p: SpawnParams): number {
   "worklet";
   const stride = DEGEN_STRIDE;
   const rot = p.baseRot;
+  const colorIndex = p.colorIndex ?? -1;
   for (let k = 0; k < p.burst; k++) {
     const slot = (rot + k) % p.slots;
     const b = slot * stride;
@@ -77,6 +86,8 @@ export function spawnBurst(buf: Float64Array, p: SpawnParams): number {
     buf[b + 5] = 1;
     buf[b + 6] =
       (p.szMin + hash(k + 400, p.now * 1000) * (p.szMax - p.szMin)) * p.sc;
+    // Fixed index colors the whole burst; -1 cycles per particle via k.
+    buf[b + 7] = colorIndex < 0 ? k : colorIndex;
   }
   return (rot + p.burst) % p.slots;
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -327,6 +327,24 @@ export interface MultiSeriesDotConfig {
   valueLabel?: boolean;
 }
 
+/** Visual style overrides for the legend (toggle chips). All fields optional. */
+export interface LegendStyle {
+  /** Font size for chip labels (px). Default `13` (`11` when compact). */
+  fontSize?: number;
+  /** Chip corner radius (px). Default `8`. */
+  borderRadius?: number;
+  /** Colored swatch diameter (px). Default `8`. */
+  dotSize?: number;
+  /** Chip background when the series is visible. */
+  activeBackground?: string;
+  /** Chip background when the series is hidden. */
+  hiddenBackground?: string;
+  /** Label color when the series is visible. */
+  activeColor?: string;
+  /** Label color when the series is hidden. */
+  hiddenColor?: string;
+}
+
 /** Legend (toggle chips) configuration for multi-series charts. */
 export interface LegendConfig {
   /** Show the legend. Default `true`. */
@@ -335,6 +353,8 @@ export interface LegendConfig {
   compact?: boolean;
   /** Position of the legend relative to the chart. Default `"top"`. */
   position?: "top" | "bottom";
+  /** Visual style overrides for the chip row. */
+  style?: LegendStyle;
 }
 
 /** Configuration for a single series in a multi-series chart. */
@@ -351,6 +371,21 @@ export interface SeriesConfig {
   label?: string;
   /** Whether this series is visible. Default `true`. */
   visible?: boolean;
+  /** Stroke style. `"dashed"` applies `intervals`. Default `"solid"`. */
+  style?: "solid" | "dashed";
+  /** Dash pattern as `[dashLength, gapLength]` when `style` is `"dashed"`. Default `[6, 4]`. */
+  intervals?: [number, number];
+  /** Per-series stroke width override (px). Falls back to the chart line width. */
+  strokeWidth?: number;
+  /** Render a soft glow behind this series' line. Default `false`. */
+  glow?: boolean;
+  /**
+   * Semantic role. `"derived"` series (e.g. a conviction trajectory) render a
+   * subdued / dashed legend chip. Default `"outcome"`.
+   */
+  kind?: "outcome" | "derived";
+  /** Value text shown next to the label inside the legend chip. */
+  valueLabel?: string;
 }
 
 /** Per-series value at a scrub position, used in the multi-series `onScrub` callback. */
@@ -547,6 +582,13 @@ export interface LiveChartSeriesProps extends LiveChartCoreProps {
   dot?: MultiSeriesDotConfig;
   /** Legend (toggle chips) configuration. `true` = defaults, `false` = hidden, or pass `LegendConfig`. Default `true`. */
   legend?: boolean | LegendConfig;
+  /**
+   * Degen mode — chart shake + a spark burst off the leading series' dot on an
+   * upward momentum swing. `true` = defaults, or pass `DegenOptions`. Default off.
+   */
+  degen?: boolean | DegenOptions;
+  /** Called on the JS thread when a degen chart shake starts. */
+  onDegenShake?: (payload: DegenShakePayload) => void;
   /**
    * Worklet callback fired on the UI thread each frame while scrubbing.
    * `null` when scrub ends. Update shared values directly — no bridge overhead.

--- a/packages/react-native-livechart/tests/components/MultiSeriesStroke.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesStroke.test.tsx
@@ -1,0 +1,57 @@
+import { Skia } from "@shopify/react-native-skia";
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { useSharedValue } from "react-native-reanimated";
+import { MultiSeriesStroke } from "../../src/components/MultiSeriesStroke";
+import type { SeriesLineStyle } from "../../src/core/multiSeriesLayout";
+import type { SeriesConfig } from "../../src/types";
+
+function StrokeFixture({ lineStyle }: { lineStyle?: SeriesLineStyle }) {
+  const paths = useSharedValue([Skia.Path.Make()]);
+  const opacities = useSharedValue([1]);
+  const series = useSharedValue<SeriesConfig[]>([
+    { id: "a", data: [], value: 1, color: "#3b82f6" },
+  ]);
+  return (
+    <MultiSeriesStroke
+      index={0}
+      paths={paths}
+      opacities={opacities}
+      series={series}
+      strokeWidth={2}
+      lineStyle={lineStyle}
+    />
+  );
+}
+
+describe("MultiSeriesStroke", () => {
+  it("renders a plain solid stroke with no lineStyle", () => {
+    render(<StrokeFixture />);
+  });
+
+  it("renders a dashed stroke with a per-series width", () => {
+    render(
+      <StrokeFixture
+        lineStyle={{
+          strokeWidth: 4,
+          dashed: true,
+          intervals: [6, 4],
+          glow: false,
+        }}
+      />,
+    );
+  });
+
+  it("renders a glowing stroke", () => {
+    render(
+      <StrokeFixture
+        lineStyle={{
+          strokeWidth: undefined,
+          dashed: false,
+          intervals: [6, 4],
+          glow: true,
+        }}
+      />,
+    );
+  });
+});

--- a/packages/react-native-livechart/tests/components/SeriesToggleChips.test.tsx
+++ b/packages/react-native-livechart/tests/components/SeriesToggleChips.test.tsx
@@ -21,6 +21,7 @@ const DEFAULT_LEGEND: ResolvedLegendConfig = {
   visible: true,
   compact: false,
   position: "top",
+  style: undefined,
 };
 
 function ChipsHarness({
@@ -173,5 +174,42 @@ describe("SeriesToggleChips", () => {
     const screen = render(<NoColorHarness />);
     await flushScheduleOnRN();
     expect(screen.getByText("Plain")).toBeTruthy();
+  });
+
+  it("applies style overrides and renders valueLabel + derived kind", async () => {
+    function StyledHarness() {
+      const series = useSharedValue<SeriesConfig[]>([
+        {
+          id: "yes",
+          label: "Yes",
+          data: [],
+          value: 1,
+          color: "#22c55e",
+          valueLabel: "62%",
+          kind: "derived",
+        },
+      ]);
+      return (
+        <SeriesToggleChips
+          series={series}
+          legend={{
+            ...DEFAULT_LEGEND,
+            style: {
+              fontSize: 16,
+              borderRadius: 20,
+              dotSize: 12,
+              activeBackground: "#101010",
+              activeColor: "#ffffff",
+            },
+          }}
+        />
+      );
+    }
+    const screen = render(<StyledHarness />);
+    await flushScheduleOnRN();
+    // valueLabel renders as a nested <Text>, so the chip's text node reads
+    // "Yes 62%" — match with regexes rather than exact strings.
+    expect(screen.getByText(/Yes/)).toBeTruthy();
+    expect(screen.getByText(/62%/)).toBeTruthy();
   });
 });

--- a/packages/react-native-livechart/tests/hooks/useMultiSeriesDegen.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useMultiSeriesDegen.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook } from "@testing-library/react-native";
+import { useSharedValue } from "react-native-reanimated";
+
+import { resolveDegen } from "../../src/core/resolveConfig";
+import { useLiveChartSeriesEngine } from "../../src/core/useLiveChartSeriesEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import { useMultiSeriesDegen } from "../../src/hooks/useMultiSeriesDegen";
+import type { SeriesConfig } from "../../src/types";
+
+function useMakeEngine() {
+  const series = useSharedValue<SeriesConfig[]>([
+    {
+      id: "a",
+      data: [{ time: 1_700_000_000, value: 50 }],
+      value: 50,
+      color: "#3b82f6",
+    },
+  ]);
+  return useLiveChartSeriesEngine({ series, timeWindow: 100, smoothing: 0.08 });
+}
+
+describe("useMultiSeriesDegen", () => {
+  it("returns pack / packRevision / shakeTransform when enabled", () => {
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      return useMultiSeriesDegen(engine, DEFAULT_PADDING, resolveDegen(true));
+    });
+    expect(result.current.pack.value).toBeInstanceOf(Float64Array);
+    expect(result.current.packRevision).toBeDefined();
+    expect(result.current.shakeTransform).toBeDefined();
+  });
+
+  it("returns a pack when cfg is null (disabled)", () => {
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      return useMultiSeriesDegen(engine, DEFAULT_PADDING, null);
+    });
+    expect(result.current.pack.value).toBeInstanceOf(Float64Array);
+  });
+
+  it("accepts shake:false, downMomentum:true and an onShake callback", () => {
+    const onShake = jest.fn();
+    const { result } = renderHook(() => {
+      const engine = useMakeEngine();
+      return useMultiSeriesDegen(
+        engine,
+        DEFAULT_PADDING,
+        resolveDegen({ shake: false, downMomentum: true }),
+        onShake,
+      );
+    });
+    expect(result.current.shakeTransform).toBeDefined();
+  });
+});

--- a/packages/react-native-livechart/tests/math/degenTick.test.ts
+++ b/packages/react-native-livechart/tests/math/degenTick.test.ts
@@ -62,6 +62,22 @@ describe("spawnBurst", () => {
     }
   });
 
+  it("cycles colorIndex per particle when colorIndex is -1 (default)", () => {
+    const buf = new Float64Array(20 * DEGEN_STRIDE);
+    spawnBurst(buf, makeParams({ burst: 5 }));
+    for (let k = 0; k < 5; k++) {
+      expect(buf[k * DEGEN_STRIDE + 7]).toBe(k);
+    }
+  });
+
+  it("writes a fixed colorIndex to every particle when set", () => {
+    const buf = new Float64Array(20 * DEGEN_STRIDE);
+    spawnBurst(buf, makeParams({ burst: 5, colorIndex: 3 }));
+    for (let k = 0; k < 5; k++) {
+      expect(buf[k * DEGEN_STRIDE + 7]).toBe(3);
+    }
+  });
+
   it("returns updated rotation", () => {
     const buf = new Float64Array(20 * DEGEN_STRIDE);
     const rot = spawnBurst(

--- a/packages/react-native-livechart/tests/multiSeriesLayout.test.ts
+++ b/packages/react-native-livechart/tests/multiSeriesLayout.test.ts
@@ -1,6 +1,8 @@
 import {
   lineColorsSignatureFromArray,
+  lineStyleSignatureFromArray,
   resolveMultiSeriesLineColorsSnapshot,
+  resolveMultiSeriesLineStylesSnapshot,
 } from "../src/core/multiSeriesLayout";
 
 import { MAX_MULTI_SERIES } from "../src/constants";
@@ -46,5 +48,70 @@ describe("resolveMultiSeriesLineColorsSnapshot", () => {
     const snap = resolveMultiSeriesLineColorsSnapshot(many);
     expect(snap[0]).toBe(SERIES_COLORS[0 % SERIES_COLORS.length]);
     expect(snap[1]).toBe(SERIES_COLORS[1 % SERIES_COLORS.length]);
+  });
+});
+
+describe("lineStyleSignatureFromArray", () => {
+  it("encodes style / strokeWidth / glow / intervals per series", () => {
+    const a: SeriesConfig[] = [
+      {
+        id: "a",
+        data: [],
+        value: 1,
+        style: "dashed",
+        strokeWidth: 3,
+        glow: true,
+        intervals: [6, 4],
+      },
+      { id: "b", data: [], value: 2 },
+    ];
+    expect(lineStyleSignatureFromArray(a)).toBe(
+      "a\x1fdashed\x1f3\x1f1\x1f6,4\x1eb\x1f\x1f\x1f0\x1f",
+    );
+  });
+
+  it("changes when a style field changes", () => {
+    const solid: SeriesConfig[] = [{ id: "a", data: [], value: 1 }];
+    const dashed: SeriesConfig[] = [
+      { id: "a", data: [], value: 1, style: "dashed" },
+    ];
+    expect(lineStyleSignatureFromArray(solid)).not.toBe(
+      lineStyleSignatureFromArray(dashed),
+    );
+  });
+});
+
+describe("resolveMultiSeriesLineStylesSnapshot", () => {
+  it("resolves dashed / width / glow and pads empty slots with defaults", () => {
+    const a: SeriesConfig[] = [
+      {
+        id: "a",
+        data: [],
+        value: 1,
+        style: "dashed",
+        strokeWidth: 4,
+        glow: true,
+        intervals: [2, 2],
+      },
+    ];
+    const snap = resolveMultiSeriesLineStylesSnapshot(a, 2);
+    expect(snap[0]).toEqual({
+      strokeWidth: 4,
+      dashed: true,
+      intervals: [2, 2],
+      glow: true,
+    });
+    expect(snap[1]).toEqual({
+      strokeWidth: undefined,
+      dashed: false,
+      intervals: [6, 4],
+      glow: false,
+    });
+  });
+
+  it("defaults to MAX_MULTI_SERIES length", () => {
+    expect(resolveMultiSeriesLineStylesSnapshot([]).length).toBe(
+      MAX_MULTI_SERIES,
+    );
   });
 });


### PR DESCRIPTION
Phase 2 of the @morfi/chart feature-parity work (stacked on phase 1).

- Per-series styling on SeriesConfig: style (solid/dashed), intervals,
  strokeWidth, glow, kind ('outcome'|'derived'), valueLabel. Rendered via a
  lineStyles snapshot synced off the series SharedValue (MultiSeriesStroke
  gains dash + per-series width + soft glow).
- Multi-series degen: degen + onDegenShake on LiveChartSeriesProps. New
  useMultiSeriesDegen hook reuses the degenTick math — a shared chart shake +
  a spark burst off the leading (highest-value visible) series' dot on an
  up-swing.
- Legend styling: LegendConfig.style (fontSize/borderRadius/dotSize/colors);
  SeriesToggleChips renders valueLabel and a subdued 'derived' chip.

Playground: multi-series page gains Styled lines / Legend style / Degen toggles.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>