### PR TITLE
chore(app): rename the example app to "LiveChart"

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "react-native-livechart",
+    "name": "LiveChart",
     "slug": "react-native-livechart",
     "version": "1.0.0",
     "orientation": "portrait",


### PR DESCRIPTION
## What

Rename the Expo example app so it shows **"LiveChart"** under the app icon instead of "react-native-livechart".

Changes `expo.name` in `app.json` — the canonical source. The native `ios/` and `android/` directories are gitignored (regenerated by `expo prebuild` from `app.json`), so this one field is what propagates to `CFBundleDisplayName` (iOS) and `app_name` (Android) on the next build.

Bundle id (`com.brandtnewlabs.react-native-livechart`), Android package, `slug`, and `scheme` are **unchanged** — only the display label.

## Note

The home-screen label updates after a native rebuild/reinstall (`npx expo prebuild` + run, or an EAS build) — the currently-installed dev client still shows the old name until then.

Part of the linear stack — based on #80, with #81 (release) on top. The rename only touches the example app, so it stays out of the package changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
