### PR TITLE
feat(multi-series): configurable, haloed series dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The tables below are a **highlight** — the **canonical, full reference is the 
 | ---------------- | ------------------------------------------- |
 | `series`         | `SharedValue<SeriesConfig[]>`               |
 | `legend`         | Toggle chips / compact legend               |
-| `dot`            | Per-series live dots, pulse, value lines    |
+| `dot`            | Per-series live dots: haloed `ring`, `show`, `color`, `radius`, `pulse`, `valueLine`, `valueLabel` |
 | `onSeriesToggle` | Chip tap                                    |
 | `onScrub`        | Worklet-friendly multi-series scrub payload |
 

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -104,6 +104,8 @@ export default function MultiSeriesScreen() {
   const [valueLines, setValueLines] = useState(false);
   const [valueLabels, setValueLabels] = useState(true);
   const [dotRadius, setDotRadius] = useState(3.5);
+  const [dots, setDots] = useState(true);
+  const [ring, setRing] = useState(true);
 
   const [legendVisible, setLegendVisible] = useState(true);
   const [legendCompact, setLegendCompact] = useState(true);
@@ -147,6 +149,8 @@ export default function MultiSeriesScreen() {
 
   const dotConfig: MultiSeriesDotConfig = {
     radius: dotRadius,
+    show: dots,
+    ring,
     pulse,
     valueLine: valueLines,
     valueLabel: valueLabels,
@@ -237,6 +241,8 @@ export default function MultiSeriesScreen() {
       <ChipRow label="Data" options={DATA_OPTIONS} value={empty} onChange={setEmpty} />
 
       <ControlRow label="Dot">
+        <ToggleChip label="Dots" value={dots} onChange={setDots} />
+        <ToggleChip label="Ring" value={ring} onChange={setRing} />
         <ToggleChip label="Pulse" value={pulse} onChange={setPulse} />
         <ToggleChip label="Labels" value={valueLabels} onChange={setValueLabels} />
         <ToggleChip

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -32,7 +32,10 @@ accepts all the shared theming, axis, range, layout, and text props from
 ## Dots
 
 <ParamField body="dot" type="MultiSeriesDotConfig">
-  Per-series live dots: `radius`, `pulse`, `valueLine`, `valueLabel`.
+  Per-series live dots: `radius`, `ring`, `show`, `color`, `pulse`, `valueLine`,
+  `valueLabel`. Each dot is haloed with a contrasting outer `ring` by default
+  (matching the single-series live dot); pass `ring: false` for a flat circle,
+  `show: false` to hide the dots, or `color` to override the per-series fill.
 </ParamField>
 
 ## Scrub

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -154,8 +154,15 @@ interface XAxisConfig { minGap?: number } // default 60
 interface ChartInsets { top?: number; right?: number; bottom?: number; left?: number }
 interface LeftEdgeFadeConfig { width?: number; startColor?: string; endColor?: string }
 
+interface DotRingConfig {
+  color?: string; // default: theme `badgeOuterBg`
+  width?: number; // default 2.5
+}
 interface MultiSeriesDotConfig {
-  radius?: number;
+  radius?: number; // color-filled dot radius, default 3.5
+  ring?: boolean | DotRingConfig; // haloed outer ring (like single-series), default true
+  show?: boolean; // default true
+  color?: string; // dot fill, defaults to each series' line color
   pulse?: boolean | PulseConfig;
   valueLine?: boolean | ValueLineConfig;
   valueLabel?: boolean;

--- a/docs/guides/multi-series.mdx
+++ b/docs/guides/multi-series.mdx
@@ -64,12 +64,29 @@ taps with `onSeriesToggle`:
 
 ## Per-series dots
 
-The `dot` prop controls the live dots, their pulse, value lines, and inline labels:
+The `dot` prop controls the live dots, their pulse, value lines, and inline labels.
+Each dot is **haloed** by default — a contrasting outer ring (in the chart
+background color) behind the colored dot, matching the single-series live dot so
+overlapping series stay legible:
 
 ```tsx
 <LiveChartSeries
   series={series}
-  dot={{ radius: 3.5, pulse: true, valueLine: true, valueLabel: true }}
+  dot={{ radius: 3.5, ring: true, pulse: true, valueLine: true, valueLabel: true }}
+/>
+```
+
+Tune or turn off the halo, hide the dots, or override the fill color:
+
+```tsx
+<LiveChartSeries
+  series={series}
+  // thicker, tinted halo
+  dot={{ ring: { color: "#0b0b0f", width: 3 } }}
+  // ...or a flat circle (no halo)
+  // dot={{ ring: false }}
+  // ...or hide the dots entirely (lines + labels still render)
+  // dot={{ show: false }}
 />
 ```
 

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -144,6 +144,9 @@ function useLiveChartSeriesController({
   const scrubEnabled = scrubCfg !== null;
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
+  // Outer footprint of a dot (the color-filled radius plus the halo ring).
+  // Used to keep the gutter labels clear of the haloed dot.
+  const dotOuterRadius = dotCfg.radius + (dotCfg.ring?.width ?? 0);
   const legendCfg = resolveLegend(legendProp);
   const degenCfg = resolveDegen(degen);
 
@@ -191,7 +194,7 @@ function useLiveChartSeriesController({
     : 0;
 
   const seriesLabelInset = dotCfg.valueLabel
-    ? dotCfg.radius + 8 + maxSeriesLabelWidth + 8
+    ? dotOuterRadius + 8 + maxSeriesLabelWidth + 8
     : 0;
 
   const representativeValue =
@@ -210,7 +213,7 @@ function useLiveChartSeriesController({
     formatValue,
     currentValue: representativeValue,
     pulse: dotCfg.pulse,
-    multiSeriesDotRadius: dotCfg.radius,
+    multiSeriesDotRadius: dotOuterRadius,
     multiSeriesValueLabel: dotCfg.valueLabel,
     multiSeriesMaxLabelWidth: maxSeriesLabelWidth,
   });
@@ -332,6 +335,7 @@ function useLiveChartSeriesController({
     scrubCfg,
     gridStyleCfg,
     dotCfg,
+    dotOuterRadius,
     legendCfg,
     degenCfg,
     allRefLines,
@@ -463,15 +467,20 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         />
       )}
 
-      <Group opacity={reveal.dotOpacity}>
-        <MultiSeriesDots
-          engine={engine}
-          padding={effectivePadding}
-          colors={lineColors}
-          radius={dotCfg.radius}
-          pulse={dotCfg.pulse}
-        />
-      </Group>
+      {dotCfg.show && (
+        <Group opacity={reveal.dotOpacity}>
+          <MultiSeriesDots
+            engine={engine}
+            padding={effectivePadding}
+            colors={lineColors}
+            radius={dotCfg.radius}
+            ring={dotCfg.ring}
+            ringColor={palette.badgeOuterBg}
+            color={dotCfg.color}
+            pulse={dotCfg.pulse}
+          />
+        </Group>
+      )}
 
       {/* Value labels are drawn later (after the crosshair layer) so the scrub
           dim — which now covers the dots + pulse rings — never clips them.
@@ -527,6 +536,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
 function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
   const {
     dotCfg,
+    dotOuterRadius,
     engine,
     effectivePadding,
     lineColors,
@@ -543,7 +553,7 @@ function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
           padding={effectivePadding}
           colors={lineColors}
           font={skiaFont}
-          dotRadius={dotCfg.radius}
+          dotRadius={dotOuterRadius}
         />
       </Group>
     </Group>
@@ -570,14 +580,18 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     crosshair,
     palette,
     dotCfg,
+    dotOuterRadius,
   } = model;
 
   // Extend the scrub dim past the plot's right edge to fully cover the series
-  // dots and their pulse rings (centered on that edge). The gutter reserves
-  // room beyond this for the value/Y-axis labels, which are drawn on top.
-  const liveDotExtent = dotCfg.pulse
-    ? pulseRadialOutset(dotCfg.pulse.maxRadius, dotCfg.pulse.strokeWidth)
-    : dotCfg.radius;
+  // dots (with their halo) and pulse rings, all centered on that edge. The
+  // gutter reserves room beyond this for the value/Y-axis labels, drawn on top.
+  const liveDotExtent = Math.max(
+    dotOuterRadius,
+    dotCfg.pulse
+      ? pulseRadialOutset(dotCfg.pulse.maxRadius, dotCfg.pulse.strokeWidth)
+      : 0,
+  );
 
   const legend =
     legendCfg.position === "top" || legendCfg.position === "bottom" ? (

--- a/packages/react-native-livechart/src/components/MultiSeriesDots.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesDots.tsx
@@ -3,7 +3,10 @@ import { Circle, Group } from "@shopify/react-native-skia";
 import { useDerivedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
-import type { ResolvedPulseConfig } from "../core/resolveConfig";
+import type {
+  ResolvedDotRingConfig,
+  ResolvedPulseConfig,
+} from "../core/resolveConfig";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 
 const MIN_PULSE_RADIUS = 6;
@@ -15,6 +18,8 @@ function SeriesDotAtIndex({
   padding,
   color,
   radius,
+  ring,
+  ringColor,
   pulse,
 }: {
   index: number;
@@ -22,6 +27,10 @@ function SeriesDotAtIndex({
   padding: ChartPadding;
   color: string;
   radius: number;
+  /** Outer halo ring, or `null` for a flat circle. */
+  ring: ResolvedDotRingConfig | null;
+  /** Fallback ring color when `ring.color` is unset (theme `badgeOuterBg`). */
+  ringColor: string;
   pulse: ResolvedPulseConfig | null;
 }) {
   const dotX = useDerivedValue(() => {
@@ -81,6 +90,14 @@ function SeriesDotAtIndex({
           opacity={pulseOpacity}
         />
       )}
+      {ring && (
+        <Circle
+          cx={dotX}
+          cy={dotY}
+          r={radius + ring.width}
+          color={ring.color ?? ringColor}
+        />
+      )}
       <Circle cx={dotX} cy={dotY} r={radius} color={color} />
     </Group>
   );
@@ -91,12 +108,21 @@ export function MultiSeriesDots({
   padding,
   colors,
   radius,
+  ring,
+  ringColor,
+  color,
   pulse,
 }: {
   engine: MultiEngineState;
   padding: ChartPadding;
   colors: string[];
   radius: number;
+  /** Outer halo ring, or `null` for flat circles. */
+  ring: ResolvedDotRingConfig | null;
+  /** Fallback ring color when `ring.color` is unset (theme `badgeOuterBg`). */
+  ringColor: string;
+  /** Fill color override; falls back to each series' line color. */
+  color: string | undefined;
   pulse: ResolvedPulseConfig | null;
 }) {
   return (
@@ -107,8 +133,10 @@ export function MultiSeriesDots({
           index={i}
           engine={engine}
           padding={padding}
-          color={colors[i] ?? "#ffffff"}
+          color={color ?? colors[i] ?? "#ffffff"}
           radius={radius}
+          ring={ring}
+          ringColor={ringColor}
           pulse={pulse}
         />
       ))}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -9,6 +9,7 @@ import type {
   LeftEdgeFadeConfig,
   LegendConfig,
   LegendStyle,
+  DotRingConfig,
   MultiSeriesDotConfig,
   PulseConfig,
   ReferenceLine,
@@ -479,8 +480,31 @@ export function resolveTradeStream(
 
 // ─── Multi-series dot ─────────────────────────────────────────────────────────
 
+/** Resolved halo ring. `color: undefined` means "use the theme `badgeOuterBg`". */
+export interface ResolvedDotRingConfig {
+  color: string | undefined;
+  width: number;
+}
+
+const RING_DEFAULTS: ResolvedDotRingConfig = {
+  color: undefined,
+  width: 2.5,
+};
+
+/** `undefined`/`true` → haloed defaults; `false` → null (flat circle). */
+export function resolveDotRing(
+  prop: boolean | DotRingConfig | undefined,
+): ResolvedDotRingConfig | null {
+  if (prop === false) return null;
+  if (prop === undefined || prop === true) return RING_DEFAULTS;
+  return { ...RING_DEFAULTS, ...prop };
+}
+
 export interface ResolvedMultiSeriesDotConfig {
   radius: number;
+  ring: ResolvedDotRingConfig | null;
+  show: boolean;
+  color: string | undefined;
   pulse: ResolvedPulseConfig | null;
   valueLine: ResolvedValueLineConfig | null;
   valueLabel: boolean;
@@ -488,6 +512,9 @@ export interface ResolvedMultiSeriesDotConfig {
 
 const MULTI_DOT_DEFAULTS: ResolvedMultiSeriesDotConfig = {
   radius: 3.5,
+  ring: RING_DEFAULTS,
+  show: true,
+  color: undefined,
   pulse: PULSE_DEFAULTS,
   valueLine: null,
   valueLabel: true,
@@ -499,6 +526,9 @@ export function resolveMultiSeriesDot(
   if (!prop) return MULTI_DOT_DEFAULTS;
   return {
     radius: prop.radius ?? MULTI_DOT_DEFAULTS.radius,
+    ring: resolveDotRing(prop.ring),
+    show: prop.show ?? MULTI_DOT_DEFAULTS.show,
+    color: prop.color,
     pulse: resolvePulse(prop.pulse ?? true),
     valueLine: resolveValueLine(prop.valueLine),
     valueLabel: prop.valueLabel ?? MULTI_DOT_DEFAULTS.valueLabel,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -392,10 +392,30 @@ export interface DegenShakePayload {
   direction: "up" | "down";
 }
 
+/** Contrasting outer ring drawn behind each series dot — the "haloed" look the
+ *  single-series live dot has, so dots stand out against the lines and one
+ *  another. */
+export interface DotRingConfig {
+  /** Ring color. Default: theme `badgeOuterBg` (a near-background halo). */
+  color?: string;
+  /** Ring thickness in pixels — how far the halo extends past the dot. Default `2.5`. */
+  width?: number;
+}
+
 /** Live dot configuration for multi-series charts. */
 export interface MultiSeriesDotConfig {
-  /** Dot radius in pixels. Default `3.5`. */
+  /** Radius of the (color-filled) dot in pixels. Default `3.5`. */
   radius?: number;
+  /**
+   * Contrasting outer ring behind each dot — matches the single-series live
+   * dot's haloed look so dots read clearly against the lines. `true` = defaults,
+   * `false` = a flat circle, or pass `DotRingConfig`. Default `true`.
+   */
+  ring?: boolean | DotRingConfig;
+  /** Show the series dots. `false` hides them (lines and labels still render). Default `true`. */
+  show?: boolean;
+  /** Dot fill color. Defaults to each series' line color. */
+  color?: string;
   /** Pulsing ring animation on each series dot. `true` = defaults, or pass `PulseConfig`. Default `true`. */
   pulse?: boolean | PulseConfig;
   /** Horizontal dashed line at each series' live value. `true` = defaults, or pass `ValueLineConfig`. Default `false`. */

--- a/packages/react-native-livechart/tests/components/MultiSeriesDots.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesDots.test.tsx
@@ -41,6 +41,9 @@ describe("MultiSeriesDots", () => {
           padding={padding}
           colors={["#3b82f6"]}
           radius={3.5}
+          ring={{ color: undefined, width: 2.5 }}
+          ringColor="#ffffff"
+          color={undefined}
           pulse={null}
         />
       );
@@ -81,6 +84,9 @@ describe("MultiSeriesDots", () => {
           padding={padding}
           colors={["#3b82f6"]}
           radius={3.5}
+          ring={{ color: undefined, width: 2.5 }}
+          ringColor="#ffffff"
+          color={undefined}
           pulse={null}
         />
       );
@@ -121,6 +127,9 @@ describe("MultiSeriesDots", () => {
           padding={padding}
           colors={["#3b82f6"]}
           radius={3.5}
+          ring={{ color: undefined, width: 2.5 }}
+          ringColor="#ffffff"
+          color={undefined}
           pulse={null}
         />
       );

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1,10 +1,12 @@
 import {
   resolveBadge,
   resolveDegen,
+  resolveDotRing,
   resolveFontConfig,
   resolveGradient,
   resolveGridStyle,
   resolveLeftEdgeFade,
+  resolveMultiSeriesDot,
   resolvePulse,
   resolveReferenceLineConfig,
   resolveScrub,
@@ -587,6 +589,66 @@ describe("resolveGridStyle", () => {
       strokeWidth: 2,
       intervals: [],
       opacity: 1,
+    });
+  });
+});
+
+// ─── resolveDotRing ───────────────────────────────────────────────────────────
+
+describe("resolveDotRing", () => {
+  it("returns null when disabled", () => {
+    expect(resolveDotRing(false)).toBeNull();
+  });
+
+  it("returns haloed defaults for true/undefined", () => {
+    expect(resolveDotRing(true)).toEqual({ color: undefined, width: 2.5 });
+    expect(resolveDotRing(undefined)).toEqual({ color: undefined, width: 2.5 });
+  });
+
+  it("merges a partial ring config over the defaults", () => {
+    expect(resolveDotRing({ color: "#000", width: 4 })).toEqual({
+      color: "#000",
+      width: 4,
+    });
+    expect(resolveDotRing({ color: "#fff" })).toEqual({
+      color: "#fff",
+      width: 2.5,
+    });
+  });
+});
+
+// ─── resolveMultiSeriesDot ──────────────────────────────────────────────────────
+
+describe("resolveMultiSeriesDot", () => {
+  it("defaults to a haloed, shown dot with pulse", () => {
+    expect(resolveMultiSeriesDot(undefined)).toEqual({
+      radius: 3.5,
+      ring: { color: undefined, width: 2.5 },
+      show: true,
+      color: undefined,
+      pulse: expect.objectContaining({ maxRadius: expect.any(Number) }),
+      valueLine: null,
+      valueLabel: true,
+    });
+  });
+
+  it("applies overrides (flat ring, hidden, color, label off)", () => {
+    expect(
+      resolveMultiSeriesDot({
+        radius: 5,
+        ring: false,
+        show: false,
+        color: "#abcdef",
+        valueLabel: false,
+      }),
+    ).toEqual({
+      radius: 5,
+      ring: null,
+      show: false,
+      color: "#abcdef",
+      pulse: expect.objectContaining({ maxRadius: expect.any(Number) }),
+      valueLine: null,
+      valueLabel: false,
     });
   });
 });


### PR DESCRIPTION
> Stacked on #76 (base branch `fix/scrub-dim-live-dot`). Review/merge #76 first; the diff here is just the final commit.

## What

Make the multi-series `LiveChartSeries` dots configurable, matching the single-series live dot — which is a **haloed** dot (a contrasting outer ring behind a colored inner dot). Multi-series dots were plain flat circles.

`MultiSeriesDotConfig` gains:

| field | type | default | notes |
| --- | --- | --- | --- |
| `ring` | `boolean \| DotRingConfig` | `true` | Outer halo ring (theme `badgeOuterBg`), like the single-series dot. `false` = flat circle, or `{ color, width }`. |
| `show` | `boolean` | `true` | Hide the dots (lines + labels still render). |
| `color` | `string` | series color | Override the per-series dot fill. |

(existing `radius`, `pulse`, `valueLine`, `valueLabel` unchanged.)

## Why "haloed by default"

The request was to make multi-series dots "configurable like the single series." The single-series dot's defining trait is its halo (outer ring + inner dot) — so the default now matches it, which also helps overlapping series read clearly. Opt out per-dot with `ring: false`.

## Implementation notes

- The halo's **outer** radius (`radius + ring.width`) is threaded through the layout — gutter padding, the value-label inset, and the scrub dim's `liveDotExtent` — so labels clear the ring and the scrub dim (from #76) still fully covers the haloed dot.

## Docs + demo

- README (root + package), `docs/api-reference/types.mdx` (+ new `DotRingConfig`), `docs/api-reference/livechart-series.mdx`, `docs/guides/multi-series.mdx`.
- Multi-series demo screen: new **Dots** and **Ring** toggles.

## Verification

- `npm run verify` (typecheck + lint + 666 tests) ✅ — added `resolveDotRing` / `resolveMultiSeriesDot` unit tests + updated `MultiSeriesDots` fixtures.
- iOS simulator: dots render haloed by default; the `ring`/`show` toggles work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
