### PR TITLE
fix: avoid ref writes and impure calls during render

### DIFF
--- a/app/demo/edge-cases.tsx
+++ b/app/demo/edge-cases.tsx
@@ -34,9 +34,10 @@ export default function EdgeCasesScreen() {
 
   const emptyData = useSharedValue<LiveChartPoint[]>([]);
   const emptyValue = useSharedValue(100);
-  const singlePointData = useSharedValue<LiveChartPoint[]>([
+  const [singlePointInit] = useState<LiveChartPoint[]>(() => [
     { time: Date.now() / 1000, value: 100 },
   ]);
+  const singlePointData = useSharedValue<LiveChartPoint[]>(singlePointInit);
 
   const sim = useSimulatedChartData({
     multiSeries: false,

--- a/app/demo/historical-data.tsx
+++ b/app/demo/historical-data.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 import { LiveChart, type LiveChartPoint } from "react-native-livechart";
 import { useSharedValue } from "react-native-reanimated";
@@ -26,10 +26,10 @@ export default function HistoricalDataScreen() {
   const [buffer, setBuffer] = useState(0);
 
   // A fixed historical dataset seeded once; maxT is the latest sample.
-  const seed = useMemo(() => {
+  const [seed] = useState(() => {
     const maxT = Date.now() / 1000;
     return { points: seedHistory(maxT), maxT };
-  }, []);
+  });
 
   const data = useSharedValue<LiveChartPoint[]>(seed.points);
   const value = useSharedValue(seed.points[seed.points.length - 1].value);

--- a/app/demo/line-playback.tsx
+++ b/app/demo/line-playback.tsx
@@ -21,7 +21,8 @@ export default function LinePlaybackScreen() {
   const [maxValue, setMaxValue] = useState<number | undefined>(undefined);
 
   const data = useSharedValue<LiveChartPoint[]>([]);
-  const value = useSharedValue(wave(Date.now() / 1000));
+  const [initialValue] = useState(() => wave(Date.now() / 1000));
+  const value = useSharedValue(initialValue);
 
   // Seed a little history once so the chart reveals immediately.
   useEffect(() => {

--- a/app/demo/markers.tsx
+++ b/app/demo/markers.tsx
@@ -55,7 +55,9 @@ export default function MarkersScreen() {
 
   // Latest glyph mode for the interval closure without re-arming it each toggle.
   const glyphRef = useRef(glyph);
-  glyphRef.current = glyph;
+  useEffect(() => {
+    glyphRef.current = glyph;
+  });
 
   const decorate = (kind: MarkerKind): Partial<Marker> => {
     const mode = glyphRef.current;

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -204,13 +204,12 @@ export function LiveChartSeries({
     return false;
   });
 
-  const morphInitRef = useRef<number | null>(null);
-  if (morphInitRef.current === null) {
+  const [initialMorphT] = useState<number>(() => {
     const anyReady = series.value.some((s) => s.data.length >= 2);
-    morphInitRef.current = loading ? 0 : anyReady ? 1 : 0;
-  }
+    return loading ? 0 : anyReady ? 1 : 0;
+  });
 
-  const reveal = useChartReveal(loading, hasData, morphInitRef.current);
+  const reveal = useChartReveal(loading, hasData, initialMorphT);
 
   const effectiveSeries = useMultiSeriesReverseMorphInputs({
     series,

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -5,6 +5,7 @@
  *
  * @see https://github.com/benjitaylor/liveline
  */
+import { useState } from "react";
 import {
   useDerivedValue,
   useFrameCallback,
@@ -156,7 +157,9 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   const displayWindow = useSharedValue(config.timeWindow);
   const canvasWidth = useSharedValue(0);
   const canvasHeight = useSharedValue(0);
-  const timestamp = useSharedValue(Date.now() / 1000);
+  // Seed once; overwritten by the frame callback on the first tick.
+  const [initialTimestamp] = useState(() => Date.now() / 1000);
+  const timestamp = useSharedValue(initialTimestamp);
 
   // High-frequency data reads directly from the caller's shared values —
   // no useDerivedValue bridging, no closure serialization per tick.

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   useDerivedValue,
   useFrameCallback,
@@ -149,7 +149,9 @@ export function useLiveChartSeriesEngine(
   const displayWindow = useSharedValue(config.timeWindow);
   const canvasWidth = useSharedValue(0);
   const canvasHeight = useSharedValue(0);
-  const timestamp = useSharedValue(Date.now() / 1000);
+  // Seed once; overwritten by the frame callback on the first tick.
+  const [initialTimestamp] = useState(() => Date.now() / 1000);
+  const timestamp = useSharedValue(initialTimestamp);
 
   const displaySeriesValues = useSharedValue<number[]>([]);
   const seriesOpacities = useSharedValue<number[]>([]);

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -57,7 +57,9 @@ export function useDegen(
   const hasOnShakeListenerSV = useSharedValue(0);
 
   const onShakeRef = useRef(onShake);
-  onShakeRef.current = onShake;
+  useEffect(() => {
+    onShakeRef.current = onShake;
+  });
 
   const emitShake = useCallback((direction: "up" | "down") => {
     onShakeRef.current?.({ direction });

--- a/packages/react-native-livechart/src/hooks/useLiveChartHasData.ts
+++ b/packages/react-native-livechart/src/hooks/useLiveChartHasData.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useState } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { CandlePoint, LiveChartPoint } from "../types";
 
@@ -31,13 +31,12 @@ export function useLiveChartHasData({
     return data.value.length >= 2;
   });
 
-  const morphInitRef = useRef<number | null>(null);
-  if (morphInitRef.current === null) {
+  const [initialMorphT] = useState<number>(() => {
     const initialHas = isCandle
       ? (candles?.value.length ?? 0) >= 2
       : data.value.length >= 2;
-    morphInitRef.current = loading ? 0 : initialHas ? 1 : 0;
-  }
+    return loading ? 0 : initialHas ? 1 : 0;
+  });
 
-  return { hasData, initialMorphT: morphInitRef.current };
+  return { hasData, initialMorphT };
 }

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Gesture } from "react-native-gesture-handler";
 import {
   runOnJS,
@@ -32,7 +32,9 @@ export function useMarkers(
   );
 
   const onHoverRef = useRef(onMarkerHover);
-  onHoverRef.current = onMarkerHover;
+  useEffect(() => {
+    onHoverRef.current = onMarkerHover;
+  });
   const emitHover = useCallback(
     /* istanbul ignore next -- invoked only from the UI-thread tap worklet */
     (event: MarkerHoverEvent | null) => {

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
@@ -65,7 +65,9 @@ export function useMultiSeriesDegen(
   const hasOnShakeListenerSV = useSharedValue(0);
 
   const onShakeRef = useRef(onShake);
-  onShakeRef.current = onShake;
+  useEffect(() => {
+    onShakeRef.current = onShake;
+  });
   const emitShake = useCallback(
     /* istanbul ignore next -- invoked only from the UI-thread frame worklet */
     (direction: "up" | "down") => {

--- a/sim/useSimulatedChartData.ts
+++ b/sim/useSimulatedChartData.ts
@@ -192,7 +192,9 @@ export function useSimulatedChartData(
   const tradesPerSecond =
     tradesPerSecondOpt ?? defaultTradesPerSecond(volatilityMode);
   const random01Ref = useRef(random01Opt ?? Math.random);
-  random01Ref.current = random01Opt ?? Math.random;
+  useEffect(() => {
+    random01Ref.current = random01Opt ?? Math.random;
+  });
 
   const buf = useRef<TickBuffers>({
     lastMid: startValue,


### PR DESCRIPTION
react-hooks-js (React Compiler) flagged several render-phase impurities:

- Latest-ref pattern: move `ref.current = latest` writes into a useEffect
  in useDegen, useMultiSeriesDegen, and useMarkers, plus the demo markers
  screen and the sim hook's RNG ref. These refs are only read from
  UI-thread worklets / async callbacks, so post-commit assignment is
  behaviourally equivalent.
- One-shot morph seed: replace the lazy-init ref read-during-render with a
  useState lazy initializer in useLiveChartHasData and LiveChartSeries.
- Date.now() during render: wrap the engine timestamp seed and three demo
  initial values in useState lazy initializers so the clock is sampled once
  instead of on every render.

No behaviour change; full suite (652 tests) still passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>