### PR TITLE
feat(single-series): configurable dot via shared DotConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The tables below are a **highlight** — the **canonical, full reference is the 
 | `degen`                                  | Particle burst + shake on momentum swings                           |
 | `scrub`                                  | Crosshair scrubbing                                                 |
 | `momentum`                               | `true` / `false` / `"up"`, `"down"`, or `"flat"` / `MomentumConfig` |
+| `dot`                                    | Live dot styling: `radius`, `ring` (halo), `show`, `color`          |
 | `onScrub`                                | Callback: `ScrubPoint` or `null`                                    |
 
 ### `LiveChartSeries` (multi-series)
@@ -151,7 +152,7 @@ The tables below are a **highlight** — the **canonical, full reference is the 
 | `onSeriesToggle` | Chip tap                                    |
 | `onScrub`        | Worklet-friendly multi-series scrub payload |
 
-These tables are a **highlight, not the full surface** (`LiveChart` alone has ~48 props). Other shared props include `font`, `insets`, `smoothing`, `xAxis`, `yAxis`, `referenceLines`, `gridStyle`, `palette`, `markers`, `leftEdgeFade`, `line`, `formatValue`, `formatTime`, and `emptyText`; single-series adds `gradient`, `badge`, `pulse`, `valueLine`, and `showValue`. See the TypeScript types and JSDoc for the complete, canonical reference.
+These tables are a **highlight, not the full surface** (`LiveChart` alone has ~48 props). Other shared props include `font`, `insets`, `smoothing`, `xAxis`, `yAxis`, `referenceLines`, `gridStyle`, `palette`, `markers`, `leftEdgeFade`, `line`, `formatValue`, `formatTime`, and `emptyText`; single-series adds `gradient`, `badge`, `pulse`, `valueLine`, and `showValue`. Both charts share the same `dot` styling (a `DotConfig` base — `radius`, `ring`, `show`, `color`); multi-series extends it with `pulse`, `valueLine`, and `valueLabel`. See the TypeScript types and JSDoc for the complete, canonical reference.
 
 ## Examples (Expo app in this repo)
 

