### PR TITLE
chore: drop stale unused-dev-dependency override (react-doctor is referenced)

### DIFF
--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -24,11 +24,6 @@ const config: ReactDoctorConfig = {
         ],
         rules: ["react-doctor/no-giant-component"],
       },
-      {
-        // react-doctor is a CLI dev tool, never imported — it flags itself.
-        files: ["package.json", "**/package.json"],
-        rules: ["deslop/unused-dev-dependency"],
-      },
     ],
   },
 };


### PR DESCRIPTION
## What
Removes the `doctor.config.ts` override for `deslop/unused-dev-dependency` on `package.json`.

## Why — the override was stale
It was suppressed on the assumption that react-doctor is "never imported." It **is** imported: `doctor.config.ts` line 1 does `import type { ReactDoctorConfig } from "react-doctor/api"`, so the devDependency is genuinely referenced and the rule no longer fires.

## Verification (this isn't a cache/skip artifact)
- Override removed → full `react-doctor --lint --dead-code` scan (dead-code analysis ran, no skipped checks): **0 diagnostics**.
- Sanity check: temporarily replacing the `react-doctor/api` import in `doctor.config.ts` makes `unused-dev-dependency@package.json` reappear — proving the rule is active and the import is exactly what satisfies it.

No code change needed — the suppression was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)