### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - Unreleased
+## [2.0.0] - 2026-06-07
 
 ### Added
 
@@ -110,4 +110,5 @@ Initial public release.
   compiles it with your own Reanimated/Worklets version. `dist/` contains only `.d.ts`
   declarations — there is no precompiled runtime `dist/*.js`.
 
+[2.0.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v2.0.0
 [1.0.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -17866,7 +17866,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.1.0",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -68,5 +68,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "1.1.0"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
Cuts **v2.0.0** (major — first breaking release).

Bumps `packages/react-native-livechart` `1.1.0 → 2.0.0` and dates the CHANGELOG `[2.0.0]` section. Rolls up the merged stack (#83–#88).

### Breaking
- Uniform `boolean | Config` feature flags; `LiveChartSeries` `scrub` now defaults to `true`.
- `DotConfig.show` deprecated → use `dot={false}` (still works).

### Added
- `metrics` token object (sizing & motion) — the geometry/feel analogue of `palette`.

### Fixed / Performance
- Crosshair `useDerivedValue` deps stabilized (React Compiler interaction).
- Line decimated to ~pixel resolution → fixes sustained-scrub FPS drop on dense/wide windows.

`npm run verify` green; `npm pack --dry-run -w react-native-livechart` produces `react-native-livechart@2.0.0` with the correct contents (src + dist/*.d.ts + README + LICENSE, no tests/configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)