### PR TITLE
chore: drop stale no-effect-event-handler override (LiveChartTransition)

### DIFF
--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -25,15 +25,6 @@ const config: ReactDoctorConfig = {
         rules: ["react-doctor/no-giant-component"],
       },
       {
-        // Timed cross-fade driven by the `active` prop (parent toggles line↔candle):
-        // mount the new child, then unmount the outgoing one after a duration timer.
-        // That's a prop change, not a user event, so there's no handler to move it
-        // into and no-effect-event-handler doesn't apply. (The two state updates
-        // were combined into a useReducer, clearing no-cascading-set-state.)
-        files: ["**/components/LiveChartTransition.tsx"],
-        rules: ["react-doctor/no-effect-event-handler"],
-      },
-      {
         // `emitShake` notifies the consumer when a momentum shake is detected on
         // the UI thread (in the frame worklet, via runOnJS) — there's no React
         // event to move the side effect into, so no-event-handler doesn't apply.


### PR DESCRIPTION
## What
Removes the `doctor.config.ts` override for `react-doctor/no-effect-event-handler` on `LiveChartTransition.tsx`.

## Why — the override was stale
`LiveChartTransition` was refactored to `useReducer` + complete effect deps in an earlier stacked PR (`3650cd3 refactor: prefer complete deps + useReducer over scoped suppressions`), which cleared the finding. The config override was left behind as dead config.

The cross-fade `useEffect` responds to the **`active` prop** changing (the parent toggles line↔candle) — not a DOM event inside this component — so there is no `onClick`/`onChange`/`onSubmit` handler to move the logic into, and the rule does not fire.

## Verification (this isn't a cache artifact)
- Override removed → `react-doctor --lint --full` (no cache, 175/138 files scanned, `LiveChartTransition.tsx` in scope): **0 diagnostics**.
- Rule is enabled (`react-doctor rules explain react-doctor/no-effect-event-handler` → "Default enabled: yes") and the engine is provably active (it fires many other rules on synthetic code).

No code change needed — the suppression was simply stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)