### PR TITLE
fix(scrub): stabilize crosshair worklet dependency arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING (soft):** `DotConfig.show` is deprecated in favor of `dot={false}`.
   `dot={{ show: false }}` still works and is equivalent.
 
+### Fixed
+
+- Crosshair overlays no longer emit React's "the final argument passed to
+  useMemo/useEffect changed size between renders" error while scrubbing. With
+  React Compiler enabled, Reanimated's auto-detected worklet dependencies could
+  change array size when the live-dot extent changed; the affected
+  `useDerivedValue`s now use explicit dependency arrays.
+
 ## [1.1.0] - 2026-06-05
 
 ### Added

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -34,27 +34,41 @@ export function CrosshairLine({
   crosshairLineColor?: string;
   crosshairDimColor?: string;
 }) {
-  const p1 = useDerivedValue(() => ({
-    x: scrubX.value,
-    y: padding.top,
-  }));
-  const p2 = useDerivedValue(() => ({
-    x: scrubX.value,
-    y: engine.canvasHeight.value - padding.bottom,
-  }));
+  // Explicit dependency arrays: with React Compiler enabled, Reanimated's
+  // auto-detected worklet dependencies can change array size between renders
+  // (e.g. when `liveDotExtent` flips 0 → the live-dot extent), which trips
+  // React's "final argument changed size between renders" error. Listing the
+  // captured plain values keeps the dependency array a constant size. SharedValue
+  // reads stay reactive regardless of this list.
+  const p1 = useDerivedValue(
+    () => ({
+      x: scrubX.value,
+      y: padding.top,
+    }),
+    [scrubX, padding.top],
+  );
+  const p2 = useDerivedValue(
+    () => ({
+      x: scrubX.value,
+      y: engine.canvasHeight.value - padding.bottom,
+    }),
+    [scrubX, engine.canvasHeight, padding.bottom],
+  );
 
   const dimWidth = useDerivedValue(() => {
     const rightEdge = engine.canvasWidth.value - padding.right + liveDotExtent;
     return Math.max(0, rightEdge - scrubX.value);
-  });
+  }, [engine.canvasWidth, padding.right, liveDotExtent, scrubX]);
   const dimHeight = useDerivedValue(
     () => engine.canvasHeight.value - padding.top - padding.bottom,
+    [engine.canvasHeight, padding.top, padding.bottom],
   );
 
   // dstOut erase color: alpha = fraction of trailing content to remove, ramped
   // by the crosshair fade-in. RGB is irrelevant for dstOut.
   const dimErase = useDerivedValue(
     () => `rgba(0,0,0,${(1 - dimOpacity) * crosshairOpacity.value})`,
+    [dimOpacity, crosshairOpacity],
   );
 
   return (

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -59,21 +59,34 @@ export function CrosshairOverlay({
   tooltipColor?: string;
   tooltipBorderColor?: string;
 }) {
-  const p1 = useDerivedValue(() => ({
-    x: scrubX.value,
-    y: padding.top,
-  }));
-  const p2 = useDerivedValue(() => ({
-    x: scrubX.value,
-    y: engine.canvasHeight.value - padding.bottom,
-  }));
+  // Explicit dependency arrays: with React Compiler enabled, Reanimated's
+  // auto-detected worklet dependencies can change array size between renders
+  // (e.g. when `liveDotExtent` flips 0 → the live-dot extent), which trips
+  // React's "final argument changed size between renders" error. Listing the
+  // captured plain values keeps the dependency array a constant size. SharedValue
+  // reads stay reactive regardless of this list.
+  const p1 = useDerivedValue(
+    () => ({
+      x: scrubX.value,
+      y: padding.top,
+    }),
+    [scrubX, padding.top],
+  );
+  const p2 = useDerivedValue(
+    () => ({
+      x: scrubX.value,
+      y: engine.canvasHeight.value - padding.bottom,
+    }),
+    [scrubX, engine.canvasHeight, padding.bottom],
+  );
 
   const dimWidth = useDerivedValue(() => {
     const rightEdge = engine.canvasWidth.value - padding.right + liveDotExtent;
     return Math.max(0, rightEdge - scrubX.value);
-  });
+  }, [engine.canvasWidth, padding.right, liveDotExtent, scrubX]);
   const dimHeight = useDerivedValue(
     () => engine.canvasHeight.value - padding.top - padding.bottom,
+    [engine.canvasHeight, padding.top, padding.bottom],
   );
 
   const tipX = useDerivedValue(() => tooltipLayout.value.x);
@@ -92,6 +105,7 @@ export function CrosshairOverlay({
   // ramped by the crosshair fade-in. Color RGB is irrelevant for dstOut.
   const dimErase = useDerivedValue(
     () => `rgba(0,0,0,${(1 - dimOpacity) * crosshairOpacity.value})`,
+    [dimOpacity, crosshairOpacity],
   );
 
   return (


### PR DESCRIPTION
With React Compiler enabled (`reactCompiler: true`), Reanimated's
auto-detected dependencies for the crosshair `useDerivedValue`s could change
array size between renders when the live-dot extent flipped 0 -> nonzero,
tripping React's "the final argument passed to %s changed size between
renders" error while scrubbing.

Give the affected derived values (p1, p2, dimWidth, dimHeight, dimErase) in
CrosshairOverlay.tsx and CrosshairLine.tsx explicit dependency arrays so the
array size stays constant. SharedValue reads remain reactive regardless.

Verified on the iOS 26.4 simulator: scrubbing renders the crosshair, tooltip,
and dim correctly with no console error across repeated scrubs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>