--- a/app/demo/line.tsx
+++ b/app/demo/line.tsx
@@ -60,6 +60,8 @@ export default function LineScreen() {
   const [valueLine, setValueLine] = useState(true);
   const [showValue, setShowValue] = useState(false);
   const [valueMomentumColor, setValueMomentumColor] = useState(false);
+  const [dots, setDots] = useState(true);
+  const [ring, setRing] = useState(true);
 
   const { data, value } = useSimulatedChartData({
     multiSeries: false,
@@ -84,6 +86,7 @@ export default function LineScreen() {
           theme={APP_THEME}
           badge={resolveBadge(badgeMode)}
           pulse={resolvePulse(pulseMode)}
+          dot={{ show: dots, ring }}
           valueLine={valueLine}
           showValue={showValue}
           valueMomentumColor={valueMomentumColor}
@@ -103,6 +106,10 @@ export default function LineScreen() {
         value={pulseMode}
         onChange={setPulseMode}
       />
+      <ControlRow label="Dot">
+        <ToggleChip label="Dot" value={dots} onChange={setDots} />
+        <ToggleChip label="Ring" value={ring} onChange={setRing} />
+      </ControlRow>
       <ControlRow label="Value line">
         <ToggleChip
           label="valueLine"

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -57,6 +57,14 @@ provided; everything else has a default.
   Pulsing ring on the live dot.
 </ParamField>
 
+<ParamField body="dot" type="DotConfig">
+  Live dot styling — `radius`, `ring` (the contrasting outer halo, on by
+  default), `show`, and `color`. Pass `ring: false` for a flat dot, `show: false`
+  to hide it, or `color` to override the fill. The same `DotConfig` is shared
+  with `LiveChartSeries` (whose `dot` extends it with `pulse`, `valueLine`, and
+  `valueLabel`).
+</ParamField>
+
 <ParamField body="valueLine" type="boolean | ValueLineConfig">
   Horizontal dashed line at the current value.
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -158,11 +158,14 @@ interface DotRingConfig {
   color?: string; // default: theme `badgeOuterBg`
   width?: number; // default 2.5
 }
-interface MultiSeriesDotConfig {
+// Shared live-dot styling (LiveChart `dot`; LiveChartSeries `dot` extends it)
+interface DotConfig {
   radius?: number; // color-filled dot radius, default 3.5
-  ring?: boolean | DotRingConfig; // haloed outer ring (like single-series), default true
+  ring?: boolean | DotRingConfig; // haloed outer ring, default true
   show?: boolean; // default true
-  color?: string; // dot fill, defaults to each series' line color
+  color?: string; // dot fill, defaults to the line color
+}
+interface MultiSeriesDotConfig extends DotConfig {
   pulse?: boolean | PulseConfig;
   valueLine?: boolean | ValueLineConfig;
   valueLabel?: boolean;

--- a/docs/guides/line-and-area.mdx
+++ b/docs/guides/line-and-area.mdx
@@ -47,6 +47,19 @@ dashed value line across the plot.
 />
 ```
 
+The live dot is a color-filled circle with a contrasting outer **ring** (halo). Style it via
+`dot` — the same `DotConfig` that `LiveChartSeries` uses:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  dot={{ radius: 4, ring: { color: "#0b0b0f", width: 3 } }}
+  // dot={{ ring: false }}  // flat dot, no halo
+  // dot={{ show: false }}  // hide the dot
+/>
+```
+
 <Note>
   Most boolean-ish props accept `true` (defaults), `false` (off), or a config object — for
   example `badge`, `pulse`, `valueLine`, `gradient`, `scrub`, and `yAxis`.

--- a/packages/react-native-livechart/src/components/DotOverlay.tsx
+++ b/packages/react-native-livechart/src/components/DotOverlay.tsx
@@ -1,17 +1,19 @@
 import { Circle, Group } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import type { ResolvedPulseConfig } from "../core/resolveConfig";
+import type {
+  ResolvedDotRingConfig,
+  ResolvedPulseConfig,
+} from "../core/resolveConfig";
 import type { LiveChartPalette } from "../types";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 
 const MIN_PULSE_RADIUS = 9;
-export const DOT_OUTER_RADIUS = 6.5;
-const DOT_INNER_RADIUS = 3.5;
 
 /**
- * Live dot + expanding pulse ring. Peak ring size uses `pulse.maxRadius` and
- * `pulse.strokeWidth`; chart padding reserves the same outer extent via
- * `pulseRadialOutset` in `draw/line.ts` (see `resolveChartLayout`).
+ * Live dot + expanding pulse ring. The dot is a color-filled circle of `radius`
+ * with an optional contrasting outer `ring` (halo). Peak pulse size uses
+ * `pulse.maxRadius` / `pulse.strokeWidth`; chart padding reserves the same outer
+ * extent via `pulseRadialOutset` in `draw/line.ts` (see `resolveChartLayout`).
  */
 export function DotOverlay({
   dotX,
@@ -19,13 +21,24 @@ export function DotOverlay({
   palette,
   engine,
   pulse,
+  radius,
+  ring,
+  color,
 }: {
   dotX: SharedValue<number>;
   dotY: SharedValue<number>;
   palette: LiveChartPalette;
   engine: ChartEngineLayout;
   pulse: ResolvedPulseConfig | null;
+  /** Radius of the color-filled dot in pixels. */
+  radius: number;
+  /** Outer halo ring, or `null` for a flat dot. */
+  ring: ResolvedDotRingConfig | null;
+  /** Dot (and pulse) fill color; falls back to the chart line color. */
+  color: string | undefined;
 }) {
+  const dotColor = color ?? palette.line;
+
   const pulseRadius = useDerivedValue(() => {
     if (!pulse) return 0;
     const nowMs = engine.timestamp.value * 1000;
@@ -49,21 +62,23 @@ export function DotOverlay({
           cx={dotX}
           cy={dotY}
           r={pulseRadius}
-          color={palette.line}
+          color={dotColor}
           style="stroke"
           strokeWidth={pulse.strokeWidth}
           opacity={pulseOpacity}
         />
       )}
 
-      <Circle
-        cx={dotX}
-        cy={dotY}
-        r={DOT_OUTER_RADIUS}
-        color={palette.badgeOuterBg}
-      />
+      {ring && (
+        <Circle
+          cx={dotX}
+          cy={dotY}
+          r={radius + ring.width}
+          color={ring.color ?? palette.badgeOuterBg}
+        />
+      )}
 
-      <Circle cx={dotX} cy={dotY} r={DOT_INNER_RADIUS} color={palette.line} />
+      <Circle cx={dotX} cy={dotY} r={radius} color={dotColor} />
     </Group>
   );
 }

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -21,6 +21,7 @@ import { DEFAULT_ACCENT_COLOR } from "../constants";
 import {
   resolveBadge,
   resolveDegen,
+  resolveDot,
   resolveGradient,
   resolveGridStyle,
   resolveLeftEdgeFade,
@@ -67,7 +68,7 @@ import type { LiveChartProps, Marker, TradeEvent } from "../types";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
-import { DOT_OUTER_RADIUS, DotOverlay } from "./DotOverlay";
+import { DotOverlay } from "./DotOverlay";
 import { LeftEdgeFade } from "./LeftEdgeFade";
 import { LoadingOverlay } from "./LoadingOverlay";
 import { MarkerOverlay } from "./MarkerOverlay";
@@ -127,6 +128,7 @@ function useLiveChartController({
   badge = true,
   momentum = true,
   pulse = true,
+  dot,
   valueLine = true,
   showValue = false,
   valueMomentumColor = false,
@@ -159,6 +161,9 @@ function useLiveChartController({
   const gradientCfg = isCandle ? null : resolveGradient(gradient);
   const valueLineCfg = resolveValueLine(valueLine);
   const pulseCfg = resolvePulse(pulse);
+  const dotCfg = resolveDot(dot);
+  // Outer footprint of the dot (color-filled radius plus the halo ring).
+  const dotOuterRadius = dotCfg.radius + (dotCfg.ring?.width ?? 0);
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const degenCfg = resolveDegen(degen);
   const tradeStreamResolved = resolveTradeStream(tradeStream);
@@ -415,6 +420,8 @@ function useLiveChartController({
     gradientCfg,
     valueLineCfg,
     pulseCfg,
+    dotCfg,
+    dotOuterRadius,
     gridStyleCfg,
     degenCfg,
     tradeStreamResolved,
@@ -501,6 +508,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     xAxisEntries,
     dotX,
     pulseCfg,
+    dotCfg,
     degenCfg,
     degenPack,
     degenPackRevision,
@@ -613,15 +621,20 @@ function ChartStack({ model }: { model: LiveChartModel }) {
 
       {/* Live dot — the badge is drawn later (after the scrub layer) so the
           scrub dim never clips the live-price badge's left edge. */}
-      <Group opacity={reveal.dotOpacity}>
-        <DotOverlay
-          dotX={dotX}
-          dotY={dotY}
-          palette={palette}
-          engine={engine}
-          pulse={pulseCfg}
-        />
-      </Group>
+      {dotCfg.show && (
+        <Group opacity={reveal.dotOpacity}>
+          <DotOverlay
+            dotX={dotX}
+            dotY={dotY}
+            palette={palette}
+            engine={engine}
+            pulse={pulseCfg}
+            radius={dotCfg.radius}
+            ring={dotCfg.ring}
+            color={dotCfg.color}
+          />
+        </Group>
+      )}
 
       {degenCfg && (
         <Group opacity={reveal.dotOpacity}>
@@ -684,16 +697,18 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
     crosshair,
     isCandle,
     pulseCfg,
+    dotOuterRadius,
   } = model;
 
   if (!tradeStreamResolved && !scrubCfg) return null;
 
   // Extend the scrub dim past the plot's right edge to fully cover the live dot
-  // and its pulse ring (both centered on that edge). The gutter reserves an
-  // 8px gap beyond this extent for the Y-axis labels, so they stay readable.
-  const liveDotExtent = pulseCfg
-    ? pulseRadialOutset(pulseCfg.maxRadius, pulseCfg.strokeWidth)
-    : DOT_OUTER_RADIUS;
+  // (with its halo) and pulse ring, all centered on that edge. The gutter
+  // reserves an 8px gap beyond this for the Y-axis labels, so they stay readable.
+  const liveDotExtent = Math.max(
+    dotOuterRadius,
+    pulseCfg ? pulseRadialOutset(pulseCfg.maxRadius, pulseCfg.strokeWidth) : 0,
+  );
 
   return (
     <Group transform={degenShakeTransform}>

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -9,6 +9,7 @@ import type {
   LeftEdgeFadeConfig,
   LegendConfig,
   LegendStyle,
+  DotConfig,
   DotRingConfig,
   MultiSeriesDotConfig,
   PulseConfig,
@@ -478,7 +479,7 @@ export function resolveTradeStream(
   };
 }
 
-// ─── Multi-series dot ─────────────────────────────────────────────────────────
+// ─── Dot (shared) ─────────────────────────────────────────────────────────────
 
 /** Resolved halo ring. `color: undefined` means "use the theme `badgeOuterBg`". */
 export interface ResolvedDotRingConfig {
@@ -500,38 +501,47 @@ export function resolveDotRing(
   return { ...RING_DEFAULTS, ...prop };
 }
 
-export interface ResolvedMultiSeriesDotConfig {
+/** Shared, fully-resolved dot styling (single- and multi-series). */
+export interface ResolvedDotConfig {
   radius: number;
   ring: ResolvedDotRingConfig | null;
   show: boolean;
   color: string | undefined;
+}
+
+const DOT_DEFAULTS: ResolvedDotConfig = {
+  radius: 3.5,
+  ring: RING_DEFAULTS,
+  show: true,
+  color: undefined,
+};
+
+export function resolveDot(prop: DotConfig | undefined): ResolvedDotConfig {
+  if (!prop) return DOT_DEFAULTS;
+  return {
+    radius: prop.radius ?? DOT_DEFAULTS.radius,
+    ring: resolveDotRing(prop.ring),
+    show: prop.show ?? DOT_DEFAULTS.show,
+    color: prop.color,
+  };
+}
+
+// ─── Multi-series dot ─────────────────────────────────────────────────────────
+
+export interface ResolvedMultiSeriesDotConfig extends ResolvedDotConfig {
   pulse: ResolvedPulseConfig | null;
   valueLine: ResolvedValueLineConfig | null;
   valueLabel: boolean;
 }
 
-const MULTI_DOT_DEFAULTS: ResolvedMultiSeriesDotConfig = {
-  radius: 3.5,
-  ring: RING_DEFAULTS,
-  show: true,
-  color: undefined,
-  pulse: PULSE_DEFAULTS,
-  valueLine: null,
-  valueLabel: true,
-};
-
 export function resolveMultiSeriesDot(
   prop: MultiSeriesDotConfig | undefined,
 ): ResolvedMultiSeriesDotConfig {
-  if (!prop) return MULTI_DOT_DEFAULTS;
   return {
-    radius: prop.radius ?? MULTI_DOT_DEFAULTS.radius,
-    ring: resolveDotRing(prop.ring),
-    show: prop.show ?? MULTI_DOT_DEFAULTS.show,
-    color: prop.color,
-    pulse: resolvePulse(prop.pulse ?? true),
-    valueLine: resolveValueLine(prop.valueLine),
-    valueLabel: prop.valueLabel ?? MULTI_DOT_DEFAULTS.valueLabel,
+    ...resolveDot(prop),
+    pulse: resolvePulse(prop?.pulse ?? true),
+    valueLine: resolveValueLine(prop?.valueLine),
+    valueLabel: prop?.valueLabel ?? true,
   };
 }
 

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -402,20 +402,28 @@ export interface DotRingConfig {
   width?: number;
 }
 
-/** Live dot configuration for multi-series charts. */
-export interface MultiSeriesDotConfig {
+/**
+ * Shared live-dot styling, used by both `LiveChart` (`dot`) and
+ * `LiveChartSeries` (`dot`, which extends this). A dot is a color-filled circle
+ * of `radius` with an optional contrasting outer `ring` (halo).
+ */
+export interface DotConfig {
   /** Radius of the (color-filled) dot in pixels. Default `3.5`. */
   radius?: number;
   /**
-   * Contrasting outer ring behind each dot — matches the single-series live
-   * dot's haloed look so dots read clearly against the lines. `true` = defaults,
-   * `false` = a flat circle, or pass `DotRingConfig`. Default `true`.
+   * Contrasting outer ring (halo) behind the dot, so it reads clearly against
+   * the line(s). `true` = defaults, `false` = a flat circle, or pass
+   * `DotRingConfig`. Default `true`.
    */
   ring?: boolean | DotRingConfig;
-  /** Show the series dots. `false` hides them (lines and labels still render). Default `true`. */
+  /** Show the dot. `false` hides it (line, badge, and labels still render). Default `true`. */
   show?: boolean;
-  /** Dot fill color. Defaults to each series' line color. */
+  /** Dot fill color. Defaults to the chart line color (per series for multi-series). */
   color?: string;
+}
+
+/** Live dot configuration for multi-series charts (extends the shared {@link DotConfig}). */
+export interface MultiSeriesDotConfig extends DotConfig {
   /** Pulsing ring animation on each series dot. `true` = defaults, or pass `PulseConfig`. Default `true`. */
   pulse?: boolean | PulseConfig;
   /** Horizontal dashed line at each series' live value. `true` = defaults, or pass `ValueLineConfig`. Default `false`. */
@@ -649,6 +657,8 @@ export interface LiveChartProps extends LiveChartCoreProps {
   momentum?: boolean | Momentum | MomentumConfig;
   /** Pulsing ring animation on the live dot. `true` = defaults, or pass `PulseConfig`. Default `true`. */
   pulse?: boolean | PulseConfig;
+  /** Live dot styling: `radius`, `ring` (halo), `show`, `color`. See {@link DotConfig}. */
+  dot?: DotConfig;
   /** Horizontal dashed line at the current live value. `true` = defaults, or pass `ValueLineConfig`. */
   valueLine?: boolean | ValueLineConfig;
   /** Render the live value as a large text overlay in the top-left. Default `false`. */

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -111,6 +111,9 @@ describe("DotOverlay", () => {
           dotY={dotY}
           palette={palette}
           engine={eng}
+          radius={3.5}
+          ring={{ color: undefined, width: 2.5 }}
+          color={undefined}
           pulse={PULSE_ON}
         />
       );
@@ -132,6 +135,9 @@ describe("DotOverlay", () => {
           dotY={dotY}
           palette={palette}
           engine={eng}
+          radius={3.5}
+          ring={null}
+          color={undefined}
           pulse={null}
         />
       );
@@ -150,6 +156,9 @@ describe("DotOverlay", () => {
           dotY={dotY}
           palette={palette}
           engine={eng}
+          radius={3.5}
+          ring={null}
+          color={undefined}
           pulse={null}
         />
       );
@@ -167,6 +176,9 @@ describe("DotOverlay", () => {
           dotY={dotY}
           palette={palette}
           engine={engine()}
+          radius={3.5}
+          ring={{ color: undefined, width: 2.5 }}
+          color="#abcdef"
           pulse={null}
         />
       );
@@ -188,6 +200,9 @@ describe("DotOverlay", () => {
           dotY={dotY}
           palette={palette}
           engine={eng}
+          radius={3.5}
+          ring={{ color: undefined, width: 2.5 }}
+          color={undefined}
           pulse={PULSE_ON}
         />
       );

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1,6 +1,7 @@
 import {
   resolveBadge,
   resolveDegen,
+  resolveDot,
   resolveDotRing,
   resolveFontConfig,
   resolveGradient,
@@ -614,6 +615,25 @@ describe("resolveDotRing", () => {
       color: "#fff",
       width: 2.5,
     });
+  });
+});
+
+// ─── resolveDot ───────────────────────────────────────────────────────────────
+
+describe("resolveDot", () => {
+  it("defaults to a haloed, shown dot (line color)", () => {
+    expect(resolveDot(undefined)).toEqual({
+      radius: 3.5,
+      ring: { color: undefined, width: 2.5 },
+      show: true,
+      color: undefined,
+    });
+  });
+
+  it("applies overrides (flat ring, hidden, color, radius)", () => {
+    expect(
+      resolveDot({ radius: 6, ring: false, show: false, color: "#abcdef" }),
+    ).toEqual({ radius: 6, ring: null, show: false, color: "#abcdef" });
   });
 });
 


### PR DESCRIPTION
> Stacked on #77 (base branch `feat/multi-series-dot-config`). Merge #76 → #77 → this. The diff here is just the final commit.

## What

Bring the **single-series** `LiveChart` dot to parity with multi-series by adding a `dot` prop, and unify both around a shared `DotConfig` type. Previously the single-series live dot was hardcoded (fixed 6.5/3.5 radii, theme colors) with no config at all.

`LiveChart` now accepts:

```tsx
dot?: DotConfig // { radius?, ring?, show?, color? }
```

| field | default | notes |
| --- | --- | --- |
| `radius` | `3.5` | color-filled dot radius |
| `ring` | `true` | contrasting outer halo; `false` = flat, or `{ color, width }` |
| `show` | `true` | hide the dot (line/badge/labels still render) |
| `color` | line color | override the dot (and pulse) fill |

## Clean types (shared base)

```ts
interface DotConfig { radius?; ring?; show?; color? }              // LiveChart.dot
interface MultiSeriesDotConfig extends DotConfig {                 // LiveChartSeries.dot
  pulse?; valueLine?; valueLabel?;
}
```

`resolveMultiSeriesDot` now builds on `resolveDot`, so there's a single source of truth for the shared knobs. `DotOverlay` takes the resolved `radius`/`ring`/`color` (was hardcoded constants), and the dot's outer radius (incl. halo) is threaded into the scrub-dim extent so the dim still fully covers it.

## ⚠️ Breaking change

The single-series dot's default **ring width is now 2.5** (shared with multi-series), so the dot's outer radius is **6.0px** instead of the old hardcoded **6.5px** — a sub-pixel visual change. Pass `dot={{ ring: { width: 3 } }}` to restore the exact previous size. (Per your note: one tester, breaking changes OK.)

## Docs + demo

- README (both), `docs/api-reference/livechart.mdx` + `types.mdx` (shared `DotConfig`), `docs/guides/line-and-area.mdx`.
- Line demo: new **Dot** + **Ring** toggles.

## Verification

- `npm run verify` (typecheck + lint + 668 tests) ✅ — `resolveDot` unit tests + updated `DotOverlay` fixtures (`DotOverlay.tsx` at 100% coverage).
- iOS simulator: single-series dot renders haloed by default; the Dot/Ring toggles work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
