### PR TITLE
Polish demo screens: safe-area headers + accurate feature showcases

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
 import { useEffect } from "react";
 import * as SplashScreen from "expo-splash-screen";
@@ -34,7 +35,9 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <Stack screenOptions={{ headerShown: false }} />
+      <SafeAreaProvider>
+        <Stack screenOptions={{ headerShown: false }} />
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/app/demo/axes-grid.tsx
+++ b/app/demo/axes-grid.tsx
@@ -60,12 +60,17 @@ export default function AxesGridScreen() {
     multiSeries: which === "multi",
     candleAggregation: false,
     tradeStream: false,
+    // Dense seed so the single-series line fills the default 30s window on first
+    // frame instead of sitting flat until live ticks arrive.
+    historySpanSeconds: 40,
+    historyRange: "1m",
   });
 
   const insetCfg = INSETS[insets];
 
   return (
     <DemoScreen
+      title="Axes & grid"
       docs="guides/theming"
       description="Hide Y, X, or both; minGap; insets. Toggle single vs multi chart."
       chart={

--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -4,13 +4,8 @@ import { LiveChart } from "react-native-livechart";
 import { useSharedValue } from "react-native-reanimated";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
-import { Chip, ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
-import {
-  ACCENT,
-  HISTORY_RANGE_PRESETS,
-  TIME_WINDOWS,
-  viewportSecsForHistoryPreset,
-} from "../../demo-lib/shared";
+import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import {
   useSimulatedChartData,
@@ -19,13 +14,47 @@ import {
 
 export const options = { title: "Candlestick" };
 
-const WINDOW_OPTIONS = TIME_WINDOWS.map((w) => ({ value: w.secs, label: w.label }));
+/**
+ * Candle timeframes. Each pairs a visible window with a candle width AND a
+ * `seedRange` whose ideal sampling interval is far finer than `candleWidthSecs`,
+ * so every OHLC bucket aggregates many sub-candle ticks. That density is what
+ * gives each candle a real body + wick — a bucket holding a single point
+ * collapses to a flat horizontal line. (`seedRange` only sets the seed's point
+ * spacing; `historySpanSeconds` sets the actual span = visible window.)
+ */
+const TIMEFRAMES = [
+  { label: "5m · 15s", windowSecs: 300, candleWidthSecs: 15, seedRange: "1m" },
+  { label: "15m · 1m", windowSecs: 900, candleWidthSecs: 60, seedRange: "5m" },
+  { label: "1h · 5m", windowSecs: 3600, candleWidthSecs: 300, seedRange: "1h" },
+] as const satisfies readonly {
+  label: string;
+  windowSecs: number;
+  candleWidthSecs: number;
+  seedRange: HistoryRange;
+}[];
+
+type TimeframeLabel = (typeof TIMEFRAMES)[number]["label"];
+
+const TIMEFRAME_OPTIONS = TIMEFRAMES.map((t) => ({
+  value: t.label,
+  label: t.label,
+}));
+
+/** Distinct from the default green/red so the palette override reads as a candle feature. */
+const CUSTOM_CANDLE_PALETTE = {
+  candleUp: "#14b8a6",
+  candleDown: "#f97316",
+  wickUp: "#0d9488",
+  wickDown: "#ea580c",
+};
 
 export default function CandlestickScreen() {
-  const [historyRange, setHistoryRange] = useState<HistoryRange>("1d");
-  const [windowSecs, setWindowSecs] = useState(300);
+  const [tfLabel, setTfLabel] = useState<TimeframeLabel>("15m · 1m");
   const [stripCandles, setStripCandles] = useState(false);
-  const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
+  const [customColors, setCustomColors] = useState(false);
+
+  const tf = TIMEFRAMES.find((t) => t.label === tfLabel) ?? TIMEFRAMES[1];
+  const candleWidthSecs = tf.candleWidthSecs;
 
   const emptyCandles = useSharedValue<CandlePoint[]>([]);
   const nullLive = useSharedValue<CandlePoint | null>(null);
@@ -35,14 +64,24 @@ export default function CandlestickScreen() {
     candleAggregation: true,
     tradeStream: false,
     candleWidth: candleWidthSecs,
-    historyRange,
-    tradesPerSecond: 5,
+    // Span = visible window; `seedRange` supplies the fine sampling interval so
+    // each candle bucket gets dozens of ticks (real bodies + wicks).
+    historySpanSeconds: tf.windowSecs,
+    historyRange: tf.seedRange,
+    volatilityMode: "volatile",
+    // The sim re-buckets a sliding `maxPoints` tick buffer every trade, so a
+    // buffer shorter than the window would evict still-visible ticks and make
+    // the oldest *committed* candle mutate each trade. Keep the buffer well
+    // longer than the largest window (3600s): 10000 / 2 tps = 5000s of history.
+    tradesPerSecond: 2,
+    maxPoints: 10000,
   });
 
   return (
     <DemoScreen
+      title="Candlestick"
       docs="guides/candlestick"
-      description={`mode=candle, candleWidth=${candleWidthSecs}s. Needs ≥2 committed candles for the chart (live bar alone is not enough).`}
+      description={`mode="candle" with ${candleWidthSecs}s OHLC buckets. Each candle aggregates many ticks, so it shows a real body + wick. Needs ≥2 committed candles before it draws.`}
       chart={
         <LiveChart
           data={data}
@@ -53,39 +92,34 @@ export default function CandlestickScreen() {
           candleWidth={candleWidthSecs}
           accentColor={ACCENT}
           theme={APP_THEME}
-          timeWindow={windowSecs}
+          timeWindow={tf.windowSecs}
+          palette={customColors ? CUSTOM_CANDLE_PALETTE : undefined}
           scrub={{ tooltip: true }}
         />
       }
     >
-      <ControlRow label="History span">
-        {HISTORY_RANGE_PRESETS.map((r) => (
-          <Chip
-            key={r.preset}
-            label={r.label}
-            active={historyRange === r.preset}
-            onPress={() => {
-              setHistoryRange(r.preset);
-              setWindowSecs(viewportSecsForHistoryPreset(r.preset));
-            }}
-          />
-        ))}
+      <ChipRow
+        label="Timeframe (window · candle)"
+        options={TIMEFRAME_OPTIONS}
+        value={tfLabel}
+        onChange={setTfLabel}
+      />
+
+      <ControlRow label="Candle colors">
+        <ToggleChip
+          label="Teal / orange palette"
+          value={customColors}
+          onChange={setCustomColors}
+        />
       </ControlRow>
 
-      <ControlRow label="Data">
+      <ControlRow label="Empty state">
         <ToggleChip
           label="No committed candles"
           value={stripCandles}
           onChange={setStripCandles}
         />
       </ControlRow>
-
-      <ChipRow
-        label="Time window"
-        options={WINDOW_OPTIONS}
-        value={windowSecs}
-        onChange={setWindowSecs}
-      />
     </DemoScreen>
   );
 }

--- a/app/demo/historical-data.tsx
+++ b/app/demo/historical-data.tsx
@@ -45,6 +45,7 @@ export default function HistoricalDataScreen() {
 
   return (
     <DemoScreen
+      title="Historical data fill"
       docs="guides/playback"
       description="nowOverride + windowBuffer — fill a fixed historical span edge-to-edge"
       chart={

--- a/app/demo/line.tsx
+++ b/app/demo/line.tsx
@@ -65,10 +65,15 @@ export default function LineScreen() {
     multiSeries: false,
     candleAggregation: false,
     tradeStream: false,
+    // Dense seed so the line is fully drawn (and lively) on first frame instead
+    // of flat until live ticks fill the default 30s window.
+    historySpanSeconds: 40,
+    historyRange: "1m",
   });
 
   return (
     <DemoScreen
+      title="Line & area"
       docs="guides/line-and-area"
       description="The single line: badge, pulse, value line, and the live value overlay."
       chart={

--- a/app/demo/markers.tsx
+++ b/app/demo/markers.tsx
@@ -76,6 +76,10 @@ export default function MarkersScreen() {
     tradesPerSecond: 5,
     tokenSymbol: "SIM",
     startValue: 100,
+    // Fill the 30s window with a lively seed so markers land on a real line from
+    // the first frame (a sparse default seed leaves it flat until live ticks land).
+    historySpanSeconds: 40,
+    historyRange: "1m",
   });
 
   const logo = useImage(require("../../assets/images/react-logo.png"));
@@ -140,6 +144,7 @@ export default function MarkersScreen() {
 
   return (
     <DemoScreen
+      title="Markers & trades"
       docs="guides/markers-and-references"
       description="markers[] — 5 kinds, tap to hover (onMarkerHover + markerHitRadius). Optional tradeStream overlay."
       chart={

--- a/app/demo/momentum-degen.tsx
+++ b/app/demo/momentum-degen.tsx
@@ -133,10 +133,16 @@ export default function MomentumDegenScreen() {
     candleAggregation: false,
     tradeStream: false,
     volatilityMode: volatility,
+    // Seed the full default 30s window with dense, volatility-driven points so the
+    // chart starts lively (and momentum/degen have something to react to) instead
+    // of a flat line that only wakes up once live ticks arrive.
+    historySpanSeconds: 40,
+    historyRange: "1m",
   });
 
   return (
     <DemoScreen
+      title="Momentum & degen"
       docs="guides/momentum-and-degen"
       description={
         "Momentum tints the value badge (green = up, red = down, blue = flat); it eases slowly, so wait a beat after switching. " +

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -95,8 +95,6 @@ export default function MultiSeriesScreen() {
   const [legendPosition, setLegendPosition] = useState<"top" | "bottom">("top");
   const [styled, setStyled] = useState(false);
   const [legendStyled, setLegendStyled] = useState(false);
-  const [degenOn, setDegenOn] = useState(false);
-  const [degenColors, setDegenColors] = useState(false);
 
   const sim = useSimulatedChartData({
     multiSeries: !empty,
@@ -157,6 +155,7 @@ export default function MultiSeriesScreen() {
 
   return (
     <DemoScreen
+      title="Multi-series"
       docs="guides/multi-series"
       description="series, onSeriesToggle, scrub, axis visibility. Chart stays empty until at least one series has ≥2 points (toggle No series for shell)."
       chart={
@@ -179,19 +178,14 @@ export default function MultiSeriesScreen() {
             loading={loading}
             smoothing={smoothing}
             exaggerate={exaggerate}
-            referenceLines={showRef ? [{ value: 52, label: "mid" }] : undefined}
+            referenceLines={
+              showRef ? [{ value: 33.3, label: "even" }] : undefined
+            }
             yAxis={yOn}
             xAxis={xOn}
             emptyText="No series"
             dot={dotConfig}
             legend={legendConfig}
-            degen={
-              degenOn
-                ? degenColors
-                  ? { colors: ["#f472b6", "#22d3ee", "#fde047"] }
-                  : true
-                : false
-            }
             scrub
             onSeriesToggle={
               empty
@@ -258,18 +252,12 @@ export default function MultiSeriesScreen() {
         onChange={setLegendPosition}
       />
 
-      <ControlRow label="Per-series style & degen">
+      <ControlRow label="Per-series style">
         <ToggleChip label="Styled lines" value={styled} onChange={setStyled} />
         <ToggleChip
           label="Legend style"
           value={legendStyled}
           onChange={setLegendStyled}
-        />
-        <ToggleChip label="Degen" value={degenOn} onChange={setDegenOn} />
-        <ToggleChip
-          label="Degen colors"
-          value={degenColors}
-          onChange={setDegenColors}
         />
       </ControlRow>
 

--- a/app/demo/playback.tsx
+++ b/app/demo/playback.tsx
@@ -63,6 +63,7 @@ export default function PlaybackScreen() {
 
   return (
     <DemoScreen
+      title="Playback"
       docs="guides/playback"
       description="timeWindow, paused, smoothing, exaggerate, nonNegative, maxValue (data sweeps ≈ -50…200)"
       chart={

--- a/app/demo/playground.tsx
+++ b/app/demo/playground.tsx
@@ -87,8 +87,11 @@ export default function PlaygroundScreen() {
   const [volatilityMode, setVolatilityMode] =
     useState<VolatilityMode>("normal");
   const [paused, setPaused] = useState(false);
-  const [windowSecs, setWindowSecs] = useState(30);
-  const [historyRange, setHistoryRange] = useState<HistoryRange>("1d");
+  // Default to a short window + fine-grained seed so the flagship screen opens on
+  // a lively, fully-drawn line (a long "1d" seed sampled coarsely renders flat in
+  // a 30s window). The History span chips still let you seed longer ranges.
+  const [windowSecs, setWindowSecs] = useState(60);
+  const [historyRange, setHistoryRange] = useState<HistoryRange>("1m");
   const [tradesPerSecond, setTradesPerSecond] = useState(5);
   const [tradeArrivalJitter, setTradeArrivalJitter] = useState(0);
   const [tokenSymbol, setTokenSymbol] = useState("");
@@ -144,6 +147,7 @@ export default function PlaygroundScreen() {
 
   return (
     <DemoScreen
+      title="Playground"
       docs="quickstart"
       description="Kitchen-sink showcase: line/candle, scrub, reference lines, trade stream, degen effects, loading + empty states."
       chart={

--- a/app/demo/reference-lines.tsx
+++ b/app/demo/reference-lines.tsx
@@ -23,6 +23,10 @@ export default function ReferenceLinesScreen() {
     candleAggregation: false,
     tradeStream: false,
     startValue: START,
+    // Dense seed so the line weaves through the reference lines/bands from the
+    // first frame instead of sitting flat until live ticks fill the window.
+    historySpanSeconds: 40,
+    historyRange: "1m",
   });
 
   // Pin the time band ONCE when it's enabled (the band lives in absolute
@@ -92,6 +96,7 @@ export default function ReferenceLinesScreen() {
 
   return (
     <DemoScreen
+      title="Reference lines & bands"
       docs="guides/markers-and-references"
       description="referenceLines array — lines, value bands, time bands, off-axis badge"
       chart={

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -41,6 +41,15 @@ export default function ScrubbingScreen() {
     candleAggregation: displayMode === "candle",
     tradeStream: false,
     candleWidth: candleWidthSecs,
+    // Dense seed (fine "1m" sampling over the window) so candle buckets get many
+    // ticks each — real bodies + wicks instead of flat one-point dojis.
+    historySpanSeconds: windowSecs,
+    historyRange: "1m",
+    volatilityMode: "volatile",
+    // Keep the re-aggregated tick buffer longer than the 300s window so the
+    // oldest committed candle never loses on-screen ticks (≈600s at the volatile
+    // default rate); otherwise it would mutate on every trade.
+    maxPoints: 6000,
   });
 
   const scrub =
@@ -60,6 +69,7 @@ export default function ScrubbingScreen() {
 
   return (
     <DemoScreen
+      title="Scrubbing"
       docs="guides/scrubbing"
       description="Scrub modes; candle mode shows ScrubPoint.candle in readout"
       chart={

--- a/app/demo/states.tsx
+++ b/app/demo/states.tsx
@@ -61,6 +61,7 @@ export default function StatesScreen() {
 
   return (
     <DemoScreen
+      title="States & formatting"
       docs="guides/states-and-formatting"
       description="The chart stays in loading/empty shell until there are at least two line points and loading is false. One point only still counts as empty. formatValue/formatTime must be worklet-safe (same pattern as src/format.ts)."
       chart={

--- a/app/demo/theming.tsx
+++ b/app/demo/theming.tsx
@@ -85,10 +85,15 @@ export default function ThemingScreen() {
     multiSeries: false,
     candleAggregation: false,
     tradeStream: false,
+    // Dense seed so the styled line is fully drawn on first frame (the default
+    // sparse "1d" seed renders flat in a 30s window until live ticks arrive).
+    historySpanSeconds: 40,
+    historyRange: "1m",
   });
 
   return (
     <DemoScreen
+      title="Theming"
       docs="guides/theming"
       description="Theming: theme, accent, gradient, line, font (Skia: system / JetBrains / Google Sans Code), grid & palette, container style"
       chart={

--- a/app/demo/transitions.tsx
+++ b/app/demo/transitions.tsx
@@ -45,10 +45,20 @@ export default function TransitionsScreen() {
     candleAggregation: true,
     tradeStream: false,
     candleWidth: CANDLE_WIDTH,
+    // Dense seed (fine "1m" sampling over the window) so the candle side of the
+    // morph shows real bodies + wicks rather than flat one-point dojis.
+    historySpanSeconds: WINDOW,
+    historyRange: "1m",
+    volatilityMode: "volatile",
+    // Keep the re-aggregated tick buffer longer than the 300s window so committed
+    // candles stay frozen (a shorter buffer evicts still-visible ticks and the
+    // oldest candle mutates each trade).
+    maxPoints: 6000,
   });
 
   return (
     <DemoScreen
+      title="Transitions"
       docs="guides/transitions"
       description="Line↔candle uses one chart's mode prop (shared y-axis morph); LiveChartTransition cross-fades two instances (here: accent color)"
       chart={

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,6 @@
 import { Link, type Href } from "expo-router";
 import { Pressable, SectionList, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { APP_FONT_FAMILY, APP_FONT_FAMILY_SEMIBOLD } from "../demo-lib/fonts";
 import { colors } from "../demo-lib/theme";
 
@@ -33,7 +34,7 @@ const SECTIONS: DemoSection[] = [
       {
         href: "/demo/candlestick",
         title: "Candlestick",
-        blurb: "mode=candle, candles, liveCandle, candleWidth.",
+        blurb: "mode=candle: timeframes, candle colors, OHLC bodies + wicks.",
       },
       {
         href: "/demo/multi-series",
@@ -135,8 +136,9 @@ const renderSectionHeader = ({
 }) => <Text style={styles.sectionHeader}>{section.title}</Text>;
 
 export default function Index() {
+  const insets = useSafeAreaInsets();
   return (
-    <View style={styles.root}>
+    <View style={[styles.root, { paddingTop: insets.top + 12 }]}>
       <Text style={styles.title}>LiveChart demos</Text>
       <Text style={styles.subtitle}>
         Grouped to match the docs. Open a screen to test one feature area.
@@ -158,7 +160,6 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: colors.background,
-    paddingTop: 56,
   },
   title: {
     color: colors.text,

--- a/demo-lib/DemoScreen.tsx
+++ b/demo-lib/DemoScreen.tsx
@@ -7,6 +7,8 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { demoStyles } from "./styles";
 
 /** Guides live in the repo's `docs/` tree; no separate docs site is deployed. */
@@ -14,6 +16,7 @@ const DOCS_BASE =
   "https://github.com/brandtnewlabs/react-native-livechart/blob/main/docs/";
 
 type DemoScreenProps = {
+  /** Screen heading, e.g. "Line & area". Shown as the page title. */
   title?: string;
   description?: string;
   /** Path under `docs/` (no extension), e.g. "guides/line-and-area". Renders a guide link. */
@@ -31,17 +34,32 @@ export function DemoScreen({
   chartWrapperStyle,
   children,
 }: DemoScreenProps) {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
   return (
-    <View style={demoStyles.demoRoot}>
-      {title ? <Text style={demoStyles.demoTitle}>{title}</Text> : null}
-      {description ? (
-        <Text style={demoStyles.demoDesc}>{description}</Text>
-      ) : null}
-      {docs ? (
-        <Pressable onPress={() => Linking.openURL(`${DOCS_BASE}${docs}.mdx`)}>
-          <Text style={demoStyles.demoDocsLink}>Read the guide ↗</Text>
+    <View style={[demoStyles.demoRoot, { paddingTop: insets.top }]}>
+      <View style={demoStyles.demoHeader}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={demoStyles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Back to demos"
+        >
+          <Text style={demoStyles.backChevron}>‹</Text>
+          <Text style={demoStyles.backText}>Demos</Text>
         </Pressable>
-      ) : null}
+        {title ? <Text style={demoStyles.demoHeading}>{title}</Text> : null}
+        {description ? (
+          <Text style={demoStyles.demoDesc}>{description}</Text>
+        ) : null}
+        {docs ? (
+          <Pressable onPress={() => Linking.openURL(`${DOCS_BASE}${docs}.mdx`)}>
+            <Text style={demoStyles.demoDocsLink}>Read the guide ↗</Text>
+          </Pressable>
+        ) : null}
+      </View>
       <View style={[demoStyles.chartContainer, chartWrapperStyle]}>
         {chart}
       </View>

--- a/demo-lib/styles.ts
+++ b/demo-lib/styles.ts
@@ -1,5 +1,9 @@
 import { StyleSheet } from "react-native";
-import { APP_FONT_FAMILY, APP_FONT_FAMILY_MEDIUM } from "./fonts";
+import {
+  APP_FONT_FAMILY,
+  APP_FONT_FAMILY_MEDIUM,
+  APP_FONT_FAMILY_SEMIBOLD,
+} from "./fonts";
 import { colors } from "./theme";
 
 export const demoStyles = StyleSheet.create({
@@ -7,27 +11,48 @@ export const demoStyles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  demoTitle: {
-    color: colors.textMuted,
-    fontSize: 12,
-    fontFamily: APP_FONT_FAMILY,
+  demoHeader: {
     paddingHorizontal: 16,
-    paddingTop: 12,
+    paddingTop: 4,
+    paddingBottom: 4,
+  },
+  backButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    paddingVertical: 6,
+    marginBottom: 2,
+  },
+  backChevron: {
+    color: colors.link,
+    fontSize: 22,
+    lineHeight: 22,
+    marginRight: 2,
+    marginTop: -2,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+  },
+  backText: {
+    color: colors.link,
+    fontSize: 15,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+  },
+  demoHeading: {
+    color: colors.text,
+    fontSize: 22,
+    fontFamily: APP_FONT_FAMILY_SEMIBOLD,
     marginBottom: 4,
   },
   demoDesc: {
-    color: colors.textFaint,
-    fontSize: 11,
+    color: colors.textMuted,
+    fontSize: 13,
     fontFamily: APP_FONT_FAMILY,
-    paddingHorizontal: 16,
     marginBottom: 8,
-    lineHeight: 16,
+    lineHeight: 18,
   },
   demoDocsLink: {
     color: colors.link,
-    fontSize: 12,
+    fontSize: 13,
     fontFamily: APP_FONT_FAMILY_MEDIUM,
-    paddingHorizontal: 16,
     marginBottom: 8,
   },
   chartContainer: {


### PR DESCRIPTION
## What & why

The demo screens jumped straight into a tiny description (rendered *under* the Dynamic Island), had no heading and no way back, and several charts didn't actually showcase the feature they were demoing (flat candle "dojis", off-screen reference lines, toggles with no visible effect). This makes every screen read like a real, titled page and fixes the chart data so each feature is obvious.

## Screen chrome
- Wrap the app in `SafeAreaProvider`; pad each screen by the top inset.
- Add a page heading (the screen title) + a "‹ Demos" back button (the demo Stack hides its header, so there was previously no visible way back).
- Home screen uses safe-area insets instead of a hardcoded `paddingTop`.

## Chart data fixed so features showcase
- **Candlestick** — rebuilt around clean timeframes (5m·15s / 15m·1m / 1h·5m) with a per-timeframe `seedRange` so each OHLC bucket aggregates many ticks → real bodies + wicks instead of flat one-point dojis. Added a candle-color palette toggle.
- **Scrubbing, Transitions** — same dense-seed fix for their candle modes.
- **Playground** — default window/seed pair so the flagship opens on a lively line *and* candles.
- **Momentum & degen, Markers, Reference lines, Line, Theming, Axes & grid** — dense seeds so the line is drawn lively on the first frame instead of flat-then-spike.

## Feature cleanup
- **Multi-series** — removed the *Degen* / *Degen colors* toggles (never fired on the gentle sum-to-100 data; covered by the Momentum & degen screen), and moved the reference line from value `52` (off-screen, above the ~30–37 series) to `33.3` "even" so it sits among the data.

## Verification
- Verified every screen on the iOS 26.4 simulator.
- `npm run verify` (typecheck + lint + 652 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)