### PR TITLE
feat(chart): windowBuffer/nowOverride, a11y props, transition wrapper

### DIFF
--- a/app/demo/historical-data.tsx
+++ b/app/demo/historical-data.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { LiveChart, type LiveChartPoint } from "react-native-livechart";
+import { useSharedValue } from "react-native-reanimated";
+
+import { DemoScreen } from "./lib/DemoScreen";
+import { ACCENT } from "./lib/shared";
+import { demoStyles } from "./lib/styles";
+
+export const options = { title: "Historical data fill" };
+
+const SPAN = 600; // 10 minutes of history
+const COUNT = 150;
+
+function seedHistory(endTime: number): LiveChartPoint[] {
+  const out: LiveChartPoint[] = [];
+  let v = 100;
+  for (let i = 0; i < COUNT; i++) {
+    v += (Math.random() - 0.48) * 2;
+    out.push({ time: endTime - SPAN + (i / (COUNT - 1)) * SPAN, value: v });
+  }
+  return out;
+}
+
+export default function HistoricalDataScreen() {
+  const [buffer, setBuffer] = useState(0);
+
+  // A fixed historical dataset seeded once; maxT is the latest sample.
+  const seed = useMemo(() => {
+    const maxT = Date.now() / 1000;
+    return { points: seedHistory(maxT), maxT };
+  }, []);
+
+  const data = useSharedValue<LiveChartPoint[]>(seed.points);
+  const value = useSharedValue(seed.points[seed.points.length - 1].value);
+
+  return (
+    <DemoScreen
+      description="nowOverride + windowBuffer — fill a fixed historical span edge-to-edge"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme="dark"
+          timeWindow={SPAN}
+          nowOverride={seed.maxT}
+          windowBuffer={buffer}
+          scrub={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Window buffer</Text>
+      <Text style={[demoStyles.chipText, { opacity: 0.6, marginBottom: 8 }]}>
+        nowOverride pins the latest sample as &quot;now&quot;. buffer=0 fills the
+        canvas; larger buffers pull the data left, off the right edge.
+      </Text>
+      <View style={demoStyles.buttonRow}>
+        {[
+          { label: "0 (fill)", value: 0 },
+          { label: "0.1", value: 0.1 },
+          { label: "0.3", value: 0.3 },
+          { label: "0.5", value: 0.5 },
+        ].map((b) => (
+          <Pressable
+            key={b.label}
+            style={[demoStyles.chip, buffer === b.value && demoStyles.chipActive]}
+            onPress={() => setBuffer(b.value)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                buffer === b.value && demoStyles.chipTextActive,
+              ]}
+            >
+              {b.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}

--- a/app/demo/transitions.tsx
+++ b/app/demo/transitions.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { LiveChart, LiveChartTransition } from "react-native-livechart";
+
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+import { DemoScreen } from "./lib/DemoScreen";
+import { ACCENT } from "./lib/shared";
+import { demoStyles } from "./lib/styles";
+
+export const options = { title: "Transitions" };
+
+const WINDOW = 300;
+const CANDLE_WIDTH = 15;
+
+type Example = "mode" | "crossfade";
+
+export default function TransitionsScreen() {
+  const [example, setExample] = useState<Example>("mode");
+  const [mode, setMode] = useState<"line" | "candle">("line");
+  const [accent, setAccent] = useState<"blue" | "violet">("blue");
+
+  const { data, value, candles, liveCandle } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: true,
+    tradeStream: false,
+    candleWidth: CANDLE_WIDTH,
+  });
+
+  return (
+    <DemoScreen
+      description="Line↔candle uses one chart's mode prop (shared y-axis morph); LiveChartTransition cross-fades two instances"
+      chart={
+        example === "mode" ? (
+          // Built-in line↔candle morph — ONE engine, so the y-axis eases
+          // smoothly between the line and candle ranges (no re-reveal).
+          <LiveChart
+            data={data}
+            value={value}
+            mode={mode}
+            candles={candles}
+            liveCandle={liveCandle}
+            candleWidth={CANDLE_WIDTH}
+            accentColor={ACCENT}
+            theme="dark"
+            timeWindow={WINDOW}
+            accessibilityLabel={`Price ${mode} chart`}
+            scrub={false}
+          />
+        ) : (
+          // Cross-fade between two instances. keepMounted lets both settle their
+          // y-range up front, so switching is a pure opacity fade. Same data +
+          // scale, so the two layers line up.
+          <LiveChartTransition active={accent} duration={350} keepMounted>
+            <LiveChart
+              key="blue"
+              data={data}
+              value={value}
+              accentColor="#3b82f6"
+              theme="dark"
+              timeWindow={WINDOW}
+              scrub={false}
+            />
+            <LiveChart
+              key="violet"
+              data={data}
+              value={value}
+              accentColor="#a855f7"
+              theme="dark"
+              timeWindow={WINDOW}
+              scrub={false}
+            />
+          </LiveChartTransition>
+        )
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>Example</Text>
+      <View style={demoStyles.buttonRow}>
+        {(
+          [
+            ["mode", "Line ↔ Candle (mode)"],
+            ["crossfade", "Cross-fade (transition)"],
+          ] as const
+        ).map(([k, label]) => (
+          <Pressable
+            key={k}
+            style={[demoStyles.chip, example === k && demoStyles.chipActive]}
+            onPress={() => setExample(k)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                example === k && demoStyles.chipTextActive,
+              ]}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {example === "mode" ? (
+        <>
+          <Text style={demoStyles.sectionLabel}>Mode</Text>
+          <View style={demoStyles.buttonRow}>
+            {(["line", "candle"] as const).map((m) => (
+              <Pressable
+                key={m}
+                style={[demoStyles.chip, mode === m && demoStyles.chipActive]}
+                onPress={() => setMode(m)}
+              >
+                <Text
+                  style={[
+                    demoStyles.chipText,
+                    mode === m && demoStyles.chipTextActive,
+                  ]}
+                >
+                  {m}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            One LiveChart with a toggled mode — the engine morphs line↔candle and
+            the y-axis eases between the two ranges (no re-reveal).
+          </Text>
+        </>
+      ) : (
+        <>
+          <Text style={demoStyles.sectionLabel}>Active layer</Text>
+          <View style={demoStyles.buttonRow}>
+            {(["blue", "violet"] as const).map((a) => (
+              <Pressable
+                key={a}
+                style={[demoStyles.chip, accent === a && demoStyles.chipActive]}
+                onPress={() => setAccent(a)}
+              >
+                <Text
+                  style={[
+                    demoStyles.chipText,
+                    accent === a && demoStyles.chipTextActive,
+                  ]}
+                >
+                  {a}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            LiveChartTransition cross-fades two chart instances (here: accent
+            color). keepMounted pre-settles both so there is no re-reveal.
+          </Text>
+        </>
+      )}
+    </DemoScreen>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -79,6 +79,16 @@ const DEMOS: { href: Href; title: string; blurb: string }[] = [
     title: "Multi-series",
     blurb: "Per-series style, degen, legend styling, toggles, scrub.",
   },
+  {
+    href: "/demo/historical-data",
+    title: "Historical data fill",
+    blurb: "nowOverride + windowBuffer: fill a fixed span edge-to-edge.",
+  },
+  {
+    href: "/demo/transitions",
+    title: "Transitions",
+    blurb: "LiveChartTransition cross-fade between line and candle.",
+  },
 ];
 
 export default function Index() {

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -107,6 +107,10 @@ export function LiveChart({
   exaggerate = false,
   nonNegative = false,
   maxValue,
+  windowBuffer = 0,
+  nowOverride,
+  accessibilityLabel,
+  accessibilityRole = "image",
   emptyText = "No data",
   formatValue = defaultFormatValue,
   formatTime = defaultFormatTime,
@@ -251,6 +255,8 @@ export function LiveChart({
     referenceValues: refValues,
     nonNegative,
     maxValue,
+    windowBuffer,
+    nowOverride,
     mode,
     candles: isCandle ? candlesEngine : candles,
     liveCandle: isCandle ? liveEngine : liveCandle,
@@ -381,7 +387,13 @@ export function LiveChart({
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <GestureDetector gesture={rootGesture}>
-      <View style={[{ flex: 1, backgroundColor }, style]} onLayout={onLayout}>
+      <View
+        style={[{ flex: 1, backgroundColor }, style]}
+        onLayout={onLayout}
+        accessible={accessibilityLabel != null}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole={accessibilityRole}
+      >
         <Canvas style={{ flex: 1 }}>
           {/* Shaken chart stack — left-edge fade is a sibling below so dstOut runs in canvas space */}
           <Group transform={degenShakeTransform}>

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -94,6 +94,10 @@ export function LiveChartSeries({
   exaggerate = false,
   nonNegative = false,
   maxValue,
+  windowBuffer = 0,
+  nowOverride,
+  accessibilityLabel,
+  accessibilityRole = "image",
   emptyText = "No data",
   formatValue = defaultFormatValue,
   formatTime = defaultFormatTime,
@@ -223,6 +227,8 @@ export function LiveChartSeries({
     referenceValues: refValues,
     nonNegative,
     maxValue,
+    windowBuffer,
+    nowOverride,
   });
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
   const linePaths = useMultiSeriesLinePaths(engine, effectivePadding);
@@ -337,7 +343,13 @@ export function LiveChartSeries({
 
   return (
     <GestureDetector gesture={rootGesture}>
-      <View style={[{ flex: 1, backgroundColor }, style]} onLayout={onLayout}>
+      <View
+        style={[{ flex: 1, backgroundColor }, style]}
+        onLayout={onLayout}
+        accessible={accessibilityLabel != null}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole={accessibilityRole}
+      >
         {legendTop}
         <Canvas style={{ flex: 1, minHeight: layoutHeight || 1 }}>
           <Group transform={degenShakeTransform}>

--- a/packages/react-native-livechart/src/components/LiveChartTransition.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartTransition.tsx
@@ -1,0 +1,113 @@
+import {
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { StyleSheet, View, type ViewStyle } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+export interface LiveChartTransitionProps {
+  /** Key of the active child to show. Must match a child's `key`. */
+  active: string;
+  /** Chart elements, each with a unique `key`. */
+  children: ReactNode;
+  /** Cross-fade duration in ms. Default `300`. */
+  duration?: number;
+  /**
+   * Keep every child mounted for the lifetime of the transition (only the
+   * opacity animates). Each chart's engine then settles its y-range once, up
+   * front, so switching is a pure cross-fade with no reveal/range re-animation.
+   * Costs more (all engines run continuously). Default `false` (mount the
+   * active child + unmount the outgoing one after the fade).
+   */
+  keepMounted?: boolean;
+  /** Container style. */
+  style?: ViewStyle;
+}
+
+function FadeLayer({
+  visible,
+  duration,
+  children,
+}: {
+  visible: boolean;
+  duration: number;
+  children: ReactNode;
+}) {
+  const opacity = useSharedValue(visible ? 1 : 0);
+  useEffect(() => {
+    opacity.value = withTiming(visible ? 1 : 0, { duration });
+  }, [visible, duration, opacity]);
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+  return (
+    <Animated.View
+      pointerEvents={visible ? "auto" : "none"}
+      style={[StyleSheet.absoluteFill, animatedStyle]}
+    >
+      {children}
+    </Animated.View>
+  );
+}
+
+/**
+ * Cross-fades between chart instances by `key` (e.g. line ↔ candle). Mounts the
+ * active child plus any outgoing child still fading out; unmounts the outgoing
+ * child once the fade completes. RN/Reanimated analogue of liveline's
+ * `LivelineTransition`.
+ */
+export function LiveChartTransition({
+  active,
+  children,
+  duration = 300,
+  keepMounted = false,
+  style,
+}: LiveChartTransitionProps) {
+  // Use the raw children (not Children.toArray, which rewrites keys to ".$key").
+  const childArray = (
+    Array.isArray(children) ? children : [children]
+  ).filter(isValidElement) as ReactElement[];
+
+  const [mounted, setMounted] = useState<Set<string>>(() => new Set([active]));
+  const prevRef = useRef(active);
+
+  useEffect(() => {
+    if (keepMounted) return;
+    if (active === prevRef.current) return;
+    const outgoing = prevRef.current;
+    prevRef.current = active;
+    setMounted((prev) => new Set([...prev, active]));
+    const timer = setTimeout(() => {
+      setMounted((prev) => {
+        const next = new Set(prev);
+        next.delete(outgoing);
+        return next;
+      });
+    }, duration + 50);
+    return () => clearTimeout(timer);
+  }, [active, duration, keepMounted]);
+
+  return (
+    <View style={[styles.root, style]}>
+      {childArray.map((child) => {
+        const key = String(child.key ?? "");
+        if (!keepMounted && !mounted.has(key)) return null;
+        return (
+          <FadeLayer key={key} visible={key === active} duration={duration}>
+            {child}
+          </FadeLayer>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, position: "relative" },
+});

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -29,6 +29,10 @@ export interface EngineTickInput {
   points: LiveChartPoint[];
   /** Seconds since Unix epoch; defaults to `Date.now() / 1000` */
   nowSeconds?: number;
+  /** Override the engine's "now" (unix seconds) — e.g. fill historical data edge-to-edge. */
+  nowOverride?: number;
+  /** Right-edge buffer as a fraction of the time window (pushes the live edge past "now"). */
+  windowBuffer?: number;
   /** When true, freeze the viewport timestamp and skip displayWindow lerp */
   paused?: boolean;
   /** Chart mode — `"candle"` uses OHLC bars for Y range instead of line points. */
@@ -48,9 +52,9 @@ export function tickLiveChartEngineFrame(
   input: EngineTickInput,
 ): void {
   "worklet";
-  const now = input.nowSeconds ?? Date.now() / 1000;
+  const baseNow = input.nowOverride ?? input.nowSeconds ?? Date.now() / 1000;
   if (!input.paused) {
-    state.timestamp = now;
+    state.timestamp = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
   }
 
   if (input.canvasWidth === 0 || input.canvasHeight === 0) return;

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -27,6 +27,10 @@ export interface MultiEngineTickInput {
   maxValue?: number;
   series: SeriesConfig[];
   nowSeconds?: number;
+  /** Override the engine's "now" (unix seconds). */
+  nowOverride?: number;
+  /** Right-edge buffer as a fraction of the time window. */
+  windowBuffer?: number;
   paused?: boolean;
 }
 
@@ -40,9 +44,9 @@ export function tickLiveChartSeriesEngineFrame(
   input: MultiEngineTickInput,
 ): void {
   "worklet";
-  const now = input.nowSeconds ?? Date.now() / 1000;
+  const baseNow = input.nowOverride ?? input.nowSeconds ?? Date.now() / 1000;
   if (!input.paused) {
-    state.timestamp = now;
+    state.timestamp = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
   }
 
   if (input.canvasWidth === 0 || input.canvasHeight === 0) return;

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -25,6 +25,8 @@ export interface EngineConfig {
   referenceValues?: number[];
   nonNegative?: boolean;
   maxValue?: number;
+  nowOverride?: number;
+  windowBuffer?: number;
   paused?: boolean;
   mode?: "line" | "candle";
   candles?: SharedValue<CandlePoint[]>;
@@ -80,6 +82,8 @@ export interface EngineFrameRefs {
   referenceValues?: SharedValue<number[] | undefined>;
   nonNegativeSV?: SharedValue<boolean>;
   maxValueSV?: SharedValue<number | undefined>;
+  nowOverrideSV?: SharedValue<number | undefined>;
+  windowBufferSV?: SharedValue<number>;
   pausedSV: SharedValue<boolean>;
   modeSV: SharedValue<"line" | "candle">;
   candles?: SharedValue<CandlePoint[]>;
@@ -114,6 +118,8 @@ export function applyLiveChartEngineFrame(
     referenceValues: sv.referenceValues?.value,
     nonNegative: sv.nonNegativeSV?.value ?? false,
     maxValue: sv.maxValueSV?.value,
+    nowOverride: sv.nowOverrideSV?.value,
+    windowBuffer: sv.windowBufferSV?.value ?? 0,
     targetValue: sv.value.value,
     points: sv.data.value,
     nowSeconds: Date.now() / 1000,
@@ -138,6 +144,8 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   const referenceValues = useDerivedValue(() => config.referenceValues);
   const nonNegativeSV = useDerivedValue(() => config.nonNegative ?? false);
   const maxValueSV = useDerivedValue(() => config.maxValue);
+  const nowOverrideSV = useDerivedValue(() => config.nowOverride);
+  const windowBufferSV = useDerivedValue(() => config.windowBuffer ?? 0);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
   const modeSV = useDerivedValue(() => config.mode ?? "line");
 
@@ -173,6 +181,8 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
       referenceValues,
       nonNegativeSV,
       maxValueSV,
+      nowOverrideSV,
+      windowBufferSV,
       pausedSV,
       modeSV,
       candles,

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -19,6 +19,8 @@ export interface MultiSeriesEngineConfig {
   referenceValues?: number[];
   nonNegative?: boolean;
   maxValue?: number;
+  nowOverride?: number;
+  windowBuffer?: number;
   paused?: boolean;
 }
 
@@ -39,6 +41,8 @@ export interface MultiEngineFrameRefs {
   referenceValues?: SharedValue<number[] | undefined>;
   nonNegativeSV?: SharedValue<boolean>;
   maxValueSV?: SharedValue<number | undefined>;
+  nowOverrideSV?: SharedValue<number | undefined>;
+  windowBufferSV?: SharedValue<number>;
   pausedSV: SharedValue<boolean>;
 }
 
@@ -108,6 +112,8 @@ export function applyLiveChartSeriesEngineFrame(
     referenceValues: sv.referenceValues?.value,
     nonNegative: sv.nonNegativeSV?.value ?? false,
     maxValue: sv.maxValueSV?.value,
+    nowOverride: sv.nowOverrideSV?.value,
+    windowBuffer: sv.windowBufferSV?.value ?? 0,
     series: seriesSnap,
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
@@ -134,6 +140,8 @@ export function useLiveChartSeriesEngine(
   const referenceValues = useDerivedValue(() => config.referenceValues);
   const nonNegativeSV = useDerivedValue(() => config.nonNegative ?? false);
   const maxValueSV = useDerivedValue(() => config.maxValue);
+  const nowOverrideSV = useDerivedValue(() => config.nowOverride);
+  const windowBufferSV = useDerivedValue(() => config.windowBuffer ?? 0);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
 
   const displayMin = useSharedValue(0);
@@ -179,6 +187,8 @@ export function useLiveChartSeriesEngine(
         referenceValues,
         nonNegativeSV,
         maxValueSV,
+        nowOverrideSV,
+        windowBufferSV,
         pausedSV,
       },
       scratch,

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -33,9 +33,13 @@ export function useMarkers(
 
   const onHoverRef = useRef(onMarkerHover);
   onHoverRef.current = onMarkerHover;
-  const emitHover = useCallback((event: MarkerHoverEvent | null) => {
-    onHoverRef.current?.(event);
-  }, []);
+  const emitHover = useCallback(
+    /* istanbul ignore next -- invoked only from the UI-thread tap worklet */
+    (event: MarkerHoverEvent | null) => {
+      onHoverRef.current?.(event);
+    },
+    [],
+  );
 
   useFrameCallback(
     /* istanbul ignore next -- worklet runs on UI thread, not in Jest */ () => {

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -10,8 +10,10 @@
 
 import { LiveChart } from "./components/LiveChart";
 import { LiveChartSeries } from "./components/LiveChartSeries";
+import { LiveChartTransition } from "./components/LiveChartTransition";
 
-export { LiveChart, LiveChartSeries };
+export { LiveChart, LiveChartSeries, LiveChartTransition };
+export type { LiveChartTransitionProps } from "./components/LiveChartTransition";
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -569,6 +569,22 @@ export interface LiveChartCoreProps {
    * `accentColor` + `theme`. Only the keys you set are replaced.
    */
   palette?: Partial<LiveChartPalette>;
+  /**
+   * Right-edge buffer as a fraction of `timeWindow`. Pushes the live edge past the
+   * current time so the latest point has breathing room; pass `0` to land the latest
+   * point exactly at the right edge. Default `0`.
+   */
+  windowBuffer?: number;
+  /**
+   * Override the engine's "now" (unix seconds). Pass the latest data timestamp to
+   * treat the most recent point as the current time — combine with `windowBuffer={0}`
+   * and `timeWindow = maxT - minT` to fill the canvas edge-to-edge with historical data.
+   */
+  nowOverride?: number;
+  /** Accessibility label for the chart container. */
+  accessibilityLabel?: string;
+  /** Accessibility role for the chart container. Default `"image"`. */
+  accessibilityRole?: "image" | "none" | "adjustable" | "summary";
   /** Crosshair scrubbing on hover/drag. `true` = defaults, `false` = disabled, or pass `ScrubConfig`. Default `true`. */
   scrub?: boolean | ScrubConfig;
   /**

--- a/packages/react-native-livechart/tests/components/LiveChartTransition.test.tsx
+++ b/packages/react-native-livechart/tests/components/LiveChartTransition.test.tsx
@@ -1,0 +1,82 @@
+import { act, render } from "@testing-library/react-native";
+import React from "react";
+import { Text } from "react-native";
+import { LiveChartTransition } from "../../src/components/LiveChartTransition";
+
+describe("LiveChartTransition", () => {
+  it("unmounts the outgoing child after the fade completes", () => {
+    jest.useFakeTimers();
+    try {
+      const screen = render(
+        <LiveChartTransition active="line" duration={10}>
+          <Text key="line">LINE</Text>
+          <Text key="candle">CANDLE</Text>
+        </LiveChartTransition>,
+      );
+      screen.rerender(
+        <LiveChartTransition active="candle" duration={10}>
+          <Text key="line">LINE</Text>
+          <Text key="candle">CANDLE</Text>
+        </LiveChartTransition>,
+      );
+      // Both mounted during the cross-fade.
+      expect(screen.getByText("LINE")).toBeTruthy();
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      // Outgoing "line" child is unmounted once the timeout fires.
+      expect(screen.queryByText("LINE")).toBeNull();
+      expect(screen.getByText("CANDLE")).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("keeps every child mounted from the start when keepMounted is set", () => {
+    const screen = render(
+      <LiveChartTransition active="line" keepMounted>
+        <Text key="line">LINE</Text>
+        <Text key="candle">CANDLE</Text>
+      </LiveChartTransition>,
+    );
+    // Both are mounted immediately (no reveal-on-switch), even the inactive one.
+    expect(screen.getByText("LINE")).toBeTruthy();
+    expect(screen.getByText("CANDLE")).toBeTruthy();
+  });
+
+  it("renders only the active child initially", () => {
+    const screen = render(
+      <LiveChartTransition active="line">
+        <Text key="line">LINE</Text>
+        <Text key="candle">CANDLE</Text>
+      </LiveChartTransition>,
+    );
+    expect(screen.getByText("LINE")).toBeTruthy();
+    expect(screen.queryByText("CANDLE")).toBeNull();
+  });
+
+  it("mounts the incoming child when active changes", () => {
+    const screen = render(
+      <LiveChartTransition active="line" duration={10}>
+        <Text key="line">LINE</Text>
+        <Text key="candle">CANDLE</Text>
+      </LiveChartTransition>,
+    );
+    screen.rerender(
+      <LiveChartTransition active="candle" duration={10}>
+        <Text key="line">LINE</Text>
+        <Text key="candle">CANDLE</Text>
+      </LiveChartTransition>,
+    );
+    expect(screen.getByText("CANDLE")).toBeTruthy();
+  });
+
+  it("accepts a single child", () => {
+    const screen = render(
+      <LiveChartTransition active="only">
+        <Text key="only">ONLY</Text>
+      </LiveChartTransition>,
+    );
+    expect(screen.getByText("ONLY")).toBeTruthy();
+  });
+});

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -444,6 +444,26 @@ describe("tickLiveChartEngineFrame", () => {
     expect(s.displayMax).toBeLessThanOrEqual(100);
   });
 
+  it("applies nowOverride and windowBuffer to the timestamp", () => {
+    const s = baseState();
+    tickLiveChartEngineFrame(s, {
+      dt: 16.67,
+      canvasWidth: 200,
+      canvasHeight: 100,
+      timeWindow: 30,
+      smoothing: 0.08,
+      exaggerate: false,
+      referenceValue: undefined,
+      nowOverride: 5000,
+      windowBuffer: 0.1,
+      targetValue: 1,
+      points: [{ time: 5000, value: 1 }],
+      nowSeconds: 1000,
+    });
+    // timestamp = nowOverride(5000) + windowBuffer(0.1) * timeWindow(30) = 5003
+    expect(s.timestamp).toBe(5003);
+  });
+
   it("freezes timestamp when paused=true", () => {
     const s = { ...baseState(), timestamp: 999 };
     tickLiveChartEngineFrame(s, {

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -83,6 +83,25 @@ describe("tickLiveChartSeriesEngineFrame", () => {
     expect(s.displayMax).toBeLessThanOrEqual(120);
   });
 
+  it("applies nowOverride and windowBuffer to the timestamp", () => {
+    const s = baseMulti();
+    tickLiveChartSeriesEngineFrame(s, {
+      dt: 16.67,
+      canvasWidth: 200,
+      canvasHeight: 100,
+      timeWindow: 60,
+      smoothing: 0.5,
+      exaggerate: false,
+      referenceValue: undefined,
+      nowOverride: 2000,
+      windowBuffer: 0.05,
+      series: [{ id: "a", data: [{ time: 2000, value: 1 }], value: 1 }],
+      nowSeconds: 1000,
+    });
+    // 2000 + 0.05 * 60 = 2003
+    expect(s.timestamp).toBe(2003);
+  });
+
   it("excludes hidden series from Y-range", () => {
     const s = baseMulti();
     tickLiveChartSeriesEngineFrame(s, {


### PR DESCRIPTION
Phase 5 of the @morfi/chart feature-parity work (stacked on phase 4).

- windowBuffer + nowOverride on both charts: push the live edge past 'now'
  by a fraction of the window, or override the engine's 'now' to fill a fixed
  historical span edge-to-edge (windowBuffer=0, nowOverride=maxT, timeWindow=
  maxT-minT). Threaded through both engine ticks + hooks.
- Accessibility: accessibilityLabel + accessibilityRole on the chart
  container View (both components).
- LiveChartTransition: an RN/Reanimated cross-fade wrapper between chart
  instances by key (line <-> candle), mirroring liveline's LivelineTransition.
  Exported from the package root.

Playground: new Historical data fill page (windowBuffer/nowOverride) and
Transitions page (LiveChartTransition + accessibilityLabel).

Note: the built-in time-window selector (windows/onWindowChange) and the
built-in candle<->line toggle row are tracked as follow-ups (host-ownable UI;
the mode/timeWindow props already exist).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>