### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-06-07
+
+### Documentation
+
+- README and docs now point to the hosted docs MCP server
+  (`react-native-livechart.brandtnewlabs.com/mcp`), so an AI assistant can be
+  connected directly to the library's documentation. No code changes.
+
 ## [2.0.0] - 2026-06-07
 
 ### Added
@@ -110,5 +118,6 @@ Initial public release.
   compiles it with your own Reanimated/Worklets version. `dist/` contains only `.d.ts`
   declarations — there is no precompiled runtime `dist/*.js`.
 
+[2.0.1]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v2.0.1
 [2.0.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v2.0.0
 [1.0.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -17866,7 +17866,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.1.0",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -68,5 +68,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "2.0.0"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
Patch release. **Docs-only** — no code changes.

- Bumps `2.0.0` → `2.0.1` and adds the CHANGELOG `[2.0.1]` entry.
- Publishes the README that mentions the hosted docs MCP server (#90) to the npm package page.

`npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)