### PR TITLE
refactor: split LiveChart/LiveChartSeries into controller hook + subcomponents (drop no-giant-component ignore)

### DIFF
--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -2,29 +2,22 @@ import type { ReactDoctorConfig } from "react-doctor/api";
 
 /**
  * react-native-livechart is a Reanimated + Skia library: data and live values
- * flow through `SharedValue`s and are drawn on the UI thread. The findings
- * suppressed below are genuine false positives for that architecture (or for
- * intentional demo code) — each is scoped to the specific files where the
- * pattern is deliberate, with the reason inline, so every rule keeps protecting
- * the rest of the codebase. Everything else react-doctor flagged was fixed in
- * code (see the PR stack): the `.value`→`.get()/.set()` migration, removing
- * redundant manual memoization, dead-code cleanup, ref/purity/effect fixes,
- * direct imports, stable keys, FlatList, and lazy ref init.
+ * flow through `SharedValue`s and are drawn on the UI thread.
+ *
+ * There are no rule suppressions: every finding react-doctor raised was fixed in
+ * code rather than ignored (see the PR stack) — the `.value`→`.get()/.set()`
+ * migration, removing redundant manual memoization, dead-code cleanup,
+ * ref/purity/effect fixes, direct imports, stable keys, FlatList, lazy ref init,
+ * children-based composition over JSX-as-prop, stable slot keys, unconditional
+ * external-store syncs in place of prop-watching effects, and splitting the two
+ * chart roots into a controller hook + presentational subcomponents.
+ *
+ * The config is kept (with an empty override list) as the project's react-doctor
+ * entry point — run `npm run doctor` to verify it stays clean.
  */
 const config: ReactDoctorConfig = {
   ignore: {
-    overrides: [
-      {
-        // LiveChart / LiveChartSeries are the top-level composition roots; their
-        // size is inherent to a fully-featured chart component. (The `tooltipBody`
-        // JSX-as-prop slot is suppressed inline at its call site in LiveChart.tsx.)
-        files: [
-          "**/components/LiveChart.tsx",
-          "**/components/LiveChartSeries.tsx",
-        ],
-        rules: ["react-doctor/no-giant-component"],
-      },
-    ],
+    overrides: [],
   },
 };
 

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -76,7 +76,13 @@ import { ValueLineOverlay } from "./ValueLineOverlay";
 import { XAxisOverlay } from "./XAxisOverlay";
 import { YAxisOverlay } from "./YAxisOverlay";
 
