### PR TITLE
chore(deps): upgrade @shopify/react-native-skia 2.2.12 → 2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
-        "@shopify/react-native-skia": "2.2.12",
+        "@shopify/react-native-skia": "2.6.4",
         "@types/jest": "29.5.14",
         "expo": "~54.0.35",
         "expo-constants": "~18.0.13",
@@ -4764,15 +4764,21 @@
       }
     },
     "node_modules/@shopify/react-native-skia": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.2.12.tgz",
-      "integrity": "sha512-P5wZSMPTp00hM0do+awNFtb5aPh5hSpodMGwy7NaxK90AV+SmUu7wZe6NGevzQIwgFa89Epn6xK3j4jKWdQi+A==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.6.4.tgz",
+      "integrity": "sha512-PhdBdEApukimzt3tJSqbOqeZnjmfQE6kG9H4XaIUaa9EDNK67nYa2jGDTR1HHChgQDguksg21K4IX0zBh5fjQA==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "canvaskit-wasm": "0.40.0",
+        "canvaskit-wasm": "0.41.0",
+        "react-native-skia-android": "147.1.0",
+        "react-native-skia-apple-ios": "147.1.0",
+        "react-native-skia-apple-macos": "147.1.0",
+        "react-native-skia-apple-tvos": "147.1.0",
         "react-reconciler": "0.31.0"
       },
       "bin": {
+        "install-skia": "scripts/install-libs.js",
         "setup-skia-web": "scripts/setup-canvaskit.js"
       },
       "peerDependencies": {
@@ -6712,9 +6718,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvaskit-wasm": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.40.0.tgz",
-      "integrity": "sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.0.tgz",
+      "integrity": "sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@webgpu/types": "0.1.21"
@@ -14892,6 +14898,30 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-skia-android": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-android/-/react-native-skia-android-147.1.0.tgz",
+      "integrity": "sha512-pWA0M0G74AhjEop0HLCkjWJMup2HJxOmuUjfPt6kSDhYeWKVx8AEzWh0Fh19ah78zE/s4hD0Of0Tyem5shhiTg==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-ios": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-ios/-/react-native-skia-apple-ios-147.1.0.tgz",
+      "integrity": "sha512-cr4rWe4Bf0H0TTutUp5cgHt5/Felttl1bh4BAAAsgAeL2F10FAK9urX8spjUshzMwjqXD7rNOWuFzU6ZcNlGKw==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-macos": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-macos/-/react-native-skia-apple-macos-147.1.0.tgz",
+      "integrity": "sha512-Qbv0Y7LgawtRKuGk8gnGeh8nDWwNiu03LcX0mVaQzBBbxFDYvqejanA+AkO3p8gsQb+fsXRc9DAk+U8cBnzZvA==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-tvos": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-tvos/-/react-native-skia-apple-tvos-147.1.0.tgz",
+      "integrity": "sha512-b+4vILXHPu++t8H41PHLBVsTab2LPqwXNdzgdScyl4+Cu8Ta34aUQW3T469cB0ogAMPdu//KV00w4YVpDZoRUQ==",
+      "license": "MIT"
     },
     "node_modules/react-native-web": {
       "version": "0.21.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
-    "@shopify/react-native-skia": "2.2.12",
+    "@shopify/react-native-skia": "2.6.4",
     "@types/jest": "29.5.14",
     "expo": "~54.0.35",
     "expo-constants": "~18.0.13",


### PR DESCRIPTION
## What

Bumps `@shopify/react-native-skia` from **2.2.12** to **2.6.4** (current latest).

This is a within-2.x bump. Peers are satisfied by this stack: `react >=19` (19.1.0), `react-native >=0.78` (0.81.5), `react-native-reanimated >=3.19.1` (4.1.1).

## Why now / non-breaking

`SkPath`'s mutating methods (`moveTo`/`lineTo`/`cubicTo`/`reset`) are **still present and not `@deprecated`** in 2.6.4, so the library's existing imperative path builders keep working with no code changes. The new immutable-`SkPath` direction in Skia's path-migration guide is forward-looking (3.0).

`Skia.PathBuilder` **is** available in 2.6.4 — this unblocks a follow-up PR that migrates the per-frame path building (and retires the pool + ping-pong workaround), gated on on-device perf.

## Verification

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` clean
- ✅ **699 tests** pass (60 suites)
- ✅ `pod install` → *"Installing react-native-skia 2.6.4 (was 2.2.12)"*
- ✅ **Built + ran on the iOS 26.4 simulator (iPhone 17 Pro)** — Skia recompiled and linked with 0 errors; the live chart renders correctly: line + gradient fill, nice-interval grid, momentum-tinted dot + badge, pulse ring, value line, axes.

Native changes (`ios/Pods`, `ios/Podfile.lock`) are gitignored, so this PR is just the dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)