### PR TITLE
refactor: remove deprecated props before first release

### DIFF
--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -136,7 +136,7 @@ export default function MultiSeriesScreen() {
             loading={loading}
             smoothing={smoothing}
             exaggerate={exaggerate}
-            referenceLine={showRef ? { value: 52, label: "mid" } : undefined}
+            referenceLines={showRef ? [{ value: 52, label: "mid" }] : undefined}
             yAxis={yOn}
             xAxis={xOn}
             emptyText="No series"

--- a/app/demo/playground.tsx
+++ b/app/demo/playground.tsx
@@ -148,8 +148,8 @@ export default function PlaygroundScreen() {
           paused={paused}
           exaggerate={exaggerate}
           valueLine={valueLine}
-          referenceLine={
-            showRefLine ? { value: startValue * 1.05, label: "+5%" } : undefined
+          referenceLines={
+            showRefLine ? [{ value: startValue * 1.05, label: "+5%" }] : undefined
           }
           scrub={{ tooltip: true }}
           loading={loading}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -127,7 +127,6 @@ function useLiveChartController({
   valueLine = true,
   showValue = false,
   valueMomentumColor = false,
-  referenceLine,
   referenceLines,
   gridStyle,
   palette: paletteOverride,
@@ -161,11 +160,7 @@ function useLiveChartController({
   const degenCfg = resolveDegen(degen);
   const tradeStreamResolved = resolveTradeStream(tradeStream);
 
-  // Merge the legacy singular `referenceLine` into the `referenceLines` array.
-  const allRefLines = [
-    ...(referenceLine ? [referenceLine] : []),
-    ...(referenceLines ?? []),
-  ];
+  const allRefLines = referenceLines ?? [];
   const refValues = collectReferenceValues(allRefLines);
 
   const badgeUsesRightGutter =

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -106,14 +106,12 @@ function useLiveChartSeriesController({
   formatTime = defaultFormatTime,
   yAxis = true,
   xAxis = true,
-  referenceLine,
   referenceLines,
   gridStyle,
   palette: paletteOverride,
   scrub = false,
   onScrub,
   onSeriesToggle,
-  seriesToggleCompact,
   dot: dotProp,
   legend: legendProp,
   degen,
@@ -132,13 +130,10 @@ function useLiveChartSeriesController({
   const scrubEnabled = scrubCfg !== null;
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
-  const legendCfg = resolveLegend(legendProp, seriesToggleCompact);
+  const legendCfg = resolveLegend(legendProp);
   const degenCfg = resolveDegen(degen);
 
-  const allRefLines = [
-    ...(referenceLine ? [referenceLine] : []),
-    ...(referenceLines ?? []),
-  ];
+  const allRefLines = referenceLines ?? [];
   const refValues = collectReferenceValues(allRefLines);
 
   const palette = applyPaletteOverride(

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -521,15 +521,14 @@ const LEGEND_DEFAULTS: ResolvedLegendConfig = {
 
 export function resolveLegend(
   prop: boolean | LegendConfig | undefined,
-  compactFallback?: boolean,
 ): ResolvedLegendConfig {
   if (prop === false) return { ...LEGEND_DEFAULTS, visible: false };
   if (prop === undefined || prop === true) {
-    return { ...LEGEND_DEFAULTS, compact: compactFallback ?? false };
+    return { ...LEGEND_DEFAULTS, compact: false };
   }
   return {
     visible: prop.visible ?? LEGEND_DEFAULTS.visible,
-    compact: prop.compact ?? compactFallback ?? LEGEND_DEFAULTS.compact,
+    compact: prop.compact ?? LEGEND_DEFAULTS.compact,
     position: prop.position ?? LEGEND_DEFAULTS.position,
     style: prop.style,
   };

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -545,12 +545,6 @@ export interface LiveChartCoreProps {
   yAxis?: boolean | YAxisConfig;
   /** X-axis time labels. `true` = defaults, `false` = hidden, or pass `XAxisConfig`. Default `true`. */
   xAxis?: boolean | XAxisConfig;
-  /**
-   * Single horizontal reference line at a fixed value.
-   * @deprecated Use `referenceLines` (supports multiple lines and bands). When both
-   * are set, this line is merged into the `referenceLines` array.
-   */
-  referenceLine?: ReferenceLine;
   /** Reference lines / bands drawn into the chart. Supports all three `ReferenceLine` forms. */
   referenceLines?: ReferenceLine[];
   /** Per-instance grid-line styling. Pass an object to override color / width / dash / opacity. */
@@ -656,11 +650,6 @@ export interface LiveChartSeriesProps extends LiveChartCoreProps {
   series: SharedValue<SeriesConfig[]>;
   /** Called when a series toggle chip is tapped. */
   onSeriesToggle?: (id: string, visible: boolean) => void;
-  /**
-   * Show only colored dots in toggle chips (no text labels). Default `false`.
-   * @deprecated Use `legend={{ compact: true }}` instead.
-   */
-  seriesToggleCompact?: boolean;
   /** Live dot configuration (radius, pulse, value line, inline labels). */
   dot?: MultiSeriesDotConfig;
   /** Legend (toggle chips) configuration. `true` = defaults, `false` = hidden, or pass `LegendConfig`. Default `true`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -59,12 +59,12 @@ describe("LiveChart", () => {
     render(<Harness gradient={false} yAxis={false} badge={false} />);
   });
 
-  it("uses custom insets and referenceLine", () => {
+  it("uses custom insets and referenceLines", () => {
     render(
       <Harness
         style={{ backgroundColor: "#111111" }}
         insets={{ top: 4, bottom: 4 }}
-        referenceLine={{ value: 40 }}
+        referenceLines={[{ value: 40 }]}
       />,
     );
   });
@@ -114,10 +114,10 @@ describe("LiveChart", () => {
     render(<Harness xAxis={false} />);
   });
 
-  it("accepts visual config on referenceLine", () => {
+  it("accepts visual config on referenceLines", () => {
     render(
       <Harness
-        referenceLine={{ value: 40, strokeWidth: 2, color: "#ff0000" }}
+        referenceLines={[{ value: 40, strokeWidth: 2, color: "#ff0000" }]}
       />,
     );
   });

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -48,8 +48,8 @@ describe("LiveChartSeries", () => {
         <LiveChartSeries
           series={series}
           scrub={{ tooltip: true }}
-          referenceLine={{ value: 11 }}
-          seriesToggleCompact
+          referenceLines={[{ value: 11 }]}
+          legend={{ compact: true }}
           onSeriesToggle={jest.fn()}
         />
       );

--- a/sim/useSimulatedChartData.ts
+++ b/sim/useSimulatedChartData.ts
@@ -104,9 +104,6 @@ export interface SimulatedChartOptions {
   random01?: () => number;
 }
 
-/** @deprecated Use `SimulatedChartOptions`. */
-export type SimulatedDataOptions = SimulatedChartOptions;
-
 export interface SimulatedData {
   data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;


### PR DESCRIPTION
No version has been published to npm yet, so deprecated API carries no value — removing it for a clean 1.0.0 surface (no consumers to break).

## Removed
- **`referenceLine`** (single-series & multi-series) → use **`referenceLines`**. Dropped the legacy "merge singular into the array" handling in `LiveChart` / `LiveChartSeries`.
- **`seriesToggleCompact`** → use **`legend={{ compact: true }}`**. Dropped the `compactFallback` parameter from `resolveLegend`.
- **`SimulatedDataOptions`** — unused deprecated alias in the example app's `sim/` hook.

## Migrated
- Example app: `app/demo/multi-series.tsx`, `app/demo/playground.tsx` now use `referenceLines`.
- Unit tests: `LiveChart.test.tsx`, `LiveChartSeries.test.tsx` updated to the current props.

## Verification
- `npm run verify` green (typecheck + lint + 652 tests).
- `npm run build:lib` regenerates `dist/*.d.ts` with the deprecated props gone and `referenceLines` retained.
- `grep` confirms zero `@deprecated` annotations remain in `src/` and `sim/`.

> Complements #67 (docs), which independently updates the README's `referenceLine` mention to `referenceLines`. The two PRs touch disjoint files and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)