### PR TITLE
docs: metrics tokens, uniform flag convention, v2 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - Unreleased
+
+### Added
+
+- **`metrics` prop** on both `LiveChart` and `LiveChartSeries` — sizing & motion
+  tokens, the geometry/feel analogue of `palette`. Namespaced (`badge`, `candle`,
+  `grid`, `motion`, `emptyState`) with per-key shallow-merge overrides. Exposes
+  previously-hardcoded constants: badge pill geometry, candle body bounds,
+  grid/axis fade speeds, badge color + adaptive catch-up lerp speeds, and
+  empty-state layout. New types: `LiveChartMetrics`, `LiveChartMetricsOverride`,
+  `BadgeMetrics`, `CandleMetrics`, `GridMetrics`, `MotionMetrics`,
+  `EmptyStateMetrics`.
+- `dot` now accepts a boolean on both charts — `dot={false}` hides the live dot,
+  `dot` / `dot={true}` uses shown defaults. Brings `dot` in line with the uniform
+  `boolean | Config` feature-flag convention shared by every other overlay.
+
+### Changed
+
+- **BREAKING:** `LiveChartSeries` enables crosshair scrubbing by default (`scrub`
+  previously defaulted to `false`, now `true`, matching `LiveChart`). Legend chips
+  sit outside the scrub gesture, so taps are unaffected. Pass `scrub={false}` to
+  restore the previous behavior.
+- Feature-flag resolution is unified behind a single `resolveToggle` helper, so
+  every overlay toggle follows the identical `boolean | Config` shape.
+
+### Deprecated
+
+- **BREAKING (soft):** `DotConfig.show` is deprecated in favor of `dot={false}`.
+  `dot={{ show: false }}` still works and is equivalent.
+
 ## [1.1.0] - 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ High-performance **live** line and candlestick charts for React Native, built on
 - 🔍 **Scrubbing** with a crosshair and worklet-friendly `onScrub` payloads
 - ⚡ **Momentum** detection and **degen** effects (particle bursts + shake on big swings)
 - 🏷️ **Trade markers** driven by a `SharedValue` trade stream
-- 🎨 **Theming** with light/dark modes and an accent-driven palette
+- 🎨 **Theming** with light/dark modes, an accent-driven `palette`, and `metrics` sizing/motion tokens
 - ⏳ **Loading** (breathing-line shell) and **paused** states out of the box
 - 🧵 **SharedValue-driven** rendering — history and live values stay on the UI thread
 
@@ -139,7 +139,8 @@ The tables below are a **highlight** — the **canonical, full reference is the 
 | `degen`                                  | Particle burst + shake on momentum swings                           |
 | `scrub`                                  | Crosshair scrubbing                                                 |
 | `momentum`                               | `true` / `false` / `"up"`, `"down"`, or `"flat"` / `MomentumConfig` |
-| `dot`                                    | Live dot styling: `radius`, `ring` (halo), `show`, `color`          |
+| `dot`                                    | `true` / `false` (hide) / `DotConfig` — `radius`, `ring` (halo), `color` |
+| `metrics`                                | Sizing & motion tokens — geometry/feel analogue of `palette`        |
 | `onScrub`                                | Callback: `ScrubPoint` or `null`                                    |
 
 ### `LiveChartSeries` (multi-series)
@@ -148,11 +149,21 @@ The tables below are a **highlight** — the **canonical, full reference is the 
 | ---------------- | ------------------------------------------- |
 | `series`         | `SharedValue<SeriesConfig[]>`               |
 | `legend`         | Toggle chips / compact legend               |
-| `dot`            | Per-series live dots: haloed `ring`, `show`, `color`, `radius`, `pulse`, `valueLine`, `valueLabel` |
+| `dot`            | `true` / `false` (hide) / `MultiSeriesDotConfig` — haloed `ring`, `color`, `radius`, `pulse`, `valueLine`, `valueLabel` |
+| `scrub`          | Crosshair scrubbing (**on by default** as of v2)            |
 | `onSeriesToggle` | Chip tap                                    |
 | `onScrub`        | Worklet-friendly multi-series scrub payload |
 
