### PR TITLE
fix: re-format X-axis labels when formatTime changes at runtime

### DIFF
--- a/packages/react-native-livechart/src/hooks/useXAxis.ts
+++ b/packages/react-native-livechart/src/hooks/useXAxis.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useDerivedValue, useSharedValue } from "react-native-reanimated";
 
 import type { SkFont } from "@shopify/react-native-skia";
@@ -15,6 +16,27 @@ export interface XAxisEntry {
 }
 
 const FADE = 0.08;
+
+/**
+ * Build a fresh label cache that re-formats every tick's `text` with
+ * `formatTime`, preserving each entry's `alpha`. The cache (see {@link useXAxis})
+ * formats each tick once for allocation reasons; this refreshes it when the
+ * `formatTime` prop changes. Returns a NEW object (and new entry objects) rather
+ * than mutating `cache` in place — the cache is also read inside the derived
+ * value worklet, and mutating an already-serialized object from the JS thread
+ * is unsafe under Reanimated's worklet model. Replacing the SharedValue with a
+ * fresh object propagates cleanly to the UI thread.
+ */
+export function reformatXAxisLabels(
+  cache: Record<number, { alpha: number; text: string }>,
+  formatTime: (t: number) => string,
+): Record<number, { alpha: number; text: string }> {
+  const next: Record<number, { alpha: number; text: string }> = {};
+  for (const key in cache) {
+    next[key] = { alpha: cache[key].alpha, text: formatTime(Number(key) / 100) };
+  }
+  return next;
+}
 
 function xAxisKeyIsTarget(key: number, targetKeys: number[]): boolean {
   "worklet";
@@ -49,6 +71,16 @@ export function useXAxis(
   const labelAlphas = useSharedValue<
     Record<number, { alpha: number; text: string }>
   >({});
+
+  // A tick's key encodes its time, so its label is formatted once (below) and
+  // never re-formatted per frame — an allocation optimization. That assumes
+  // `formatTime` is stable; if the consumer swaps it at runtime, already-cached
+  // labels would otherwise keep their old text until they scroll off-window.
+  // Rebuild the cache with the new formatter (alphas preserved, so no fade
+  // restart) whenever the formatter identity changes.
+  useEffect(() => {
+    labelAlphas.set(reformatXAxisLabels(labelAlphas.get(), formatTime));
+  }, [formatTime, labelAlphas]);
 
   const xAxisEntries = useDerivedValue(() => {
     const w = engine.canvasWidth.get();

--- a/packages/react-native-livechart/tests/hooks/useXAxis.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useXAxis.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react-native";
 
 import { DEFAULT_PADDING } from "../../src/draw/line";
 import type { EngineState } from "../../src/core/useLiveChartEngine";
-import { useXAxis } from "../../src/hooks/useXAxis";
+import { reformatXAxisLabels, useXAxis } from "../../src/hooks/useXAxis";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
 const font = {
@@ -102,5 +102,47 @@ describe("useXAxis", () => {
     });
     expect(result.current.xAxisEntries.value.length).toBeGreaterThanOrEqual(0);
     expect(first).toBeGreaterThanOrEqual(0);
+  });
+
+  // The X-axis label cache formats each tick once (an allocation optimization),
+  // so a `formatTime` swapped at runtime would otherwise leave already-cached
+  // labels stale until they scroll off-window. `reformatXAxisLabels` is the
+  // refresh the hook runs (via an effect) when the formatter identity changes.
+  // We assert it directly: under the reanimated jest mock `useDerivedValue`
+  // does not recompute on rerender, so the effect's result is not observable
+  // through `xAxisEntries` here.
+  it("reformatXAxisLabels returns a fresh cache re-formatted with the new formatter, alpha preserved", () => {
+    const kA = Math.round(1699999920 * 100);
+    const kB = Math.round(1699999980 * 100);
+    const cache = {
+      [kA]: { alpha: 0.5, text: `A${1699999920}` },
+      [kB]: { alpha: 1, text: `A${1699999980}` },
+    };
+
+    const next = reformatXAxisLabels(cache, (t) => `B${Math.floor(t)}`);
+
+    expect(next[kA].text).toBe("B1699999920");
+    expect(next[kB].text).toBe("B1699999980");
+    // Alphas are carried over, so swapping the formatter doesn't restart the fade.
+    expect(next[kA].alpha).toBe(0.5);
+    expect(next[kB].alpha).toBe(1);
+    // The original cache is NOT mutated (it may already be serialized to a worklet).
+    expect(next).not.toBe(cache);
+    expect(next[kA]).not.toBe(cache[kA]);
+    expect(cache[kA].text).toBe("A1699999920");
+  });
+
+  it("re-runs the relabel effect without error when formatTime changes", () => {
+    const eng = makeEngine(400, 200, 120);
+    const { rerender } = renderHook(
+      ({ f }: { f: (t: number) => string }) =>
+        useXAxis(eng, DEFAULT_PADDING, f, font),
+      { initialProps: { f: (t: number) => `A${Math.floor(t)}` } },
+    );
+    expect(() =>
+      act(() => {
+        rerender({ f: (t: number) => `B${Math.floor(t)}` });
+      }),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Problem

The X-axis label cache in `useXAxis` formats each tick's text **once** — when its key first appears — as a per-frame allocation optimization, then never re-formats it (see the existing comment: *"A key encodes its time, so the formatted text never changes…"*). That assumes the `formatTime` prop is stable for the component's life.

If a consumer **swaps `formatTime` at runtime**, already-cached tick labels keep their old text until they scroll off-window; only newly-appearing ticks use the new formatter. The axis briefly shows a mix of old- and new-format labels.

Repro in the example app: **States & formatting → toggle `$ + ISO time`**. Before the fix you briefly see local-time labels (`14:53`) alongside the new UTC formatter (`12:53`); it self-heals once the window turns over (~one `timeWindow`).

Low severity (runtime formatter swaps are uncommon, self-healing) and **not platform-specific** — pure JS memoization.

## Fix

- Extract `reformatXAxisLabels(cache, formatTime)` — a pure, exported helper that **rebuilds the cache into a fresh object** with the new formatter, **preserving each entry's `alpha`** (so labels don't restart their fade).
- Invoke it from a `useEffect` keyed on `formatTime`, replacing the `labelAlphas` SharedValue with the rebuilt object.

It returns a **new** object rather than mutating in place on purpose: the cache is also read inside the derived-value worklet, and mutating an already-serialized object from the JS thread trips Reanimated 4's *"modified an object already passed to a worklet"* guard — and may not propagate to the UI thread at all. Replacing the SharedValue with a fresh object is worklet-safe and propagates cleanly.

The Y-axis (`grid.ts`) already re-formats every frame, so `formatValue` has no equivalent staleness — no change needed there.

## Tests

- `reformatXAxisLabels` unit test: re-formats every cached label, preserves `alpha`, and does not mutate the original cache.
- Effect smoke test: rerendering `useXAxis` with a changed `formatTime` runs the relabel effect without error.
- Full suite green: `npm run verify` (typecheck + lint + 661 tests).

## Verification on real hardware

Built a release APK and ran it on a physical **Samsung Galaxy S24** (Android 16, Reanimated 4 / Vulkan). Toggling the `$ + ISO time` formatter now flips **all** axis labels local↔UTC **instantly**, in both directions — no stale mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)