### PR TITLE
feat: Tailwind zinc 50–950 as the neutral base (bg + text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 [![npm version](https://img.shields.io/npm/v/react-native-livechart.svg)](https://www.npmjs.com/package/react-native-livechart)
 [![CI](https://github.com/brandtnewlabs/react-native-livechart/actions/workflows/test.yml/badge.svg)](https://github.com/brandtnewlabs/react-native-livechart/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/npm/l/react-native-livechart.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-online-3323E6.svg)](https://react-native-livechart.brandtnewlabs.com)
 
 High-performance **live** line and candlestick charts for React Native, built on **[@shopify/react-native-skia](https://shopify.github.io/react-native-skia/)**, **[react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/)**, and **[react-native-gesture-handler](https://docs.swmansion.com/react-native-gesture-handler/)**. Data and live values flow through Reanimated `SharedValue`s, so the UI thread animates without per-frame JS bridge traffic.
+
+📖 **[Documentation →](https://react-native-livechart.brandtnewlabs.com)**
 
 <!-- TODO(hero): replace this comment with a demo GIF/screenshot, e.g.:
      <p align="center"><img src="assets/images/demo.gif" alt="react-native-livechart demo" width="320" /></p>
@@ -86,7 +89,7 @@ function LivePrice() {
 
   return (
     <View style={{ height: 240 }}>
-      <LiveChart data={data} value={value} accentColor="#3b82f6" />
+      <LiveChart data={data} value={value} accentColor="#3323E6" />
     </View>
   );
 }

--- a/demo-lib/shared.ts
+++ b/demo-lib/shared.ts
@@ -5,7 +5,7 @@ import {
   type TradeSource,
 } from "../sim/useSimulatedChartData";
 
-export const ACCENT = "#3b82f6";
+export const ACCENT = "#3323E6";
 
 /** Sim seed span presets (see `useSimulatedChartData` `historyRange`). */
 export const HISTORY_RANGE_PRESETS: {
@@ -68,7 +68,7 @@ export const SMOOTHING_PRESETS: { label: string; value: number }[] = [
 ];
 
 export const ACCENT_PRESETS = [
-  "#3b82f6",
+  "#3323E6",
   "#22c55e",
   "#eab308",
   "#ef4444",

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -171,7 +171,7 @@ provided; everything else has a default.
   Color scheme.
 </ParamField>
 
-<ParamField body="accentColor" type="string" default='"#3b82f6"'>
+<ParamField body="accentColor" type="string" default='"#3323E6"'>
   Primary accent; the palette is derived from it.
 </ParamField>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,9 +4,9 @@
   "name": "react-native-livechart",
   "description": "High-performance live line and candlestick charts for React Native, built on Skia and Reanimated.",
   "colors": {
-    "primary": "#3b82f6",
-    "light": "#60a5fa",
-    "dark": "#2563eb"
+    "primary": "#3323E6",
+    "light": "#5C4FEB",
+    "dark": "#291CC3"
   },
   "favicon": "/favicon.png",
   "icons": {

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -7,7 +7,7 @@ description: "Theme the chart with a color scheme, accent color, palette overrid
 ## Theme & accent
 
 The palette is derived from two props: a `theme` (`"light"` or `"dark"`, default `"dark"`) and
-an `accentColor` (default `#3b82f6`). Setting just these gets you a cohesive look.
+an `accentColor` (default `#3323E6`). Setting just these gets you a cohesive look.
 
 ```tsx
 <LiveChart data={data} value={value} theme="light" accentColor="#8b5cf6" />

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -43,7 +43,7 @@ export function LivePrice() {
 
   return (
     <View style={{ height: 240 }}>
-      <LiveChart data={data} value={value} accentColor="#3b82f6" />
+      <LiveChart data={data} value={value} accentColor="#3323E6" />
     </View>
   );
 }

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -24,7 +24,7 @@
     "src",
     "LICENSE"
   ],
-  "homepage": "https://github.com/brandtnewlabs/react-native-livechart#readme",
+  "homepage": "https://react-native-livechart.brandtnewlabs.com",
   "keywords": [
     "react-native",
     "chart",

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -16,6 +16,7 @@ import {
   vec,
 } from "@shopify/react-native-skia";
 
+import { DEFAULT_ACCENT_COLOR } from "../constants";
 import {
   resolveBadge,
   resolveDegen,
@@ -89,7 +90,7 @@ function useLiveChartController({
 
   // ── Appearance ──────────────────────────────────────────────────────────
   theme = "dark",
-  accentColor = "#3b82f6",
+  accentColor = DEFAULT_ACCENT_COLOR,
   gradient = true,
   line: lineProp,
   font: fontProp,

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -15,7 +15,7 @@ import {
   type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
-import { MAX_MULTI_SERIES } from "../constants";
+import { DEFAULT_ACCENT_COLOR, MAX_MULTI_SERIES } from "../constants";
 import {
   lineColorsSignatureFromArray,
   lineStyleSignatureFromArray,
@@ -85,7 +85,7 @@ function lineColorsSig(s: SharedValue<SeriesConfig[]>) {
 function useLiveChartSeriesController({
   series,
   theme = "dark",
-  accentColor = "#3b82f6",
+  accentColor = DEFAULT_ACCENT_COLOR,
   line: lineProp,
   font: fontProp,
   insets,

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -35,3 +35,10 @@ export const EMPTY_GAP_FADE_WIDTH = 30;
  * Layout is fixed; not on `DegenOptions` because changing it needs matching renderer changes.
  */
 export const DEGEN_STRIDE = 8;
+
+/**
+ * Default chart accent color — the full light/dark palette is derived from this
+ * when a consumer omits `accentColor`. Single source of truth for the brand
+ * default; change it here to re-brand the default everywhere.
+ */
+export const DEFAULT_ACCENT_COLOR = "#3323E6";

--- a/packages/react-native-livechart/src/theme.ts
+++ b/packages/react-native-livechart/src/theme.ts
@@ -14,15 +14,26 @@ import type { LiveChartPalette, SeriesConfig, ThemeMode } from "./types";
 const TW = {
   white: "#ffffff",
   black: "#000000",
-  neutral: {
-    /** neutral-200 */
-    200: "#e5e5e5",
-    /** neutral-900 */
-    900: "#171717",
-    /** neutral-950 */
-    950: "#0a0a0a",
-  },
+  /** Neutral base scale (backgrounds + text). Tailwind zinc 50–950. */
   zinc: {
+    /** zinc-50 */
+    50: "#fafafa",
+    /** zinc-100 */
+    100: "#f4f4f5",
+    /** zinc-200 */
+    200: "#e4e4e7",
+    /** zinc-300 */
+    300: "#d4d4d8",
+    /** zinc-400 */
+    400: "#a1a1aa",
+    /** zinc-500 */
+    500: "#71717a",
+    /** zinc-600 */
+    600: "#52525b",
+    /** zinc-700 */
+    700: "#3f3f46",
+    /** zinc-800 */
+    800: "#27272a",
     /** zinc-900 */
     900: "#18181b",
     /** zinc-950 */
@@ -159,12 +170,12 @@ export function resolveTheme(color: string, mode: ThemeMode): LiveChartPalette {
     crosshairLine: isDark ? twAlpha(TW.white, 0.2) : twAlpha(TW.black, 0.12),
     crosshairDim: twAlpha(TW.black, 0.12),
     tooltipBg: isDark ? twAlpha(TW.zinc[950], 0.95) : twAlpha(TW.white, 0.95),
-    tooltipText: isDark ? TW.neutral[200] : TW.neutral[900],
+    tooltipText: isDark ? TW.zinc[200] : TW.zinc[900],
     tooltipBorder: isDark ? twAlpha(TW.white, 0.1) : twAlpha(TW.black, 0.08),
 
     bgRgb: isDark
-      ? (parseColorRgb(TW.neutral[950]) as [number, number, number])
-      : (parseColorRgb(TW.white) as [number, number, number]),
+      ? (parseColorRgb(TW.zinc[950]) as [number, number, number])
+      : (parseColorRgb(TW.zinc[50]) as [number, number, number]),
 
     labelFontSize: 11,
     valueFontSize: 11,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -496,7 +496,7 @@ export interface CandlePoint {
 export interface LiveChartCoreProps {
   /** Color scheme. Default `"dark"`. */
   theme?: ThemeMode;
-  /** Primary accent color — the full palette is derived from this. Default `"#3b82f6"`. */
+  /** Primary accent color — the full palette is derived from this. Default `"#3323E6"`. */
   accentColor?: string;
   /** Font configuration for all chart text (axes, badges, tooltips). */
   font?: FontConfig;

--- a/packages/react-native-livechart/tests/theme.test.ts
+++ b/packages/react-native-livechart/tests/theme.test.ts
@@ -60,16 +60,16 @@ describe("resolveTheme", () => {
   it("builds dark palette", () => {
     const p = resolveTheme("#ff0000", "dark");
     expect(p.line).toBe("#ff0000");
-    expect(p.bgRgb).toEqual([10, 10, 10]);
+    expect(p.bgRgb).toEqual([9, 9, 11]);
     expect(p.gridLine).toMatch(/^rgba\(/);
-    expect(p.tooltipText).toBe("#e5e5e5");
+    expect(p.tooltipText).toBe("#e4e4e7");
   });
 
   it("builds light palette", () => {
     const p = resolveTheme("#00ff00", "light");
-    expect(p.bgRgb).toEqual([255, 255, 255]);
+    expect(p.bgRgb).toEqual([250, 250, 250]);
     expect(p.gridLine).toMatch(/^rgba\(/);
-    expect(p.tooltipText).toBe("#171717");
+    expect(p.tooltipText).toBe("#18181b");
   });
 });
 


### PR DESCRIPTION
Make Tailwind **zinc** the default neutral base for backgrounds and text (replacing the partial `neutral` scale).

## Changes (`src/theme.ts`)
- Define the **full zinc 50–950 ramp** in the internal `TW` palette; drop the partial `neutral` scale.
- **Background** (`bgRgb`): `zinc-950` (dark) / `zinc-50` (light) — was `neutral-950` / pure white.
- **Solid text** (`tooltipText`): `zinc-200` (dark) / `zinc-900` (light) — was `neutral-200` / `neutral-900`.
- `badgeOuterBg` / `tooltipBg` already used zinc — now consistent with the full ramp.

## Intentionally kept as-is
Grid lines and axis/reference **labels** keep their `white`/`black` **opacity** treatment (e.g. `gridLabel` = white@0.4) — that's a deliberate adaptive pattern so they blend over any background, rather than fixed zinc tones. Happy to convert those to solid zinc steps (e.g. `zinc-400`/`zinc-500`) if you'd prefer fully-solid label text.

## Verification
- `npm run verify` green (652 tests); updated the 4 theme-test assertions for the new zinc bg/text values.

> Stacked on #69 (base = `chore/brand-color-and-docs-url`). The in-progress font refactor is **not** included. Retarget to `main` once #69 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)