### PR TITLE
fix(scrub): dim the full live dot + pulse, keep the badge above it

### DIFF
--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -15,6 +15,7 @@ export function CrosshairLine({
   padding,
   palette,
   dimOpacity = 0.3,
+  liveDotExtent = 0,
   crosshairLineColor,
   crosshairDimColor,
 }: {
@@ -25,6 +26,11 @@ export function CrosshairLine({
   palette: LiveChartPalette;
   /** Opacity of content right of the crosshair (dstOut fade). Default 0.3. */
   dimOpacity?: number;
+  /** How far the live series dots extend past the plot's right edge. The dim
+   *  region extends by this much so it fully covers the dots — centered on that
+   *  edge, otherwise only half-dimmed — while leaving the value/Y-axis labels
+   *  the gutter reserves beyond them bright. Default 0. */
+  liveDotExtent?: number;
   crosshairLineColor?: string;
   crosshairDimColor?: string;
 }) {
@@ -38,7 +44,7 @@ export function CrosshairLine({
   }));
 
   const dimWidth = useDerivedValue(() => {
-    const rightEdge = engine.canvasWidth.value - padding.right;
+    const rightEdge = engine.canvasWidth.value - padding.right + liveDotExtent;
     return Math.max(0, rightEdge - scrubX.value);
   });
   const dimHeight = useDerivedValue(

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -26,6 +26,7 @@ export function CrosshairOverlay({
   showTooltip = true,
   children,
   dimOpacity = 0.3,
+  liveDotExtent = 0,
   crosshairLineColor,
   crosshairDimColor,
   tooltipBackground,
@@ -46,6 +47,12 @@ export function CrosshairOverlay({
   children?: ReactNode;
   /** Opacity of content right of the crosshair (dstOut fade). Default 0.3. */
   dimOpacity?: number;
+  /** How far the live dot (and its pulse ring) extends past the plot's right
+   *  edge. The dim region extends by this much so it fully covers the live
+   *  indicator — which is centered on that edge and would otherwise be only
+   *  half-dimmed — while stopping short of the Y-axis labels the gutter
+   *  reserves beyond it. Default 0. */
+  liveDotExtent?: number;
   crosshairLineColor?: string;
   crosshairDimColor?: string;
   tooltipBackground?: string;
@@ -62,7 +69,7 @@ export function CrosshairOverlay({
   }));
 
   const dimWidth = useDerivedValue(() => {
-    const rightEdge = engine.canvasWidth.value - padding.right;
+    const rightEdge = engine.canvasWidth.value - padding.right + liveDotExtent;
     return Math.max(0, rightEdge - scrubX.value);
   });
   const dimHeight = useDerivedValue(

--- a/packages/react-native-livechart/src/components/DotOverlay.tsx
+++ b/packages/react-native-livechart/src/components/DotOverlay.tsx
@@ -5,7 +5,7 @@ import type { LiveChartPalette } from "../types";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 
 const MIN_PULSE_RADIUS = 9;
-const DOT_OUTER_RADIUS = 6.5;
+export const DOT_OUTER_RADIUS = 6.5;
 const DOT_INNER_RADIUS = 3.5;
 
 /**

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -499,7 +499,6 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     downBodiesPath,
     xAxisCfg,
     xAxisEntries,
-    badgeData,
     dotX,
     pulseCfg,
     degenCfg,
@@ -612,13 +611,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         />
       )}
 
-      {/* Badge and live dot */}
-      {badgeCfg && (
-        <Group opacity={reveal.badgeOpacity}>
-          <BadgeOverlay badge={badgeData} font={skiaFont} />
-        </Group>
-      )}
-
+      {/* Live dot — the badge is drawn later (after the scrub layer) so the
+          scrub dim never clips the live-price badge's left edge. */}
       <Group opacity={reveal.dotOpacity}>
         <DotOverlay
           dotX={dotX}
@@ -784,6 +778,20 @@ function ChartValueOverlay({ model }: { model: LiveChartModel }) {
   );
 }
 
+/** Live-price badge, drawn above the scrub dim so the dim never clips its left
+ *  edge. Shares the degen shake transform so it tracks the shaken stack. */
+function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
+  const { badgeCfg, badgeData, skiaFont, reveal, degenShakeTransform } = model;
+  if (!badgeCfg) return null;
+  return (
+    <Group transform={degenShakeTransform}>
+      <Group opacity={reveal.badgeOpacity}>
+        <BadgeOverlay badge={badgeData} font={skiaFont} />
+      </Group>
+    </Group>
+  );
+}
+
 export function LiveChart(props: LiveChartProps) {
   const model = useLiveChartController(props);
   const {
@@ -824,6 +832,10 @@ export function LiveChart(props: LiveChartProps) {
           <ChartValueOverlay model={model} />
 
           <ChartScrubLayer model={model} />
+
+          {/* Live-price badge on top of the scrub dim so the dim never clips
+              its left edge (the badge tracks the live value, not the scrub). */}
+          <ChartBadgeLayer model={model} />
         </Canvas>
       </View>
     </GestureDetector>

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -32,6 +32,7 @@ import {
   resolveYAxis,
 } from "../core/resolveConfig";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
+import { pulseRadialOutset } from "../draw/line";
 import { resolveChartLayout } from "../hooks/resolveChartLayout";
 import { useBadge } from "../hooks/useBadge";
 import { useCandlePaths } from "../hooks/useCandlePaths";
@@ -66,7 +67,7 @@ import type { LiveChartProps, Marker, TradeEvent } from "../types";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
-import { DotOverlay } from "./DotOverlay";
+import { DOT_OUTER_RADIUS, DotOverlay } from "./DotOverlay";
 import { LeftEdgeFade } from "./LeftEdgeFade";
 import { LoadingOverlay } from "./LoadingOverlay";
 import { MarkerOverlay } from "./MarkerOverlay";
@@ -688,9 +689,17 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
     reveal,
     crosshair,
     isCandle,
+    pulseCfg,
   } = model;
 
   if (!tradeStreamResolved && !scrubCfg) return null;
+
+  // Extend the scrub dim past the plot's right edge to fully cover the live dot
+  // and its pulse ring (both centered on that edge). The gutter reserves an
+  // 8px gap beyond this extent for the Y-axis labels, so they stay readable.
+  const liveDotExtent = pulseCfg
+    ? pulseRadialOutset(pulseCfg.maxRadius, pulseCfg.strokeWidth)
+    : DOT_OUTER_RADIUS;
 
   return (
     <Group transform={degenShakeTransform}>
@@ -716,6 +725,7 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
           font={skiaFont}
           showTooltip={scrubCfg.tooltip}
           dimOpacity={scrubCfg.dimOpacity}
+          liveDotExtent={liveDotExtent}
           crosshairLineColor={scrubCfg.crosshairLineColor}
           crosshairDimColor={scrubCfg.crosshairDimColor}
           tooltipBackground={scrubCfg.tooltipBackground}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -34,6 +34,7 @@ import {
   resolveYAxis,
 } from "../core/resolveConfig";
 import { useLiveChartSeriesEngine } from "../core/useLiveChartSeriesEngine";
+import { pulseRadialOutset } from "../draw/line";
 import { resolveChartLayout } from "../hooks/resolveChartLayout";
 import { useCanvasLayout } from "../hooks/useCanvasLayout";
 import { useChartReveal } from "../hooks/useChartReveal";
@@ -472,17 +473,9 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         />
       </Group>
 
-      {dotCfg.valueLabel && (
-        <Group opacity={reveal.dotOpacity}>
-          <MultiSeriesValueLabels
-            engine={engine}
-            padding={effectivePadding}
-            colors={lineColors}
-            font={skiaFont}
-            dotRadius={dotCfg.radius}
-          />
-        </Group>
-      )}
+      {/* Value labels are drawn later (after the crosshair layer) so the scrub
+          dim — which now covers the dots + pulse rings — never clips them.
+          They track each series' live value, not the scrub point. */}
 
       {degenCfg && (
         <Group opacity={reveal.dotOpacity}>
@@ -528,6 +521,35 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
   );
 }
 
+/** Per-series live-value labels, drawn above the scrub dim so the dim (which
+ *  covers the dots + pulse rings) never clips them. Keeps the degen shake
+ *  transform so they track the shaken stack. */
+function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
+  const {
+    dotCfg,
+    engine,
+    effectivePadding,
+    lineColors,
+    skiaFont,
+    reveal,
+    degenShakeTransform,
+  } = model;
+  if (!dotCfg.valueLabel) return null;
+  return (
+    <Group transform={degenShakeTransform}>
+      <Group opacity={reveal.dotOpacity}>
+        <MultiSeriesValueLabels
+          engine={engine}
+          padding={effectivePadding}
+          colors={lineColors}
+          font={skiaFont}
+          dotRadius={dotCfg.radius}
+        />
+      </Group>
+    </Group>
+  );
+}
+
 export function LiveChartSeries(props: LiveChartSeriesProps) {
   const model = useLiveChartSeriesController(props);
   const {
@@ -549,6 +571,13 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     palette,
     dotCfg,
   } = model;
+
+  // Extend the scrub dim past the plot's right edge to fully cover the series
+  // dots and their pulse rings (centered on that edge). The gutter reserves
+  // room beyond this for the value/Y-axis labels, which are drawn on top.
+  const liveDotExtent = dotCfg.pulse
+    ? pulseRadialOutset(dotCfg.pulse.maxRadius, dotCfg.pulse.strokeWidth)
+    : dotCfg.radius;
 
   const legend =
     legendCfg.position === "top" || legendCfg.position === "bottom" ? (
@@ -595,11 +624,15 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 padding={effectivePadding}
                 palette={palette}
                 dimOpacity={scrubCfg.dimOpacity}
-                liveDotExtent={dotCfg.radius}
+                liveDotExtent={liveDotExtent}
                 crosshairLineColor={scrubCfg.crosshairLineColor}
                 crosshairDimColor={scrubCfg.crosshairDimColor}
               />
             )}
+
+            {/* Per-series value labels on top of the scrub dim so the dim never
+                clips them (they track each series' live value, not the scrub). */}
+            <SeriesValueLabelLayer model={model} />
           </Canvas>
         </View>
       </GestureDetector>

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -547,6 +547,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     scrubCfg,
     crosshair,
     palette,
+    dotCfg,
   } = model;
 
   const legend =
@@ -594,6 +595,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 padding={effectivePadding}
                 palette={palette}
                 dimOpacity={scrubCfg.dimOpacity}
+                liveDotExtent={dotCfg.radius}
                 crosshairLineColor={scrubCfg.crosshairLineColor}
                 crosshairDimColor={scrubCfg.crosshairDimColor}
               />


### PR DESCRIPTION
## Problem

A user reported that while scrubbing, the dim overlay *"doesn't overlay the whole dot indicator on the right — only half of it."* The pulse ring and the live-price badge had the same issue.

The scrub dim region stopped its right edge at the plot's inner edge (`canvasWidth - padding.right`), which lands exactly on the live dot's **center**. The dot, its pulse ring, and the gutter indicators all extend past that edge, so only their left half got dimmed.

## Fix

**1. Extend the dim to cover the whole live dot + pulse** (`liveDotExtent` prop on the shared crosshair components):
- `LiveChart` (`CrosshairOverlay`) and `LiveChartSeries` (`CrosshairLine`): the pulse ring's outset (`pulseRadialOutset`) when a pulse is configured, else the dot radius.

The right gutter already reserves a gap beyond that extent for the value / Y-axis labels (via `minPaddingRightForYAxisWithPulse`), so those labels stay readable — the dim fills the whole chart **minus the Y-axis**.

**2. Draw the live-value indicators above the scrub dim.** Extending the dim exposed a second issue: the single-series **badge** and the multi-series **per-series value labels** lived in the content layer *under* the scrub layer, so the dim erased their left edges. Both are moved to their own layer after the crosshair so they always paint on top — they track the live value, not the scrub point, so they should never be dimmed.

## Commits

1. `dim the full live dot + pulse, not half of it`
2. `draw the live-price badge above the scrub dim` (single-series)
3. `cover the series dots' pulse rings in multi-series too` (+ value labels above the dim)

## Verification

- `npm run verify` (typecheck + lint + 661 tests) ✅
- Manually verified on the iOS simulator for **both** the single-series scrubbing demo and the multi-series demo: dots + pulse rings fade uniformly, while the Y-axis labels, badge, and per-series value labels stay bright with no clipped edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
