### PR TITLE
chore(publish): add publish/update-library skills, fix prepack README copy, tighten .npmignore + exports order

### DIFF
--- a/.claude/skills/publish-library/SKILL.md
+++ b/.claude/skills/publish-library/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: publish-library
+description: >-
+  Publish the react-native-livechart library to npm from this monorepo. Use
+  this whenever the user wants to publish, ship, or release the package to npm —
+  including the first-ever publish — or asks how publishing works here. Covers
+  the workspace-scoping gotcha (a bare `npm publish` targets the Expo example
+  app, not the library), the `private: false` gate, the source-shipping/prepack
+  model, dry-run verification, and post-publish tagging. Trigger even if the
+  user just says "push it to npm", "can we publish now", or "ship the package"
+  without naming the skill. For deciding a version bump + CHANGELOG first, see
+  the update-library skill.
+---
+
+# Publish react-native-livechart to npm
+
+This repo is an **npm-workspaces monorepo**. The publishable library lives at
+`packages/react-native-livechart/`; the repo root is the **Expo example app**
+(`react-native-livechart-expo-example`, kept `"private": true`).
+
+## The one rule that breaks everything: scope to the workspace
+
+Every npm command that touches the library **must** be scoped with
+`-w react-native-livechart`. A bare `npm publish` / `npm pack` run from the root
+operates on the **example app**, not the library — it'll sweep the whole repo
+(demo screens, assets, tests) into a tarball named `react-native-livechart-expo-example`.
+
+The root's `"private": true` is the safety net that stops an accidental root
+publish, but don't rely on it — always pass `-w`.
+
+```bash
+npm pack    --dry-run -w react-native-livechart   # inspect what would ship
+npm publish           -w react-native-livechart   # publish
+```
+
+## Mental model (why the steps below look the way they do)
+
+- **The library ships TypeScript _source_.** `main`/`module`/`react-native` and
+  every `exports` condition except `types` point at `src/index.ts`. The
+  consumer's Metro + Babel compiles it — so worklets get processed by the
+  consumer's `react-native-worklets/plugin`. `dist/` contains **only `.d.ts`**.
+- **`prepack` builds for you.** `npm publish` runs `prepare` → `prepack`
+  automatically, which does `tsc -p tsconfig.build.json` (emits `dist/*.d.ts`)
+  and copies the repo-root `README.md` into the package. **Do not** hand-build
+  or hand-copy the README — let the lifecycle do it.
+- **`react`, `react-native`, Skia, Reanimated, Worklets, and Gesture Handler
+  are peer dependencies.** They must never appear in `dependencies`.
+
+## Preflight checklist
+
+1. **Branch & tree.** Be on the branch you intend to release from with a clean
+   working tree (`git status`). Releases normally go from `main`.
+2. **Green build.** `npm run verify` (typecheck + lint + test) passes. The
+   husky pre-commit hook also runs tests, but verify explicitly here.
+3. **`private` gate.** Open `packages/react-native-livechart/package.json` and
+   confirm `"private": false`. **On the first-ever publish it is `true`** — flip
+   it to `false` and commit that change. (Leave the root `package.json` private.)
+4. **Version sanity.** Check the `version` field is the one you intend and isn't
+   already on the registry: `npm view react-native-livechart version`. An E404
+   means it's never been published (expected for the first release). If you need
+   to bump the version, stop and use the **update-library** skill first.
+5. **Auth.** `npm whoami` (run `npm login` if it errors). Have your 2FA code
+   ready if the account enforces OTP.
+
+## Inspect what will ship — always dry-run first
+
+```bash
+npm pack --dry-run -w react-native-livechart
+```
+
+Verify in the output:
+- **`name: react-native-livechart`** (NOT `...-expo-example` — if you see that,
+  you forgot `-w`).
+- Contents are `src/**` + `dist/**/*.d.ts` + `README.md` + `LICENSE` only.
+- **No** `tests/`, `tsconfig*.json`, `babel.lib.config.cjs`, or other configs.
+
+The `files` allowlist (`dist`, `src`, `LICENSE`) plus the package `.npmignore`
+control this; `README` and `LICENSE` are always included by npm regardless.
+
+## Publish
+
+```bash
+npm publish -w react-native-livechart
+```
+
+- `react-native-livechart` is **unscoped and public**, so you do **not** need
+  `--access public` (that flag is only for `@scope/...` packages).
+- If 2FA is on: append `--otp=<6-digit-code>`.
+- `npm publish --dry-run -w react-native-livechart` does a full rehearsal
+  (including the registry handshake) without uploading — use it if you want one
+  more confirmation beyond `npm pack --dry-run`.
+
+## Post-publish
+
+1. **Confirm it's live:** `npm view react-native-livechart version`.
+2. **Tag the release** (there are no tags yet, so this establishes the
+   convention):
+   ```bash
+   git tag v$(node -p "require('./packages/react-native-livechart/package.json').version")
+   git push --tags
+   ```
+3. Optionally cut a GitHub release from that tag.
+
+## If something's wrong after publishing
+
+You generally **cannot** silently overwrite a published version — npm forbids
+re-publishing the same version number. Within 72 hours you can
+`npm unpublish react-native-livechart@<version>` (use sparingly; it breaks
+consumers). Otherwise bump a new patch via the **update-library** skill, or
+`npm deprecate react-native-livechart@<version> "<reason>"` to warn installers.

