### PR TITLE
fix: read SharedValue from closure in scheduleOnRN snapshot callbacks

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -234,15 +234,19 @@ function useLiveChartSeriesController({
     resolveMultiSeriesLineColorsSnapshot(series.value),
   );
 
-  const syncColors = (sv: SharedValue<SeriesConfig[]>) => {
-    setLineColors(resolveMultiSeriesLineColorsSnapshot(sv.value));
+  // Read the `series` prop from closure, not a SharedValue passed through
+  // `scheduleOnRN`: the handle serialized across the worklet→JS boundary keeps
+  // the native `.value` accessor but loses the `.get()` method (`.get()` on it
+  // throws). Reading the prop directly is robust to either accessor.
+  const syncColors = () => {
+    setLineColors(resolveMultiSeriesLineColorsSnapshot(series.value));
   };
 
   useAnimatedReaction(
     () => lineColorsSig(series),
     /* istanbul ignore next -- scheduleOnRN from UI-thread reaction */
     (sig, prev) => {
-      if (sig !== prev) scheduleOnRN(syncColors, series);
+      if (sig !== prev) scheduleOnRN(syncColors);
     },
     [series, syncColors],
   );
@@ -253,15 +257,15 @@ function useLiveChartSeriesController({
     resolveMultiSeriesLineStylesSnapshot(series.value),
   );
 
-  const syncStyles = (sv: SharedValue<SeriesConfig[]>) => {
-    setLineStyles(resolveMultiSeriesLineStylesSnapshot(sv.value));
+  const syncStyles = () => {
+    setLineStyles(resolveMultiSeriesLineStylesSnapshot(series.value));
   };
 
   useAnimatedReaction(
     () => lineStyleSignatureFromArray(series.value),
     /* istanbul ignore next -- scheduleOnRN from UI-thread reaction */
     (sig, prev) => {
-      if (sig !== prev) scheduleOnRN(syncStyles, series);
+      if (sig !== prev) scheduleOnRN(syncStyles);
     },
     [series, syncStyles],
   );

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -249,15 +249,19 @@ export function MarkerOverlay({
   // Seed from the current markers at mount; the reaction below keeps it in sync.
   const [snapshot, setSnapshot] = useState<Marker[]>(() => markers.get().slice());
 
-  const pull = (sv: SharedValue<Marker[]>) => {
-    setSnapshot(sv.get().slice());
+  // Read the `markers` prop from closure rather than a SharedValue passed
+  // through `scheduleOnRN`: the handle serialized across the worklet→JS
+  // boundary exposes the native `.value` accessor but NOT the `.get()` method,
+  // so calling `.get()` on it throws ("sv.get is not a function").
+  const pull = () => {
+    setSnapshot(markers.get().slice());
   };
 
   useAnimatedReaction(
     () => markersSignature(markers.get()),
     /* istanbul ignore next -- scheduleOnRN from UI-thread reaction */
     (sig, prev) => {
-      if (sig !== prev) scheduleOnRN(pull, markers);
+      if (sig !== prev) scheduleOnRN(pull);
     },
     [markers, pull],
   );

--- a/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
+++ b/packages/react-native-livechart/src/components/SeriesToggleChips.tsx
@@ -26,8 +26,12 @@ export function SeriesToggleChips({
     series.get().slice(),
   );
 
-  const pullSnapshot = (sv: SharedValue<SeriesConfig[]>) => {
-    setSnapshot(sv.get().slice());
+  // Read the `series` prop from closure rather than a SharedValue passed
+  // through `scheduleOnRN`: the handle serialized across the worklet→JS
+  // boundary exposes the native `.value` accessor but NOT the `.get()` method,
+  // so calling `.get()` on it throws ("sv.get is not a function").
+  const pullSnapshot = () => {
+    setSnapshot(series.get().slice());
   };
 
   useAnimatedReaction(
@@ -35,7 +39,7 @@ export function SeriesToggleChips({
     /* istanbul ignore next -- Reanimated reaction; snapshot seeded at mount, pulled here on change */
     (sig, prev) => {
       if (sig !== prev) {
-        scheduleOnRN(pullSnapshot, series);
+        scheduleOnRN(pullSnapshot);
       }
     },
     [series, pullSnapshot],


### PR DESCRIPTION
PR #53 migrated SharedValue `.value` reads to `.get()`. Two of those reads were inside callbacks that receive a SharedValue passed *through* `scheduleOnRN` from a UI-thread `useAnimatedReaction`: SeriesToggleChips `pullSnapshot` and MarkerOverlay `pull`.

The handle serialized across the worklet→JS boundary keeps the native `.value` accessor but loses the JS-side `.get()` method, so `sv.get()` throws "sv.get is not a function" on the first reaction tick (which fires with prev===undefined). This red-boxed the entire multi-series chart and any chart mounted with `markers`.

Fix: drop the passed `sv` arg and read the component-scope prop (`series`/`markers`) from closure — the real SharedValue, matching the useState seeds and the toggle handler. Also applied to LiveChartSeries `syncColors`/`syncStyles` (they used `.value` and worked, but were the same fragile pattern) so all four scheduleOnRN call sites are consistent and robust to either accessor.

Verified on the iOS 26 sim: multi-series + legend toggle, axes-insets→LiveChartSeries, and the markers demo all render without crashing. 652 tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>