### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-05
+
+### Added
+
+- `LiveChart` `dot` prop — style the single-series live dot: `radius`, `ring`
+  (the haloed outer ring), `show`, and `color`.
+- `LiveChartSeries` `dot` gains `ring`, `show`, and `color`.
+- Shared `DotConfig` type for both charts (`MultiSeriesDotConfig` extends it),
+  plus `DotRingConfig`.
+- `scrub.panGestureDelay` — a press-and-hold delay (ms) before scrubbing
+  activates, so a quick horizontal swipe falls through to a parent gesture
+  (e.g. a navigator's swipe-back-to-previous-route). Defaults to `0` (immediate).
+
+### Changed
+
+- Multi-series dots now render a contrasting outer ring (halo) by default,
+  matching the single-series live dot. Pass `dot={{ ring: false }}` for flat
+  circles.
+- The single-series live dot's default outer radius is now 6.0px (was 6.5px),
+  from the shared 2.5px ring width. Pass `dot={{ ring: { width: 3 } }}` to
+  restore the previous size.
+
+### Fixed
+
+- The scrub dim now fully covers the live dot and its pulse ring while
+  scrubbing (previously only the left half was dimmed), on both charts. The
+  live-price badge and per-series value labels are drawn above the dim so they
+  are no longer clipped, and the dim stops short of the Y-axis labels.
+
+### Performance
+
+- The scrub tooltip no longer calls Skia `measureText` on every frame; it sizes
+  the monospace text by character count instead. Fixes a UI-thread frame-rate
+  drop while scrubbing.
+
 ## [1.0.0] - 2026-06-04
 
 Initial public release.

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -68,5 +68,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
> **Release PR — top of the linear stack** (base `chore/rename-app-livechart`). Diff is just the version bump + changelog.

Cuts **`react-native-livechart@1.1.0`**: bumps `packages/react-native-livechart/package.json` `1.0.0 → 1.1.0` and adds the `CHANGELOG.md` entry.

This sits on top of the full stack — `#76 → #77 → #78 → #80 → #79 → #81` — so once the stack merges down to `main` in order, the released code and the changelog land together. No merge-ordering gotcha. (#79's app rename is the example app and is intentionally **not** in the package changelog.)

## Why 1.1.0 (not 2.0.0)

The public API is purely additive (new `dot` prop, new dot fields, new `panGestureDelay`, new shared types — nothing removed or renamed). The only deltas are **default visuals** (multi-series dots haloed; single dot 6.5→6.0px), both one opt-out away — cosmetic, not an API break. By the same logic, the scrub-dim bug fix also changes visuals and clearly isn't major.

## After the stack merges to `main` (not done here)

1. `npm run verify`
2. Publish — **workspace-scoped**: `npm publish -w react-native-livechart` (a bare `npm publish` targets the example app). Use the `publish-library` flow (dry-run + `private: false` gate).
3. `git tag v1.1.0 && git push --tags`

I won't publish without your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
