### PR TITLE
Demo perf: UI-thread scrubbing readout + author footer

### DIFF
--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -1,7 +1,11 @@
-import { Text } from "react-native";
+import { TextInput } from "react-native";
 
 import { useState } from "react";
-import { formatTime, LiveChart, type ScrubPoint } from "react-native-livechart";
+import { formatTime, LiveChart } from "react-native-livechart";
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+} from "react-native-reanimated";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
@@ -11,6 +15,8 @@ import { demoStyles } from "../../demo-lib/styles";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
 export const options = { title: "Scrubbing" };
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 type ScrubMode = "off" | "on" | "noTooltip";
 
@@ -31,7 +37,15 @@ export default function ScrubbingScreen() {
   const [scrubMode, setScrubMode] = useState<ScrubMode>("on");
   const [displayMode, setDisplayMode] = useState<DisplayMode>("line");
   const [styledTooltip, setStyledTooltip] = useState(false);
-  const [readout, setReadout] = useState("—");
+
+  // Readout flows through a SharedValue + animatedProps so each scrub frame
+  // updates the text on the UI thread — no React re-render per pointer move.
+  // (A plain setState here re-rendered the whole screen ~60x/sec while scrubbing.)
+  const readoutText = useSharedValue("—");
+  const readoutProps = useAnimatedProps(() => {
+    const text = readoutText.get();
+    return { text, defaultValue: text };
+  });
 
   const windowSecs = 300;
   const candleWidthSecs = Math.max(5, Math.round(windowSecs / 20));
@@ -85,25 +99,32 @@ export default function ScrubbingScreen() {
           timeWindow={windowSecs}
           scrub={scrub}
           onScrub={(point) => {
+            "worklet";
             if (point === null) {
-              setReadout("— (live)");
+              readoutText.set("— (live)");
               return;
             }
-            const sp = point as ScrubPoint;
             let extra = "";
-            if (sp.candle) {
-              extra = ` | O:${sp.candle.open.toFixed(2)} H:${sp.candle.high.toFixed(2)} L:${sp.candle.low.toFixed(2)} C:${sp.candle.close.toFixed(2)}`;
+            if (point.candle) {
+              const c = point.candle;
+              extra = ` | O:${c.open.toFixed(2)} H:${c.high.toFixed(2)} L:${c.low.toFixed(2)} C:${c.close.toFixed(2)}`;
             }
-            setReadout(
-              `${sp.value.toFixed(4)} @ ${formatTime(sp.time)}${extra}`,
+            readoutText.set(
+              `${point.value.toFixed(4)} @ ${formatTime(point.time)}${extra}`,
             );
           }}
         />
       }
     >
-      <Text style={demoStyles.scrubReadout} numberOfLines={3}>
-        {readout}
-      </Text>
+      <AnimatedTextInput
+        editable={false}
+        multiline
+        numberOfLines={3}
+        scrollEnabled={false}
+        underlineColorAndroid="transparent"
+        style={demoStyles.scrubReadout}
+        animatedProps={readoutProps}
+      />
 
       <ChipRow
         label="Scrub"

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,18 @@
 import { Link, type Href } from "expo-router";
-import { Pressable, SectionList, StyleSheet, Text, View } from "react-native";
+import {
+  Linking,
+  Pressable,
+  SectionList,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { APP_FONT_FAMILY, APP_FONT_FAMILY_SEMIBOLD } from "../demo-lib/fonts";
+import {
+  APP_FONT_FAMILY,
+  APP_FONT_FAMILY_MEDIUM,
+  APP_FONT_FAMILY_SEMIBOLD,
+} from "../demo-lib/fonts";
 import { colors } from "../demo-lib/theme";
 
 type Demo = { href: Href; title: string; blurb: string };
@@ -135,6 +146,25 @@ const renderSectionHeader = ({
   section: DemoSection;
 }) => <Text style={styles.sectionHeader}>{section.title}</Text>;
 
+/** brandtnew labs — Lennart Brandt (Product Designer & React Native dev). */
+const SITE_URL = "https://www.brandtnewlabs.com";
+const X_URL = "https://x.com/brandtnewlabs";
+
+const Footer = () => (
+  <View style={styles.footer}>
+    <Text style={styles.footerMade}>Made by Lennart Brandt</Text>
+    <Text style={styles.footerLinks}>
+      <Text style={styles.footerLink} onPress={() => Linking.openURL(X_URL)}>
+        @brandtnewlabs
+      </Text>
+      <Text style={styles.footerDot}>{"  ·  "}</Text>
+      <Text style={styles.footerLink} onPress={() => Linking.openURL(SITE_URL)}>
+        brandtnewlabs.com
+      </Text>
+    </Text>
+  </View>
+);
+
 export default function Index() {
   const insets = useSafeAreaInsets();
   return (
@@ -150,6 +180,7 @@ export default function Index() {
         keyExtractor={(d) => d.title}
         renderItem={renderDemoItem}
         renderSectionHeader={renderSectionHeader}
+        ListFooterComponent={Footer}
         stickySectionHeadersEnabled={false}
       />
     </View>
@@ -203,5 +234,30 @@ const styles = StyleSheet.create({
     fontFamily: APP_FONT_FAMILY,
     lineHeight: 17,
     marginTop: 6,
+  },
+  footer: {
+    marginTop: 32,
+    paddingTop: 20,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
+  },
+  footerMade: {
+    color: colors.textFaint,
+    fontSize: 12,
+    fontFamily: APP_FONT_FAMILY,
+  },
+  footerLinks: {
+    marginTop: 5,
+    fontSize: 12,
+  },
+  footerLink: {
+    color: colors.link,
+    fontSize: 12,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+  },
+  footerDot: {
+    color: colors.textFaint,
+    fontSize: 12,
+    fontFamily: APP_FONT_FAMILY,
   },
 });


### PR DESCRIPTION
Stacked on #72.

## Performance fix — scrubbing readout
Profiled every demo screen with React DevTools (over Metro; agent-device fps/memory sampling needs a connected physical device, which wasn't online). The screens are SharedValue-driven and don't re-render on data ticks — **multi-series and playground showed 0 render commits at rest**. The one outlier was **Scrubbing**: it pushed each scrub point into React state, so every pointer move re-rendered the whole screen subtree (DemoScreen + controls ScrollView + chart). A short scrub produced **~189 render commits**.

Fix: move the readout to the same worklet → SharedValue → `AnimatedTextInput`/`useAnimatedProps` pattern the multi-series and playground readouts already use. The same scrub now produces **0 React commits** — the text updates entirely on the UI thread.

(`AnimatedTrendTextInput`'s one-render-per-tick was left as-is: it's an intentional, documented trade-off to avoid a native-memory leak from continuously pushing text via `animatedProps`, and it's contained to that small component.)

## Author footer
Added a footer below the demo list on the home screen:

> Made by Lennart Brandt
> @brandtnewlabs · brandtnewlabs.com

Both links are tappable (`@brandtnewlabs` → X, `brandtnewlabs.com` → site), verified opening on the simulator.

## Verification
- React DevTools: scrubbing 189 → 0 commits; multi-series / playground 0 at rest.
- `npm run verify` (typecheck + lint + 652 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)