### PR TITLE
docs: advertise the hosted docs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ High-performance **live** line and candlestick charts for React Native, built on
 
 📖 **[Documentation →](https://react-native-livechart.brandtnewlabs.com)**
 
+🤖 **Docs MCP** — point an AI assistant (Claude, Cursor, …) at the docs via the hosted MCP server: `https://react-native-livechart.brandtnewlabs.com/mcp`
+
 <!-- TODO(hero): replace this comment with a demo GIF/screenshot, e.g.:
      <p align="center"><img src="https://raw.githubusercontent.com/brandtnewlabs/react-native-livechart/main/assets/images/demo.gif" alt="react-native-livechart demo" width="320" /></p>
      Capture from the Expo example app (npm start). -->

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -45,6 +45,17 @@ It's built on [`@shopify/react-native-skia`](https://shopify.github.io/react-nat
   </Card>
 </CardGroup>
 
+<Info>
+  **Using an AI assistant?** Connect it to these docs through our hosted MCP server:
+
+  ```
+  https://react-native-livechart.brandtnewlabs.com/mcp
+  ```
+
+  Add that URL in Claude, Cursor, or any MCP-compatible client to let it search
+  and cite the library's documentation directly.
+</Info>
+
 <Note>
   The design and API are conceptually inspired by
   [liveline](https://github.com/benjitaylor/liveline) by Benji Taylor — reimagined for React


### PR DESCRIPTION
Adds a short note — in the README (under the Documentation link) and on the docs home page — that the library's documentation is available as a hosted **MCP server**, so developers can point an AI assistant (Claude, Cursor, any MCP client) at it:

`https://react-native-livechart.brandtnewlabs.com/mcp`

Docs-only; no code or version change. The README note reaches npm on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)