### PR TITLE
perf(scrub): size the scrub tooltip by char count, not per-frame measureText

### DIFF
--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -109,6 +109,11 @@ export function computeTooltipLayout(
   formatValue: (v: number) => string,
   formatTime: (t: number) => string,
   font: SkFont,
+  /** Monospace advance width. When > 0, text width is `len * monoCharWidth`
+   *  instead of a per-frame Skia `measureText` — scrubbing re-runs this worklet
+   *  every frame, and `measureText` shapes text each call (a real cost,
+   *  especially in the simulator). Falls back to `measureText` when 0. */
+  monoCharWidth = 0,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || scrubValue === null) return HIDDEN_TOOLTIP;
@@ -122,8 +127,14 @@ export function computeTooltipLayout(
   const lineH = -fm.ascent + fm.descent;
   const totalH = TOOLTIP_PAD_Y * 2 + lineH * 2 + TOOLTIP_LINE_GAP;
 
-  const valueW = measureFontTextWidth(font, valueStr);
-  const timeW = measureFontTextWidth(font, timeStr);
+  const valueW =
+    monoCharWidth > 0
+      ? valueStr.length * monoCharWidth
+      : measureFontTextWidth(font, valueStr);
+  const timeW =
+    monoCharWidth > 0
+      ? timeStr.length * monoCharWidth
+      : measureFontTextWidth(font, timeStr);
   const contentW = Math.max(valueW, timeW);
   const pillW = contentW + TOOLTIP_PAD_X * 2;
 
@@ -166,6 +177,9 @@ export function computeTooltipLayoutMulti(
   padding: ChartPadding,
   canvasWidth: number,
   font: SkFont,
+  /** Monospace advance width; when > 0, sizes text by length instead of a
+   *  per-frame Skia `measureText`. See {@link computeTooltipLayout}. */
+  monoCharWidth = 0,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || lines.length === 0) return HIDDEN_TOOLTIP;
@@ -179,7 +193,10 @@ export function computeTooltipLayoutMulti(
   let contentW = 0;
   const lineWidths: number[] = [];
   for (let i = 0; i < n; i++) {
-    const w = measureFontTextWidth(font, lines[i].text);
+    const w =
+      monoCharWidth > 0
+        ? lines[i].text.length * monoCharWidth
+        : measureFontTextWidth(font, lines[i].text);
     lineWidths.push(w);
     if (w > contentW) contentW = w;
   }
@@ -237,6 +254,7 @@ export function computeCandleTooltipLayout(
   formatValue: (v: number) => string,
   formatTime: (t: number) => string,
   font: SkFont,
+  monoCharWidth = 0,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || !candle) return HIDDEN_TOOLTIP;
@@ -254,6 +272,7 @@ export function computeCandleTooltipLayout(
     padding,
     canvasWidth,
     font,
+    monoCharWidth,
   );
 }
 
@@ -279,6 +298,7 @@ export function deriveCrosshairTooltipSingle(
   formatValue: (v: number) => string,
   formatTime: (t: number) => string,
   font: SkFont,
+  monoCharWidth = 0,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || scrubTime < 0) return HIDDEN_TOOLTIP;
@@ -292,5 +312,6 @@ export function deriveCrosshairTooltipSingle(
     formatValue,
     formatTime,
     font,
+    monoCharWidth,
   );
 }

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -112,6 +112,11 @@ export function useCrosshair(
     ),
   );
 
+  // Monospace advance width, measured once per render (not per scrub frame) so
+  // the tooltip layout worklet can size text by character count instead of a
+  // per-frame Skia measureText.
+  const monoCharWidth = font.measureText("0").width;
+
   const tooltipLayout = useDerivedValue(() => {
     if (isCandleMode) {
       return computeCandleTooltipLayout(
@@ -124,6 +129,7 @@ export function useCrosshair(
         formatValue,
         formatTime,
         font,
+        monoCharWidth,
       );
     }
     return deriveCrosshairTooltipSingle(
@@ -136,6 +142,7 @@ export function useCrosshair(
       formatValue,
       formatTime,
       font,
+      monoCharWidth,
     );
   });
 

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -188,6 +188,24 @@ describe("computeTooltipLayout", () => {
     expect(layout.timeStr.length).toBeGreaterThan(0);
   });
 
+  it("sizes text by character count when monoCharWidth is set (skips measureText)", () => {
+    const layout = computeTooltipLayout(
+      true,
+      50,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8, // monospace advance
+    );
+    // timeStr "HH:MM:SS" (8 chars) is the widest line; pill = 8*8 + 2*PAD_X(8)
+    expect(layout.timeStr.length).toBe(8);
+    expect(layout.w).toBe(8 * 8 + 16);
+  });
+
   it("places tooltip to the right of crosshair when space is available", () => {
     const layout = computeTooltipLayout(
       true,
@@ -262,6 +280,23 @@ describe("computeTooltipLayoutMulti", () => {
       font,
     );
     expect(layout.x).toBeLessThan(0);
+  });
+
+  it("sizes rows by character count when monoCharWidth is set (skips measureText)", () => {
+    const layout = computeTooltipLayoutMulti(
+      true,
+      50,
+      [
+        { text: "abc", dim: false },
+        { text: "abcde", dim: true }, // widest, 5 chars
+      ],
+      padding,
+      400,
+      font,
+      8, // monospace advance
+    );
+    // widest row is 5 chars; pill = 5*8 + 2*PAD_X(8)
+    expect(layout.w).toBe(5 * 8 + 16);
   });
 
   it("builds stackedLines for each row", () => {


### PR DESCRIPTION
## Problem

While scrubbing, the **UI thread tanks** — a user reported it dropping to <30 fps, down to ~18 while dragging. Measured on the iOS simulator (Perf Monitor):

| state | UI fps |
|---|---|
| not scrubbing | 58 |
| scrub held, **no tooltip** | 58 |
| scrub held, **tooltip on** | **42** |

The tooltip's value/time text changes **every frame** (the value under the crosshair updates as the chart keeps advancing), so the layout worklet calls Skia's **`measureText` twice per frame** to size and center the pill. Text shaping on every frame is a real per-frame cost; dragging makes it worse because the pan gesture fires faster than 60 Hz, so the worklet (and `measureText`) runs even more often.

This is a genuine inefficiency that hits real devices too — the simulator's software text rendering just made it obvious.

## Fix

The chart font is **monospace**, so `textWidth = length * advance`. Measure the advance **once per render** (`font.measureText("0")`) and pass it into the tooltip layout worklets:
- `computeTooltipLayout` (single-series line)
- `computeTooltipLayoutMulti` / `computeCandleTooltipLayout` (candle mode)

They now size text by character count and **never shape text during scrubbing**. Falls back to `measureText` when the advance is `0` (default), so nothing else changes.

## Verification

- On the iOS simulator, a held scrub went **42 → 58 UI fps** (back to the non-scrub baseline). User confirmed scrolling is fixed on their end too.
- `npm run verify` (typecheck + lint + tests). Added unit tests for the `monoCharWidth` path; `crosshairShared.ts` is at 100% coverage.

## Stack

Part of the **1.1.0** stack (base #79, with #81 release on top); included in the 1.1.0 changelog under **Performance**. The touched lines don't overlap the gesture changes in #80, so it sits cleanly in the chain.

## Follow-up

A secondary, smaller cost remains while *actively dragging* (the gesture driving re-renders faster than the display); can be a separate change if it's still noticeable on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
