### PR TITLE
fix: mirror degen config to SharedValues unconditionally (drop no-event-handler ignore)

### DIFF
--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -25,13 +25,6 @@ const config: ReactDoctorConfig = {
         rules: ["react-doctor/no-giant-component"],
       },
       {
-        // `emitShake` notifies the consumer when a momentum shake is detected on
-        // the UI thread (in the frame worklet, via runOnJS) — there's no React
-        // event to move the side effect into, so no-event-handler doesn't apply.
-        files: ["**/hooks/useDegen.ts", "**/hooks/useMultiSeriesDegen.ts"],
-        rules: ["react-doctor/no-event-handler"],
-      },
-      {
         // Demo simulation hook: history is fed through a callback by design and
         // its side effects are reaction/timer-driven, not user-event-driven.
         files: ["**/useSimulatedChartData.ts"],

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -84,20 +84,17 @@ export function useDegen(
   const resolvedSpeedMax = cfg?.speedMax ?? 160;
 
   useEffect(() => {
-    if (degenOff) {
-      enabledSV.set(0);
-      shakeEnabledSV.set(0);
-      hasOnShakeListenerSV.set(0);
-      shakeStart.set(0);
-      shakeX.set(0);
-      shakeY.set(0);
-      return;
-    }
-    hasOnShakeListenerSV.set(onShake != null ? 1 : 0);
-    enabledSV.set(1);
+    // Mirror the resolved config into SharedValues for the UI-thread worklet.
+    // Everything is set unconditionally — no prop-derived `if` branch — so this
+    // is a plain external-store sync, not a disguised event handler. When degen
+    // is off, enabledSV is 0 and the frame worklet early-returns (zeroing the
+    // particle buffer and shake itself), so the remaining values are inert; the
+    // resolved* defaults already stand in for the null-config case.
+    enabledSV.set(degenOff ? 0 : 1);
+    shakeEnabledSV.set(!degenOff && resolvedShake ? 1 : 0);
+    hasOnShakeListenerSV.set(!degenOff && onShake != null ? 1 : 0);
     scaleSV.set(resolvedScale);
     downSV.set(resolvedDown ? 1 : 0);
-    shakeEnabledSV.set(resolvedShake ? 1 : 0);
     shakeIntensitySV.set(resolvedShakeIntensity);
     shakeDurationSecSV.set(resolvedShakeDurationSec);
     slotCountSV.set(resolvedSlotCount);
@@ -111,11 +108,6 @@ export function useDegen(
     jitterYSV.set(resolvedJitterY);
     speedMinSV.set(resolvedSpeedMin);
     speedMaxSV.set(resolvedSpeedMax);
-    if (!resolvedShake) {
-      shakeStart.set(0);
-      shakeX.set(0);
-      shakeY.set(0);
-    }
   }, [
     degenOff,
     onShake,

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesDegen.ts
@@ -77,38 +77,30 @@ export function useMultiSeriesDegen(
   const degenOff = cfg === null;
 
   useEffect(() => {
-    if (degenOff) {
-      enabledSV.set(0);
-      shakeEnabledSV.set(0);
-      hasOnShakeListenerSV.set(0);
-      shakeStart.set(0);
-      shakeX.set(0);
-      shakeY.set(0);
-      return;
-    }
-    hasOnShakeListenerSV.set(onShake != null ? 1 : 0);
-    enabledSV.set(1);
-    scaleSV.set(cfg.scale);
-    downSV.set(cfg.downMomentum ? 1 : 0);
-    shakeEnabledSV.set(cfg.shake ? 1 : 0);
-    shakeIntensitySV.set(cfg.shakeIntensity);
-    shakeDurationSecSV.set(cfg.shakeDurationSec);
-    slotCountSV.set(cfg.particleSlotCount);
-    burstParticleCountSV.set(cfg.burstParticleCount);
-    particleBurstDurationSecSV.set(cfg.particleBurstDurationSec);
-    dragSV.set(cfg.drag);
-    sizeMinSV.set(cfg.particleSizeMin);
-    sizeMaxSV.set(cfg.particleSizeMax);
-    spreadAngleSV.set(cfg.spreadAngle);
-    jitterXSV.set(cfg.positionJitterX);
-    jitterYSV.set(cfg.positionJitterY);
-    speedMinSV.set(cfg.speedMin);
-    speedMaxSV.set(cfg.speedMax);
-    if (!cfg.shake) {
-      shakeStart.set(0);
-      shakeX.set(0);
-      shakeY.set(0);
-    }
+    // Mirror the resolved config into SharedValues for the UI-thread worklet.
+    // Everything is set unconditionally — no prop-derived `if` branch — so this
+    // is a plain external-store sync, not a disguised event handler. When degen
+    // is off, enabledSV is 0 and the frame worklet early-returns (zeroing the
+    // particle buffer and shake itself), so the remaining values are inert; the
+    // `?? default` fallbacks stand in for the null-config case.
+    enabledSV.set(degenOff ? 0 : 1);
+    shakeEnabledSV.set(cfg?.shake ? 1 : 0);
+    hasOnShakeListenerSV.set(!degenOff && onShake != null ? 1 : 0);
+    scaleSV.set(cfg?.scale ?? 1);
+    downSV.set(cfg?.downMomentum ? 1 : 0);
+    shakeIntensitySV.set(cfg?.shakeIntensity ?? 1);
+    shakeDurationSecSV.set(cfg?.shakeDurationSec ?? 0.45);
+    slotCountSV.set(cfg?.particleSlotCount ?? 60);
+    burstParticleCountSV.set(cfg?.burstParticleCount ?? 20);
+    particleBurstDurationSecSV.set(cfg?.particleBurstDurationSec ?? 1.0);
+    dragSV.set(cfg?.drag ?? 0.95);
+    sizeMinSV.set(cfg?.particleSizeMin ?? 1);
+    sizeMaxSV.set(cfg?.particleSizeMax ?? 2.2);
+    spreadAngleSV.set(cfg?.spreadAngle ?? Math.PI * 1.2);
+    jitterXSV.set(cfg?.positionJitterX ?? 24);
+    jitterYSV.set(cfg?.positionJitterY ?? 8);
+    speedMinSV.set(cfg?.speedMin ?? 60);
+    speedMaxSV.set(cfg?.speedMax ?? 160);
   }, [
     degenOff,
     onShake,


### PR DESCRIPTION
## What
Removes the `doctor.config.ts` override for `react-doctor/no-event-handler` on `useDegen.ts` and `useMultiSeriesDegen.ts`, fixing the underlying effect shape.

## Why
Both hooks mirrored the resolved degen config into SharedValues inside a `useEffect` shaped like:
```ts
if (degenOff) { enabledSV.set(0); …; return; }   // test derives from the `cfg` prop
…
if (!resolvedShake) { shakeStart.set(0); … }      // ditto
```
`no-event-handler` flags these: the `if` tests derive from the `cfg` **prop**, and the consequents aren't recognized as pure early-exits (the rule doesn't treat Reanimated `sv.set()` as setter statements), so the effect reads as a disguised event handler.

## How
Rewrite both effects as a plain **external-store sync** — set every SharedValue unconditionally, using the `resolved*` defaults / `?? default` fallbacks for the null-config case. The branching is unnecessary because the frame worklet already gates on `enabledSV`/`shakeEnabledSV`:
- degen off → `enabledSV = 0` → worklet early-returns, zeroing the particle buffer **and** shake (`shakeStart/X/Y`).
- shake off → `shakeEnabledSV = 0` → worklet's `else if (shakeEnabledSV < 0.5)` zeroes the shake.

So the prior explicit resets were redundant (at most a one-frame difference, imperceptible at 60fps). No behavior change.

## Verification
- `react-doctor --lint --full`: 0 diagnostics
- `tsc --noEmit`: clean · `npm run lint`: clean · `npm run test:lib`: 639 passed / 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)