### PR TITLE
feat(chart): live-value overlay + crosshair tooltip styling

### DIFF
--- a/app/demo/badge-pulse.tsx
+++ b/app/demo/badge-pulse.tsx
@@ -42,6 +42,8 @@ function resolvePulse(mode: PulseMode): boolean | PulseConfig {
 export default function BadgePulseScreen() {
   const [badgeMode, setBadgeMode] = useState<BadgeMode>("on");
   const [pulseMode, setPulseMode] = useState<PulseMode>("on");
+  const [showValue, setShowValue] = useState(false);
+  const [valueMomentumColor, setValueMomentumColor] = useState(false);
 
   const { data, value } = useSimulatedChartData({
     multiSeries: false,
@@ -60,6 +62,8 @@ export default function BadgePulseScreen() {
           theme="dark"
           badge={resolveBadge(badgeMode)}
           pulse={resolvePulse(pulseMode)}
+          showValue={showValue}
+          valueMomentumColor={valueMomentumColor}
           scrub={false}
         />
       }
@@ -117,6 +121,36 @@ export default function BadgePulseScreen() {
             </Text>
           </Pressable>
         ))}
+      </View>
+
+      <Text style={demoStyles.sectionLabel}>Live value overlay</Text>
+      <View style={demoStyles.buttonRow}>
+        <Pressable
+          style={[demoStyles.chip, showValue && demoStyles.chipActive]}
+          onPress={() => setShowValue((v) => !v)}
+        >
+          <Text
+            style={[demoStyles.chipText, showValue && demoStyles.chipTextActive]}
+          >
+            showValue
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[
+            demoStyles.chip,
+            valueMomentumColor && demoStyles.chipActive,
+          ]}
+          onPress={() => setValueMomentumColor((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              valueMomentumColor && demoStyles.chipTextActive,
+            ]}
+          >
+            Momentum color
+          </Text>
+        </Pressable>
       </View>
     </DemoScreen>
   );

--- a/app/demo/scrub.tsx
+++ b/app/demo/scrub.tsx
@@ -12,6 +12,7 @@ export const options = { title: "Scrub" };
 export default function ScrubScreen() {
   const [scrubMode, setScrubMode] = useState<"off" | "on" | "noTooltip">("on");
   const [displayMode, setDisplayMode] = useState<"line" | "candle">("line");
+  const [styledTooltip, setStyledTooltip] = useState(false);
   const [readout, setReadout] = useState("—");
 
   const windowSecs = 300;
@@ -27,9 +28,17 @@ export default function ScrubScreen() {
   const scrub =
     scrubMode === "off"
       ? false
-      : scrubMode === "on"
-        ? true
-        : { tooltip: false };
+      : scrubMode === "noTooltip"
+        ? { tooltip: false }
+        : styledTooltip
+          ? {
+              tooltip: true,
+              tooltipBackground: "#1e293b",
+              tooltipColor: "#fbbf24",
+              tooltipBorderColor: "#fbbf24",
+              crosshairLineColor: "#fbbf24",
+            }
+          : true;
 
   return (
     <DemoScreen
@@ -91,6 +100,19 @@ export default function ScrubScreen() {
             </Text>
           </Pressable>
         ))}
+        <Pressable
+          style={[demoStyles.chip, styledTooltip && demoStyles.chipActive]}
+          onPress={() => setStyledTooltip((v) => !v)}
+        >
+          <Text
+            style={[
+              demoStyles.chipText,
+              styledTooltip && demoStyles.chipTextActive,
+            ]}
+          >
+            Styled tooltip
+          </Text>
+        </Pressable>
       </View>
 
       <Text style={demoStyles.sectionLabel}>Display</Text>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -36,7 +36,7 @@ const DEMOS: { href: Href; title: string; blurb: string }[] = [
   {
     href: "/demo/badge-pulse",
     title: "Badge & pulse",
-    blurb: "Badge variants and pulse / PulseConfig.",
+    blurb: "Badge variants, pulse, showValue overlay + momentum color.",
   },
   {
     href: "/demo/momentum",
@@ -47,7 +47,7 @@ const DEMOS: { href: Href; title: string; blurb: string }[] = [
   {
     href: "/demo/scrub",
     title: "Scrub",
-    blurb: "Scrub modes, onScrub readout, candle OHLC payload.",
+    blurb: "Scrub modes, styled tooltip, onScrub readout, candle OHLC.",
   },
   {
     href: "/demo/horizontal-lines",

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -27,6 +27,9 @@ export function CrosshairOverlay({
   tooltipBody,
   crosshairLineColor,
   crosshairDimColor,
+  tooltipBackground,
+  tooltipColor,
+  tooltipBorderColor,
 }: {
   scrubX: SharedValue<number>;
   crosshairOpacity: SharedValue<number>;
@@ -39,6 +42,9 @@ export function CrosshairOverlay({
   tooltipBody?: ReactNode;
   crosshairLineColor?: string;
   crosshairDimColor?: string;
+  tooltipBackground?: string;
+  tooltipColor?: string;
+  tooltipBorderColor?: string;
 }) {
   const p1 = useDerivedValue(() => ({
     x: scrubX.value,
@@ -94,7 +100,7 @@ export function CrosshairOverlay({
             width={tipW}
             height={tipH}
             r={TOOLTIP_RADIUS}
-            color={palette.tooltipBg}
+            color={tooltipBackground ?? palette.tooltipBg}
           />
 
           <RoundedRect
@@ -103,7 +109,7 @@ export function CrosshairOverlay({
             width={tipW}
             height={tipH}
             r={TOOLTIP_RADIUS}
-            color={palette.tooltipBorder}
+            color={tooltipBorderColor ?? palette.tooltipBorder}
             style="stroke"
             strokeWidth={1}
           />
@@ -115,7 +121,7 @@ export function CrosshairOverlay({
                 y={line1Y}
                 text={valueStr}
                 font={font}
-                color={palette.tooltipText}
+                color={tooltipColor ?? palette.tooltipText}
               />
               <SkiaText
                 x={timeTextX}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -72,6 +72,7 @@ import { LeftEdgeFade } from "./LeftEdgeFade";
 import { LoadingOverlay } from "./LoadingOverlay";
 import { MarkerOverlay } from "./MarkerOverlay";
 import { MultiSeriesTooltipStack } from "./MultiSeriesTooltipStack";
+import { ValueTextOverlay } from "./ValueTextOverlay";
 import { ReferenceLineOverlay } from "./ReferenceLineOverlay";
 import { TradeStreamOverlay } from "./TradeStreamOverlay";
 import { ValueLineOverlay } from "./ValueLineOverlay";
@@ -117,6 +118,8 @@ export function LiveChart({
   momentum = true,
   pulse = true,
   valueLine = true,
+  showValue = false,
+  valueMomentumColor = false,
   referenceLine,
   referenceLines,
   gridStyle,
@@ -182,6 +185,13 @@ export function LiveChart({
     fontProp,
     MONO_FONT_FAMILY,
     palette.labelFontSize,
+  );
+
+  // Larger font for the optional live-value text overlay (showValue).
+  const valueFont = useChartSkiaFont(
+    fontProp,
+    MONO_FONT_FAMILY,
+    palette.valueFontSize * 2,
   );
 
   const pulseConfig = pulseCfg
@@ -508,6 +518,20 @@ export function LiveChart({
               </Group>
             )}
 
+            {showValue && (
+              <Group opacity={reveal.lineOpacity}>
+                <ValueTextOverlay
+                  engine={engine}
+                  padding={effectivePadding}
+                  palette={palette}
+                  font={valueFont}
+                  formatValue={formatValue}
+                  momentum={momentumSV}
+                  momentumColor={valueMomentumColor}
+                />
+              </Group>
+            )}
+
             {markersActive && (
               <Group opacity={reveal.dotOpacity}>
                 <MarkerOverlay
@@ -571,6 +595,9 @@ export function LiveChart({
                   showTooltip={scrubCfg.tooltip}
                   crosshairLineColor={scrubCfg.crosshairLineColor}
                   crosshairDimColor={scrubCfg.crosshairDimColor}
+                  tooltipBackground={scrubCfg.tooltipBackground}
+                  tooltipColor={scrubCfg.tooltipColor}
+                  tooltipBorderColor={scrubCfg.tooltipBorderColor}
                   tooltipBody={
                     isCandle ? (
                       <MultiSeriesTooltipStack

--- a/packages/react-native-livechart/src/components/ValueTextOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ValueTextOverlay.tsx
@@ -1,0 +1,43 @@
+import { Text as SkiaText, type SkFont } from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import type { ChartEngineWithLiveValue } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import type { LiveChartPalette, Momentum } from "../types";
+
+/**
+ * Large live-value text rendered in the top-left of the plot. Tracks the
+ * engine's smoothed display value on the UI thread; optionally tinted by
+ * momentum (green up / red down / accent flat).
+ */
+export function ValueTextOverlay({
+  engine,
+  padding,
+  palette,
+  font,
+  formatValue,
+  momentum,
+  momentumColor,
+}: {
+  engine: ChartEngineWithLiveValue;
+  padding: ChartPadding;
+  palette: LiveChartPalette;
+  font: SkFont;
+  formatValue: (v: number) => string;
+  momentum?: SharedValue<Momentum>;
+  momentumColor: boolean;
+}) {
+  const text = useDerivedValue(() => formatValue(engine.displayValue.value));
+
+  const color = useDerivedValue(() => {
+    if (!momentumColor || !momentum) return palette.line;
+    const m = momentum.value;
+    if (m === "up") return palette.dotUp;
+    if (m === "down") return palette.dotDown;
+    return palette.dotFlat;
+  });
+
+  const x = padding.left + 6;
+  const y = padding.top + font.getSize();
+
+  return <SkiaText x={x} y={y} text={text} font={font} color={color} />;
+}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -52,6 +52,12 @@ export interface ResolvedScrubConfig {
   crosshairLineColor: string | undefined;
   /** undefined → palette.crosshairDim */
   crosshairDimColor: string | undefined;
+  /** undefined → palette.tooltipBg */
+  tooltipBackground: string | undefined;
+  /** undefined → palette.tooltipText */
+  tooltipColor: string | undefined;
+  /** undefined → palette.tooltipBorder */
+  tooltipBorderColor: string | undefined;
 }
 
 export interface ResolvedGradientConfig {
@@ -200,6 +206,9 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltip: true,
   crosshairLineColor: undefined,
   crosshairDimColor: undefined,
+  tooltipBackground: undefined,
+  tooltipColor: undefined,
+  tooltipBorderColor: undefined,
 };
 
 /**

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -184,6 +184,12 @@ export interface ScrubConfig {
   crosshairLineColor?: string;
   /** Dimmed region fill to the right of the crosshair. Omit to use theme `crosshairDim`. */
   crosshairDimColor?: string;
+  /** Tooltip pill background. Omit to use theme `tooltipBg`. */
+  tooltipBackground?: string;
+  /** Tooltip text color. Omit to use theme `tooltipText`. */
+  tooltipColor?: string;
+  /** Tooltip pill border color. Omit to use theme `tooltipBorder`. */
+  tooltipBorderColor?: string;
 }
 
 /** Left-edge fade — soft erase so the chart blends into the left gutter (web liveline parity). */
@@ -592,6 +598,10 @@ export interface LiveChartProps extends LiveChartCoreProps {
   pulse?: boolean | PulseConfig;
   /** Horizontal dashed line at the current live value. `true` = defaults, or pass `ValueLineConfig`. */
   valueLine?: boolean | ValueLineConfig;
+  /** Render the live value as a large text overlay in the top-left. Default `false`. */
+  showValue?: boolean;
+  /** Tint the `showValue` text by momentum (green up / red down). Default `false`. */
+  valueMomentumColor?: boolean;
 
   // ── Candlestick mode ──────────────────────────────────────────────────
   /** Chart display mode (default `"line"`). `"candle"` renders OHLC bars. */

--- a/packages/react-native-livechart/tests/components/ValueTextOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ValueTextOverlay.test.tsx
@@ -1,0 +1,67 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { useSharedValue } from "react-native-reanimated";
+import type { ChartEngineWithLiveValue } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import { ValueTextOverlay } from "../../src/components/ValueTextOverlay";
+import { resolveTheme } from "../../src/theme";
+import type { Momentum } from "../../src/types";
+
+const palette = resolveTheme("#3b82f6", "dark");
+const font = {
+  getSize: () => 22,
+  measureText: (s: string) => ({ x: 0, y: 0, width: s.length * 12, height: 22 }),
+  getMetrics: () => ({ ascent: -18, descent: 4, leading: 0 }),
+} as never;
+
+function engine(): ChartEngineWithLiveValue {
+  return {
+    displayMin: { value: 0 },
+    displayMax: { value: 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: 300 },
+    timestamp: { value: 1000 },
+    displayValue: { value: 42.5 },
+  } as unknown as ChartEngineWithLiveValue;
+}
+
+const fmt = (v: number) => v.toFixed(2);
+
+describe("ValueTextOverlay", () => {
+  it("renders the value without momentum coloring", () => {
+    function Fixture() {
+      return (
+        <ValueTextOverlay
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          formatValue={fmt}
+          momentumColor={false}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("tints by momentum when momentumColor is set", () => {
+    function Fixture({ m }: { m: Momentum }) {
+      const momentum = useSharedValue<Momentum>(m);
+      return (
+        <ValueTextOverlay
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          formatValue={fmt}
+          momentum={momentum}
+          momentumColor
+        />
+      );
+    }
+    render(<Fixture m="up" />);
+    render(<Fixture m="down" />);
+    render(<Fixture m="flat" />);
+  });
+});


### PR DESCRIPTION
Phase 4 of the @morfi/chart feature-parity work (stacked on phase 3).

- showValue + valueMomentumColor on LiveChart: a large live-value text
  overlay (top-left), optionally tinted by momentum (green up / red down /
  accent flat). New ValueTextOverlay reads the engine's smoothed value on the
  UI thread; rendered with a 2x label font.
- Crosshair tooltip styling: ScrubConfig gains tooltipBackground /
  tooltipColor / tooltipBorderColor, threaded through CrosshairOverlay
  (fall back to the theme palette). The line-only layout is already available
  via scrub={{ tooltip: false }}.

Playground: badge-pulse gains showValue + momentum-color toggles; scrub gains
a Styled tooltip toggle.

Note: the multi-series per-series-pill crosshair layout (the larger half of
this phase in the plan) is tracked as a follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>