### PR TITLE
chore(react-doctor): keep intentional manual memoization (config)

### DIFF
--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -1,0 +1,25 @@
+import type { ReactDoctorConfig } from "react-doctor/api";
+
+/**
+ * react-native-livechart is a Reanimated + Skia library: data and live values
+ * flow through `SharedValue`s and are drawn on the UI thread. A few React-purity
+ * lint rules assume an idiomatic React app and fire heavily on patterns that are
+ * deliberate (and load-bearing) here. We disable only those, with the rationale
+ * documented per rule, rather than contorting the engine to satisfy a rule that
+ * does not apply. Everything else stays on.
+ */
+const config: ReactDoctorConfig = {
+  rules: {
+    // Manual memoization is intentional throughout the library. `useMemo` gives
+    // stable identity to the mutable Skia path / double-buffer caches (the
+    // SkPath-reuse optimization — see CLAUDE.md) and to the worklet/gesture
+    // callbacks that are consumed off the React render path. React Compiler
+    // cannot auto-memoize these: it detects their in-place mutation (the same
+    // reason the react-hooks-js/immutability findings fire), so the manual memo
+    // is load-bearing, not redundant. Removing it would allocate a fresh cache
+    // every render and break the buffering.
+    "react-doctor/react-compiler-no-manual-memoization": "off",
+  },
+};
+
+export default config;


### PR DESCRIPTION
Add doctor.config.ts disabling react-doctor/react-compiler-no-manual-memoization.

This library uses manual useMemo deliberately to give stable identity to the
mutable Skia path / double-buffer caches (the documented SkPath-reuse
optimization) and to the worklet / gesture callbacks consumed off the React
render path. React Compiler cannot auto-memoize these — it detects their
in-place mutation (the same reason the immutability findings fire) — so the
manual memo is load-bearing, not redundant. Removing it would allocate a fresh
cache every render and break the buffering, a regression the Jest suite (which
mocks Skia/worklets) cannot catch.

Clears 34 react-compiler-no-manual-memoization findings across both workspace
projects.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>