### PR TITLE
fix: resolve remaining react-doctor findings in code

### DIFF
--- a/app/demo/horizontal-lines.tsx
+++ b/app/demo/horizontal-lines.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 import { LiveChart, type ReferenceLine } from "react-native-livechart";
 
@@ -28,15 +28,21 @@ export default function HorizontalLinesScreen() {
   // Pin the time band ONCE when it's enabled (the band lives in absolute
   // unix-seconds space, so it then scrolls smoothly leftward with the chart).
   // Re-pinning on an interval would make it jump back to the right each tick.
+  // Pinned directly in the toggle handler below — it's a response to the button
+  // press, not derived state, so it doesn't belong in an effect.
   const [timeWindow, setTimeWindow] = useState<{
     from: number;
     to: number;
   } | null>(null);
-  useEffect(() => {
-    if (!timeBand) return;
-    const now = Date.now() / 1000;
-    setTimeWindow({ from: now - 20, to: now - 8 });
-  }, [timeBand]);
+
+  const toggleTimeBand = () => {
+    const next = !timeBand;
+    setTimeBand(next);
+    if (next) {
+      const now = Date.now() / 1000;
+      setTimeWindow({ from: now - 20, to: now - 8 });
+    }
+  };
 
   const referenceLines: ReferenceLine[] = [];
   if (lines) {
@@ -111,7 +117,7 @@ export default function HorizontalLinesScreen() {
         <Toggle
           label="Time band"
           on={timeBand}
-          onPress={() => setTimeBand((v) => !v)}
+          onPress={toggleTimeBand}
         />
       </View>
       <View style={demoStyles.buttonRow}>

--- a/app/demo/lib/AnimatedTrendTextInput.tsx
+++ b/app/demo/lib/AnimatedTrendTextInput.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useState } from "react";
 import { StyleSheet, type TextStyle } from "react-native";
 import Animated, {
   Easing,
   interpolateColor,
-  runOnJS,
   type SharedValue,
   useAnimatedReaction,
   useAnimatedStyle,
@@ -11,6 +10,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
 
 const FLASH_IN_MS = 100;
 const FLASH_OUT_MS = 280;
@@ -20,41 +20,47 @@ const TW_ZINC_400 = "#a1a1aa";
 const TW_EMERALD_400 = "#34d399";
 const TW_RED_400 = "#f87171";
 
-export type NumberFormatConfig = {
-  locales?: Intl.LocalesArgument;
-  options?: Intl.NumberFormatOptions;
-};
-
 export type AnimatedTrendTextInputProps = {
   sharedValue: SharedValue<number>;
   maximumFractionDigits?: number;
   /**
-   * When set, the label is formatted with `Intl.NumberFormat` (grouping, locale
-   * decimals, currency, etc.). Omit for a plain `toFixed`.
+   * Pre-built `Intl.NumberFormat` for grouping/locale/currency formatting.
+   * Construct it once at module scope and pass it in (building one is slow, so
+   * don't redo it per render); omit for a plain `toFixed`.
    */
-  numberFormat?: NumberFormatConfig;
+  formatter?: Intl.NumberFormat;
   baseColor?: string;
   upColor?: string;
   downColor?: string;
   style?: TextStyle;
 };
 
+function formatValue(
+  n: number,
+  formatter: Intl.NumberFormat | undefined,
+  maximumFractionDigits: number,
+): string {
+  if (!Number.isFinite(n)) return "—";
+  return formatter ? formatter.format(n) : n.toFixed(maximumFractionDigits);
+}
+
 /**
  * Live numeric readout that flashes green/red on change and fades back to
  * neutral.
  *
- * The text content is pushed into React state from a UI-thread
- * `useAnimatedReaction` (throttled to one render per value change). It used to
- * drive an `Animated.createAnimatedComponent(TextInput)` and set `text` via
- * `useAnimatedProps` every tick — that pattern leaks native memory on iOS
- * (resident memory climbs for as long as the value keeps updating). The color
- * flash stays on the UI thread via `useAnimatedStyle` (animating a `color`
- * style does not leak); only the string content crosses to JS.
+ * The latest raw value is pushed into React state from a UI-thread
+ * `useAnimatedReaction` (one render per value change); the displayed string is
+ * derived from it during render, so toggling the formatter re-formats without an
+ * effect. It used to drive an `Animated.createAnimatedComponent(TextInput)` and
+ * set `text` via `useAnimatedProps` every tick — that pattern leaks native
+ * memory on iOS (resident memory climbs for as long as the value keeps
+ * updating). The color flash stays on the UI thread via `useAnimatedStyle`
+ * (animating a `color` style does not leak); only the raw number crosses to JS.
  */
 export function AnimatedTrendTextInput({
   sharedValue,
   maximumFractionDigits = 6,
-  numberFormat,
+  formatter,
   baseColor = TW_ZINC_400,
   upColor = TW_EMERALD_400,
   downColor = TW_RED_400,
@@ -62,46 +68,11 @@ export function AnimatedTrendTextInput({
 }: AnimatedTrendTextInputProps) {
   const flash = useSharedValue(0);
 
-  // Explicitly memoized: constructing Intl.NumberFormat per render is wasteful
-  // (js-hoist-intl), and a stable `format` keeps the effect/reaction deps below
-  // from re-firing every render (no-effect-with-fresh-deps).
-  const formatter = useMemo(
-    () =>
-      numberFormat
-        ? new Intl.NumberFormat(numberFormat.locales, {
-            maximumFractionDigits,
-            ...numberFormat.options,
-          })
-        : null,
-    [numberFormat, maximumFractionDigits],
-  );
+  const [rawValue, setRawValue] = useState(() => sharedValue.get());
 
-  const format = useCallback(
-    (n: number) => {
-      if (!Number.isFinite(n)) return "—";
-      return formatter ? formatter.format(n) : n.toFixed(maximumFractionDigits);
-    },
-    [formatter, maximumFractionDigits],
-  );
+  const display = formatValue(rawValue, formatter, maximumFractionDigits);
 
-  const latest = useRef<number | null>(null);
-  if (latest.current === null) latest.current = sharedValue.get();
-  const [display, setDisplay] = useState(() => format(sharedValue.get()));
-
-  const onValue = useCallback(
-    (n: number) => {
-      latest.current = n;
-      setDisplay(format(n));
-    },
-    [format],
-  );
-
-  // Re-format the current value when the formatter changes (e.g. toggling Intl).
-  useEffect(() => {
-    setDisplay(format(latest.current!));
-  }, [format]);
-
-  // One reaction drives both the color flash (UI thread) and the text update
+  // One reaction drives both the color flash (UI thread) and the value update
   // (marshalled to JS once per change — not a per-frame native text push).
   useAnimatedReaction(
     () => sharedValue.get(),
@@ -123,9 +94,8 @@ export function AnimatedTrendTextInput({
           ),
         );
       }
-      runOnJS(onValue)(current);
+      runOnJS(setRawValue)(current);
     },
-    [onValue],
   );
 
   const animatedStyle = useAnimatedStyle(() => ({

--- a/app/demo/playground.tsx
+++ b/app/demo/playground.tsx
@@ -25,10 +25,7 @@ import {
   type HistoryRange,
   type TradeSource,
 } from "../../sim/useSimulatedChartData";
-import {
-  AnimatedTrendTextInput,
-  type NumberFormatConfig,
-} from "./lib/AnimatedTrendTextInput";
+import { AnimatedTrendTextInput } from "./lib/AnimatedTrendTextInput";
 import {
   HISTORY_RANGE_PRESETS,
   PRICE_RANGES,
@@ -42,14 +39,12 @@ export const options = { title: "Playground" };
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
-const PLAYGROUND_HEADER_NUMBER_FORMAT: NumberFormatConfig = {
-  locales: "en-US",
-  options: {
-    useGrouping: true,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  },
-};
+// Built once at module scope so it isn't reconstructed per render (js-hoist-intl).
+const PLAYGROUND_HEADER_FORMATTER = new Intl.NumberFormat("en-US", {
+  useGrouping: true,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
 
 export default function PlaygroundScreen() {
   const [volatilityMode, setVolatilityMode] =
@@ -122,9 +117,8 @@ export default function PlaygroundScreen() {
         </Text>
         <AnimatedTrendTextInput
           sharedValue={value}
-          maximumFractionDigits={headerReadoutIntl ? 2 : 6}
           {...(headerReadoutIntl
-            ? { numberFormat: PLAYGROUND_HEADER_NUMBER_FORMAT }
+            ? { formatter: PLAYGROUND_HEADER_FORMATTER }
             : {})}
           style={styles.subtitle}
         />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
 import { Link, type Href } from "expo-router";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { MONO_FONT_FAMILY } from "react-native-livechart";
 
 const DEMOS: { href: Href; title: string; blurb: string }[] = [
@@ -91,6 +91,15 @@ const DEMOS: { href: Href; title: string; blurb: string }[] = [
   },
 ];
 
+const renderDemoItem = ({ item: d }: { item: (typeof DEMOS)[number] }) => (
+  <Link href={d.href} asChild>
+    <Pressable style={styles.row}>
+      <Text style={styles.rowTitle}>{d.title}</Text>
+      <Text style={styles.rowBlurb}>{d.blurb}</Text>
+    </Pressable>
+  </Link>
+);
+
 export default function Index() {
   return (
     <View style={styles.root}>
@@ -98,19 +107,13 @@ export default function Index() {
       <Text style={styles.subtitle}>
         Open a screen to manually test one feature area.
       </Text>
-      <ScrollView
+      <FlatList
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
-      >
-        {DEMOS.map((d) => (
-          <Link key={d.title} href={d.href} asChild>
-            <Pressable style={styles.row}>
-              <Text style={styles.rowTitle}>{d.title}</Text>
-              <Text style={styles.rowBlurb}>{d.blurb}</Text>
-            </Pressable>
-          </Link>
-        ))}
-      </ScrollView>
+        data={DEMOS}
+        keyExtractor={(d) => d.title}
+        renderItem={renderDemoItem}
+      />
     </View>
   );
 }

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -85,12 +85,6 @@ const config: ReactDoctorConfig = {
         ],
       },
       {
-        // Demo: the time band is pinned once (to the current clock) when enabled,
-        // so it scrolls with the chart instead of re-pinning every tick.
-        files: ["**/demo/horizontal-lines.tsx"],
-        rules: ["react-hooks-js/set-state-in-effect"],
-      },
-      {
         // react-doctor is a CLI dev tool, never imported — it flags itself.
         files: ["package.json", "**/package.json"],
         rules: ["deslop/unused-dev-dependency"],

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -25,17 +25,13 @@ const config: ReactDoctorConfig = {
       },
       {
         // LiveChart / LiveChartSeries are the top-level composition roots; their
-        // size is inherent to a fully-featured chart component. The optional
-        // `tooltipBody` slot intentionally accepts JSX content as a prop (a
-        // standard slot-style API); React Compiler handles its memoization.
+        // size is inherent to a fully-featured chart component. (The `tooltipBody`
+        // JSX-as-prop slot is suppressed inline at its call site in LiveChart.tsx.)
         files: [
           "**/components/LiveChart.tsx",
           "**/components/LiveChartSeries.tsx",
         ],
-        rules: [
-          "react-doctor/no-giant-component",
-          "react-doctor/jsx-no-jsx-as-prop",
-        ],
+        rules: ["react-doctor/no-giant-component"],
       },
       {
         // Timed cross-fade driven by the `active` prop (parent toggles line↔candle):
@@ -52,20 +48,6 @@ const config: ReactDoctorConfig = {
         // event to move the side effect into, so no-event-handler doesn't apply.
         files: ["**/hooks/useDegen.ts", "**/hooks/useMultiSeriesDegen.ts"],
         rules: ["react-doctor/no-event-handler"],
-      },
-      {
-        // Demo trend input: the displayed text mirrors a Reanimated SharedValue
-        // via a reaction; the formatter-change re-format can't be derived during
-        // render (the value updates off the render path). The Intl formatter and
-        // its callbacks are deliberately memoized (js-hoist-intl + stable effect /
-        // reaction deps), which conflicts with the redundant-memoization rule.
-        files: ["**/AnimatedTrendTextInput.tsx"],
-        rules: [
-          "react-doctor/exhaustive-deps",
-          "react-doctor/no-derived-state",
-          "react-doctor/no-pass-data-to-parent",
-          "react-doctor/react-compiler-no-manual-memoization",
-        ],
       },
       {
         // Demo simulation hook: history is fed through a callback by design and

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -47,12 +47,6 @@ const config: ReactDoctorConfig = {
         rules: ["react-doctor/no-effect-event-handler"],
       },
       {
-        // The gesture is built with Gesture.Tap() and its worklet runs on the UI
-        // thread; the latest-value ref it reaches is touched on tap, not in render.
-        files: ["**/hooks/useMarkers.ts"],
-        rules: ["react-hooks-js/refs"],
-      },
-      {
         // `emitShake` notifies the consumer when a momentum shake is detected on
         // the UI thread (in the frame worklet, via runOnJS) — there's no React
         // event to move the side effect into, so no-event-handler doesn't apply.

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -2,33 +2,32 @@ import type { ReactDoctorConfig } from "react-doctor/api";
 
 /**
  * react-native-livechart is a Reanimated + Skia library: data and live values
- * flow through `SharedValue`s and are drawn on the UI thread. Several
- * React-purity lint rules assume an idiomatic React app and fire on patterns
- * that are deliberate (and load-bearing) here.
- *
- * The two rules below are turned off globally because they conflict with the
- * library's core model everywhere it appears. Everything more localized is
- * suppressed per-file in `ignore.overrides` (so the rule keeps protecting the
- * rest of the codebase), each with the reason it's intentional at that spot.
+ * flow through `SharedValue`s and are drawn on the UI thread. The findings
+ * suppressed below are genuine false positives for that architecture (or for
+ * intentional demo code) — each is scoped to the specific files where the
+ * pattern is deliberate, with the reason inline, so every rule keeps protecting
+ * the rest of the codebase. Everything else react-doctor flagged was fixed in
+ * code (see the PR stack): the `.value`→`.get()/.set()` migration, removing
+ * redundant manual memoization, dead-code cleanup, ref/purity/effect fixes,
+ * direct imports, stable keys, FlatList, and lazy ref init.
  */
 const config: ReactDoctorConfig = {
-  rules: {
-    // The library deliberately uses internal barrels (`../hooks`, `../components`)
-    // for organization; public consumers import from the package root barrel.
-    "react-doctor/no-barrel-import": "off",
-
-    // Every flagged list here is a fixed-size render-slot pool (particle slots,
-    // trade-tape labels) or static reference-line config — the array index is the
-    // genuine stable identity, never reorderable user data.
-    "react-doctor/no-array-index-as-key": "off",
-    "react-doctor/no-array-index-key": "off",
-  },
   ignore: {
     overrides: [
       {
+        // Fixed-size render-slot pools (particle slots, trade-tape labels): the
+        // array index IS the stable slot identity, not reorderable user data.
+        files: [
+          "**/components/DegenParticlesOverlay.tsx",
+          "**/components/TradeStreamOverlay.tsx",
+        ],
+        rules: ["react-doctor/no-array-index-as-key"],
+      },
+      {
         // LiveChart / LiveChartSeries are the top-level composition roots; their
-        // size is inherent to a fully-featured chart. The conditional tooltip JSX
-        // prop is fine under React Compiler.
+        // size is inherent to a fully-featured chart component. The optional
+        // `tooltipBody` slot intentionally accepts JSX content as a prop (a
+        // standard slot-style API); React Compiler handles its memoization.
         files: [
           "**/components/LiveChart.tsx",
           "**/components/LiveChartSeries.tsx",
@@ -37,11 +36,6 @@ const config: ReactDoctorConfig = {
           "react-doctor/no-giant-component",
           "react-doctor/jsx-no-jsx-as-prop",
         ],
-      },
-      {
-        // `seriesMetaSig` is a worklet helper intentionally exported for tests.
-        files: ["**/components/SeriesToggleChips.tsx"],
-        rules: ["react-doctor/only-export-components"],
       },
       {
         // Timed cross-fade: mounting/unmounting children on an `active` prop
@@ -53,18 +47,15 @@ const config: ReactDoctorConfig = {
         ],
       },
       {
-        // The gesture is built in useMemo and its worklet runs on the UI thread;
-        // the latest-value ref it reaches is touched on tap, not during render.
+        // The gesture is built with Gesture.Tap() and its worklet runs on the UI
+        // thread; the latest-value ref it reaches is touched on tap, not in render.
         files: ["**/hooks/useMarkers.ts"],
         rules: ["react-hooks-js/refs"],
       },
       {
         // Degen effects are driven by the frame loop / SharedValue signatures, not
         // user events; deps are deliberately narrowed to avoid re-arming the loop.
-        files: [
-          "**/hooks/useDegen.ts",
-          "**/hooks/useMultiSeriesDegen.ts",
-        ],
+        files: ["**/hooks/useDegen.ts", "**/hooks/useMultiSeriesDegen.ts"],
         rules: [
           "react-doctor/exhaustive-deps",
           "react-doctor/no-event-handler",
@@ -72,13 +63,10 @@ const config: ReactDoctorConfig = {
       },
       {
         // Demo trend input: the displayed text mirrors a Reanimated SharedValue
-        // via a reaction; when the formatter changes we re-format the latest
-        // value in an effect. It can't be derived during render (the value
-        // updates asynchronously off the render path), so the derived-state /
-        // pass-data effect rules don't apply here. The Intl formatter and the
-        // `format`/`onValue` callbacks are deliberately memoized (js-hoist-intl
-        // + stable effect/reaction deps), so the redundant-manual-memoization
-        // rule — which conflicts with those — is also waived for this file.
+        // via a reaction; the formatter-change re-format can't be derived during
+        // render (the value updates off the render path). The Intl formatter and
+        // its callbacks are deliberately memoized (js-hoist-intl + stable effect /
+        // reaction deps), which conflicts with the redundant-memoization rule.
         files: ["**/AnimatedTrendTextInput.tsx"],
         rules: [
           "react-doctor/exhaustive-deps",
@@ -88,12 +76,11 @@ const config: ReactDoctorConfig = {
         ],
       },
       {
-        // Demo simulation hook: RNG/bonding state seeded once, history fed through
-        // a callback by design; side effects are reaction-driven, not event-driven.
+        // Demo simulation hook: history is fed through a callback by design and
+        // its side effects are reaction/timer-driven, not user-event-driven.
         files: ["**/useSimulatedChartData.ts"],
         rules: [
           "react-doctor/no-event-handler",
-          "react-doctor/rerender-lazy-ref-init",
           "react-doctor/no-pass-data-to-parent",
         ],
       },
@@ -104,12 +91,7 @@ const config: ReactDoctorConfig = {
         rules: ["react-hooks-js/set-state-in-effect"],
       },
       {
-        // Demo home screen: a short, static list of links — a ScrollView is fine.
-        files: ["app/index.tsx", "**/app/index.tsx"],
-        rules: ["react-doctor/rn-no-scrollview-mapped-list"],
-      },
-      {
-        // react-doctor is a CLI dev tool, never imported — flagging itself.
+        // react-doctor is a CLI dev tool, never imported — it flags itself.
         files: ["package.json", "**/package.json"],
         rules: ["deslop/unused-dev-dependency"],
       },

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -38,13 +38,13 @@ const config: ReactDoctorConfig = {
         ],
       },
       {
-        // Timed cross-fade: mounting/unmounting children on an `active` prop
-        // change via a duration timer is exactly what an effect is for.
+        // Timed cross-fade driven by the `active` prop (parent toggles line↔candle):
+        // mount the new child, then unmount the outgoing one after a duration timer.
+        // That's a prop change, not a user event, so there's no handler to move it
+        // into and no-effect-event-handler doesn't apply. (The two state updates
+        // were combined into a useReducer, clearing no-cascading-set-state.)
         files: ["**/components/LiveChartTransition.tsx"],
-        rules: [
-          "react-doctor/no-cascading-set-state",
-          "react-doctor/no-effect-event-handler",
-        ],
+        rules: ["react-doctor/no-effect-event-handler"],
       },
       {
         // The gesture is built with Gesture.Tap() and its worklet runs on the UI
@@ -53,13 +53,11 @@ const config: ReactDoctorConfig = {
         rules: ["react-hooks-js/refs"],
       },
       {
-        // Degen effects are driven by the frame loop / SharedValue signatures, not
-        // user events; deps are deliberately narrowed to avoid re-arming the loop.
+        // `emitShake` notifies the consumer when a momentum shake is detected on
+        // the UI thread (in the frame worklet, via runOnJS) — there's no React
+        // event to move the side effect into, so no-event-handler doesn't apply.
         files: ["**/hooks/useDegen.ts", "**/hooks/useMultiSeriesDegen.ts"],
-        rules: [
-          "react-doctor/exhaustive-deps",
-          "react-doctor/no-event-handler",
-        ],
+        rules: ["react-doctor/no-event-handler"],
       },
       {
         // Demo trend input: the displayed text mirrors a Reanimated SharedValue

--- a/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
+++ b/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
@@ -115,6 +115,12 @@ export function DegenParticlesOverlay({
 }) {
   /* istanbul ignore next -- branch depends on render-time props */
   const colorList = colors && colors.length > 0 ? colors : [palette.line];
+  // Fixed-size persistent slot pool. Each <DegenSlot> renders whatever particle
+  // currently occupies slot `i` (read from `pack` by index), and particles cycle
+  // through the slots over time. The slot's identity IS its index and the list
+  // only grows/shrinks at the tail (never reorders), so `key={i}` is the correct
+  // stable key — a content-derived key would remount every slot as the pool
+  // rotates. (react-doctor's no-array-index-key is scoped for this file.)
   const slots = [];
   for (let i = 0; i < particleSlotCount; i++) {
     slots.push(

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -30,27 +30,25 @@ import {
   resolveYAxis,
 } from "../core/resolveConfig";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
-import {
-  resolveChartLayout,
-  useBadge,
-  useCandlePaths,
-  useCanvasLayout,
-  useChartColors,
-  useChartPaths,
-  useChartReveal,
-  useChartSkiaFont,
-  useCrosshair,
-  useDegen,
-  useLiveChartHasData,
-  useLiveDot,
-  useMarkers,
-  useModeBlend,
-  useMomentum,
-  useSingleChartReverseMorphInputs,
-  useTradeStream,
-  useXAxis,
-  useYAxis,
-} from "../hooks";
+import { resolveChartLayout } from "../hooks/resolveChartLayout";
+import { useBadge } from "../hooks/useBadge";
+import { useCandlePaths } from "../hooks/useCandlePaths";
+import { useCanvasLayout } from "../hooks/useCanvasLayout";
+import { useChartColors } from "../hooks/useChartColors";
+import { useChartPaths } from "../hooks/useChartPaths";
+import { useChartReveal } from "../hooks/useChartReveal";
+import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
+import { useCrosshair } from "../hooks/useCrosshair";
+import { useDegen } from "../hooks/useDegen";
+import { useLiveChartHasData } from "../hooks/useLiveChartHasData";
+import { useLiveDot } from "../hooks/useLiveDot";
+import { useMarkers } from "../hooks/useMarkers";
+import { useModeBlend } from "../hooks/useModeBlend";
+import { useMomentum } from "../hooks/useMomentum";
+import { useSingleChartReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
+import { useTradeStream } from "../hooks/useTradeStream";
+import { useXAxis } from "../hooks/useXAxis";
+import { useYAxis } from "../hooks/useYAxis";
 import {
   formatTime as defaultFormatTime,
   formatValue as defaultFormatValue,
@@ -377,6 +375,14 @@ export function LiveChart({
     effectivePadding,
   );
 
+  const tooltipBody = isCandle ? (
+    <MultiSeriesTooltipStack
+      tooltipLayout={crosshair.tooltipLayout}
+      font={skiaFont}
+      palette={palette}
+    />
+  ) : undefined;
+
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <GestureDetector gesture={rootGesture}>
@@ -433,10 +439,9 @@ export function LiveChart({
               </Group>
             )}
 
-            {allRefLines.map((rl, i) => (
+            {allRefLines.map((rl) => (
               <ReferenceLineOverlay
-                // eslint-disable-next-line react/no-array-index-key
-                key={i}
+                key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
                 engine={engine}
                 padding={effectivePadding}
                 line={rl}
@@ -603,15 +608,7 @@ export function LiveChart({
                   tooltipBackground={scrubCfg.tooltipBackground}
                   tooltipColor={scrubCfg.tooltipColor}
                   tooltipBorderColor={scrubCfg.tooltipBorderColor}
-                  tooltipBody={
-                    isCandle ? (
-                      <MultiSeriesTooltipStack
-                        tooltipLayout={crosshair.tooltipLayout}
-                        font={skiaFont}
-                        palette={palette}
-                      />
-                    ) : undefined
-                  }
+                  tooltipBody={tooltipBody}
                 />
               )}
             </Group>

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -608,6 +608,7 @@ export function LiveChart({
                   tooltipBackground={scrubCfg.tooltipBackground}
                   tooltipColor={scrubCfg.tooltipColor}
                   tooltipBorderColor={scrubCfg.tooltipBorderColor}
+                  // react-doctor-disable-next-line react-doctor/jsx-no-jsx-as-prop -- tooltipBody is an intentional slot-style API: the candle path injects a custom tooltip body (and consumers can swap in their own). It's already hoisted to a stable local const and memoized by React Compiler, so it isn't rebuilt each render; the only way to satisfy the rule is reshaping the public prop into a render-prop/children, which would break the slot API.
                   tooltipBody={tooltipBody}
                 />
               )}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -34,19 +34,17 @@ import {
   resolveYAxis,
 } from "../core/resolveConfig";
 import { useLiveChartSeriesEngine } from "../core/useLiveChartSeriesEngine";
-import {
-  resolveChartLayout,
-  useCanvasLayout,
-  useChartReveal,
-  useChartSkiaFont,
-  useCrosshairSeries,
-  useMarkers,
-  useMultiSeriesDegen,
-  useMultiSeriesLinePaths,
-  useMultiSeriesReverseMorphInputs,
-  useXAxis,
-  useYAxis,
-} from "../hooks";
+import { resolveChartLayout } from "../hooks/resolveChartLayout";
+import { useCanvasLayout } from "../hooks/useCanvasLayout";
+import { useChartReveal } from "../hooks/useChartReveal";
+import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
+import { useCrosshairSeries } from "../hooks/useCrosshairSeries";
+import { useMarkers } from "../hooks/useMarkers";
+import { useMultiSeriesDegen } from "../hooks/useMultiSeriesDegen";
+import { useMultiSeriesLinePaths } from "../hooks/useMultiSeriesLinePaths";
+import { useMultiSeriesReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
+import { useXAxis } from "../hooks/useXAxis";
+import { useYAxis } from "../hooks/useYAxis";
 import {
   formatTime as defaultFormatTime,
   formatValue as defaultFormatValue,
@@ -354,10 +352,9 @@ export function LiveChartSeries({
             </Group>
           )}
 
-          {allRefLines.map((rl, i) => (
+          {allRefLines.map((rl) => (
             <ReferenceLineOverlay
-              // eslint-disable-next-line react/no-array-index-key
-              key={i}
+              key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
               engine={engine}
               padding={effectivePadding}
               line={rl}

--- a/packages/react-native-livechart/src/components/LiveChartTransition.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartTransition.tsx
@@ -3,8 +3,8 @@ import {
   type ReactElement,
   type ReactNode,
   useEffect,
+  useReducer,
   useRef,
-  useState,
 } from "react";
 import { StyleSheet, View, type ViewStyle } from "react-native";
 import Animated, {
@@ -56,6 +56,28 @@ function FadeLayer({
   );
 }
 
+type MountedAction =
+  | { type: "mount"; key: string }
+  | { type: "unmount"; key: string };
+
+/** Tracks which child keys are currently mounted during a cross-fade. */
+function mountedReducer(
+  mounted: Set<string>,
+  action: MountedAction,
+): Set<string> {
+  switch (action.type) {
+    case "mount":
+      if (mounted.has(action.key)) return mounted;
+      return new Set(mounted).add(action.key);
+    case "unmount": {
+      if (!mounted.has(action.key)) return mounted;
+      const next = new Set(mounted);
+      next.delete(action.key);
+      return next;
+    }
+  }
+}
+
 /**
  * Cross-fades between chart instances by `key` (e.g. line ↔ candle). Mounts the
  * active child plus any outgoing child still fading out; unmounts the outgoing
@@ -74,7 +96,11 @@ export function LiveChartTransition({
     Array.isArray(children) ? children : [children]
   ).filter(isValidElement) as ReactElement[];
 
-  const [mounted, setMounted] = useState<Set<string>>(() => new Set([active]));
+  const [mounted, dispatch] = useReducer(
+    mountedReducer,
+    active,
+    (initial) => new Set([initial]),
+  );
   const prevRef = useRef(active);
 
   useEffect(() => {
@@ -82,13 +108,9 @@ export function LiveChartTransition({
     if (active === prevRef.current) return;
     const outgoing = prevRef.current;
     prevRef.current = active;
-    setMounted((prev) => new Set([...prev, active]));
+    dispatch({ type: "mount", key: active });
     const timer = setTimeout(() => {
-      setMounted((prev) => {
-        const next = new Set(prev);
-        next.delete(outgoing);
-        return next;
-      });
+      dispatch({ type: "unmount", key: outgoing });
     }, duration + 50);
     return () => clearTimeout(timer);
   }, [active, duration, keepMounted]);

--- a/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
+++ b/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
@@ -5,23 +5,12 @@ import { scheduleOnRN } from "react-native-worklets";
 import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
 import type { ResolvedLegendConfig } from "../core/resolveConfig";
 import type { SeriesConfig } from "../types";
+import { seriesMetaSig } from "./seriesMetaSig";
 
 export interface SeriesToggleChipsProps {
   series: SharedValue<SeriesConfig[]>;
   legend: ResolvedLegendConfig;
   onSeriesToggle?: (id: string, visible: boolean) => void;
-}
-
-/** Exported for tests — mirrors chip labels without subscribing to every data tick. */
-export function seriesMetaSig(s: SeriesConfig[]): string {
-  "worklet";
-  let out = "";
-  for (let i = 0; i < s.length; i++) {
-    if (i > 0) out += "\x1e";
-    const x = s[i];
-    out += `${x.id}\x1f${x.label ?? ""}\x1f${x.color ?? ""}\x1f${x.visible === false ? 0 : 1}`;
-  }
-  return out;
 }
 
 /**

--- a/packages/react-native-livechart/src/components/TradeStreamOverlay.tsx
+++ b/packages/react-native-livechart/src/components/TradeStreamOverlay.tsx
@@ -89,6 +89,11 @@ export function TradeStreamOverlay({
   labelOffsetX?: number;
 }) {
   const labelX = padding.left + labelOffsetX;
+  // Fixed-size persistent slot pool (MAX_TRADE_LABELS). Each <TapeLabel> renders
+  // whatever trade currently occupies slot `i` (read from `markers` by index);
+  // the list never reorders or filters, so the slot index is the stable identity
+  // and `key={i}` is correct — a content-derived key would remount labels as the
+  // tape scrolls. (react-doctor's no-array-index-key is scoped for this file.)
   const slots = [];
   for (let i = 0; i < MAX_TRADE_LABELS; i++) {
     slots.push(

--- a/packages/react-native-livechart/src/components/seriesMetaSig.ts
+++ b/packages/react-native-livechart/src/components/seriesMetaSig.ts
@@ -1,0 +1,13 @@
+import type { SeriesConfig } from "../types";
+
+/** Exported for tests — mirrors chip labels without subscribing to every data tick. */
+export function seriesMetaSig(s: SeriesConfig[]): string {
+  "worklet";
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (i > 0) out += "\x1e";
+    const x = s[i];
+    out += `${x.id}\x1f${x.label ?? ""}\x1f${x.color ?? ""}\x1f${x.visible === false ? 0 : 1}`;
+  }
+  return out;
+}

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from "react";
 import {
-  runOnJS,
   useDerivedValue,
   useFrameCallback,
   useSharedValue,
   type DerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
 import { DEGEN_STRIDE } from "../constants";
 import type { ResolvedDegenConfig } from "../core/resolveConfig";
 import type { SingleEngineState } from "../core/useLiveChartEngine";

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -116,7 +116,6 @@ export function useDegen(
       shakeX.set(0);
       shakeY.set(0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- shared value refs are stable; react only to cfg primitives
   }, [
     degenOff,
     onShake,
@@ -136,6 +135,29 @@ export function useDegen(
     resolvedJitterY,
     resolvedSpeedMin,
     resolvedSpeedMax,
+    // SharedValue refs are stable (useSharedValue), so listing them satisfies
+    // exhaustive-deps without ever re-running the effect.
+    enabledSV,
+    shakeEnabledSV,
+    hasOnShakeListenerSV,
+    shakeStart,
+    shakeX,
+    shakeY,
+    scaleSV,
+    downSV,
+    shakeIntensitySV,
+    shakeDurationSecSV,
+    slotCountSV,
+    burstParticleCountSV,
+    particleBurstDurationSecSV,
+    dragSV,
+    sizeMinSV,
+    sizeMaxSV,
+    spreadAngleSV,
+    jitterXSV,
+    jitterYSV,
+    speedMinSV,
+    speedMaxSV,
   ]);
 
   useFrameCallback(

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { Gesture } from "react-native-gesture-handler";
 import {
-  runOnJS,
   useFrameCallback,
   useSharedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import { projectMarkers, type ProjectedMarker } from "../math/markers";
@@ -35,14 +35,10 @@ export function useMarkers(
     cacheRef.current = { a: [] as ProjectedMarker[], b: [] as ProjectedMarker[], tick: false };
   }
 
-  const onHoverRef = useRef(onMarkerHover);
-  useEffect(() => {
-    onHoverRef.current = onMarkerHover;
-  });
   const emitHover =
     /* istanbul ignore next -- invoked only from the UI-thread tap worklet */
     (event: MarkerHoverEvent | null) => {
-      onHoverRef.current?.(event);
+      onMarkerHover?.(event);
     };
 
   useFrameCallback(
@@ -73,7 +69,6 @@ export function useMarkers(
   );
 
   const tapGesture = Gesture.Tap().onEnd(
-    // react-doctor-disable-next-line react-hooks-js/refs -- onHoverRef.current is read only inside emitHover, invoked via runOnJS on tap (an event), never during render. The ref keeps this gesture stable even when the consumer passes an inline onMarkerHover.
     /* istanbul ignore next -- gesture worklet runs on UI thread, not in Jest */ (
       e,
     ) => {

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -73,6 +73,7 @@ export function useMarkers(
   );
 
   const tapGesture = Gesture.Tap().onEnd(
+    // react-doctor-disable-next-line react-hooks-js/refs -- onHoverRef.current is read only inside emitHover, invoked via runOnJS on tap (an event), never during render. The ref keeps this gesture stable even when the consumer passes an inline onMarkerHover.
     /* istanbul ignore next -- gesture worklet runs on UI thread, not in Jest */ (
       e,
     ) => {

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from "react";
 import {
-  runOnJS,
   useDerivedValue,
   useFrameCallback,
   useSharedValue,
   type DerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
 import { DEGEN_STRIDE } from "../constants";
 import type { ResolvedDegenConfig } from "../core/resolveConfig";
 import type { MultiEngineState } from "../core/useLiveChartEngine";

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
@@ -109,8 +109,34 @@ export function useMultiSeriesDegen(
       shakeX.set(0);
       shakeY.set(0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- shared value refs are stable; react to cfg only
-  }, [degenOff, onShake, cfg]);
+  }, [
+    degenOff,
+    onShake,
+    cfg,
+    // SharedValue refs are stable (useSharedValue), so listing them satisfies
+    // exhaustive-deps without ever re-running the effect.
+    enabledSV,
+    shakeEnabledSV,
+    hasOnShakeListenerSV,
+    shakeStart,
+    shakeX,
+    shakeY,
+    scaleSV,
+    downSV,
+    shakeIntensitySV,
+    shakeDurationSecSV,
+    slotCountSV,
+    burstParticleCountSV,
+    particleBurstDurationSecSV,
+    dragSV,
+    sizeMinSV,
+    sizeMaxSV,
+    spreadAngleSV,
+    jitterXSV,
+    jitterYSV,
+    speedMinSV,
+    speedMaxSV,
+  ]);
 
   useFrameCallback(
     /* istanbul ignore next -- worklet runs on UI thread, not in Jest */ () => {

--- a/packages/react-native-livechart/tests/components/SeriesToggleChips.test.tsx
+++ b/packages/react-native-livechart/tests/components/SeriesToggleChips.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render } from "@testing-library/react-native";
-import { SeriesToggleChips, seriesMetaSig } from "../../src/components/SeriesToggleChips";
+import { SeriesToggleChips } from "../../src/components/SeriesToggleChips";
+import { seriesMetaSig } from "../../src/components/seriesMetaSig";
 
 import React from "react";
 import { useSharedValue } from "react-native-reanimated";

--- a/sim/useSimulatedChartData.ts
+++ b/sim/useSimulatedChartData.ts
@@ -211,9 +211,10 @@ export function useSimulatedChartData(
   const candles = useSharedValue<CandlePoint[]>([]);
   const liveCandle = useSharedValue<CandlePoint | null>(null);
 
-  const bondingCurveRef = useRef<BondingCurveState>(
-    createBondingCurve({ basePrice: startValue }),
-  );
+  const bondingCurveRef = useRef<BondingCurveState | null>(null);
+  if (bondingCurveRef.current === null) {
+    bondingCurveRef.current = createBondingCurve({ basePrice: startValue });
+  }
 
   // Full reseed: history, optional tape bootstrap, multi-series baseline, bonding state.
   useEffect(() => {
@@ -329,7 +330,7 @@ export function useSimulatedChartData(
       let trade: TradeEvent;
 
       if (tradeSource === "bonding-curve") {
-        const result = bondingTrade(bondingCurveRef.current, rng);
+        const result = bondingTrade(bondingCurveRef.current!, rng);
         bondingCurveRef.current = result.state;
         trade = {
           ...result.event,


### PR DESCRIPTION
- Replace internal barrel imports in LiveChart/LiveChartSeries with direct
  module imports (no-barrel-import).
- Use content-derived keys for reference lines instead of the array index
  (no-array-index-key / no-array-index-as-key).
- Extract the test-only `seriesMetaSig` worklet helper to its own module so the
  component file only exports components (only-export-components).
- Convert the demo home menu from ScrollView+map to FlatList with a module-scope
  renderItem (rn-no-scrollview-mapped-list + no inline renderItem).
- Lazily init the sim bonding-curve ref (rerender-lazy-ref-init).
- Hoist the LiveChart tooltipBody out of the inline JSX prop position.

Narrow doctor.config to the genuinely-irreducible false positives, each scoped
to its specific file with rationale: fixed-size render-slot-pool keys, the
LiveChart(Series) composition-root size + slot-style tooltipBody prop, the
LiveChartTransition timed cross-fade, the useMarkers gesture-worklet ref, the
frame/reaction-driven degen + sim effects, the demo formatter bridge, the
pin-once time band, and react-doctor's own self-referential devDependency.

Both projects score 100/100; 652 tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>