### PR TITLE
fix: seed SharedValue-mirrored state at mount instead of in an effect

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -5,7 +5,7 @@
  * @see https://github.com/benjitaylor/liveline
  */
 import { Canvas, Group } from "@shopify/react-native-skia";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import {
@@ -232,8 +232,9 @@ export function LiveChartSeries({
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
   const linePaths = useMultiSeriesLinePaths(engine, effectivePadding);
 
+  // Seed from the current series at mount; the reaction below keeps it in sync.
   const [lineColors, setLineColors] = useState<string[]>(() =>
-    Array.from({ length: MAX_MULTI_SERIES }, () => "#ffffff"),
+    resolveMultiSeriesLineColorsSnapshot(series.value),
   );
 
   const syncColors = useCallback((sv: SharedValue<SeriesConfig[]>) => {
@@ -249,14 +250,10 @@ export function LiveChartSeries({
     [series, syncColors],
   );
 
-  useEffect(() => {
-    syncColors(series);
-  }, [series, syncColors]);
-
   // Per-series stroke style (dash / width / glow) — synced to React state when
   // the style signature changes (not on every data tick), like the colors above.
   const [lineStyles, setLineStyles] = useState<SeriesLineStyle[]>(() =>
-    resolveMultiSeriesLineStylesSnapshot([]),
+    resolveMultiSeriesLineStylesSnapshot(series.value),
   );
 
   const syncStyles = useCallback((sv: SharedValue<SeriesConfig[]>) => {
@@ -271,10 +268,6 @@ export function LiveChartSeries({
     },
     [series, syncStyles],
   );
-
-  useEffect(() => {
-    syncStyles(series);
-  }, [series, syncStyles]);
 
   const {
     pack: degenPack,

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -8,7 +8,7 @@ import {
   type SkFont,
   type SkPath,
 } from "@shopify/react-native-skia";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   useAnimatedReaction,
   useDerivedValue,
@@ -248,7 +248,8 @@ export function MarkerOverlay({
   /** Multi-series data, used to anchor markers by `seriesId`. */
   series?: SharedValue<SeriesConfig[]>;
 }) {
-  const [snapshot, setSnapshot] = useState<Marker[]>([]);
+  // Seed from the current markers at mount; the reaction below keeps it in sync.
+  const [snapshot, setSnapshot] = useState<Marker[]>(() => markers.value.slice());
 
   const pull = useCallback((sv: SharedValue<Marker[]>) => {
     setSnapshot(sv.value.slice());
@@ -262,10 +263,6 @@ export function MarkerOverlay({
     },
     [markers, pull],
   );
-
-  useEffect(() => {
-    setSnapshot(markers.value.slice());
-  }, [markers, pull]);
 
   const axisY = useDerivedValue(
     () => engine.canvasHeight.value - padding.bottom,

--- a/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
+++ b/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useAnimatedReaction, type SharedValue } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
@@ -32,7 +32,10 @@ export function SeriesToggleChips({
   legend,
   onSeriesToggle,
 }: SeriesToggleChipsProps) {
-  const [snapshot, setSnapshot] = useState<SeriesConfig[]>([]);
+  // Seed from the current series at mount; the reaction below keeps it in sync.
+  const [snapshot, setSnapshot] = useState<SeriesConfig[]>(() =>
+    series.value.slice(),
+  );
 
   const pullSnapshot = useCallback((sv: SharedValue<SeriesConfig[]>) => {
     setSnapshot(sv.value.slice());
@@ -40,7 +43,7 @@ export function SeriesToggleChips({
 
   useAnimatedReaction(
     () => seriesMetaSig(series.value),
-    /* istanbul ignore next -- Reanimated reaction; snapshot pulled in useEffect */
+    /* istanbul ignore next -- Reanimated reaction; snapshot seeded at mount, pulled here on change */
     (sig, prev) => {
       if (sig !== prev) {
         scheduleOnRN(pullSnapshot, series);
@@ -48,10 +51,6 @@ export function SeriesToggleChips({
     },
     [series, pullSnapshot],
   );
-
-  useEffect(() => {
-    setSnapshot(series.value.slice());
-  }, [series]);
 
   if (!legend.visible) return null;
 


### PR DESCRIPTION
LiveChartSeries, MarkerOverlay, and SeriesToggleChips mirror a Reanimated
SharedValue (series / markers) into React state, refreshing only when a
signature changes via useAnimatedReaction. The initial sync was done in a
mount useEffect that called setState, which react-hooks-js flags as
set-state-in-effect / no-derived-state.

Seed the React state lazily from the SharedValue's current value in the
useState initializer and drop the redundant mount effect; the reaction
still drives every subsequent update. This also removes a wasted render
pass (and a one-frame flash of placeholder state) on mount.

The remaining state/effect findings are intentional Reanimated patterns
(timed cross-fade, frame-driven side effects) handled via doctor.config.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>