-These tables are a **highlight, not the full surface** (`LiveChart` alone has ~48 props). Other shared props include `font`, `insets`, `smoothing`, `xAxis`, `yAxis`, `referenceLines`, `gridStyle`, `palette`, `markers`, `leftEdgeFade`, `line`, `formatValue`, `formatTime`, and `emptyText`; single-series adds `gradient`, `badge`, `pulse`, `valueLine`, and `showValue`. Both charts share the same `dot` styling (a `DotConfig` base — `radius`, `ring`, `show`, `color`); multi-series extends it with `pulse`, `valueLine`, and `valueLabel`. See the TypeScript types and JSDoc for the complete, canonical reference.
+These tables are a **highlight, not the full surface** (`LiveChart` alone has ~48 props). Other shared props include `font`, `insets`, `smoothing`, `xAxis`, `yAxis`, `referenceLines`, `gridStyle`, `palette`, `metrics`, `markers`, `leftEdgeFade`, `line`, `formatValue`, `formatTime`, and `emptyText`; single-series adds `gradient`, `badge`, `pulse`, `valueLine`, and `showValue`. Every overlay toggle follows the same **`boolean | Config`** convention (`badge`, `gradient`, `pulse`, `valueLine`, `scrub`, `yAxis`, `xAxis`, `leftEdgeFade`, `legend`, and `dot`) — pass `true`/omit for defaults, `false` to disable, or an object to customize. Both charts share the same `dot` styling (a `DotConfig` base — `radius`, `ring`, `color`); multi-series extends it with `pulse`, `valueLine`, and `valueLabel`. Beyond `palette` (color), `metrics` exposes sizing & motion tokens (badge/candle geometry, grid/motion speeds) with the same per-key override model. See the TypeScript types and JSDoc for the complete, canonical reference.
+
+## Migrating to v2
+
+v2 makes the feature-flag surface uniform and adds the `metrics` token object. Two behavior changes to know about:
+
+- **`LiveChartSeries` scrubs by default.** Crosshair scrubbing is now on by default (it previously defaulted off), matching `LiveChart`. Pass `scrub={false}` to restore the old behavior.
+- **`dot.show` is deprecated.** Prefer `dot={false}` to hide the live dot — every overlay toggle now follows the same `boolean | Config` convention. `dot={{ show: false }}` still works.
+
+Everything else is additive: the new [`metrics`](https://react-native-livechart.brandtnewlabs.com/guides/theming#sizing-and-motion-tokens) prop is optional, and omitting it keeps the built-in geometry and motion.
 
 ## Examples (Expo app in this repo)
 

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -10,8 +10,8 @@ import { LiveChartSeries } from "react-native-livechart";
 
 `LiveChartSeries` draws several line series sharing an axis, time window, and crosshair. It
 accepts all the shared theming, axis, range, layout, and text props from
-[`LiveChart`](/api-reference/livechart) (`theme`, `accentColor`, `palette`, `font`, `timeWindow`,
-`yAxis`, `referenceLines`, `formatValue`, …), plus the multi-series props below.
+[`LiveChart`](/api-reference/livechart) (`theme`, `accentColor`, `palette`, `metrics`, `font`,
+`timeWindow`, `yAxis`, `referenceLines`, `formatValue`, …), plus the multi-series props below.
 
 ## Series data
 
@@ -31,17 +31,19 @@ accepts all the shared theming, axis, range, layout, and text props from
 
 ## Dots
 
-<ParamField body="dot" type="MultiSeriesDotConfig">
-  Per-series live dots: `radius`, `ring`, `show`, `color`, `pulse`, `valueLine`,
+<ParamField body="dot" type="boolean | MultiSeriesDotConfig" default="true">
+  Per-series live dots: `radius`, `ring`, `color`, `pulse`, `valueLine`,
   `valueLabel`. Each dot is haloed with a contrasting outer `ring` by default
   (matching the single-series live dot); pass `ring: false` for a flat circle,
-  `show: false` to hide the dots, or `color` to override the per-series fill.
+  `dot={false}` to hide the dots, or `color` to override the per-series fill.
+  (The deprecated `dot={{ show: false }}` still hides them.)
 </ParamField>
 
 ## Scrub
 
 <ParamField body="scrub" type="boolean | ScrubConfig" default="true">
-  Crosshair scrubbing on drag.
+  Crosshair scrubbing on drag. **As of v2 this defaults to `true`** (it previously
+  defaulted to `false`); pass `scrub={false}` to disable.
 </ParamField>
 
 <ParamField body="onScrub" type="(point: ScrubPointMulti | null) => void">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -57,12 +57,13 @@ provided; everything else has a default.
   Pulsing ring on the live dot.
 </ParamField>
 
-<ParamField body="dot" type="DotConfig">
-  Live dot styling — `radius`, `ring` (the contrasting outer halo, on by
-  default), `show`, and `color`. Pass `ring: false` for a flat dot, `show: false`
-  to hide it, or `color` to override the fill. The same `DotConfig` is shared
+<ParamField body="dot" type="boolean | DotConfig" default="true">
+  Live dot styling. Pass `false` to hide the dot, or a `DotConfig` for `radius`,
+  `ring` (the contrasting outer halo, on by default), and `color` — `ring: false`
+  gives a flat dot, `color` overrides the fill. The same `DotConfig` is shared
   with `LiveChartSeries` (whose `dot` extends it with `pulse`, `valueLine`, and
-  `valueLabel`).
+  `valueLabel`). `dot={false}` is the canonical "hide" — the deprecated
+  `dot={{ show: false }}` still works.
 </ParamField>
 
 <ParamField body="valueLine" type="boolean | ValueLineConfig">
