### PR TITLE
fix: compose CrosshairOverlay tooltip via children (drop jsx-as-prop suppression)

### DIFF
--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -24,7 +24,7 @@ export function CrosshairOverlay({
   palette,
   font,
   showTooltip = true,
-  tooltipBody,
+  children,
   crosshairLineColor,
   crosshairDimColor,
   tooltipBackground,
@@ -39,7 +39,10 @@ export function CrosshairOverlay({
   palette: LiveChartPalette;
   font: SkFont;
   showTooltip?: boolean;
-  tooltipBody?: ReactNode;
+  /** Optional custom tooltip body rendered in place of the default value/time
+   *  text (e.g. the multi-line candle stack). Passed as children so it composes
+   *  instead of being threaded through as a JSX-valued prop. */
+  children?: ReactNode;
   crosshairLineColor?: string;
   crosshairDimColor?: string;
   tooltipBackground?: string;
@@ -114,7 +117,7 @@ export function CrosshairOverlay({
             strokeWidth={1}
           />
 
-          {tooltipBody ?? (
+          {children ?? (
             <Group>
               <SkiaText
                 x={valueTextX}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -375,14 +375,6 @@ export function LiveChart({
     effectivePadding,
   );
 
-  const tooltipBody = isCandle ? (
-    <MultiSeriesTooltipStack
-      tooltipLayout={crosshair.tooltipLayout}
-      font={skiaFont}
-      palette={palette}
-    />
-  ) : undefined;
-
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <GestureDetector gesture={rootGesture}>
@@ -608,9 +600,18 @@ export function LiveChart({
                   tooltipBackground={scrubCfg.tooltipBackground}
                   tooltipColor={scrubCfg.tooltipColor}
                   tooltipBorderColor={scrubCfg.tooltipBorderColor}
-                  // react-doctor-disable-next-line react-doctor/jsx-no-jsx-as-prop -- tooltipBody is an intentional slot-style API: the candle path injects a custom tooltip body (and consumers can swap in their own). It's already hoisted to a stable local const and memoized by React Compiler, so it isn't rebuilt each render; the only way to satisfy the rule is reshaping the public prop into a render-prop/children, which would break the slot API.
-                  tooltipBody={tooltipBody}
-                />
+                >
+                  {/* Candle charts render a multi-line OHLC tooltip; the line
+                      chart falls back to CrosshairOverlay's default value/time
+                      body. Composed as children rather than a JSX-valued prop. */}
+                  {isCandle ? (
+                    <MultiSeriesTooltipStack
+                      tooltipLayout={crosshair.tooltipLayout}
+                      font={skiaFont}
+                      palette={palette}
+                    />
+                  ) : null}
+                </CrosshairOverlay>
               )}
             </Group>
           )}

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -415,14 +415,13 @@ describe("CrosshairOverlay", () => {
           palette={palette}
           font={font}
           showTooltip
-          tooltipBody={
-            <MultiSeriesTooltipStack
-              tooltipLayout={tooltipLayout}
-              font={font}
-              palette={palette}
-            />
-          }
-        />
+        >
+          <MultiSeriesTooltipStack
+            tooltipLayout={tooltipLayout}
+            font={font}
+            palette={palette}
+          />
+        </CrosshairOverlay>
       );
     }
     render(<Fixture />);


### PR DESCRIPTION
## What

Removes the inline `react-doctor-disable-next-line react-doctor/jsx-no-jsx-as-prop` at `LiveChart.tsx` and fixes the underlying issue in code instead.

## Why

The internal `CrosshairOverlay` received the custom candle tooltip as a JSX-valued `tooltipBody` prop. `react-doctor/jsx-no-jsx-as-prop` (the `eslint-plugin-react-perf` rule) flags this: the child receives brand-new JSX each render. `CrosshairOverlay` is **internal plumbing**, not public API — there is no slot-style API to preserve.

## How

- `CrosshairOverlay`: `tooltipBody?: ReactNode` prop → `children?: ReactNode`, rendered as `{children ?? <default body>}`.
- `LiveChart`: drop the hoisted `tooltipBody` const + the suppression; compose the candle `MultiSeriesTooltipStack` via JSX **nesting** at the call site (`<CrosshairOverlay …>{isCandle ? … : null}</CrosshairOverlay>`).
- Updated the `CrosshairOverlay` test fixture to pass the body as children.

`react-perf` only inspects `JSXAttribute` nodes, so children-as-composition is the idiomatic, lint-clean shape — no suppression needed (verified: `react-doctor` reports 0 diagnostics).

## Verification
- `react-doctor --lint`: 0 diagnostics
- `tsc --noEmit`: clean
- `npm run lint`: clean
- `npm run test:lib`: 639 passed / 3 skipped

Part of the stack removing every react-doctor suppression one rule at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)