### PR TITLE
perf(chart): hoist font metrics out of per-frame worklets in marker/reference overlays

### DIFF
--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -157,16 +157,25 @@ function MarkerGlyph({
     layout.value.visible ? layout.value.y - size / 2 : OFF,
   );
 
-  // Text / emoji icon centered on the marker.
-  const iconX = useDerivedValue(() => {
-    if (!layout.value.visible) return OFF;
-    return layout.value.x - measureFontTextWidth(font, icon ?? "") / 2;
-  });
-  const iconY = useDerivedValue(() => {
-    if (!layout.value.visible) return OFF;
+  // Text / emoji icon centering — width + baseline shift depend only on the
+  // (stable) font and icon, so measure once instead of every frame. Skia
+  // `measureText`/`getMetrics` both allocate, so hoisting them out of the
+  // per-frame worklet removes one measure + one metrics call per glyph/frame.
+  const halfIconW = useMemo(
+    () => measureFontTextWidth(font, icon ?? "") / 2,
+    [font, icon],
+  );
+  const iconBaselineShift = useMemo(() => {
     const fm = font.getMetrics();
-    return layout.value.y - (fm.ascent + fm.descent) / 2;
-  });
+    return (fm.ascent + fm.descent) / 2;
+  }, [font]);
+
+  const iconX = useDerivedValue(() =>
+    layout.value.visible ? layout.value.x - halfIconW : OFF,
+  );
+  const iconY = useDerivedValue(() =>
+    layout.value.visible ? layout.value.y - iconBaselineShift : OFF,
+  );
 
   if (image) {
     return (

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -188,20 +188,26 @@ export function ReferenceLineOverlay({
   const labelY = useDerivedValue(() => layout.value.labelY);
   const labelText = useDerivedValue(() => layout.value.label);
 
+  // Font metrics depend only on the (stable) font, so read them once instead of
+  // on every frame inside the pill worklets (`getMetrics` allocates + crosses
+  // JSI). The off-axis pill's ascent offset and height are then plain constants.
+  const { ascent: fontAscent, height: pillH } = useMemo(() => {
+    const fm = font.getMetrics();
+    return {
+      ascent: fm.ascent,
+      height: fm.descent - fm.ascent + OFF_AXIS_PILL_PAD_Y * 2,
+    };
+  }, [font]);
+
   // Off-axis badge pill — a rounded background behind the chevron + label.
   const pillX = useDerivedValue(() => layout.value.x1 + 2);
-  const pillY = useDerivedValue(() => {
-    const fm = font.getMetrics();
-    return layout.value.labelY + fm.ascent - OFF_AXIS_PILL_PAD_Y;
-  });
+  const pillY = useDerivedValue(
+    () => layout.value.labelY + fontAscent - OFF_AXIS_PILL_PAD_Y,
+  );
   const pillW = useDerivedValue(() => {
     const l = layout.value;
     const textW = measureFontTextWidth(font, l.label);
     return l.labelX + textW + OFF_AXIS_PILL_PAD_X - (l.x1 + 2);
-  });
-  const pillH = useDerivedValue(() => {
-    const fm = font.getMetrics();
-    return fm.descent - fm.ascent + OFF_AXIS_PILL_PAD_Y * 2;
   });
 
   return (


### PR DESCRIPTION
### TL;DR

Hoisted Skia font metric calculations out of per-frame worklets in `MarkerOverlay` and `ReferenceLineOverlay` to reduce allocations during animation.

### What changed?

Font measurements (`getMetrics`, `measureText`) that were previously called inside `useDerivedValue` worklets on every frame are now computed once using `useMemo`, since they only depend on the stable `font` and `icon` values. In `MarkerOverlay`, `halfIconW` and `iconBaselineShift` are memoized and referenced directly in the derived value worklets. In `ReferenceLineOverlay`, `fontAscent` and `pillH` are extracted from a single memoized `getMetrics` call, replacing two separate per-frame metric reads and converting `pillH` from a derived value to a plain constant.

### How to test?

Render a chart with marker glyphs and reference lines, particularly during live/animated updates, and verify that markers and reference line pills remain correctly positioned. Profiling the UI thread should show fewer allocations per frame compared to before.

### Why make this change?

Skia's `getMetrics` and `measureText` both allocate objects and cross the JSI boundary. Calling them inside `useDerivedValue` meant they ran on every frame for every visible glyph and reference line. Since font metrics are stable for a given font and icon, computing them once and reusing the result eliminates unnecessary per-frame work and reduces GC pressure during animations.