### PR TITLE
feat(flags)!: uniform boolean|Config feature flags

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -125,7 +125,7 @@ function useLiveChartSeriesController({
   gridStyle,
   palette: paletteOverride,
   metrics,
-  scrub = false,
+  scrub = true,
   onScrub,
   onSeriesToggle,
   dot: dotProp,

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -148,6 +148,28 @@ export interface ResolvedLeftEdgeFadeConfig {
 
 // ─── Resolver functions ───────────────────────────────────────────────────────
 
+/**
+ * Uniform `boolean | Config` feature-flag resolver, shared by every toggle below.
+ * - `false` → `null` (explicitly disabled)
+ * - `undefined` → `defaultOn ? defaults : null` (the feature's default state)
+ * - `true` → `defaults`
+ * - object → defaults shallow-merged with the caller's overrides
+ *
+ * `defaultOn` makes each toggle's default explicit at the resolver. Toggles whose
+ * default-on is owned by the component prop (e.g. `badge = true`) pass
+ * `defaultOn: false` here, so a bare resolver call without that default stays off.
+ */
+function resolveToggle<C extends object, R extends object>(
+  prop: boolean | C | undefined,
+  defaults: R,
+  defaultOn: boolean,
+): R | null {
+  if (prop === false) return null;
+  if (prop == null) return defaultOn ? defaults : null;
+  if (prop === true) return defaults;
+  return { ...defaults, ...prop } as R;
+}
+
 const VALUE_LINE_DEFAULTS: ResolvedValueLineConfig = {
   strokeWidth: 1,
   intervals: [4, 4],
@@ -161,9 +183,7 @@ const VALUE_LINE_DEFAULTS: ResolvedValueLineConfig = {
 export function resolveValueLine(
   prop: boolean | ValueLineConfig | undefined,
 ): ResolvedValueLineConfig | null {
-  if (!prop) return null;
-  if (prop === true) return VALUE_LINE_DEFAULTS;
-  return { ...VALUE_LINE_DEFAULTS, ...prop };
+  return resolveToggle(prop, VALUE_LINE_DEFAULTS, false);
 }
 
 const BADGE_DEFAULTS: ResolvedBadgeConfig = {
@@ -180,9 +200,7 @@ const BADGE_DEFAULTS: ResolvedBadgeConfig = {
 export function resolveBadge(
   prop: boolean | BadgeConfig | undefined,
 ): ResolvedBadgeConfig | null {
-  if (!prop) return null;
-  if (prop === true) return BADGE_DEFAULTS;
-  return { ...BADGE_DEFAULTS, ...prop };
+  return resolveToggle(prop, BADGE_DEFAULTS, false);
 }
 
 const Y_AXIS_DEFAULTS: ResolvedYAxisConfig = {
@@ -196,9 +214,7 @@ const Y_AXIS_DEFAULTS: ResolvedYAxisConfig = {
 export function resolveYAxis(
   prop: boolean | YAxisConfig | undefined,
 ): ResolvedYAxisConfig | null {
-  if (!prop) return null;
-  if (prop === true) return Y_AXIS_DEFAULTS;
-  return { ...Y_AXIS_DEFAULTS, ...prop };
+  return resolveToggle(prop, Y_AXIS_DEFAULTS, false);
 }
 
 const X_AXIS_DEFAULTS: ResolvedXAxisConfig = {
@@ -207,14 +223,12 @@ const X_AXIS_DEFAULTS: ResolvedXAxisConfig = {
 
 /**
  * Resolves `xAxis` prop to a fully-typed config or null (disabled).
- * Defaults to enabled (`true`) so `undefined` also returns the defaults.
+ * Defaults to enabled (`true`) so a bare `undefined` also returns the defaults.
  */
 export function resolveXAxis(
   prop: boolean | XAxisConfig | undefined,
 ): ResolvedXAxisConfig | null {
-  if (prop === false) return null;
-  if (prop === undefined || prop === true) return X_AXIS_DEFAULTS;
-  return { ...X_AXIS_DEFAULTS, ...prop };
+  return resolveToggle(prop, X_AXIS_DEFAULTS, true);
 }
 
 const SCRUB_DEFAULTS: ResolvedScrubConfig = {
@@ -235,9 +249,7 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
 export function resolveScrub(
   prop: boolean | ScrubConfig | undefined,
 ): ResolvedScrubConfig | null {
-  if (!prop) return null;
-  if (prop === true) return SCRUB_DEFAULTS;
-  return { ...SCRUB_DEFAULTS, ...prop };
+  return resolveToggle(prop, SCRUB_DEFAULTS, false);
 }
 
 const GRADIENT_DEFAULTS: ResolvedGradientConfig = {
@@ -252,9 +264,7 @@ const GRADIENT_DEFAULTS: ResolvedGradientConfig = {
 export function resolveGradient(
   prop: boolean | GradientConfig | undefined,
 ): ResolvedGradientConfig | null {
-  if (!prop) return null;
-  if (prop === true) return GRADIENT_DEFAULTS;
-  return { ...GRADIENT_DEFAULTS, ...prop };
+  return resolveToggle(prop, GRADIENT_DEFAULTS, false);
 }
 
 /** Fallback when no theme background is passed (e.g. unit tests). */
@@ -304,9 +314,7 @@ const PULSE_DEFAULTS: ResolvedPulseConfig = {
 export function resolvePulse(
   prop: boolean | PulseConfig | undefined,
 ): ResolvedPulseConfig | null {
-  if (!prop) return null;
-  if (prop === true) return PULSE_DEFAULTS;
-  return { ...PULSE_DEFAULTS, ...prop };
+  return resolveToggle(prop, PULSE_DEFAULTS, false);
 }
 
 const REFERENCE_LINE_VISUAL_DEFAULTS = {
@@ -508,9 +516,7 @@ const RING_DEFAULTS: ResolvedDotRingConfig = {
 export function resolveDotRing(
   prop: boolean | DotRingConfig | undefined,
 ): ResolvedDotRingConfig | null {
-  if (prop === false) return null;
-  if (prop === undefined || prop === true) return RING_DEFAULTS;
-  return { ...RING_DEFAULTS, ...prop };
+  return resolveToggle(prop, RING_DEFAULTS, true);
 }
 
 /** Shared, fully-resolved dot styling (single- and multi-series). */
@@ -528,8 +534,18 @@ const DOT_DEFAULTS: ResolvedDotConfig = {
   color: undefined,
 };
 
-export function resolveDot(prop: DotConfig | undefined): ResolvedDotConfig {
-  if (!prop) return DOT_DEFAULTS;
+/**
+ * Resolves the `dot` prop. Always returns a config (the live dot's geometry is
+ * read unconditionally); visibility rides on `show`.
+ * - `false` → defaults with `show: false` (the canonical "hide the dot")
+ * - `undefined`/`true` → shown defaults
+ * - object → merged with defaults (honoring an explicit `show`)
+ */
+export function resolveDot(
+  prop: boolean | DotConfig | undefined,
+): ResolvedDotConfig {
+  if (prop === false) return { ...DOT_DEFAULTS, show: false };
+  if (prop == null || prop === true) return DOT_DEFAULTS;
   return {
     radius: prop.radius ?? DOT_DEFAULTS.radius,
     ring: resolveDotRing(prop.ring),
@@ -547,13 +563,14 @@ export interface ResolvedMultiSeriesDotConfig extends ResolvedDotConfig {
 }
 
 export function resolveMultiSeriesDot(
-  prop: MultiSeriesDotConfig | undefined,
+  prop: boolean | MultiSeriesDotConfig | undefined,
 ): ResolvedMultiSeriesDotConfig {
+  const cfg = typeof prop === "object" && prop !== null ? prop : undefined;
   return {
     ...resolveDot(prop),
-    pulse: resolvePulse(prop?.pulse ?? true),
-    valueLine: resolveValueLine(prop?.valueLine),
-    valueLabel: prop?.valueLabel ?? true,
+    pulse: resolvePulse(cfg?.pulse ?? true),
+    valueLine: resolveValueLine(cfg?.valueLine),
+    valueLabel: cfg?.valueLabel ?? true,
   };
 }
 

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -424,7 +424,12 @@ export interface DotConfig {
    * `DotRingConfig`. Default `true`.
    */
   ring?: boolean | DotRingConfig;
-  /** Show the dot. `false` hides it (line, badge, and labels still render). Default `true`. */
+  /**
+   * Show the dot. `false` hides it (line, badge, and labels still render). Default `true`.
+   *
+   * @deprecated Pass `dot={false}` to hide the dot — the uniform `boolean | Config`
+   * convention. `show` still works and is equivalent to `dot={{ show: false }}`.
+   */
   show?: boolean;
   /** Dot fill color. Defaults to the chart line color (per series for multi-series). */
   color?: string;
@@ -757,8 +762,11 @@ export interface LiveChartProps extends LiveChartCoreProps {
   momentum?: boolean | Momentum | MomentumConfig;
   /** Pulsing ring animation on the live dot. `true` = defaults, or pass `PulseConfig`. Default `true`. */
   pulse?: boolean | PulseConfig;
-  /** Live dot styling: `radius`, `ring` (halo), `show`, `color`. See {@link DotConfig}. */
-  dot?: DotConfig;
+  /**
+   * Live dot styling. `true`/omitted = shown defaults, `false` = hidden, or pass
+   * `DotConfig` (`radius`, `ring` halo, `color`). See {@link DotConfig}. Default `true`.
+   */
+  dot?: boolean | DotConfig;
   /** Horizontal dashed line at the current live value. `true` = defaults, or pass `ValueLineConfig`. */
   valueLine?: boolean | ValueLineConfig;
   /** Render the live value as a large text overlay in the top-left. Default `false`. */
@@ -803,8 +811,12 @@ export interface LiveChartSeriesProps extends LiveChartCoreProps {
   series: SharedValue<SeriesConfig[]>;
   /** Called when a series toggle chip is tapped. */
   onSeriesToggle?: (id: string, visible: boolean) => void;
-  /** Live dot configuration (radius, pulse, value line, inline labels). */
-  dot?: MultiSeriesDotConfig;
+  /**
+   * Per-series live dot configuration. `true`/omitted = shown defaults, `false` =
+   * hidden, or pass `MultiSeriesDotConfig` (radius, pulse, value line, inline
+   * labels). Default `true`.
+   */
+  dot?: boolean | MultiSeriesDotConfig;
   /** Legend (toggle chips) configuration. `true` = defaults, `false` = hidden, or pass `LegendConfig`. Default `true`. */
   legend?: boolean | LegendConfig;
   /**

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -657,6 +657,20 @@ describe("resolveDot", () => {
       resolveDot({ radius: 6, ring: false, show: false, color: "#abcdef" }),
     ).toEqual({ radius: 6, ring: null, show: false, color: "#abcdef" });
   });
+
+  it("treats `true` as shown defaults", () => {
+    expect(resolveDot(true)).toEqual(resolveDot(undefined));
+    expect(resolveDot(true).show).toBe(true);
+  });
+
+  it("treats `false` as shown:false over the defaults (dot={false})", () => {
+    expect(resolveDot(false)).toEqual({
+      radius: 3.5,
+      ring: { color: undefined, width: 2.5 },
+      show: false,
+      color: undefined,
+    });
+  });
 });
 
 // ─── resolveMultiSeriesDot ──────────────────────────────────────────────────────
@@ -692,6 +706,19 @@ describe("resolveMultiSeriesDot", () => {
       valueLine: null,
       valueLabel: false,
     });
+  });
+
+  it("treats `true` as shown defaults with pulse", () => {
+    expect(resolveMultiSeriesDot(true)).toEqual(
+      resolveMultiSeriesDot(undefined),
+    );
+  });
+
+  it("treats `false` as a hidden dot (dot={false})", () => {
+    const r = resolveMultiSeriesDot(false);
+    expect(r.show).toBe(false);
+    expect(r.radius).toBe(3.5);
+    expect(r.valueLabel).toBe(true);
   });
 });
 


### PR DESCRIPTION
Normalizes the feature-flag surface so every overlay toggle follows the same
boolean | Config convention, resolved through a single resolveToggle helper.

- dot now accepts a boolean on both LiveChart and LiveChartSeries:
  dot={false} hides the dot (equivalent to dot={{ show: false }}). DotConfig.show
  is deprecated in favor of dot={false} but keeps working.
- resolveToggle(prop, defaults, defaultOn) unifies the resolver shape; each
  toggle's default-on/off is now explicit at the resolver.
- Multi-series scrub now defaults to true, matching single-series (legend chips
  already sit outside the scrub gesture, so taps are unaffected).

BREAKING CHANGE: LiveChartSeries enables crosshair scrubbing by default
(scrub previously defaulted to false). Pass scrub={false} to restore the old
behavior. DotConfig.show is deprecated; prefer dot={false}.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>