### PR TITLE
perf(line): decimate line to ~pixel resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change array size when the live-dot extent changed; the affected
   `useDerivedValue`s now use explicit dependency arrays.
 
+### Performance
+
+- The line is now decimated to ~2 points per horizontal pixel (min/max per pixel
+  column, preserving the envelope and volatility spikes). Previously every visible
+  sample was rebuilt and stroked each frame, so a dense or wide time window that
+  saturated over time made the per-frame cost scale with sample count rather than
+  canvas width — dropping frames, most visibly while scrubbing. Sparse windows are
+  unchanged. Bounds the per-frame line cost to the canvas width regardless of data
+  density.
+
 ## [1.1.0] - 2026-06-05
 
 ### Added

--- a/packages/react-native-livechart/src/draw/line.ts
+++ b/packages/react-native-livechart/src/draw/line.ts
@@ -252,12 +252,80 @@ export function buildLinePoints(
   }
   const startIdx = Math.max(0, lo - 1);
 
-  for (let i = startIdx; i < data.length; i++) {
-    if (data[i].time > now) break;
+  // End of the visible range: first index strictly after `now` (upper bound).
+  let elo = startIdx;
+  let ehi = data.length;
+  while (elo < ehi) {
+    const emid = (elo + ehi) >> 1;
+    if (data[emid].time <= now) elo = emid + 1;
+    else ehi = emid;
+  }
+  const endIdx = elo;
+
+  const xScale = chartW / windowSecs;
+  const yScale = chartH / valRange;
+
+  // Decimate to ~2 points per horizontal pixel once the window is denser than
+  // that. Drawing more points than the canvas is wide is wasted per-frame work
+  // (array build + Skia stroke) that scales with sample count rather than
+  // pixels — the dominant cost on dense / wide-window charts, and the reason
+  // scrubbing a saturated window drops frames. Below the threshold we keep the
+  // exact per-sample path (and existing behaviour) untouched.
+  const maxPlainPoints = Math.ceil(chartW * 2);
+
+  if (endIdx - startIdx <= maxPlainPoints) {
+    for (let i = startIdx; i < endIdx; i++) {
+      pts.push(
+        padding.left + (data[i].time - winStart) * xScale,
+        padding.top + (displayMax - data[i].value) * yScale,
+      );
+    }
+  } else {
+    // Min/max-per-pixel-column decimation: within each pixel column keep the
+    // lowest- and highest-value samples (emitted in their original time order)
+    // so the line's envelope and any volatility spikes survive at full vertical
+    // fidelity while the point count stays bounded by the canvas width.
+    let curCol = -2147483648;
+    let minIdx = startIdx;
+    let maxIdx = startIdx;
+    for (let i = startIdx; i < endIdx; i++) {
+      const col = ((data[i].time - winStart) * xScale) | 0;
+      if (col !== curCol) {
+        if (curCol !== -2147483648) {
+          const a = minIdx <= maxIdx ? minIdx : maxIdx;
+          const b = minIdx <= maxIdx ? maxIdx : minIdx;
+          pts.push(
+            padding.left + (data[a].time - winStart) * xScale,
+            padding.top + (displayMax - data[a].value) * yScale,
+          );
+          if (b !== a) {
+            pts.push(
+              padding.left + (data[b].time - winStart) * xScale,
+              padding.top + (displayMax - data[b].value) * yScale,
+            );
+          }
+        }
+        curCol = col;
+        minIdx = i;
+        maxIdx = i;
+      } else {
+        if (data[i].value < data[minIdx].value) minIdx = i;
+        if (data[i].value > data[maxIdx].value) maxIdx = i;
+      }
+    }
+    // Flush the final column.
+    const a = minIdx <= maxIdx ? minIdx : maxIdx;
+    const b = minIdx <= maxIdx ? maxIdx : minIdx;
     pts.push(
-      padding.left + ((data[i].time - winStart) / windowSecs) * chartW,
-      padding.top + ((displayMax - data[i].value) / valRange) * chartH,
+      padding.left + (data[a].time - winStart) * xScale,
+      padding.top + (displayMax - data[a].value) * yScale,
     );
+    if (b !== a) {
+      pts.push(
+        padding.left + (data[b].time - winStart) * xScale,
+        padding.top + (displayMax - data[b].value) * yScale,
+      );
+    }
   }
 
   // Live tip at current time with smoothed value

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -274,3 +274,37 @@ describe("badge geometry metrics overrides", () => {
     expect(wide.right - base.right).toBe(8);
   });
 });
+
+describe("buildLinePoints decimation", () => {
+  const pad = DEFAULT_PADDING;
+  const canvasW = 400;
+  const canvasH = 200;
+  const chartW = canvasW - pad.left - pad.right; // 376
+
+  it("keeps the exact per-sample path below ~2 points per pixel", () => {
+    const data = Array.from({ length: 50 }, (_, i) => ({ time: i, value: i }));
+    const out = buildLinePoints(data, 49, 49, 50, 0, 50, canvasW, canvasH, pad);
+    // 50 visible samples + the live tip, no decimation.
+    expect(out.length / 2).toBe(51);
+  });
+
+  it("decimates a dense window to ~pixel resolution", () => {
+    const N = 2000;
+    const data = Array.from({ length: N }, (_, i) => ({ time: i, value: 1 }));
+    const out = buildLinePoints(data, 1, N - 1, N, 0, 100, canvasW, canvasH, pad);
+    const count = out.length / 2;
+    expect(count).toBeLessThan(N); // far fewer than the sample count
+    expect(count).toBeLessThanOrEqual(chartW * 2 + 4); // bounded by ~2/pixel + tip
+  });
+
+  it("preserves volatility spikes through decimation (min/max per column)", () => {
+    const N = 2000;
+    const data = Array.from({ length: N }, (_, i) => ({ time: i, value: 1 }));
+    data[1000].value = 100; // single tall spike mid-window
+    const out = buildLinePoints(data, 1, N - 1, N, 0, 100, canvasW, canvasH, pad);
+    // The spike (value 100 => y at padding.top) must survive as the column max.
+    let minY = Infinity;
+    for (let i = 1; i < out.length; i += 2) minY = Math.min(minY, out[i]);
+    expect(minY).toBeCloseTo(pad.top, 0);
+  });
+});


### PR DESCRIPTION
buildLinePoints rebuilt and Skia-stroked every visible sample each frame, so a
dense or wide time window (e.g. a 300s window that saturates with high-frequency
ticks over 1-2 min) made per-frame cost scale with sample count instead of canvas
width. On a saturated window this dropped frames — most visibly while scrubbing,
where the crosshair overlay adds per-frame work on top — and worsened over time as
the window filled. Confirmed on device and simulator (30s window held 60fps; 300s
window fell to ~40 and into the 20s during sustained scrub).

Decimate to ~2 points per horizontal pixel using min/max-per-pixel-column (keeps
the lowest and highest sample in each column, in time order, so the envelope and
volatility spikes survive at full vertical fidelity). Windows below the threshold
keep the exact per-sample path, so sparse charts are byte-for-byte unchanged.

Validated on the simulator: saturated 300s window sustained-scrub recovered from
~40 (dropping to ~20) to ~59 UI FPS. Pre-existing issue, not introduced by the
2.0.0 feature work.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>