### PR TITLE
perf(markers): render markers via a single drawAtlas

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -71,6 +71,27 @@ jest.mock("@shopify/react-native-skia", () => {
     rewind: jest.fn(),
   });
 
+  const createCanvas = () => ({
+    save: jest.fn(),
+    restore: jest.fn(),
+    translate: jest.fn(),
+    drawCircle: jest.fn(),
+    drawText: jest.fn(),
+    drawPath: jest.fn(),
+    drawImageRect: jest.fn(),
+    drawImage: jest.fn(),
+    clear: jest.fn(),
+  });
+
+  const createMockPaint = () => ({
+    setAntiAlias: jest.fn(),
+    setColor: jest.fn(),
+    setStyle: jest.fn(),
+    setStrokeWidth: jest.fn(),
+    setStrokeCap: jest.fn(),
+    setStrokeJoin: jest.fn(),
+  });
+
   const mockFont = {
     getSize: () => 12,
     measureText: (text) => ({
@@ -96,8 +117,13 @@ jest.mock("@shopify/react-native-skia", () => {
     DashPathEffect: View,
     Blur: View,
     Image: View,
+    Atlas: View,
     LinearGradient: View,
     vec: (x, y) => ({ x, y }),
+    PaintStyle: { Fill: 0, Stroke: 1 },
+    StrokeCap: { Butt: 0, Round: 1, Square: 2 },
+    StrokeJoin: { Miter: 0, Round: 1, Bevel: 2 },
+    drawAsImageFromPicture: jest.fn(() => ({})),
     matchFont: jest.fn(() => mockFont),
     useFont: jest.fn(() => mockFont),
     useFonts: jest.fn(() => null),
@@ -108,6 +134,14 @@ jest.mock("@shopify/react-native-skia", () => {
       FontMgr: {
         System: jest.fn(() => ({})),
       },
+      PictureRecorder: jest.fn(() => ({
+        beginRecording: jest.fn(() => createCanvas()),
+        finishRecordingAsPicture: jest.fn(() => ({})),
+      })),
+      RSXform: jest.fn((scos, ssin, tx, ty) => ({ scos, ssin, tx, ty })),
+      XYWHRect: jest.fn((x, y, width, height) => ({ x, y, width, height })),
+      Color: jest.fn((c) => c),
+      Paint: jest.fn(() => createMockPaint()),
     },
   };
 });

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -1,87 +1,70 @@
 import {
-  Circle,
+  Atlas,
   Group,
-  Image as SkiaImage,
   Path,
   Skia,
-  Text as SkiaText,
   type SkFont,
   type SkPath,
 } from "@shopify/react-native-skia";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
-  useAnimatedReaction,
   useDerivedValue,
+  useAnimatedReaction,
   type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
-import { markersSignature, projectPoint } from "../math/markers";
+import {
+  buildMarkerAtlas,
+  defaultMarkerColor,
+  isConnectorMarker,
+  markerAppearanceSig,
+  type AtlasCell,
+} from "../draw/markerAtlas";
+import {
+  markersSignature,
+  projectMarkers,
+  projectPoint,
+  type ProjectedMarker,
+} from "../math/markers";
 import type {
   LiveChartPalette,
   LiveChartPoint,
   Marker,
-  MarkerKind,
   SeriesConfig,
 } from "../types";
 
-/** Default glyph color per kind when `marker.color` is unset. */
-function defaultMarkerColor(kind: MarkerKind, palette: LiveChartPalette): string {
-  switch (kind) {
-    case "trade":
-      return palette.line;
-    case "boost":
-      return palette.refLine;
-    case "graduation":
-      return palette.dotUp;
-    case "winner":
-      return palette.dotUp;
-    case "clawback":
-      return palette.refLabel;
-  }
-}
-
 const OFF = -9999;
-const DEFAULT_ICON_SIZE = 16;
-/** Circular badge: padding around the icon glyph, background-colored ring width,
- *  and the icon color drawn on the fill. */
-const PILL_PAD = 2;
-const PILL_BORDER = 2;
-const PILL_TEXT_COLOR = "#ffffff";
 
-function MarkerGlyph({
+/**
+ * Self-projecting fallback for the axis-anchored kinds (graduation stem + flag,
+ * clawback box) that can't be fixed-size atlas sprites. Rare, so the per-glyph
+ * worklet cost here is negligible; each glyph still projects its OWN marker so
+ * reordering the array can't make it flash another marker's position.
+ */
+function ConnectorGlyph({
   marker,
   color,
-  bgColor,
   engine,
   padding,
   seriesSV,
   lineDataSV,
-  font,
   axisY,
 }: {
   marker: Marker;
   color: string;
-  /** Chart background color, drawn as a ring behind a `pill` badge. */
-  bgColor?: string;
   engine: ChartEngineLayout;
   padding: ChartPadding;
   seriesSV?: SharedValue<SeriesConfig[]>;
   lineDataSV?: SharedValue<LiveChartPoint[]>;
-  font: SkFont;
   axisY: SharedValue<number>;
 }) {
-  // Capture only primitive anchor fields — never the full marker (which may
-  // carry non-serializable `data` / `image`) — in the worklet closure.
-  const { kind, icon, image, pill } = marker;
+  const { kind } = marker;
   const time = marker.time;
   const value = marker.value;
   const seriesId = marker.seriesId;
-  const size = marker.size ?? DEFAULT_ICON_SIZE;
 
-  // Each glyph projects its OWN marker — no shared index buffer, so reordering
-  // the marker array can't make a glyph flash another marker's position.
   const layout = useDerivedValue(() =>
     projectPoint(time, value, seriesId, {
       canvasWidth: engine.canvasWidth.get(),
@@ -99,12 +82,6 @@ function MarkerGlyph({
     }),
   );
 
-  const cx = useDerivedValue(() =>
-    layout.get().visible ? layout.get().x : OFF,
-  );
-  const cy = useDerivedValue(() =>
-    layout.get().visible ? layout.get().y : OFF,
-  );
   const opacity = useDerivedValue(() => (layout.get().visible ? 1 : 0));
 
   const cacheRef = useRef<{ a: SkPath; b: SkPath; tick: boolean } | null>(null);
@@ -119,30 +96,9 @@ function MarkerGlyph({
     p.reset();
     const l = layout.get();
     if (!l.visible) return p;
-    const x = l.x;
+    const x = l.visible ? l.x : OFF;
     const y = l.y;
-    if (kind === "winner") {
-      const outer = 7;
-      const inner = 3;
-      for (let k = 0; k < 10; k++) {
-        const ang = -Math.PI / 2 + (k * Math.PI) / 5;
-        const rad = k % 2 === 0 ? outer : inner;
-        const px = x + rad * Math.cos(ang);
-        const py = y + rad * Math.sin(ang);
-        if (k === 0) p.moveTo(px, py);
-        else p.lineTo(px, py);
-      }
-      p.close();
-    } else if (kind === "boost") {
-      const L = 6;
-      for (let k = 0; k < 4; k++) {
-        const ang = (k * Math.PI) / 4;
-        const dx = L * Math.cos(ang);
-        const dy = L * Math.sin(ang);
-        p.moveTo(x - dx, y - dy);
-        p.lineTo(x + dx, y + dy);
-      }
-    } else if (kind === "graduation") {
+    if (kind === "graduation") {
       p.moveTo(x, axisY.get());
       p.lineTo(x, y);
       p.moveTo(x, y - 7);
@@ -161,88 +117,7 @@ function MarkerGlyph({
     return p;
   });
 
-  // Image icon centered on the marker.
-  const imgX = useDerivedValue(() =>
-    layout.get().visible ? layout.get().x - size / 2 : OFF,
-  );
-  const imgY = useDerivedValue(() =>
-    layout.get().visible ? layout.get().y - size / 2 : OFF,
-  );
-
-  // Text / emoji icon centering — width + baseline shift depend only on the
-  // (stable) font and icon, so measure once instead of every frame. Skia
-  // `measureText`/`getMetrics` both allocate, so hoisting them out of the
-  // per-frame worklet removes one measure + one metrics call per glyph/frame.
-  // Center the icon glyph on the marker using its measured bounds — tighter and
-  // more accurate than font ascent/descent, so `+` / `−` etc. sit centered both
-  // horizontally and vertically in the badge. Stable per render, not per frame.
-  const iconBounds = font.measureText(icon ?? "");
-  const iconDX = iconBounds.x + iconBounds.width / 2;
-  const iconDY = iconBounds.y + iconBounds.height / 2;
-
-  const iconX = useDerivedValue(() =>
-    layout.get().visible ? layout.get().x - iconDX : OFF,
-  );
-  const iconY = useDerivedValue(() =>
-    layout.get().visible ? layout.get().y - iconDY : OFF,
-  );
-
-  // Circular badge radius — fits the glyph's larger dimension + padding.
-  const pillR = Math.max(iconBounds.width, iconBounds.height) / 2 + PILL_PAD;
-
-  if (image) {
-    return (
-      <Group opacity={opacity}>
-        <SkiaImage
-          image={image}
-          x={imgX}
-          y={imgY}
-          width={size}
-          height={size}
-          fit="contain"
-        />
-      </Group>
-    );
-  }
-
-  if (icon) {
-    if (pill) {
-      // Filled circular badge in the marker color with the icon in white — e.g.
-      // a green `+` buy / red `−` sell tag. A background-colored ring underneath
-      // separates it from the line passing behind.
-      return (
-        <Group opacity={opacity}>
-          {bgColor !== undefined && (
-            <Circle cx={cx} cy={cy} r={pillR + PILL_BORDER} color={bgColor} />
-          )}
-          <Circle cx={cx} cy={cy} r={pillR} color={color} />
-          <SkiaText
-            x={iconX}
-            y={iconY}
-            text={icon}
-            font={font}
-            color={PILL_TEXT_COLOR}
-          />
-        </Group>
-      );
-    }
-    return (
-      <Group opacity={opacity}>
-        <SkiaText x={iconX} y={iconY} text={icon} font={font} color={color} />
-      </Group>
-    );
-  }
-
-  if (kind === "trade") {
-    return (
-      <Group opacity={opacity}>
-        <Circle cx={cx} cy={cy} r={5} color={color} style="stroke" strokeWidth={2} />
-        <Circle cx={cx} cy={cy} r={2} color={color} />
-      </Group>
-    );
-  }
-
-  const fill = kind === "winner" || kind === "clawback";
+  const fill = kind === "clawback";
   return (
     <Group opacity={opacity}>
       <Path
@@ -258,10 +133,14 @@ function MarkerGlyph({
 }
 
 /**
- * Renders the `markers` SharedValue as canvas glyphs. Marker metadata is
- * mirrored into React state when it changes; each glyph projects its own
- * position every frame (keyed by id), so adding/removing markers never makes a
- * surviving glyph flash another marker's position.
+ * Renders the `markers` SharedValue as canvas glyphs.
+ *
+ * Every "stamp" glyph (icon, pill, image, and the trade/winner/boost shapes) is
+ * pre-rasterized once per distinct appearance into a single packed atlas image,
+ * then drawn each frame with ONE `drawAtlas` call driven by a single worklet —
+ * so per-frame UI-thread cost is O(1) mappers + one draw, not O(markers × ~9
+ * derived values + N Skia subtrees). Axis-anchored kinds (graduation/clawback)
+ * fall back to `ConnectorGlyph`.
  *
  * Glyph precedence per marker: `image` → `icon` (text) → built-in `kind` shape.
  */
@@ -288,9 +167,7 @@ export function MarkerOverlay({
   const [snapshot, setSnapshot] = useState<Marker[]>(() => markers.get().slice());
 
   // Read the `markers` prop from closure rather than a SharedValue passed
-  // through `scheduleOnRN`: the handle serialized across the worklet→JS
-  // boundary exposes the native `.value` accessor but NOT the `.get()` method,
-  // so calling `.get()` on it throws ("sv.get is not a function").
+  // through `scheduleOnRN` (which loses `.get()`); mirrors the data model.
   const pull = () => {
     setSnapshot(markers.get().slice());
   };
@@ -304,25 +181,103 @@ export function MarkerOverlay({
     [markers, pull],
   );
 
+  // Rebuild the atlas image only when the set of distinct appearances or the
+  // theme/font changes — never per frame. `markersSignature` already drives the
+  // snapshot, so this useMemo re-runs at most at the snapshot cadence.
+  const appearanceKey = useMemo(() => {
+    const sigs = new Set<string>();
+    for (let i = 0; i < snapshot.length; i++) {
+      const m = snapshot[i];
+      if (!isConnectorMarker(m)) sigs.add(markerAppearanceSig(m));
+    }
+    return Array.from(sigs).sort().join("\x1e");
+  }, [snapshot]);
+  // Cells bake in resolved colors; include the palette fields they depend on.
+  const paletteKey = `${palette.bgRgb.join(",")}|${palette.line}|${palette.refLine}|${palette.dotUp}|${palette.refLabel}`;
+  const atlas = useMemo(
+    () => buildMarkerAtlas(snapshot, palette, font),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- appearanceKey/paletteKey capture the inputs that change cell pixels
+    [appearanceKey, paletteKey, font],
+  );
+  const cells: Record<string, AtlasCell> = atlas.cells;
+  const atlasImage = atlas.image;
+
+  // One pooled, ping-ponged projection buffer reused every frame (no per-frame
+  // array allocation for the projection itself).
+  const projRef = useRef<{
+    a: ProjectedMarker[];
+    b: ProjectedMarker[];
+    tick: boolean;
+  } | null>(null);
+  if (projRef.current === null) {
+    projRef.current = { a: [], b: [], tick: false };
+  }
+
+  // Single per-frame worklet: project all markers, then emit a transform +
+  // source rect for each visible atlas marker. Three mappers total regardless
+  // of marker count (this + the two thin readers below).
+  const atlasData = useDerivedValue(
+    () => {
+      const ms = markers.get();
+      const proj = projRef.current!;
+      proj.tick = !proj.tick;
+      const buf = proj.tick ? proj.a : proj.b;
+      projectMarkers(ms, buf, {
+        canvasWidth: engine.canvasWidth.get(),
+        canvasHeight: engine.canvasHeight.get(),
+        padTop: padding.top,
+        padBottom: padding.bottom,
+        padLeft: padding.left,
+        padRight: padding.right,
+        timestamp: engine.timestamp.get(),
+        displayWindow: engine.displayWindow.get(),
+        displayMin: engine.displayMin.get(),
+        displayMax: engine.displayMax.get(),
+        series: series?.get(),
+        lineData: lineData?.get(),
+      });
+      const transforms = [];
+      const sprites = [];
+      for (let i = 0; i < ms.length; i++) {
+        const pt = buf[i];
+        if (!pt.visible) continue;
+        const m = ms[i];
+        if (isConnectorMarker(m)) continue;
+        const cell = cells[markerAppearanceSig(m)];
+        if (!cell) continue;
+        // Center the cell on the projected point (RSXform: scale 1, no rotation).
+        transforms.push(
+          Skia.RSXform(1, 0, pt.x - cell.w / 2, pt.y - cell.h / 2),
+        );
+        sprites.push(cell.rect);
+      }
+      return { transforms, sprites };
+    },
+    [cells, markers, engine, padding, series, lineData],
+  );
+  const transforms = useDerivedValue(() => atlasData.get().transforms, [atlasData]);
+  const sprites = useDerivedValue(() => atlasData.get().sprites, [atlasData]);
+
   const axisY = useDerivedValue(
     () => engine.canvasHeight.get() - padding.bottom,
   );
 
-  const bgColor = `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
+  const connectors = snapshot.filter(isConnectorMarker);
 
   return (
     <Group>
-      {snapshot.map((m) => (
-        <MarkerGlyph
+      {atlasImage && (
+        <Atlas image={atlasImage} sprites={sprites} transforms={transforms} />
+      )}
+      {connectors.map((m) => (
+        <ConnectorGlyph
           key={m.id}
           marker={m}
           color={m.color ?? defaultMarkerColor(m.kind, palette)}
-          bgColor={bgColor}
           engine={engine}
           padding={padding}
           seriesSV={series}
           lineDataSV={lineData}
-          font={font}
           axisY={axisY}
         />
       ))}

--- a/packages/react-native-livechart/src/draw/markerAtlas.ts
+++ b/packages/react-native-livechart/src/draw/markerAtlas.ts
@@ -1,0 +1,304 @@
+import {
+  Skia,
+  PaintStyle,
+  StrokeCap,
+  StrokeJoin,
+  drawAsImageFromPicture,
+  type SkCanvas,
+  type SkFont,
+  type SkImage,
+  type SkPaint,
+  type SkRect,
+} from "@shopify/react-native-skia";
+import type { LiveChartPalette, Marker, MarkerKind } from "../types";
+
+/** Default icon box (px) when `marker.size` is unset. */
+export const DEFAULT_ICON_SIZE = 16;
+/** Circular badge padding around the icon glyph + background ring width. */
+const PILL_PAD = 2;
+const PILL_BORDER = 2;
+const PILL_TEXT_COLOR = "#ffffff";
+/** Anti-alias breathing room baked around every cell so sprites don't clip. */
+const CELL_MARGIN = 2;
+
+/** Default glyph color per kind when `marker.color` is unset. */
+export function defaultMarkerColor(
+  kind: MarkerKind,
+  palette: LiveChartPalette,
+): string {
+  switch (kind) {
+    case "trade":
+      return palette.line;
+    case "boost":
+      return palette.refLine;
+    case "graduation":
+      return palette.dotUp;
+    case "winner":
+      return palette.dotUp;
+    case "clawback":
+      return palette.refLabel;
+  }
+}
+
+/**
+ * Axis-anchored kinds whose geometry depends on the chart's baseline (a
+ * variable-length stem, or a box pinned to the axis) and therefore cannot be a
+ * fixed-size sprite. These fall back to a self-projecting glyph component.
+ *
+ * Only applies when the marker has no `icon`/`image` override — those take
+ * precedence and render as ordinary centered stamps via the atlas.
+ */
+export function isConnectorMarker(m: Marker): boolean {
+  "worklet";
+  return (
+    !m.image &&
+    !m.icon &&
+    (m.kind === "graduation" || m.kind === "clawback")
+  );
+}
+
+/**
+ * Stable key for a marker's *visual appearance* (excludes position/anchor).
+ * Two markers with the same signature share one atlas cell. Called both on the
+ * JS thread (to build the atlas) and inside the per-frame worklet (to look a
+ * marker's cell up), so it must stay worklet-safe and primitive-only.
+ */
+export function markerAppearanceSig(m: Marker): string {
+  "worklet";
+  if (m.image) return `img\x1f${m.id}\x1f${m.size ?? DEFAULT_ICON_SIZE}`;
+  const size = m.size ?? "";
+  if (m.icon)
+    return `ic\x1f${m.icon}\x1f${m.pill ? 1 : 0}\x1f${m.color ?? ""}\x1f${size}`;
+  return `k\x1f${m.kind}\x1f${m.color ?? ""}\x1f${size}`;
+}
+
+/** One packed glyph in the atlas image: its source rect + box size. */
+export interface AtlasCell {
+  rect: SkRect;
+  w: number;
+  h: number;
+}
+
+export interface MarkerAtlas {
+  /** Packed glyph texture, or null when there are no atlas-rendered markers. */
+  image: SkImage | null;
+  /** appearance-signature → cell. */
+  cells: Record<string, AtlasCell>;
+}
+
+const EMPTY_ATLAS: MarkerAtlas = { image: null, cells: {} };
+
+function fillPaint(color: string): SkPaint {
+  const p = Skia.Paint();
+  p.setAntiAlias(true);
+  p.setColor(Skia.Color(color));
+  p.setStyle(PaintStyle.Fill);
+  return p;
+}
+
+function strokePaint(color: string, width: number, round = false): SkPaint {
+  const p = Skia.Paint();
+  p.setAntiAlias(true);
+  p.setColor(Skia.Color(color));
+  p.setStyle(PaintStyle.Stroke);
+  p.setStrokeWidth(width);
+  if (round) {
+    p.setStrokeCap(StrokeCap.Round);
+    p.setStrokeJoin(StrokeJoin.Round);
+  }
+  return p;
+}
+
+interface CellSpec {
+  w: number;
+  h: number;
+  /** Draw the glyph centered at (cx, cy) in the recording canvas. */
+  draw: (canvas: SkCanvas, cx: number, cy: number) => void;
+}
+
+/**
+ * Geometry + draw routine for one marker appearance. Mirrors the per-glyph
+ * rendering the old `MarkerGlyph` did inline, so the atlas is pixel-equivalent.
+ */
+function cellSpec(m: Marker, palette: LiveChartPalette, font: SkFont): CellSpec {
+  const color = m.color ?? defaultMarkerColor(m.kind, palette);
+  const m2 = CELL_MARGIN * 2;
+
+  if (m.image) {
+    const img = m.image;
+    const size = m.size ?? DEFAULT_ICON_SIZE;
+    const imgPaint = Skia.Paint();
+    imgPaint.setAntiAlias(true);
+    return {
+      w: size + m2,
+      h: size + m2,
+      draw: (canvas, cx, cy) => {
+        const iw = img.width();
+        const ih = img.height();
+        // `contain` fit: scale to fit the box without distorting aspect.
+        const scale = iw > 0 && ih > 0 ? Math.min(size / iw, size / ih) : 1;
+        const dw = iw * scale;
+        const dh = ih * scale;
+        canvas.drawImageRect(
+          img,
+          Skia.XYWHRect(0, 0, iw, ih),
+          Skia.XYWHRect(cx - dw / 2, cy - dh / 2, dw, dh),
+          imgPaint,
+        );
+      },
+    };
+  }
+
+  if (m.icon) {
+    const icon = m.icon;
+    const b = font.measureText(icon);
+    // Center the glyph on its measured bounds (tighter than ascent/descent).
+    const iconDX = b.x + b.width / 2;
+    const iconDY = b.y + b.height / 2;
+
+    if (m.pill) {
+      const bgColor = `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
+      const pillR = Math.max(b.width, b.height) / 2 + PILL_PAD;
+      const ringR = pillR + PILL_BORDER;
+      const box = Math.ceil(2 * ringR) + m2;
+      return {
+        w: box,
+        h: box,
+        draw: (canvas, cx, cy) => {
+          canvas.drawCircle(cx, cy, ringR, fillPaint(bgColor));
+          canvas.drawCircle(cx, cy, pillR, fillPaint(color));
+          canvas.drawText(
+            icon,
+            cx - iconDX,
+            cy - iconDY,
+            fillPaint(PILL_TEXT_COLOR),
+            font,
+          );
+        },
+      };
+    }
+
+    return {
+      w: Math.ceil(Math.max(b.width, 1)) + m2,
+      h: Math.ceil(Math.max(b.height, 1)) + m2,
+      draw: (canvas, cx, cy) => {
+        canvas.drawText(icon, cx - iconDX, cy - iconDY, fillPaint(color), font);
+      },
+    };
+  }
+
+  if (m.kind === "trade") {
+    const box = 2 * (5 + 1) + m2; // ring r=5 stroked w=2
+    return {
+      w: box,
+      h: box,
+      draw: (canvas, cx, cy) => {
+        canvas.drawCircle(cx, cy, 5, strokePaint(color, 2));
+        canvas.drawCircle(cx, cy, 2, fillPaint(color));
+      },
+    };
+  }
+
+  if (m.kind === "winner") {
+    const outer = 7;
+    const inner = 3;
+    const box = 2 * outer + m2;
+    return {
+      w: box,
+      h: box,
+      draw: (canvas, cx, cy) => {
+        const p = Skia.Path.Make();
+        for (let k = 0; k < 10; k++) {
+          const ang = -Math.PI / 2 + (k * Math.PI) / 5;
+          const rad = k % 2 === 0 ? outer : inner;
+          const px = cx + rad * Math.cos(ang);
+          const py = cy + rad * Math.sin(ang);
+          if (k === 0) p.moveTo(px, py);
+          else p.lineTo(px, py);
+        }
+        p.close();
+        canvas.drawPath(p, fillPaint(color));
+      },
+    };
+  }
+
+  if (m.kind === "boost") {
+    const L = 6;
+    const box = 2 * L + m2;
+    return {
+      w: box,
+      h: box,
+      draw: (canvas, cx, cy) => {
+        const p = Skia.Path.Make();
+        for (let k = 0; k < 4; k++) {
+          const ang = (k * Math.PI) / 4;
+          const dx = L * Math.cos(ang);
+          const dy = L * Math.sin(ang);
+          p.moveTo(cx - dx, cy - dy);
+          p.lineTo(cx + dx, cy + dy);
+        }
+        canvas.drawPath(p, strokePaint(color, 1.5, true));
+      },
+    };
+  }
+
+  // Connector kinds are handled outside the atlas; this is a defensive dot.
+  const box = 6 + m2;
+  return {
+    w: box,
+    h: box,
+    draw: (canvas, cx, cy) => canvas.drawCircle(cx, cy, 3, fillPaint(color)),
+  };
+}
+
+/**
+ * Rasterize every distinct marker appearance into a single packed atlas image,
+ * once per appearance-set change (NOT per frame). The per-frame worklet then
+ * blits these cells via one `drawAtlas` call.
+ *
+ * Connector kinds (see `isConnectorMarker`) are skipped — they render via a
+ * self-projecting fallback component.
+ */
+export function buildMarkerAtlas(
+  markers: Marker[],
+  palette: LiveChartPalette,
+  font: SkFont,
+): MarkerAtlas {
+  const seen = new Set<string>();
+  const specs: { sig: string; spec: CellSpec }[] = [];
+  for (let i = 0; i < markers.length; i++) {
+    const m = markers[i];
+    if (isConnectorMarker(m)) continue;
+    const sig = markerAppearanceSig(m);
+    if (seen.has(sig)) continue;
+    seen.add(sig);
+    specs.push({ sig, spec: cellSpec(m, palette, font) });
+  }
+  if (specs.length === 0) return EMPTY_ATLAS;
+
+  let totalW = 0;
+  let maxH = 0;
+  for (let i = 0; i < specs.length; i++) {
+    totalW += specs[i].spec.w;
+    if (specs[i].spec.h > maxH) maxH = specs[i].spec.h;
+  }
+  const W = Math.max(1, Math.ceil(totalW));
+  const H = Math.max(1, Math.ceil(maxH));
+
+  const recorder = Skia.PictureRecorder();
+  const canvas = recorder.beginRecording(Skia.XYWHRect(0, 0, W, H));
+  const cells: Record<string, AtlasCell> = {};
+  let x = 0;
+  for (let i = 0; i < specs.length; i++) {
+    const { sig, spec } = specs[i];
+    canvas.save();
+    canvas.translate(x, 0);
+    spec.draw(canvas, spec.w / 2, H / 2);
+    canvas.restore();
+    cells[sig] = { rect: Skia.XYWHRect(x, 0, spec.w, H), w: spec.w, h: H };
+    x += spec.w;
+  }
+  const picture = recorder.finishRecordingAsPicture();
+  const image = drawAsImageFromPicture(picture, { width: W, height: H });
+  return { image, cells };
+}

--- a/packages/react-native-livechart/tests/components/MarkerOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/MarkerOverlay.test.tsx
@@ -97,7 +97,7 @@ describe("MarkerOverlay", () => {
           time: 999,
           kind: "trade",
           value: 50,
-          image: {} as never,
+          image: { width: () => 20, height: () => 20 } as never,
           size: 20,
         },
       ]);

--- a/packages/react-native-livechart/tests/draw/markerAtlas.test.ts
+++ b/packages/react-native-livechart/tests/draw/markerAtlas.test.ts
@@ -1,0 +1,111 @@
+import {
+  buildMarkerAtlas,
+  defaultMarkerColor,
+  isConnectorMarker,
+  markerAppearanceSig,
+} from "../../src/draw/markerAtlas";
+import { resolveTheme } from "../../src/theme";
+import type { Marker } from "../../src/types";
+
+const palette = resolveTheme("#3b82f6", "dark");
+
+const font = {
+  getSize: () => 12,
+  measureText: (s: string) => ({ x: 0, y: 0, width: s.length * 7, height: 12 }),
+  getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+} as never;
+
+function m(over: Partial<Marker> & Pick<Marker, "id">): Marker {
+  return { time: 100, kind: "trade", ...over } as Marker;
+}
+
+describe("markerAppearanceSig", () => {
+  it("ignores position/anchor but distinguishes visual fields", () => {
+    // Same appearance, different time/value → same signature (one shared cell).
+    expect(markerAppearanceSig(m({ id: "a", icon: "+", pill: true, time: 1 }))).toBe(
+      markerAppearanceSig(m({ id: "b", icon: "+", pill: true, time: 999, value: 5 })),
+    );
+    // Pill vs no-pill differ; color differs; kind differs.
+    expect(markerAppearanceSig(m({ id: "a", icon: "+", pill: true }))).not.toBe(
+      markerAppearanceSig(m({ id: "a", icon: "+" })),
+    );
+    expect(markerAppearanceSig(m({ id: "a", kind: "winner" }))).not.toBe(
+      markerAppearanceSig(m({ id: "a", kind: "boost" })),
+    );
+    // Image markers key on id (can't share a texture cell with another image).
+    expect(
+      markerAppearanceSig(m({ id: "x", image: {} as never })),
+    ).not.toBe(markerAppearanceSig(m({ id: "y", image: {} as never })));
+  });
+});
+
+describe("isConnectorMarker", () => {
+  it("is true only for axis-anchored kinds without an icon/image override", () => {
+    expect(isConnectorMarker(m({ id: "a", kind: "graduation" }))).toBe(true);
+    expect(isConnectorMarker(m({ id: "a", kind: "clawback" }))).toBe(true);
+    expect(isConnectorMarker(m({ id: "a", kind: "trade" }))).toBe(false);
+    // An icon/image override turns it into an ordinary atlas stamp.
+    expect(isConnectorMarker(m({ id: "a", kind: "graduation", icon: "!" }))).toBe(false);
+  });
+});
+
+describe("buildMarkerAtlas", () => {
+  it("returns an empty atlas when there are no stamp markers", () => {
+    const atlas = buildMarkerAtlas(
+      [m({ id: "g", kind: "graduation" }), m({ id: "c", kind: "clawback" })],
+      palette,
+      font,
+    );
+    expect(atlas.image).toBeNull();
+    expect(Object.keys(atlas.cells)).toHaveLength(0);
+  });
+
+  it("packs one cell per distinct appearance and shares duplicates", () => {
+    const markers: Marker[] = [
+      m({ id: "1", icon: "+", pill: true, color: "#16a34a" }),
+      m({ id: "2", icon: "−", pill: true, color: "#dc2626" }),
+      m({ id: "3", icon: "+", pill: true, color: "#16a34a" }), // dup of #1
+      m({ id: "4", kind: "winner" }),
+    ];
+    const atlas = buildMarkerAtlas(markers, palette, font);
+    // 3 distinct appearances: green +, red −, winner.
+    expect(Object.keys(atlas.cells)).toHaveLength(3);
+    expect(atlas.image).not.toBeNull();
+    // Cells are keyed by appearance signature, not by marker id/order.
+    expect(atlas.cells[markerAppearanceSig(markers[0])]).toBeDefined();
+    expect(atlas.cells[markerAppearanceSig(markers[0])]).toBe(
+      atlas.cells[markerAppearanceSig(markers[2])],
+    );
+  });
+
+  it("produces the same cell set regardless of marker order (no index aliasing)", () => {
+    const a = m({ id: "a", icon: "+", pill: true });
+    const b = m({ id: "b", kind: "boost" });
+    const c = m({ id: "c", icon: "★" });
+    const forward = buildMarkerAtlas([a, b, c], palette, font);
+    const reordered = buildMarkerAtlas([c, a, b], palette, font);
+    expect(Object.keys(forward.cells).sort()).toEqual(
+      Object.keys(reordered.cells).sort(),
+    );
+  });
+
+  it("builds cells for image and trade markers", () => {
+    const atlas = buildMarkerAtlas(
+      [
+        m({ id: "img", image: { width: () => 24, height: () => 12 } as never, size: 20 }),
+        m({ id: "t", kind: "trade" }),
+      ],
+      palette,
+      font,
+    );
+    expect(Object.keys(atlas.cells)).toHaveLength(2);
+  });
+});
+
+describe("defaultMarkerColor", () => {
+  it("maps every kind to a palette color", () => {
+    for (const kind of ["trade", "boost", "graduation", "winner", "clawback"] as const) {
+      expect(typeof defaultMarkerColor(kind, palette)).toBe("string");
+    }
+  });
+});


### PR DESCRIPTION
Replace MarkerOverlay's per-glyph fan-out — one <MarkerGlyph> per
marker, each with ~6-9 useDerivedValue mappers and its own Skia subtree,
re-projecting every marker each frame — with a single packed Skia atlas
drawn in one drawAtlas call.

Each distinct marker appearance is rasterized once into an atlas SkImage
(PictureRecorder + drawAsImageFromPicture) at snapshot cadence, in final
colors so there is no per-instance tint blend. A single per-frame worklet
projects all markers (reusing the pooled projectMarkers buffer) and emits
the RSXform transforms + sprite rects, so per-frame UI-thread cost is O(1)
mappers + one draw regardless of marker count.

Axis-anchored kinds (graduation/clawback) keep a self-projecting
ConnectorGlyph fallback. The no-flicker-on-reorder invariant is preserved:
each marker resolves its own cell by appearance signature, no shared index
buffer. Public API unchanged.

Measured on a 120-pill dense field (iPhone 17 Pro, iOS 26.4 sim, Debug,
markers moving, top -pid, A->B->A): ~90% -> ~42% of one core CPU and
~348MB -> ~262MB, visually pixel-equivalent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>