@@ -185,6 +186,13 @@ provided; everything else has a default.
 
 <ParamField body="palette" type="Partial<LiveChartPalette>">
   Override individual resolved-palette keys.
+</ParamField>
+
+<ParamField body="metrics" type="LiveChartMetricsOverride">
+  Sizing & motion tokens — the geometry/feel analogue of `palette`. Namespaced
+  (`badge`, `candle`, `grid`, `motion`, `emptyState`); only the keys you set are
+  replaced. See the [Theming guide](/guides/theming#sizing-and-motion-tokens) and
+  [`LiveChartMetrics`](/api-reference/types).
 </ParamField>
 
 <ParamField body="font" type="FontConfig">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -163,7 +163,7 @@ interface DotRingConfig {
 interface DotConfig {
   radius?: number; // color-filled dot radius, default 3.5
   ring?: boolean | DotRingConfig; // haloed outer ring, default true
-  show?: boolean; // default true
+  show?: boolean; // @deprecated — prefer dot={false}; default true
   color?: string; // dot fill, defaults to the line color
 }
 interface MultiSeriesDotConfig extends DotConfig {
@@ -222,4 +222,60 @@ interface LiveChartPalette {
   tooltipBg: string; tooltipText: string; tooltipBorder: string;
   // ...glow, badge, and font-size keys
 }
+```
+
+## Metrics
+
+The geometry/motion analogue of `LiveChartPalette`. Override any subset via the `metrics` prop
+(per-namespace shallow merge — only the keys you set are replaced). See the
+[Theming guide](/guides/theming#sizing-and-motion-tokens).
+
+```ts
+interface LiveChartMetrics {
+  badge: BadgeMetrics;
+  candle: CandleMetrics;
+  grid: GridMetrics;
+  motion: MotionMetrics;
+  emptyState: EmptyStateMetrics;
+}
+
+interface BadgeMetrics {
+  padX: number;        // pill horizontal padding, default 10
+  padY: number;        // pill vertical padding, default 3
+  tailLength: number;  // tail spike toward the dot, default 5
+  marginEdge: number;  // gap from the canvas edge, default 4
+  dotGap: number;      // gap between the dot and the tail tip, default 12
+  tailSpread: number;  // tail curve control-point spread, default 2.5
+}
+
+interface CandleMetrics {
+  minBodyPx: number;      // min body height so dojis stay visible, default 1
+  maxBodyPx: number;      // max body width, default 40
+  bodyWidthRatio: number; // body width as a fraction of the slot, default 0.8
+}
+
+interface GridMetrics {
+  fadeInSpeed: number;  // per-frame alpha lerp when a line/label fades in, default 0.18
+  fadeOutSpeed: number; // per-frame alpha lerp when it fades out, default 0.12
+}
+
+interface MotionMetrics {
+  badgeColorSpeed: number;    // badge color transition lerp speed, default 0.08
+  adaptiveSpeedBoost: number; // extra catch-up over `smoothing` when the value lags, default 0.12
+}
+
+interface EmptyStateMetrics {
+  labelOpacity: number; // empty-state label opacity, default 0.35
+  gapPad: number;       // half-padding around the empty text, default 20
+  gapFadeWidth: number; // fade width each side of the empty-text gap, default 30
+}
+
+// `metrics` prop type — every namespace and field optional:
+type LiveChartMetricsOverride = {
+  badge?: Partial<BadgeMetrics>;
+  candle?: Partial<CandleMetrics>;
+  grid?: Partial<GridMetrics>;
+  motion?: Partial<MotionMetrics>;
+  emptyState?: Partial<EmptyStateMetrics>;
+};
 ```

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -45,6 +45,38 @@ Common keys include `line`, `fillTop` / `fillBottom`, `gridLine` / `gridLabel`,
 `crosshairLine`, and `tooltipBg` / `tooltipText`. See the [types reference](/api-reference/types)
 for the full `LiveChartPalette`.
 
+## Sizing and motion tokens
+
+Where `palette` controls _color_, `metrics` controls _shape_ (badge geometry, candle bounds) and
+_feel_ (fade and lerp speeds) — the same override model, namespaced. Only the keys you set are
+replaced; everything else keeps the built-in default.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  metrics={{
+    badge: { padX: 14, tailLength: 8 }, // roomier value pill
+    candle: { maxBodyPx: 24 }, // thinner candles
+    grid: { fadeInSpeed: 0.3 }, // snappier grid fade-in
+    motion: { badgeColorSpeed: 0.2 }, // faster badge color transitions
+  }}
+/>
+```
+
+The five namespaces:
+
+| Namespace    | Controls                                                                                  |
+| ------------ | ----------------------------------------------------------------------------------------- |
+| `badge`      | Value-pill geometry: `padX`, `padY`, `tailLength`, `marginEdge`, `dotGap`, `tailSpread`.   |
+| `candle`     | Candle geometry: `minBodyPx`, `maxBodyPx`, `bodyWidthRatio`.                               |
+| `grid`       | Grid + axis-label fade: `fadeInSpeed`, `fadeOutSpeed`.                                     |
+| `motion`     | Lerp speeds: `badgeColorSpeed`, `adaptiveSpeedBoost` (extra catch-up on top of `smoothing`). |
+| `emptyState` | No-data layout: `labelOpacity`, `gapPad`, `gapFadeWidth`.                                  |
+
+`metrics` is available on both `LiveChart` and `LiveChartSeries`. See the
+[types reference](/api-reference/types) for the full `LiveChartMetrics` shape and every default.
+
 ## Grid & axes
 
 ```tsx


### PR DESCRIPTION
- Theming guide: new "Sizing and motion tokens" section documenting the
  `metrics` prop (badge/candle/grid/motion/emptyState) alongside `palette`.
- API reference: document `metrics` on both components, the normalized
  `dot` boolean (with dot.show deprecation), and the multi-series scrub
  default flip; add LiveChartMetrics + sub-interfaces to the types page.
- README: metrics in the prop tables + feature list, uniform boolean|Config
  note, and a "Migrating to v2" section.
- CHANGELOG: 2.0.0 entry (Added / Changed / Deprecated, with BREAKING notes).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>