-export function LiveChart({
+/**
+ * Resolves props → configs → theme/layout → engine → per-frame derived values and
+ * overlay hooks, returning a single render model. All the chart's wiring lives
+ * here so the rendered pieces (`ChartStack`, `ChartScrubLayer`, `LiveChart`) stay
+ * small and presentational.
+ */
+function useLiveChartController({
   // ── Data ────────────────────────────────────────────────────────────────
   data,
   value,
@@ -375,7 +381,378 @@ export function LiveChart({
     effectivePadding,
   );
 
-  // ── Render ─────────────────────────────────────────────────────────────
+  return {
+    // passthrough props the render needs
+    style,
+    accessibilityLabel,
+    accessibilityRole,
+    emptyText,
+    showValue,
+    valueMomentumColor,
+    lineProp,
+    formatValue,
+    isCandle,
+    // configs
+    yAxisCfg,
+    xAxisCfg,
+    badgeCfg,
+    scrubCfg,
+    gradientCfg,
+    valueLineCfg,
+    pulseCfg,
+    gridStyleCfg,
+    degenCfg,
+    tradeStreamResolved,
+    leftEdgeFadeCfg,
+    allRefLines,
+    badgeUsesRightGutter,
+    // theme / layout / fonts
+    palette,
+    skiaFont,
+    valueFont,
+    strokeWidth,
+    effectivePadding,
+    // engine + reveal
+    engine,
+    reveal,
+    // derived render values
+    backgroundColor,
+    gradientEnd,
+    gradientTopColor,
+    gradientBottomColor,
+    lineGroupOpacity,
+    candleGroupOpacity,
+    onLayout,
+    linePath,
+    fillPath,
+    upBodiesPath,
+    downBodiesPath,
+    upWicksPath,
+    downWicksPath,
+    dotX,
+    dotY,
+    momentumSV,
+    tradeMarkers,
+    degenPack,
+    degenPackRevision,
+    degenShakeTransform,
+    yAxisEntries,
+    xAxisEntries,
+    badgeData,
+    crosshair,
+    rootGesture,
+    markersActive,
+    markersSV,
+  };
+}
+
+type LiveChartModel = ReturnType<typeof useLiveChartController>;
+
+/** Main shaken chart stack: grid, fill, line/candles, axes, badge, dot, degen,
+ *  value text, markers, and the loading/empty art. */
+function ChartStack({ model }: { model: LiveChartModel }) {
+  const {
+    degenShakeTransform,
+    yAxisCfg,
+    reveal,
+    yAxisEntries,
+    engine,
+    effectivePadding,
+    palette,
+    skiaFont,
+    badgeUsesRightGutter,
+    badgeCfg,
+    gridStyleCfg,
+    gradientCfg,
+    fillPath,
+    gradientEnd,
+    gradientTopColor,
+    gradientBottomColor,
+    valueLineCfg,
+    dotY,
+    allRefLines,
+    formatValue,
+    lineGroupOpacity,
+    linePath,
+    strokeWidth,
+    lineProp,
+    candleGroupOpacity,
+    upWicksPath,
+    downWicksPath,
+    upBodiesPath,
+    downBodiesPath,
+    xAxisCfg,
+    xAxisEntries,
+    badgeData,
+    dotX,
+    pulseCfg,
+    degenCfg,
+    degenPack,
+    degenPackRevision,
+    showValue,
+    valueFont,
+    momentumSV,
+    valueMomentumColor,
+    markersActive,
+    markersSV,
+    emptyText,
+  } = model;
+
+  return (
+    <Group transform={degenShakeTransform}>
+      {/* Y-axis grid */}
+      {yAxisCfg && (
+        <Group opacity={reveal.yAxisOpacity}>
+          <YAxisOverlay
+            entries={yAxisEntries}
+            engine={engine}
+            padding={effectivePadding}
+            palette={palette}
+            font={skiaFont}
+            badge={badgeUsesRightGutter}
+            badgeTail={badgeCfg?.tail ?? true}
+            gridStyle={gridStyleCfg}
+          />
+        </Group>
+      )}
+
+      {/* Area gradient fill */}
+      {gradientCfg && (
+        <Group opacity={reveal.fillOpacity}>
+          <Path path={fillPath} style="fill">
+            <LinearGradient
+              start={vec(0, effectivePadding.top)}
+              end={vec(0, gradientEnd)}
+              colors={[gradientTopColor, gradientBottomColor]}
+            />
+          </Path>
+        </Group>
+      )}
+
+      {/* Value line + reference line (behind chart line) */}
+      {valueLineCfg && (
+        <Group opacity={reveal.lineOpacity}>
+          <ValueLineOverlay
+            dotY={dotY}
+            engine={engine}
+            padding={effectivePadding}
+            strokeWidth={valueLineCfg.strokeWidth}
+            intervals={valueLineCfg.intervals}
+            color={valueLineCfg.color ?? palette.dashLine}
+          />
+        </Group>
+      )}
+
+      {allRefLines.map((rl) => (
+        <ReferenceLineOverlay
+          key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
+          engine={engine}
+          padding={effectivePadding}
+          line={rl}
+          palette={palette}
+          formatValue={formatValue}
+          font={skiaFont}
+        />
+      ))}
+
+      {/* Chart line (fades out in candle mode) */}
+      <Group opacity={lineGroupOpacity}>
+        <Path
+          path={linePath}
+          style="stroke"
+          strokeWidth={strokeWidth}
+          color={lineProp?.color ?? palette.line}
+          strokeCap="round"
+          strokeJoin="round"
+        />
+      </Group>
+
+      {/* Candle bodies/wicks (fades in in candle mode) */}
+      <Group opacity={candleGroupOpacity}>
+        <Path
+          path={upWicksPath}
+          style="stroke"
+          strokeWidth={1}
+          color={palette.wickUp}
+        />
+        <Path
+          path={downWicksPath}
+          style="stroke"
+          strokeWidth={1}
+          color={palette.wickDown}
+        />
+        <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
+        <Path
+          path={downBodiesPath}
+          style="fill"
+          color={palette.candleDown}
+        />
+      </Group>
+
+      {/* X-axis time labels */}
+      {xAxisCfg && (
+        <XAxisOverlay
+          entries={xAxisEntries}
+          engine={engine}
+          padding={effectivePadding}
+          palette={palette}
+          font={skiaFont}
+        />
+      )}
+
+      {/* Badge and live dot */}
+      {badgeCfg && (
+        <Group opacity={reveal.badgeOpacity}>
+          <BadgeOverlay badge={badgeData} font={skiaFont} />
+        </Group>
+      )}
+
+      <Group opacity={reveal.dotOpacity}>
+        <DotOverlay
+          dotX={dotX}
+          dotY={dotY}
+          palette={palette}
+          engine={engine}
+          pulse={pulseCfg}
+        />
+      </Group>
+
+      {degenCfg && (
+        <Group opacity={reveal.dotOpacity}>
+          <DegenParticlesOverlay
+            pack={degenPack}
+            packRevision={degenPackRevision}
+            engine={engine}
+            palette={palette}
+            particleSlotCount={degenCfg.particleSlotCount}
+            particleBurstDurationSec={degenCfg.particleBurstDurationSec}
+            particleOpacity={degenCfg.particleOpacity}
+            colors={degenCfg.colors}
+          />
+        </Group>
+      )}
+
+      {showValue && (
+        <Group opacity={reveal.lineOpacity}>
+          <ValueTextOverlay
+            engine={engine}
+            padding={effectivePadding}
+            palette={palette}
+            font={valueFont}
+            formatValue={formatValue}
+            momentum={momentumSV}
+            momentumColor={valueMomentumColor}
+          />
+        </Group>
+      )}
+
+      {markersActive && (
+        <Group opacity={reveal.dotOpacity}>
+          <MarkerOverlay
+            markers={markersSV}
+            engine={engine}
+            padding={effectivePadding}
+            palette={palette}
+            font={skiaFont}
+          />
+        </Group>
+      )}
+
+      {/* Loading / empty state — before left-edge fade so the squiggle/empty art fades like the chart */}
+      <LoadingOverlay
+        engine={engine}
+        padding={effectivePadding}
+        palette={palette}
+        font={skiaFont}
+        morphT={reveal.morphT}
+        isLoading={reveal.isLoading}
+        isEmpty={reveal.isEmpty}
+        emptyText={emptyText}
+        strokeWidth={strokeWidth}
+        badge={badgeCfg !== null}
+        badgeTail={badgeCfg?.tail ?? true}
+      />
+    </Group>
+  );
+}
+
+/** Trade-tape labels and the scrub crosshair/tooltip (drawn in canvas space, on
+ *  top of the shaken stack). */
+function ChartScrubLayer({ model }: { model: LiveChartModel }) {
+  const {
+    tradeStreamResolved,
+    scrubCfg,
+    degenShakeTransform,
+    tradeMarkers,
+    palette,
+    effectivePadding,
+    skiaFont,
+    reveal,
+    crosshair,
+    isCandle,
+  } = model;
+
+  if (!tradeStreamResolved && !scrubCfg) return null;
+
+  return (
+    <Group transform={degenShakeTransform}>
+      {tradeStreamResolved && (
+        <TradeStreamOverlay
+          markers={tradeMarkers}
+          palette={palette}
+          padding={effectivePadding}
+          font={skiaFont}
+          opacity={reveal.dotOpacity}
+          labelOffsetX={tradeStreamResolved.labelOffsetX}
+        />
+      )}
+
+      {scrubCfg && (
+        <CrosshairOverlay
+          scrubX={crosshair.scrubX}
+          crosshairOpacity={crosshair.crosshairOpacity}
+          tooltipLayout={crosshair.tooltipLayout}
+          engine={model.engine}
+          padding={effectivePadding}
+          palette={palette}
+          font={skiaFont}
+          showTooltip={scrubCfg.tooltip}
+          crosshairLineColor={scrubCfg.crosshairLineColor}
+          crosshairDimColor={scrubCfg.crosshairDimColor}
+          tooltipBackground={scrubCfg.tooltipBackground}
+          tooltipColor={scrubCfg.tooltipColor}
+          tooltipBorderColor={scrubCfg.tooltipBorderColor}
+        >
+          {/* Candle charts render a multi-line OHLC tooltip; the line
+              chart falls back to CrosshairOverlay's default value/time
+              body. Composed as children rather than a JSX-valued prop. */}
+          {isCandle ? (
+            <MultiSeriesTooltipStack
+              tooltipLayout={crosshair.tooltipLayout}
+              font={skiaFont}
+              palette={palette}
+            />
+          ) : null}
+        </CrosshairOverlay>
+      )}
+    </Group>
+  );
+}
+
+export function LiveChart(props: LiveChartProps) {
+  const model = useLiveChartController(props);
+  const {
+    rootGesture,
+    backgroundColor,
+    style,
+    onLayout,
+    accessibilityLabel,
+    accessibilityRole,
+    leftEdgeFadeCfg,
+    effectivePadding,
+    engine,
+  } = model;
+
   return (
     <GestureDetector gesture={rootGesture}>
       <View
@@ -387,180 +764,7 @@ export function LiveChart({
       >
         <Canvas style={{ flex: 1 }}>
           {/* Shaken chart stack — left-edge fade is a sibling below so dstOut runs in canvas space */}
-          <Group transform={degenShakeTransform}>
-            {/* Y-axis grid */}
-            {yAxisCfg && (
-              <Group opacity={reveal.yAxisOpacity}>
-                <YAxisOverlay
-                  entries={yAxisEntries}
-                  engine={engine}
-                  padding={effectivePadding}
-                  palette={palette}
-                  font={skiaFont}
-                  badge={badgeUsesRightGutter}
-                  badgeTail={badgeCfg?.tail ?? true}
-                  gridStyle={gridStyleCfg}
-                />
-              </Group>
-            )}
-
-            {/* Area gradient fill */}
-            {gradientCfg && (
-              <Group opacity={reveal.fillOpacity}>
-                <Path path={fillPath} style="fill">
-                  <LinearGradient
-                    start={vec(0, effectivePadding.top)}
-                    end={vec(0, gradientEnd)}
-                    colors={[gradientTopColor, gradientBottomColor]}
-                  />
-                </Path>
-              </Group>
-            )}
-
-            {/* Value line + reference line (behind chart line) */}
-            {valueLineCfg && (
-              <Group opacity={reveal.lineOpacity}>
-                <ValueLineOverlay
-                  dotY={dotY}
-                  engine={engine}
-                  padding={effectivePadding}
-                  strokeWidth={valueLineCfg.strokeWidth}
-                  intervals={valueLineCfg.intervals}
-                  color={valueLineCfg.color ?? palette.dashLine}
-                />
-              </Group>
-            )}
-
-            {allRefLines.map((rl) => (
-              <ReferenceLineOverlay
-                key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
-                engine={engine}
-                padding={effectivePadding}
-                line={rl}
-                palette={palette}
-                formatValue={formatValue}
-                font={skiaFont}
-              />
-            ))}
-
-            {/* Chart line (fades out in candle mode) */}
-            <Group opacity={lineGroupOpacity}>
-              <Path
-                path={linePath}
-                style="stroke"
-                strokeWidth={strokeWidth}
-                color={lineProp?.color ?? palette.line}
-                strokeCap="round"
-                strokeJoin="round"
-              />
-            </Group>
-
-            {/* Candle bodies/wicks (fades in in candle mode) */}
-            <Group opacity={candleGroupOpacity}>
-              <Path
-                path={upWicksPath}
-                style="stroke"
-                strokeWidth={1}
-                color={palette.wickUp}
-              />
-              <Path
-                path={downWicksPath}
-                style="stroke"
-                strokeWidth={1}
-                color={palette.wickDown}
-              />
-              <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
-              <Path
-                path={downBodiesPath}
-                style="fill"
-                color={palette.candleDown}
-              />
-            </Group>
-
-            {/* X-axis time labels */}
-            {xAxisCfg && (
-              <XAxisOverlay
-                entries={xAxisEntries}
-                engine={engine}
-                padding={effectivePadding}
-                palette={palette}
-                font={skiaFont}
-              />
-            )}
-
-            {/* Badge and live dot */}
-            {badgeCfg && (
-              <Group opacity={reveal.badgeOpacity}>
-                <BadgeOverlay badge={badgeData} font={skiaFont} />
-              </Group>
-            )}
-
-            <Group opacity={reveal.dotOpacity}>
-              <DotOverlay
-                dotX={dotX}
-                dotY={dotY}
-                palette={palette}
-                engine={engine}
-                pulse={pulseCfg}
-              />
-            </Group>
-
-            {degenCfg && (
-              <Group opacity={reveal.dotOpacity}>
-                <DegenParticlesOverlay
-                  pack={degenPack}
-                  packRevision={degenPackRevision}
-                  engine={engine}
-                  palette={palette}
-                  particleSlotCount={degenCfg.particleSlotCount}
-                  particleBurstDurationSec={degenCfg.particleBurstDurationSec}
-                  particleOpacity={degenCfg.particleOpacity}
-                  colors={degenCfg.colors}
-                />
-              </Group>
-            )}
-
-            {showValue && (
-              <Group opacity={reveal.lineOpacity}>
-                <ValueTextOverlay
-                  engine={engine}
-                  padding={effectivePadding}
-                  palette={palette}
-                  font={valueFont}
-                  formatValue={formatValue}
-                  momentum={momentumSV}
-                  momentumColor={valueMomentumColor}
-                />
-              </Group>
-            )}
-
-            {markersActive && (
-              <Group opacity={reveal.dotOpacity}>
-                <MarkerOverlay
-                  markers={markersSV}
-                  engine={engine}
-                  padding={effectivePadding}
-                  palette={palette}
-                  font={skiaFont}
-                />
-              </Group>
-            )}
-
-            {/* Loading / empty state — before left-edge fade so the squiggle/empty art fades like the chart */}
-            <LoadingOverlay
-              engine={engine}
-              padding={effectivePadding}
-              palette={palette}
-              font={skiaFont}
-              morphT={reveal.morphT}
-              isLoading={reveal.isLoading}
-              isEmpty={reveal.isEmpty}
-              emptyText={emptyText}
-              strokeWidth={strokeWidth}
-              badge={badgeCfg !== null}
-              badgeTail={badgeCfg?.tail ?? true}
-            />
-          </Group>
+          <ChartStack model={model} />
 
           {leftEdgeFadeCfg && (
             <LeftEdgeFade
@@ -572,49 +776,7 @@ export function LiveChart({
             />
           )}
 
-          {(tradeStreamResolved || scrubCfg) && (
-            <Group transform={degenShakeTransform}>
-              {tradeStreamResolved && (
-                <TradeStreamOverlay
-                  markers={tradeMarkers}
-                  palette={palette}
-                  padding={effectivePadding}
-                  font={skiaFont}
-                  opacity={reveal.dotOpacity}
-                  labelOffsetX={tradeStreamResolved.labelOffsetX}
-                />
-              )}
-
-              {scrubCfg && (
-                <CrosshairOverlay
-                  scrubX={crosshair.scrubX}
-                  crosshairOpacity={crosshair.crosshairOpacity}
-                  tooltipLayout={crosshair.tooltipLayout}
-                  engine={engine}
-                  padding={effectivePadding}
-                  palette={palette}
-                  font={skiaFont}
-                  showTooltip={scrubCfg.tooltip}
-                  crosshairLineColor={scrubCfg.crosshairLineColor}
-                  crosshairDimColor={scrubCfg.crosshairDimColor}
-                  tooltipBackground={scrubCfg.tooltipBackground}
-                  tooltipColor={scrubCfg.tooltipColor}
-                  tooltipBorderColor={scrubCfg.tooltipBorderColor}
-                >
-                  {/* Candle charts render a multi-line OHLC tooltip; the line
-                      chart falls back to CrosshairOverlay's default value/time
-                      body. Composed as children rather than a JSX-valued prop. */}
-                  {isCandle ? (
-                    <MultiSeriesTooltipStack
-                      tooltipLayout={crosshair.tooltipLayout}
-                      font={skiaFont}
-                      palette={palette}
-                    />
-                  ) : null}
-                </CrosshairOverlay>
-              )}
-            </Group>
-          )}
+          <ChartScrubLayer model={model} />
         </Canvas>
       </View>
     </GestureDetector>

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -5,7 +5,7 @@
  * @see https://github.com/benjitaylor/liveline
  */
 import { Canvas, Group } from "@shopify/react-native-skia";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import {
@@ -77,7 +77,12 @@ function lineColorsSig(s: SharedValue<SeriesConfig[]>) {
   return lineColorsSignatureFromArray(s.value);
 }
 
-export function LiveChartSeries({
+/**
+ * Resolves props → configs → theme/layout → engine → per-frame derived values,
+ * overlay hooks and the color/style reaction state, returning a single render
+ * model so `SeriesChartStack` and `LiveChartSeries` stay small and presentational.
+ */
+function useLiveChartSeriesController({
   series,
   theme = "dark",
   accentColor = "#3b82f6",
@@ -307,17 +312,241 @@ export function LiveChartSeries({
 
   const backgroundColor = `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
 
-  const legendTop =
-    legendCfg.position === "top" ? (
-      <SeriesToggleChips
-        series={series}
-        legend={legendCfg}
-        onSeriesToggle={onSeriesToggle}
-      />
-    ) : null;
+  return {
+    // passthrough props the render needs
+    series,
+    style,
+    accessibilityLabel,
+    accessibilityRole,
+    emptyText,
+    formatValue,
+    onSeriesToggle,
+    // configs
+    yAxisCfg,
+    xAxisCfg,
+    scrubCfg,
+    gridStyleCfg,
+    dotCfg,
+    legendCfg,
+    degenCfg,
+    allRefLines,
+    leftEdgeFadeCfg,
+    // theme / layout / fonts
+    palette,
+    skiaFont,
+    seriesLabelInset,
+    strokeWidth,
+    effectivePadding,
+    backgroundColor,
+    // engine + reveal
+    engine,
+    reveal,
+    effectiveSeries,
+    layoutHeight,
+    onLayout,
+    linePaths,
+    lineColors,
+    lineStyles,
+    degenPack,
+    degenPackRevision,
+    degenShakeTransform,
+    yAxisEntries,
+    xAxisEntries,
+    crosshair,
+    rootGesture,
+    markersActive,
+    markersSV,
+  };
+}
 
-  const legendBottom =
-    legendCfg.position === "bottom" ? (
+type LiveChartSeriesModel = ReturnType<typeof useLiveChartSeriesController>;
+
+/** The shaken multi-series stack: grid, reference/value lines, per-series strokes,
+ *  axis, dots, value labels, degen, markers, and the loading/empty art. */
+function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
+  const {
+    degenShakeTransform,
+    yAxisCfg,
+    reveal,
+    yAxisEntries,
+    engine,
+    effectivePadding,
+    palette,
+    skiaFont,
+    seriesLabelInset,
+    gridStyleCfg,
+    allRefLines,
+    formatValue,
+    dotCfg,
+    lineColors,
+    linePaths,
+    effectiveSeries,
+    strokeWidth,
+    lineStyles,
+    xAxisCfg,
+    xAxisEntries,
+    degenCfg,
+    degenPack,
+    degenPackRevision,
+    markersActive,
+    markersSV,
+    series,
+    emptyText,
+  } = model;
+
+  return (
+    <Group transform={degenShakeTransform}>
+      {yAxisCfg && (
+        <Group opacity={reveal.yAxisOpacity}>
+          <YAxisOverlay
+            entries={yAxisEntries}
+            engine={engine}
+            padding={effectivePadding}
+            palette={palette}
+            font={skiaFont}
+            badge={false}
+            seriesLabelInset={seriesLabelInset}
+            gridStyle={gridStyleCfg}
+          />
+        </Group>
+      )}
+
+      {allRefLines.map((rl) => (
+        <ReferenceLineOverlay
+          key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
+          engine={engine}
+          padding={effectivePadding}
+          line={rl}
+          palette={palette}
+          formatValue={formatValue}
+          font={skiaFont}
+        />
+      ))}
+
+      {dotCfg.valueLine && (
+        <Group opacity={reveal.lineOpacity}>
+          <MultiSeriesValueLines
+            engine={engine}
+            padding={effectivePadding}
+            colors={lineColors}
+            config={dotCfg.valueLine}
+          />
+        </Group>
+      )}
+
+      <Group opacity={reveal.lineOpacity}>
+        {Array.from({ length: MAX_MULTI_SERIES }, (_, i) => (
+          <MultiSeriesStroke
+            key={i}
+            index={i}
+            paths={linePaths}
+            opacities={engine.seriesOpacities}
+            series={effectiveSeries}
+            strokeWidth={strokeWidth}
+            lineStyle={lineStyles[i]}
+          />
+        ))}
+      </Group>
+
+      {xAxisCfg && (
+        <XAxisOverlay
+          entries={xAxisEntries}
+          engine={engine}
+          padding={effectivePadding}
+          palette={palette}
+          font={skiaFont}
+        />
+      )}
+
+      <Group opacity={reveal.dotOpacity}>
+        <MultiSeriesDots
+          engine={engine}
+          padding={effectivePadding}
+          colors={lineColors}
+          radius={dotCfg.radius}
+          pulse={dotCfg.pulse}
+        />
+      </Group>
+
+      {dotCfg.valueLabel && (
+        <Group opacity={reveal.dotOpacity}>
+          <MultiSeriesValueLabels
+            engine={engine}
+            padding={effectivePadding}
+            colors={lineColors}
+            font={skiaFont}
+            dotRadius={dotCfg.radius}
+          />
+        </Group>
+      )}
+
+      {degenCfg && (
+        <Group opacity={reveal.dotOpacity}>
+          <DegenParticlesOverlay
+            pack={degenPack}
+            packRevision={degenPackRevision}
+            engine={engine}
+            palette={palette}
+            particleSlotCount={degenCfg.particleSlotCount}
+            particleBurstDurationSec={degenCfg.particleBurstDurationSec}
+            particleOpacity={degenCfg.particleOpacity}
+            colors={degenCfg.colors ?? lineColors}
+          />
+        </Group>
+      )}
+
+      {markersActive && (
+        <Group opacity={reveal.dotOpacity}>
+          <MarkerOverlay
+            markers={markersSV}
+            engine={engine}
+            padding={effectivePadding}
+            palette={palette}
+            font={skiaFont}
+            series={series}
+          />
+        </Group>
+      )}
+
+      <LoadingOverlay
+        engine={engine}
+        padding={effectivePadding}
+        palette={palette}
+        font={skiaFont}
+        morphT={reveal.morphT}
+        isLoading={reveal.isLoading}
+        isEmpty={reveal.isEmpty}
+        emptyText={emptyText}
+        strokeWidth={strokeWidth}
+        badge={false}
+      />
+    </Group>
+  );
+}
+
+export function LiveChartSeries(props: LiveChartSeriesProps) {
+  const model = useLiveChartSeriesController(props);
+  const {
+    rootGesture,
+    backgroundColor,
+    style,
+    onLayout,
+    accessibilityLabel,
+    accessibilityRole,
+    layoutHeight,
+    legendCfg,
+    series,
+    onSeriesToggle,
+    leftEdgeFadeCfg,
+    effectivePadding,
+    engine,
+    scrubCfg,
+    crosshair,
+    palette,
+  } = model;
+
+  const legend =
+    legendCfg.position === "top" || legendCfg.position === "bottom" ? (
       <SeriesToggleChips
         series={series}
         legend={legendCfg}
@@ -334,134 +563,9 @@ export function LiveChartSeries({
         accessibilityLabel={accessibilityLabel}
         accessibilityRole={accessibilityRole}
       >
-        {legendTop}
+        {legendCfg.position === "top" ? legend : null}
         <Canvas style={{ flex: 1, minHeight: layoutHeight || 1 }}>
-          <Group transform={degenShakeTransform}>
-          {yAxisCfg && (
-            <Group opacity={reveal.yAxisOpacity}>
-              <YAxisOverlay
-                entries={yAxisEntries}
-                engine={engine}
-                padding={effectivePadding}
-                palette={palette}
-                font={skiaFont}
-                badge={false}
-                seriesLabelInset={seriesLabelInset}
-                gridStyle={gridStyleCfg}
-              />
-            </Group>
-          )}
-
-          {allRefLines.map((rl) => (
-            <ReferenceLineOverlay
-              key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
-              engine={engine}
-              padding={effectivePadding}
-              line={rl}
-              palette={palette}
-              formatValue={formatValue}
-              font={skiaFont}
-            />
-          ))}
-
-          {dotCfg.valueLine && (
-            <Group opacity={reveal.lineOpacity}>
-              <MultiSeriesValueLines
-                engine={engine}
-                padding={effectivePadding}
-                colors={lineColors}
-                config={dotCfg.valueLine}
-              />
-            </Group>
-          )}
-
-          <Group opacity={reveal.lineOpacity}>
-            {Array.from({ length: MAX_MULTI_SERIES }, (_, i) => (
-              <MultiSeriesStroke
-                key={i}
-                index={i}
-                paths={linePaths}
-                opacities={engine.seriesOpacities}
-                series={effectiveSeries}
-                strokeWidth={strokeWidth}
-                lineStyle={lineStyles[i]}
-              />
-            ))}
-          </Group>
-
-          {xAxisCfg && (
-            <XAxisOverlay
-              entries={xAxisEntries}
-              engine={engine}
-              padding={effectivePadding}
-              palette={palette}
-              font={skiaFont}
-            />
-          )}
-
-          <Group opacity={reveal.dotOpacity}>
-            <MultiSeriesDots
-              engine={engine}
-              padding={effectivePadding}
-              colors={lineColors}
-              radius={dotCfg.radius}
-              pulse={dotCfg.pulse}
-            />
-          </Group>
-
-          {dotCfg.valueLabel && (
-            <Group opacity={reveal.dotOpacity}>
-              <MultiSeriesValueLabels
-                engine={engine}
-                padding={effectivePadding}
-                colors={lineColors}
-                font={skiaFont}
-                dotRadius={dotCfg.radius}
-              />
-            </Group>
-          )}
-
-          {degenCfg && (
-            <Group opacity={reveal.dotOpacity}>
-              <DegenParticlesOverlay
-                pack={degenPack}
-                packRevision={degenPackRevision}
-                engine={engine}
-                palette={palette}
-                particleSlotCount={degenCfg.particleSlotCount}
-                particleBurstDurationSec={degenCfg.particleBurstDurationSec}
-                particleOpacity={degenCfg.particleOpacity}
-                colors={degenCfg.colors ?? lineColors}
-              />
-            </Group>
-          )}
-
-          {markersActive && (
-            <Group opacity={reveal.dotOpacity}>
-              <MarkerOverlay
-                markers={markersSV}
-                engine={engine}
-                padding={effectivePadding}
-                palette={palette}
-                font={skiaFont}
-                series={series}
-              />
-            </Group>
-          )}
-
-          <LoadingOverlay
-            engine={engine}
-            padding={effectivePadding}
-            palette={palette}
-            font={skiaFont}
-            morphT={reveal.morphT}
-            isLoading={reveal.isLoading}
-            isEmpty={reveal.isEmpty}
-            emptyText={emptyText}
-            strokeWidth={strokeWidth}
-            badge={false}
-          />
-          </Group>
+          <SeriesChartStack model={model} />
 
           {leftEdgeFadeCfg && (
             <LeftEdgeFade
@@ -485,7 +589,7 @@ export function LiveChartSeries({
             />
           )}
         </Canvas>
-        {legendBottom}
+        {legendCfg.position === "bottom" ? legend : null}
       </View>
     </GestureDetector>
   );


### PR DESCRIPTION
## What
Removes the final `doctor.config.ts` override — `react-doctor/no-giant-component` on `LiveChart.tsx` and `LiveChartSeries.tsx` — by splitting both components. **After this PR the overrides list is empty: every react-doctor finding in the stack is fixed in code, none suppressed.**

## Why
The rule flags component functions over **300 lines** (LiveChart was 544, LiveChartSeries 413). Each mixed all prop-defaulting, config resolution, engine wiring and overlay hooks with a large render tree in one function.

## How — split along the rule's recommended seam
- **`useLiveChartController` / `useLiveChartSeriesController`** — a hook doing the full resolve → engine → derived-value wiring, returning a single render *model*. Hooks contain no JSX, so they aren't components and aren't size-flagged.
- **Presentational subcomponents** taking the model: `ChartStack` + `ChartScrubLayer` (single-series), `SeriesChartStack` (multi-series).
- The exported `LiveChart` / `LiveChartSeries` now just call the hook and compose the subcomponents.

The JSX is moved **verbatim**, so rendering is unchanged. Also drops a pre-existing unused `useRef` import in `LiveChartSeries`.

`doctor.config.ts` is kept (empty overrides + the `react-doctor/api` import that PR #62 relies on) as the project's react-doctor entry point.

## Verification
- `react-doctor --lint --dead-code --full`: **0 diagnostics** (whole project, no suppressions)
- `tsc --noEmit`: clean · `npm run lint`: clean · `npm test`: 652 passed / 3 skipped
- Each component function is now < 300 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)