--- a/.claude/skills/update-library/SKILL.md
+++ b/.claude/skills/update-library/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: update-library
+description: >-
+  Cut and release a NEW version of the react-native-livechart library: choose
+  the semver bump, update the version field, update the CHANGELOG, verify, then
+  publish. Use this whenever the user wants to release a new version, bump the
+  version, ship an update/patch/minor/major, publish changes since the last
+  release, or "cut a release" of the package — even if they don't name the
+  skill. This skill owns the versioning + changelog decisions; for the npm
+  publish mechanics themselves it hands off to the publish-library skill.
+---
+
+# Release a new version of react-native-livechart
+
+Use this to turn merged changes into a published version. The flow is: **decide
+the bump → write it down (version + CHANGELOG) → verify → publish**. The actual
+`npm publish` mechanics (workspace scoping, the `private` gate, dry-run, tagging)
+live in the **publish-library** skill — follow it for the final step rather than
+duplicating those commands here.
+
+All version/changelog edits target the **library** package
+(`packages/react-native-livechart/`), never the repo root (the root is the
+private example app).
+
+## Step 1 — Choose the semver bump
+
+The package is past `1.0.0`, so semver is in full effect. Decide based on what
+changed since the last release, paying special attention to the **public API**
+(exported components, props, types) and **peer dependency ranges**:
+
+- **patch** (`x.y.Z`) — bug fixes, internal/perf changes, doc-only changes. No
+  consumer code or install changes required.
+- **minor** (`x.Y.0`) — new backward-compatible surface: new props, new exports,
+  new optional config. Existing code keeps working untouched.
+- **major** (`X.0.0`) — anything that can break a consumer: removed/renamed
+  props or exports, changed default behavior, or **widening/raising a peer
+  dependency requirement** (e.g. requiring a newer Reanimated/Skia). Peer-range
+  changes are easy to forget — treat them as breaking.
+
+If you're unsure which changes landed, `git log --oneline v<last-version>..HEAD`
+(or since the last release commit) is the source of truth.
+
+## Step 2 — Bump the version
+
+Edit `version` in `packages/react-native-livechart/package.json`, or let npm do
+it **without** touching git (workspace git-tagging behaves inconsistently, so we
+tag explicitly later in publish-library):
+
+```bash
+npm version <patch|minor|major> -w react-native-livechart --no-git-tag-version
+```
+
+This rewrites only the library's `version`. Note the new version for the
+CHANGELOG and the eventual tag.
+
+## Step 3 — Update the CHANGELOG
+
+Maintain `CHANGELOG.md` at the **repo root** (it's the single README/changelog
+home for the project). If it doesn't exist yet, create it using the
+[Keep a Changelog](https://keepachangelog.com/) format with a `## [Unreleased]`
+section at the top.
+
+For this release, move the relevant `Unreleased` notes (or write fresh ones)
+under a new heading:
+
+```markdown
+## [X.Y.Z] — YYYY-MM-DD
+
+### Added
+- ...
+### Changed
+- ...
+### Fixed
+- ...
+### Breaking  (only for a major)
+- ...
+```
+
+Group entries from the user's perspective (props, behavior, peers) — not by
+commit. Keep `### Breaking` honest; it's what tells consumers whether the
+upgrade is safe.
+
+## Step 4 — Verify
+
+```bash
+npm run verify
+```
+
+Typecheck + lint + test must pass before you publish a release.
+
+## Step 5 — Commit the release
+
+```bash
+git add packages/react-native-livechart/package.json CHANGELOG.md
+git commit -m "chore(release): v<X.Y.Z>"
+```
+
+(If the repo's convention is to release via PR into `main`, open the PR here and
+let it merge before publishing. Otherwise commit on the release branch / `main`
+per the user's flow.)
+
+## Step 6 — Publish
+
+Hand off to the **publish-library** skill for the rest: dry-run inspection,
+`npm publish -w react-native-livechart`, the post-publish `npm view` check, and
+tagging `v<X.Y.Z>`. Don't re-derive those commands — that skill is the source of
+truth for the npm mechanics and the workspace-scoping gotcha.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ app-example
 /android
 
 *.tgz
+
+# Generated at pack time from the repo-root README (single source of truth)
+/packages/react-native-livechart/README.md

--- a/packages/react-native-livechart/.npmignore
+++ b/packages/react-native-livechart/.npmignore
@@ -1,5 +1,5 @@
+# The `files` allowlist in package.json (dist, src, LICENSE) is the source of
+# truth for what ships. These globs only guard against co-located test files
+# accidentally landing under src/ — tests normally live in the sibling tests/ dir.
 **/*.test.ts
 **/*.test.tsx
-tsconfig.json
-tsconfig.build.json
-babel.lib.config.cjs

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -17,11 +17,11 @@
   },
   "exports": {
     ".": {
-      "default": "./src/index.ts",
-      "import": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "react-native": "./src/index.ts",
+      "import": "./src/index.ts",
       "require": "./src/index.ts",
-      "types": "./dist/index.d.ts"
+      "default": "./src/index.ts"
     }
   },
   "files": [
@@ -61,7 +61,7 @@
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "build:types:watch": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
-    "prepack": "npm run build",
+    "prepack": "npm run build && node -e \"require('fs').copyFileSync('../../README.md','README.md')\"",
     "prepare": "node -e \"if (!require('fs').existsSync('dist/index.d.ts')) process.exit(1)\" || npm run build",
     "test": "npm --prefix ../.. run test:lib",
     "test:coverage": "npm --prefix ../.. run test:coverage -- packages/react-native-livechart",


### PR DESCRIPTION
### TL;DR

Adds Claude AI skills for publishing and releasing the library to npm, and fixes the package configuration to correctly handle README distribution and export ordering.

### What changed?

Two Claude skills were added under `.claude/skills/`:

- **`publish-library`** — Documents the full npm publish flow for this monorepo, including the critical workspace-scoping requirement (`-w react-native-livechart`), the `private: false` gate, dry-run verification steps, post-publish tagging, and how to recover from a bad publish.
- **`update-library`** — Documents the end-to-end release flow: choosing the correct semver bump (including the often-missed case of peer dependency range changes counting as breaking), bumping the version without git tagging, maintaining the CHANGELOG, verifying, and handing off to `publish-library` for the actual npm mechanics.

Package configuration changes:

- The `prepack` script now copies the repo-root `README.md` into the package directory at pack time, making the root README the single source of truth rather than maintaining a separate copy in the package.
- The `packages/react-native-livechart/README.md` path is added to `.gitignore` since it is now generated at pack time and should not be committed.
- The `exports` map was reordered so `types` appears first, which is the correct order for TypeScript resolution.
- The `.npmignore` was simplified — config files (`tsconfig.json`, `tsconfig.build.json`, `babel.lib.config.cjs`) are removed from it since the `files` allowlist in `package.json` already controls what ships, and the ignore file now only guards against test files accidentally placed under `src/`.

### How to test?

Run `npm pack --dry-run -w react-native-livechart` and verify:
- The package name is `react-native-livechart` (not `react-native-livechart-expo-example`).
- The tarball contents include `src/**`, `dist/**/*.d.ts`, `README.md`, and `LICENSE` only — no test files, tsconfig files, or babel configs.
- `README.md` is present and reflects the repo-root README content.

### Why make this change?

Publishing from an npm-workspaces monorepo has a non-obvious footgun: a bare `npm publish` targets the root (the private example app), not the library. The skills encode the correct commands, gotchas, and release conventions so they aren't rediscovered each time. The package config fixes ensure the README is always in sync with the repo root and that the published tarball contains exactly what it should.