### PR TITLE
perf(paths): migrate all path building to Skia PathBuilder

### DIFF
--- a/docs/pathbuilder-perf.md
+++ b/docs/pathbuilder-perf.md
@@ -1,0 +1,58 @@
+# PathBuilder migration — on-device performance
+
+This documents the measurements behind migrating all per-frame path construction
+from the **pooled mutable `SkPath` + ping-pong** pattern to **`Skia.PathBuilder`
+reused via a SharedValue + `detach()`** (see `src/hooks/usePathBuilder.ts`).
+
+## Why migrate
+
+`@shopify/react-native-skia` is moving `SkPath` toward **immutable** (see the
+[path-migration guide](https://shopify.github.io/react-native-skia/docs/shapes/path-migration/));
+the mutating methods (`moveTo`/`lineTo`/`cubicTo`/`reset`) the pool relied on are
+slated for removal in 3.0. `PathBuilder` is the forward-compatible construction
+API. The pool also needed a two-`SkPath` ping-pong purely to defeat Reanimated's
+value-equality short-circuit; `detach()` returns a fresh reference each frame, so
+that machinery goes away (net **−150 lines**).
+
+## Method
+
+- Device: iPhone 17 Pro simulator, iOS 26.4, Skia 2.6.4, debug build via Metro.
+- Scene: the multi-series demo (3 series animating, the built-in RAM/UI/JS HUD).
+- Each variant swapped via Metro Fast Refresh (same process / pid), then sampled
+  for **90 s**: app process RSS (`ps`) and mean CPU, plus the in-app fps HUD.
+- Single runs — treat ≤~2pp CPU differences as within run-to-run noise.
+
+## Results
+
+| Variant | RSS over 90s | mean CPU | fps |
+| --- | --- | --- | --- |
+| Pooled `SkPath` + ping-pong (old) | ~438–442 MB, **flat** (−4.9) | 36.9% | 60/60 |
+| PathBuilder, **`Make()` inside the worklet** (builder **+** path / frame) | ~450–452 MB, **flat** (+0.4) | 39.1% | 60/60 |
+| PathBuilder, **reused via SharedValue** (path-only / frame) — *adopted* | ~439–440 MB, **flat** (+0.3) | 35.2% | 60/60 |
+
+## Findings
+
+1. **No memory leak from per-frame allocation on 2.6.4.** The pool's docstring
+   warned that per-frame `SkPath` allocation makes iOS resident memory "climb
+   steadily." It does not — every variant, including per-frame allocation, held
+   **flat RSS over 90 s**. Skia 2.6.4 reclaims per-frame paths fine.
+
+2. **`SkPathBuilder` is not a Reanimated-shareable host object.** Stashing a
+   builder in a `useRef` and reading it inside a `useDerivedValue` worklet throws
+   `"Cannot convert undefined value to object"`. Builders cross into the worklet
+   only through a **`SharedValue`** (what `usePathBuilder` does) or by being
+   `Make()`-d inside the worklet. This is the key structural constraint of the
+   migration.
+
+3. **Reused-builder PathBuilder is perf-equivalent to the pool** (35.2% vs 36.9%
+   CPU — within noise — and the same RSS band). Allocating the builder *per frame*
+   (variant 2) is the only measurable cost (+2pp CPU, +11 MB), which the reused
+   structure avoids.
+
+## Decision
+
+Migrate to **reused-builder-via-SharedValue PathBuilder + `detach()`** everywhere
+(`usePathBuilder` / `usePathBuilders`). It is perf-neutral today, removes the
+ping-pong, and is the only construction path that survives the immutable-`SkPath`
+change in Skia 3.0. The `flatPts` point-buffer ping-pong in `useChartPaths` /
+`useMultiSeriesLinePaths` is unrelated (it drives intermediate re-runs) and stays.

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -71,6 +71,36 @@ jest.mock("@shopify/react-native-skia", () => {
     rewind: jest.fn(),
   });
 
+  // Mutable builder → immutable SkPath (build/detach return a mock path).
+  const createPathBuilder = () => {
+    const b = {
+      moveTo: jest.fn(() => b),
+      lineTo: jest.fn(() => b),
+      quadTo: jest.fn(() => b),
+      conicTo: jest.fn(() => b),
+      cubicTo: jest.fn(() => b),
+      close: jest.fn(() => b),
+      addRect: jest.fn(() => b),
+      addRRect: jest.fn(() => b),
+      addOval: jest.fn(() => b),
+      addCircle: jest.fn(() => b),
+      addPath: jest.fn(() => b),
+      addPoly: jest.fn(() => b),
+      arcToOval: jest.fn(() => b),
+      setFillType: jest.fn(() => b),
+      setIsVolatile: jest.fn(() => b),
+      offset: jest.fn(() => b),
+      transform: jest.fn(() => b),
+      reset: jest.fn(() => b),
+      computeBounds: jest.fn(() => ({ x: 0, y: 0, width: 0, height: 0 })),
+      isEmpty: jest.fn(() => true),
+      countPoints: jest.fn(() => 0),
+      build: jest.fn(() => createPath()),
+      detach: jest.fn(() => createPath()),
+    };
+    return b;
+  };
+
   const createCanvas = () => ({
     save: jest.fn(),
     restore: jest.fn(),
@@ -130,6 +160,10 @@ jest.mock("@shopify/react-native-skia", () => {
     Skia: {
       Path: {
         Make: jest.fn(() => createPath()),
+      },
+      PathBuilder: {
+        Make: jest.fn(() => createPathBuilder()),
+        MakeFromPath: jest.fn(() => createPathBuilder()),
       },
       FontMgr: {
         System: jest.fn(() => ({})),

--- a/packages/react-native-livechart/src/components/LoadingOverlay.tsx
+++ b/packages/react-native-livechart/src/components/LoadingOverlay.tsx
@@ -4,13 +4,10 @@ import {
   Path,
   Rect,
   RoundedRect,
-  Skia,
   Text as SkiaText,
   vec,
   type SkFont,
-  type SkPath,
 } from "@shopify/react-native-skia";
-import { useRef } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import {
   BADGE_METRICS_DEFAULTS,
@@ -22,6 +19,10 @@ import {
   pillTextLeftX,
   type ChartPadding,
 } from "../draw/line";
+import {
+  usePathBuilder,
+  type ReanimatedPathBuilder,
+} from "../hooks/usePathBuilder";
 import { drawSpline } from "../math/spline";
 import { buildSquigglyPts } from "../math/squiggly";
 import type {
@@ -37,14 +38,14 @@ const RECT_H = 4;
 const RECT_R = 4;
 const RECT_SPACING = 32;
 
-function buildSplineInto(path: ReturnType<typeof Skia.Path.Make>, pts: number[]) {
+function buildSplineDetached(b: ReanimatedPathBuilder, pts: number[]) {
   "worklet";
-  path.reset();
   const n = pts.length >> 1;
-  if (n < 2) return path;
-  path.moveTo(pts[0], pts[1]);
-  drawSpline(path, pts);
-  return path;
+  if (n >= 2) {
+    b.moveTo(pts[0], pts[1]);
+    drawSpline(b, pts);
+  }
+  return b.detach();
 }
 
 export function LoadingOverlay({
@@ -85,29 +86,14 @@ export function LoadingOverlay({
   const leftInset =
     badgeMetrics.dotGap + badgeTailAndCap(font.getSize(), badgeTail, badgeMetrics);
 
-  // Ping-pong persistent paths — avoid allocating a JSI-backed SkPath per frame
-  // while the squiggly loading/empty-state animation is running.
-  const squigglyCacheRef = useRef<{
-    a: SkPath;
-    b: SkPath;
-    tick: boolean;
-  } | null>(null);
-  if (squigglyCacheRef.current === null) {
-    squigglyCacheRef.current = {
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
-    };
-  }
+  // Squiggly path — built into a reused PathBuilder and detach()-ed each frame.
+  const squigglyBuilder = usePathBuilder();
 
   // Squiggly path — animated each frame via timestamp
   const squigglyPath = useDerivedValue(() => {
-    const squigglyCache = squigglyCacheRef.current!;
-    squigglyCache.tick = !squigglyCache.tick;
-    const path = squigglyCache.tick ? squigglyCache.a : squigglyCache.b;
+    const b = squigglyBuilder.value;
     if (!isLoading.get() && !isEmpty.value && morphT.get() >= 1) {
-      path.reset();
-      return path;
+      return b.detach();
     }
     const pts = buildSquigglyPts(
       engine.canvasWidth.get(),
@@ -115,7 +101,7 @@ export function LoadingOverlay({
       padding,
       engine.timestamp.get(),
     );
-    return buildSplineInto(path, pts);
+    return buildSplineDetached(b, pts);
   });
 
   // Fades out quickly as the reveal animation begins (first 33% of morphT)

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -4,7 +4,6 @@ import {
   Path,
   Skia,
   type SkFont,
-  type SkPath,
 } from "@shopify/react-native-skia";
 import { useMemo, useRef, useState } from "react";
 import {
@@ -15,6 +14,7 @@ import {
 import { scheduleOnRN } from "react-native-worklets";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
+import { usePathBuilder } from "../hooks/usePathBuilder";
 import {
   buildMarkerAtlas,
   defaultMarkerColor,
@@ -84,37 +84,32 @@ function ConnectorGlyph({
 
   const opacity = useDerivedValue(() => (layout.get().visible ? 1 : 0));
 
-  const cacheRef = useRef<{ a: SkPath; b: SkPath; tick: boolean } | null>(null);
-  if (cacheRef.current === null) {
-    cacheRef.current = { a: Skia.Path.Make(), b: Skia.Path.Make(), tick: false };
-  }
+  const glyphBuilder = usePathBuilder();
 
   const glyphPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.tick = !cache.tick;
-    const p: SkPath = cache.tick ? cache.a : cache.b;
-    p.reset();
+    const b = glyphBuilder.value;
     const l = layout.get();
-    if (!l.visible) return p;
-    const x = l.visible ? l.x : OFF;
-    const y = l.y;
-    if (kind === "graduation") {
-      p.moveTo(x, axisY.get());
-      p.lineTo(x, y);
-      p.moveTo(x, y - 7);
-      p.lineTo(x + 8, y - 4);
-      p.lineTo(x, y - 1);
-      p.close();
-    } else if (kind === "clawback") {
-      const s = 5;
-      const ay = axisY.get() - s;
-      p.moveTo(x - s, ay);
-      p.lineTo(x + s, ay);
-      p.lineTo(x + s, ay + s * 2);
-      p.lineTo(x - s, ay + s * 2);
-      p.close();
+    if (l.visible) {
+      const x = l.x;
+      const y = l.y;
+      if (kind === "graduation") {
+        b.moveTo(x, axisY.get());
+        b.lineTo(x, y);
+        b.moveTo(x, y - 7);
+        b.lineTo(x + 8, y - 4);
+        b.lineTo(x, y - 1);
+        b.close();
+      } else if (kind === "clawback") {
+        const s = 5;
+        const ay = axisY.get() - s;
+        b.moveTo(x - s, ay);
+        b.lineTo(x + s, ay);
+        b.lineTo(x + s, ay + s * 2);
+        b.lineTo(x - s, ay + s * 2);
+        b.close();
+      }
     }
-    return p;
+    return b.detach();
   });
 
   const fill = kind === "clawback";

--- a/packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx
@@ -1,17 +1,11 @@
-import {
-  DashPathEffect,
-  Group,
-  Path,
-  Skia,
-  type SkPath,
-} from "@shopify/react-native-skia";
+import { DashPathEffect, Group, Path } from "@shopify/react-native-skia";
 
-import { useRef } from "react";
 import { useDerivedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
 import type { ResolvedValueLineConfig } from "../core/resolveConfig";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
+import { usePathBuilder } from "../hooks/usePathBuilder";
 
 function SeriesValueLineAtIndex({
   index,
@@ -26,44 +20,30 @@ function SeriesValueLineAtIndex({
   color: string;
   config: ResolvedValueLineConfig;
 }) {
-  const cacheRef = useRef<{
-    a: SkPath;
-    b: SkPath;
-    tick: boolean;
-  } | null>(null);
-  if (cacheRef.current === null) {
-    cacheRef.current = {
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
-    };
-  }
+  const builder = usePathBuilder();
 
   const path = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.tick = !cache.tick;
-    const p = cache.tick ? cache.a : cache.b;
-    p.reset();
+    const b = builder.value;
     const h = engine.canvasHeight.get();
-    if (h === 0) return p;
     const s = engine.series.get();
     const displays = engine.displaySeriesValues.get();
-    if (index >= s.length) return p;
+    if (h !== 0 && index < s.length) {
+      const chartH = h - padding.top - padding.bottom;
+      const dMin = engine.displayMin.get();
+      const dMax = engine.displayMax.get();
+      const valRange = dMax - dMin;
+      const v = displays[index] ?? s[index].value;
+      const y =
+        valRange === 0
+          ? padding.top + chartH / 2
+          : padding.top + ((dMax - v) / valRange) * chartH;
 
-    const chartH = h - padding.top - padding.bottom;
-    const dMin = engine.displayMin.get();
-    const dMax = engine.displayMax.get();
-    const valRange = dMax - dMin;
-    const v = displays[index] ?? s[index].value;
-    const y =
-      valRange === 0
-        ? padding.top + chartH / 2
-        : padding.top + ((dMax - v) / valRange) * chartH;
-
-    if (y < 0) return p;
-    p.moveTo(padding.left, y);
-    p.lineTo(engine.canvasWidth.get() - padding.right, y);
-    return p;
+      if (y >= 0) {
+        b.moveTo(padding.left, y);
+        b.lineTo(engine.canvasWidth.get() - padding.right, y);
+      }
+    }
+    return b.detach();
   });
 
   const opacity = useDerivedValue(() => {

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -3,16 +3,14 @@ import {
   Group,
   Path,
   RoundedRect,
-  Skia,
   Text as SkiaText,
   type SkFont,
-  type SkPath,
 } from "@shopify/react-native-skia";
-import { useRef } from "react";
 import { useDerivedValue } from "react-native-reanimated";
 
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
+import { usePathBuilder } from "../hooks/usePathBuilder";
 import { useReferenceLine } from "../hooks/useReferenceLine";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { referenceLineForm } from "../math/referenceLines";
@@ -65,131 +63,91 @@ export function ReferenceLineOverlay({
   const badgeBorderColor = line.badgeBorderColor ?? color;
   const badgeRadius = line.badgeRadius ?? OFF_AXIS_PILL_RADIUS;
 
-  const cacheRef = useRef<{
-    lineA: SkPath;
-    lineB: SkPath;
-    lineT: boolean;
-    bandA: SkPath;
-    bandB: SkPath;
-    bandT: boolean;
-    borderA: SkPath;
-    borderB: SkPath;
-    borderT: boolean;
-    offA: SkPath;
-    offB: SkPath;
-    offT: boolean;
-    chevA: SkPath;
-    chevB: SkPath;
-    chevT: boolean;
-  } | null>(null);
-  if (cacheRef.current === null) {
-    cacheRef.current = {
-      lineA: Skia.Path.Make(),
-      lineB: Skia.Path.Make(),
-      lineT: false,
-      bandA: Skia.Path.Make(),
-      bandB: Skia.Path.Make(),
-      bandT: false,
-      borderA: Skia.Path.Make(),
-      borderB: Skia.Path.Make(),
-      borderT: false,
-      offA: Skia.Path.Make(),
-      offB: Skia.Path.Make(),
-      offT: false,
-      chevA: Skia.Path.Make(),
-      chevB: Skia.Path.Make(),
-      chevT: false,
-    };
-  }
+  const lineBuilder = usePathBuilder();
+  const bandBuilder = usePathBuilder();
+  const borderBuilder = usePathBuilder();
+  const offBuilder = usePathBuilder();
+  const chevBuilder = usePathBuilder();
 
   const linePath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.lineT = !cache.lineT;
-    const p = cache.lineT ? cache.lineA : cache.lineB;
-    p.reset();
+    const b = lineBuilder.value;
     const l = layout.get();
-    if (!l.visible || l.offAxis || isBand) return p;
-    p.moveTo(l.x1, l.y);
-    p.lineTo(l.x2, l.y);
-    return p;
+    if (l.visible && !l.offAxis && !isBand) {
+      b.moveTo(l.x1, l.y);
+      b.lineTo(l.x2, l.y);
+    }
+    return b.detach();
   });
 
   const bandPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.bandT = !cache.bandT;
-    const p = cache.bandT ? cache.bandA : cache.bandB;
-    p.reset();
+    const b = bandBuilder.value;
     const l = layout.get();
-    if (!l.visible || !isBand) return p;
-    p.moveTo(l.x1, l.y);
-    p.lineTo(l.x2, l.y);
-    p.lineTo(l.x2, l.yBottom);
-    p.lineTo(l.x1, l.yBottom);
-    p.close();
-    return p;
+    if (l.visible && isBand) {
+      b.moveTo(l.x1, l.y);
+      b.lineTo(l.x2, l.y);
+      b.lineTo(l.x2, l.yBottom);
+      b.lineTo(l.x1, l.yBottom);
+      b.close();
+    }
+    return b.detach();
   });
 
   const bandBorderPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.borderT = !cache.borderT;
-    const p = cache.borderT ? cache.borderA : cache.borderB;
-    p.reset();
+    const b = borderBuilder.value;
     const l = layout.get();
-    if (!l.visible || !hasBandBorder) return p;
-    if (form === "time-band") {
-      // Vertical edges at the band's left / right.
-      p.moveTo(l.x1, l.y);
-      p.lineTo(l.x1, l.yBottom);
-      p.moveTo(l.x2, l.y);
-      p.lineTo(l.x2, l.yBottom);
-    } else {
-      // Horizontal edges at the band's top / bottom.
-      p.moveTo(l.x1, l.y);
-      p.lineTo(l.x2, l.y);
-      p.moveTo(l.x1, l.yBottom);
-      p.lineTo(l.x2, l.yBottom);
+    if (l.visible && hasBandBorder) {
+      if (form === "time-band") {
+        // Vertical edges at the band's left / right.
+        b.moveTo(l.x1, l.y);
+        b.lineTo(l.x1, l.yBottom);
+        b.moveTo(l.x2, l.y);
+        b.lineTo(l.x2, l.yBottom);
+      } else {
+        // Horizontal edges at the band's top / bottom.
+        b.moveTo(l.x1, l.y);
+        b.lineTo(l.x2, l.y);
+        b.moveTo(l.x1, l.yBottom);
+        b.lineTo(l.x2, l.yBottom);
+      }
     }
-    return p;
+    return b.detach();
   });
 
   const offLinePath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.offT = !cache.offT;
-    const p = cache.offT ? cache.offA : cache.offB;
-    p.reset();
+    const b = offBuilder.value;
     const l = layout.get();
-    if (!l.visible || !l.offAxis) return p;
-    // Start the connector just past the badge pill's right edge so the dashed
-    // line runs out to the chart edge rather than behind the badge.
-    const pillRight =
-      l.labelX + measureFontTextWidth(font, l.label) + OFF_AXIS_PILL_PAD_X;
-    const start = pillRight + 4;
-    if (start >= l.x2) return p;
-    p.moveTo(start, l.y);
-    p.lineTo(l.x2, l.y);
-    return p;
+    if (l.visible && l.offAxis) {
+      // Start the connector just past the badge pill's right edge so the dashed
+      // line runs out to the chart edge rather than behind the badge.
+      const pillRight =
+        l.labelX + measureFontTextWidth(font, l.label) + OFF_AXIS_PILL_PAD_X;
+      const start = pillRight + 4;
+      if (start < l.x2) {
+        b.moveTo(start, l.y);
+        b.lineTo(l.x2, l.y);
+      }
+    }
+    return b.detach();
   });
 
   const chevronPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.chevT = !cache.chevT;
-    const p = cache.chevT ? cache.chevA : cache.chevB;
-    p.reset();
+    const b = chevBuilder.value;
     const l = layout.get();
-    if (!l.visible || !l.offAxis) return p;
-    const cx = l.x1 + 6;
-    const cy = l.y;
-    const s = 4;
-    if (l.chevronUp) {
-      p.moveTo(cx - s, cy + s);
-      p.lineTo(cx, cy - s);
-      p.lineTo(cx + s, cy + s);
-    } else {
-      p.moveTo(cx - s, cy - s);
-      p.lineTo(cx, cy + s);
-      p.lineTo(cx + s, cy - s);
+    if (l.visible && l.offAxis) {
+      const cx = l.x1 + 6;
+      const cy = l.y;
+      const s = 4;
+      if (l.chevronUp) {
+        b.moveTo(cx - s, cy + s);
+        b.lineTo(cx, cy - s);
+        b.lineTo(cx + s, cy + s);
+      } else {
+        b.moveTo(cx - s, cy - s);
+        b.lineTo(cx, cy + s);
+        b.lineTo(cx + s, cy - s);
+      }
     }
-    return p;
+    return b.detach();
   });
 
   const lineOpacity = useDerivedValue(() =>

--- a/packages/react-native-livechart/src/components/ValueLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ValueLineOverlay.tsx
@@ -1,14 +1,9 @@
-import {
-  DashPathEffect,
-  Path,
-  Skia,
-  type SkPath,
-} from "@shopify/react-native-skia";
-import { useRef } from "react";
+import { DashPathEffect, Path } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ChartPadding } from "../draw/line";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import { usePathBuilder } from "../hooks/usePathBuilder";
 
 /**
  * A dashed horizontal line that tracks the live display value — sitting at
@@ -29,30 +24,16 @@ export function ValueLineOverlay({
   intervals: [number, number];
   color: string;
 }) {
-  // Ping-pong persistent paths — avoid allocating a JSI-backed SkPath per frame.
-  const cacheRef = useRef<{
-    a: SkPath;
-    b: SkPath;
-    tick: boolean;
-  } | null>(null);
-  if (cacheRef.current === null) {
-    cacheRef.current = {
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
-    };
-  }
+  const builder = usePathBuilder();
 
   const path = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.tick = !cache.tick;
-    const p = cache.tick ? cache.a : cache.b;
-    p.reset();
+    const b = builder.value;
     const y = dotY.get();
-    if (y < 0) return p;
-    p.moveTo(padding.left, y);
-    p.lineTo(engine.canvasWidth.get() - padding.right, y);
-    return p;
+    if (y >= 0) {
+      b.moveTo(padding.left, y);
+      b.lineTo(engine.canvasWidth.get() - padding.right, y);
+    }
+    return b.detach();
   });
 
   return (

--- a/packages/react-native-livechart/src/components/XAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/XAxisOverlay.tsx
@@ -1,15 +1,9 @@
-import {
-  Group,
-  Path,
-  Skia,
-  type SkFont,
-  type SkPath,
-} from "@shopify/react-native-skia";
-import { useRef } from "react";
+import { Group, Path, type SkFont } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import type { XAxisEntry } from "../hooks/useXAxis";
+import { usePathBuilder } from "../hooks/usePathBuilder";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import type { LiveChartPalette } from "../types";
 import { AnimatedLabel } from "./AnimatedLabel";
@@ -31,40 +25,26 @@ export function XAxisOverlay({
   palette: LiveChartPalette;
   font: SkFont;
 }) {
-  const axisCacheRef = useRef<{
-    a: SkPath;
-    b: SkPath;
-    tick: boolean;
-  } | null>(null);
-  if (axisCacheRef.current === null) {
-    axisCacheRef.current = {
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
-    };
-  }
+  const axisBuilder = usePathBuilder();
 
   const axisPath = useDerivedValue(() => {
     "worklet";
-    const axisCache = axisCacheRef.current!;
-    axisCache.tick = !axisCache.tick;
-    const path = axisCache.tick ? axisCache.a : axisCache.b;
-    path.reset();
+    const b = axisBuilder.value;
     const w = engine.canvasWidth.get();
     const h = engine.canvasHeight.get();
     const lineY = h - padding.bottom;
 
     // Bottom axis line
-    path.moveTo(padding.left, lineY);
-    path.lineTo(w - padding.right, lineY);
+    b.moveTo(padding.left, lineY);
+    b.lineTo(w - padding.right, lineY);
 
     // Tick marks
     const items = entries.get();
     for (let i = 0; i < items.length; i++) {
-      path.moveTo(items[i].x, lineY);
-      path.lineTo(items[i].x, lineY + TICK_HEIGHT);
+      b.moveTo(items[i].x, lineY);
+      b.lineTo(items[i].x, lineY + TICK_HEIGHT);
     }
-    return path;
+    return b.detach();
   });
 
   // Transform XAxisEntry[] into { x, y, label, alpha } for AnimatedLabel

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -2,11 +2,8 @@ import {
   DashPathEffect,
   Group,
   Path,
-  Skia,
   type SkFont,
-  type SkPath,
 } from "@shopify/react-native-skia";
-import { useRef } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { BADGE_METRICS_DEFAULTS } from "../constants";
 import type { ResolvedGridStyleConfig } from "../core/resolveConfig";
@@ -18,6 +15,7 @@ import {
   pillTextLeftX,
   type ChartPadding,
 } from "../draw/line";
+import { usePathBuilder } from "../hooks/usePathBuilder";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import type { BadgeMetrics, LiveChartPalette } from "../types";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
@@ -57,31 +55,17 @@ export function YAxisOverlay({
   const gridWidth = gridStyle?.strokeWidth ?? 1;
   const gridIntervals = gridStyle?.intervals ?? [];
   const gridOpacity = gridStyle?.opacity ?? 1;
-  const gridCacheRef = useRef<{
-    a: SkPath;
-    b: SkPath;
-    tick: boolean;
-  } | null>(null);
-  if (gridCacheRef.current === null) {
-    gridCacheRef.current = {
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
-    };
-  }
+  const gridBuilder = usePathBuilder();
 
   const gridLinesPath = useDerivedValue(() => {
-    const gridCache = gridCacheRef.current!;
-    gridCache.tick = !gridCache.tick;
-    const path = gridCache.tick ? gridCache.a : gridCache.b;
-    path.reset();
+    const b = gridBuilder.value;
     const items = entries.get();
     const w = engine.canvasWidth.get();
     for (let i = 0; i < items.length; i++) {
-      path.moveTo(padding.left, items[i].y);
-      path.lineTo(w - padding.right, items[i].y);
+      b.moveTo(padding.left, items[i].y);
+      b.lineTo(w - padding.right, items[i].y);
     }
-    return path;
+    return b.detach();
   });
 
   const leftInset =

--- a/packages/react-native-livechart/src/draw/markerAtlas.ts
+++ b/packages/react-native-livechart/src/draw/markerAtlas.ts
@@ -207,17 +207,17 @@ function cellSpec(m: Marker, palette: LiveChartPalette, font: SkFont): CellSpec 
       w: box,
       h: box,
       draw: (canvas, cx, cy) => {
-        const p = Skia.Path.Make();
+        const pb = Skia.PathBuilder.Make();
         for (let k = 0; k < 10; k++) {
           const ang = -Math.PI / 2 + (k * Math.PI) / 5;
           const rad = k % 2 === 0 ? outer : inner;
           const px = cx + rad * Math.cos(ang);
           const py = cy + rad * Math.sin(ang);
-          if (k === 0) p.moveTo(px, py);
-          else p.lineTo(px, py);
+          if (k === 0) pb.moveTo(px, py);
+          else pb.lineTo(px, py);
         }
-        p.close();
-        canvas.drawPath(p, fillPaint(color));
+        pb.close();
+        canvas.drawPath(pb.detach(), fillPaint(color));
       },
     };
   }
@@ -229,15 +229,15 @@ function cellSpec(m: Marker, palette: LiveChartPalette, font: SkFont): CellSpec 
       w: box,
       h: box,
       draw: (canvas, cx, cy) => {
-        const p = Skia.Path.Make();
+        const pb = Skia.PathBuilder.Make();
         for (let k = 0; k < 4; k++) {
           const ang = (k * Math.PI) / 4;
           const dx = L * Math.cos(ang);
           const dy = L * Math.sin(ang);
-          p.moveTo(cx - dx, cy - dy);
-          p.lineTo(cx + dx, cy + dy);
+          pb.moveTo(cx - dx, cy - dy);
+          pb.lineTo(cx + dx, cy + dy);
         }
-        canvas.drawPath(p, strokePaint(color, 1.5, true));
+        canvas.drawPath(pb.detach(), strokePaint(color, 1.5, true));
       },
     };
   }

--- a/packages/react-native-livechart/src/hooks/useBadge.ts
+++ b/packages/react-native-livechart/src/hooks/useBadge.ts
@@ -1,5 +1,4 @@
-import { Skia, type SkFont, type SkPath } from "@shopify/react-native-skia";
-import { useRef } from "react";
+import { type SkFont } from "@shopify/react-native-skia";
 import {
   useDerivedValue,
   useSharedValue,
@@ -25,6 +24,7 @@ import type {
   LiveChartPalette,
   Momentum,
 } from "../types";
+import { usePathBuilder } from "./usePathBuilder";
 
 export function useBadge(
   engine: ChartEngineWithLiveValue,
@@ -48,32 +48,17 @@ export function useBadge(
   const downRgb = hexToRgb(palette.dotDown);
   const accentRgb = hexToRgb(palette.badgeBg);
 
-  // Ping-pong between two persistent badge paths so the derived value always
-  // returns a freshly-mutated SkPath without allocating a new one every frame.
-  // See useChartPaths for the full rationale on per-frame Skia.Path.Make().
-  const cacheRef = useRef<{
-    a: SkPath;
-    b: SkPath;
-    tick: boolean;
-  } | null>(null);
-  if (cacheRef.current === null) {
-    cacheRef.current = {
-      a: Skia.Path.Make(),
-      b: Skia.Path.Make(),
-      tick: false,
-    };
-  }
+  // Pill path is built into a reused PathBuilder and finalized with detach()
+  // each frame — a fresh immutable SkPath, no per-frame Skia.Path.Make().
+  const badgeBuilder = usePathBuilder();
 
   const badge = useDerivedValue(() => {
-    const cache = cacheRef.current!;
+    const b = badgeBuilder.value;
     const w = engine.canvasWidth.get();
     const h = engine.canvasHeight.get();
-    cache.tick = !cache.tick;
-    const path = cache.tick ? cache.a : cache.b;
-    path.reset();
     if (w === 0 || h === 0) {
       return {
-        path,
+        path: b.detach(),
         textX: 0,
         textY: 0,
         text: "",
@@ -108,7 +93,7 @@ export function useBadge(
       const bodyLeft = Math.max(badgeMetrics.marginEdge, bodyRight - pillW);
       const pillBodyW = bodyRight - bodyLeft;
       textX = (bodyLeft + bodyRight - textW) / 2;
-      path.addRRect({
+      b.addRRect({
         rect: { x: bodyLeft, y: badgeY, width: pillBodyW, height: pillH },
         rx: r,
         ry: r,
@@ -132,16 +117,16 @@ export function useBadge(
         const badgeX = w - padding.right + badgeMetrics.dotGap;
         const cx = tl + pillW - r;
 
-        path.moveTo(badgeX + tl, badgeY);
-        path.lineTo(badgeX + cx, badgeY);
-        path.arcToOval(
+        b.moveTo(badgeX + tl, badgeY);
+        b.lineTo(badgeX + cx, badgeY);
+        b.arcToOval(
           { x: badgeX + cx - r, y: badgeY, width: r * 2, height: pillH },
           -90,
           180,
           false,
         );
-        path.lineTo(badgeX + tl, badgeY + pillH);
-        path.cubicTo(
+        b.lineTo(badgeX + tl, badgeY + pillH);
+        b.cubicTo(
           badgeX + badgeMetrics.tailLength + 2,
           badgeY + pillH,
           badgeX + 3,
@@ -149,7 +134,7 @@ export function useBadge(
           badgeX,
           badgeY + r,
         );
-        path.cubicTo(
+        b.cubicTo(
           badgeX + 3,
           badgeY + r - badgeMetrics.tailSpread,
           badgeX + badgeMetrics.tailLength + 2,
@@ -157,9 +142,9 @@ export function useBadge(
           badgeX + tl,
           badgeY,
         );
-        path.close();
+        b.close();
       } else {
-        path.addRRect({
+        b.addRRect({
           rect: { x: bodyLeft, y: badgeY, width: pillW, height: pillH },
           rx: r,
           ry: r,
@@ -199,7 +184,7 @@ export function useBadge(
     const textColor =
       variant === "minimal" ? "rgba(100,100,100,1)" : palette.badgeText;
 
-    return { path, textX, textY, text, bgColor, textColor };
+    return { path: b.detach(), textX, textY, text, bgColor, textColor };
   });
 
   return badge;

--- a/packages/react-native-livechart/src/hooks/useCandlePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useCandlePaths.ts
@@ -1,5 +1,4 @@
-import { Skia, type SkPath } from "@shopify/react-native-skia";
-import { useRef } from "react";
+import { Skia } from "@shopify/react-native-skia";
 import {
   useDerivedValue,
   useFrameCallback,
@@ -12,15 +11,15 @@ import { buildCandleGeometry } from "../draw/candle";
 import type { ChartPadding } from "../draw/line";
 import { lerp } from "../math/lerp";
 import type { CandleMetrics, CandlePoint } from "../types";
+import { usePathBuilder } from "./usePathBuilder";
 
 const CANDLE_WIDTH_LERP_SPEED = 0.08;
 
 /**
- * Persistent candle `SkPath`s — two per geometry slot (up/down bodies + up/down wicks).
- * Each derived value ping-pongs between its pair and mutates the picked path in place
- * so we don't allocate a new JSI-backed `SkPath` per frame. See {@link useChartPaths}
- * for the rationale (this was the primary driver of the iOS memory climb under live
- * ticking).
+ * Candle paths (up/down bodies + up/down wicks). Each is built into a reused
+ * `Skia.PathBuilder` and finalized with `detach()` each frame — a fresh
+ * immutable `SkPath`, so Skia repaints without a per-curve ping-pong and no
+ * mutable `SkPath` is retained across frames.
  */
 export function useCandlePaths(
   engine: SingleEngineState,
@@ -34,36 +33,10 @@ export function useCandlePaths(
   const targetCandleWidth = useDerivedValue(() => candleWidthSecs);
   const displayCandleWidth = useSharedValue(candleWidthSecs);
 
-  const cacheRef = useRef<{
-    upBodiesA: SkPath;
-    upBodiesB: SkPath;
-    downBodiesA: SkPath;
-    downBodiesB: SkPath;
-    upWicksA: SkPath;
-    upWicksB: SkPath;
-    downWicksA: SkPath;
-    downWicksB: SkPath;
-    ubTick: boolean;
-    dbTick: boolean;
-    uwTick: boolean;
-    dwTick: boolean;
-  } | null>(null);
-  if (cacheRef.current === null) {
-    cacheRef.current = {
-      upBodiesA: Skia.Path.Make(),
-      upBodiesB: Skia.Path.Make(),
-      downBodiesA: Skia.Path.Make(),
-      downBodiesB: Skia.Path.Make(),
-      upWicksA: Skia.Path.Make(),
-      upWicksB: Skia.Path.Make(),
-      downWicksA: Skia.Path.Make(),
-      downWicksB: Skia.Path.Make(),
-      ubTick: false,
-      dbTick: false,
-      uwTick: false,
-      dwTick: false,
-    };
-  }
+  const upBodiesBuilder = usePathBuilder();
+  const downBodiesBuilder = usePathBuilder();
+  const upWicksBuilder = usePathBuilder();
+  const downWicksBuilder = usePathBuilder();
 
   useFrameCallback((frameInfo) => {
     "worklet";
@@ -99,68 +72,56 @@ export function useCandlePaths(
 
   /* istanbul ignore next -- worklet */
   const upBodiesPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.ubTick = !cache.ubTick;
-    const path = cache.ubTick ? cache.upBodiesA : cache.upBodiesB;
-    path.reset();
+    const b = upBodiesBuilder.value;
     const { bodies } = geometry.value;
     for (let i = 0; i < bodies.length; i++) {
       if (bodies[i].up) {
-        path.addRect(
+        b.addRect(
           Skia.XYWHRect(bodies[i].x, bodies[i].y, bodies[i].w, bodies[i].h),
         );
       }
     }
-    return path;
+    return b.detach();
   });
 
   /* istanbul ignore next -- worklet */
   const downBodiesPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.dbTick = !cache.dbTick;
-    const path = cache.dbTick ? cache.downBodiesA : cache.downBodiesB;
-    path.reset();
+    const b = downBodiesBuilder.value;
     const { bodies } = geometry.value;
     for (let i = 0; i < bodies.length; i++) {
       if (!bodies[i].up) {
-        path.addRect(
+        b.addRect(
           Skia.XYWHRect(bodies[i].x, bodies[i].y, bodies[i].w, bodies[i].h),
         );
       }
     }
-    return path;
+    return b.detach();
   });
 
   /* istanbul ignore next -- worklet */
   const upWicksPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.uwTick = !cache.uwTick;
-    const path = cache.uwTick ? cache.upWicksA : cache.upWicksB;
-    path.reset();
+    const b = upWicksBuilder.value;
     const { wicks } = geometry.value;
     for (let i = 0; i < wicks.length; i++) {
       if (wicks[i].up) {
-        path.moveTo(wicks[i].x, wicks[i].y1);
-        path.lineTo(wicks[i].x, wicks[i].y2);
+        b.moveTo(wicks[i].x, wicks[i].y1);
+        b.lineTo(wicks[i].x, wicks[i].y2);
       }
     }
-    return path;
+    return b.detach();
   });
 
   /* istanbul ignore next -- worklet */
   const downWicksPath = useDerivedValue(() => {
-    const cache = cacheRef.current!;
-    cache.dwTick = !cache.dwTick;
-    const path = cache.dwTick ? cache.downWicksA : cache.downWicksB;
-    path.reset();
+    const b = downWicksBuilder.value;
     const { wicks } = geometry.value;
     for (let i = 0; i < wicks.length; i++) {
       if (!wicks[i].up) {
-        path.moveTo(wicks[i].x, wicks[i].y1);
-        path.lineTo(wicks[i].x, wicks[i].y2);
+        b.moveTo(wicks[i].x, wicks[i].y1);
+        b.lineTo(wicks[i].x, wicks[i].y2);
       }
     }
-    return path;
+    return b.detach();
   });
 
   return { upBodiesPath, downBodiesPath, upWicksPath, downWicksPath } as const;

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -5,30 +5,29 @@ import type { SingleEngineState } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline, makeSplineScratch } from "../math/spline";
 import { blendPtsY, squigglifyPts } from "../math/squiggly";
+import { usePathBuilder } from "./usePathBuilder";
 
 /**
- * Persistent `linePath` / `fillPath` `SkPath`s that are **mutated in place** each frame.
+ * Builds the `linePath` / `fillPath` with `Skia.PathBuilder`s reused across
+ * frames (one per curve, held in a SharedValue) and finalized with `detach()` —
+ * which returns a fresh immutable `SkPath` each frame and resets the builder.
+ * The fresh reference makes Reanimated notify subscribers (re-record + repaint)
+ * without the two-SkPath ping-pong the mutable-path pool needed.
  *
- * Why not `useDerivedValue(() => Skia.Path.Make())`? Each call would allocate a brand-new
- * JSI-backed `SkPath`, and on iOS the native GC lags the JS GC under a steady firehose —
- * resident memory climbs steadily for as long as the chart is mounted. Here we allocate
- * two paths per curve once and ping-pong the reference each frame so Reanimated's
- * value-equality early-return still fires its subscribers (i.e. the Skia reanimated
- * container re-records and repaints).
+ * The flat point buffer still ping-pongs (ptsA/ptsB) so the intermediate
+ * `flatPts` derived value changes reference each frame and re-runs linePath /
+ * fillPath.
  */
 export function useChartPaths(
   engine: SingleEngineState,
   padding: ChartPadding,
   morphT?: SharedValue<number>,
 ) {
-  // Two persistent paths per curve; ping-pong so the returned reference changes
-  // every frame, which keeps Reanimated's setter from short-circuiting the notify.
+  const lineBuilder = usePathBuilder();
+  const fillBuilder = usePathBuilder();
+
   const cacheRef = useRef<{
-    lineA: SkPath;
-    lineB: SkPath;
-    fillA: SkPath;
-    fillB: SkPath;
-    tick: boolean;
+    emptyPath: SkPath;
     ptsA: number[];
     ptsB: number[];
     ptsTick: boolean;
@@ -36,13 +35,7 @@ export function useChartPaths(
   } | null>(null);
   if (cacheRef.current === null) {
     cacheRef.current = {
-      lineA: Skia.Path.Make(),
-      lineB: Skia.Path.Make(),
-      fillA: Skia.Path.Make(),
-      fillB: Skia.Path.Make(),
-      tick: false,
-      // Ping-pong point buffers: reused across frames but the returned reference
-      // still alternates, so Reanimated keeps notifying linePath/fillPath.
+      emptyPath: Skia.Path.Make(),
       ptsA: [] as number[],
       ptsB: [] as number[],
       ptsTick: false,
@@ -89,32 +82,27 @@ export function useChartPaths(
   const linePath = useDerivedValue(() => {
     const cache = cacheRef.current!;
     const pts = flatPts.get();
-    cache.tick = !cache.tick;
-    const path = cache.tick ? cache.lineA : cache.lineB;
-    path.reset();
     const n = pts.length >> 1;
-    if (n < 2) return path;
-    path.moveTo(pts[0], pts[1]);
-    drawSpline(path, pts, cache.scratch);
-    return path;
+    if (n < 2) return cache.emptyPath;
+    const b = lineBuilder.value;
+    b.moveTo(pts[0], pts[1]);
+    drawSpline(b, pts, cache.scratch);
+    return b.detach();
   });
 
   const fillPath = useDerivedValue(() => {
     const cache = cacheRef.current!;
     const pts = flatPts.get();
-    // Use the same tick flag flipped by linePath — flipping again here would
-    // keep both paths in sync, so just read the current parity.
-    const path = cache.tick ? cache.fillA : cache.fillB;
-    path.reset();
     const n = pts.length >> 1;
-    if (n < 2) return path;
-    path.moveTo(pts[0], pts[1]);
-    drawSpline(path, pts, cache.scratch);
+    if (n < 2) return cache.emptyPath;
+    const b = fillBuilder.value;
+    b.moveTo(pts[0], pts[1]);
+    drawSpline(b, pts, cache.scratch);
     const bottom = engine.canvasHeight.get() - padding.bottom;
-    path.lineTo(pts[(n - 1) * 2], bottom);
-    path.lineTo(pts[0], bottom);
-    path.close();
-    return path;
+    b.lineTo(pts[(n - 1) * 2], bottom);
+    b.lineTo(pts[0], bottom);
+    b.close();
+    return b.detach();
   });
 
   return { linePath, fillPath } as const;

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -5,51 +5,46 @@ import { MAX_MULTI_SERIES } from "../constants";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline, makeSplineScratch } from "../math/spline";
+import { usePathBuilders } from "./usePathBuilder";
 
 /**
- * One derived shared value holding up to `MAX_MULTI_SERIES` Skia paths (unused slots are empty paths).
+ * One derived shared value holding up to `MAX_MULTI_SERIES` Skia paths (unused
+ * slots reuse one cached empty path).
  *
- * Each slot ping-pongs between two persistent `SkPath`s so `MultiSeriesStroke`'s
- * per-slot `useDerivedValue(() => paths.value[index])` sees a fresh reference each
- * tick (otherwise Reanimated's setter short-circuits and Skia never repaints).
- * No new JSI-backed `SkPath` is allocated per frame. See {@link useChartPaths}
- * for the memory rationale.
+ * Each visible series' path is built into a per-slot `Skia.PathBuilder` (reused
+ * across frames via a SharedValue) and finalized with `detach()` — a fresh
+ * immutable `SkPath` per frame, so `MultiSeriesStroke`'s per-slot
+ * `useDerivedValue(() => paths.value[index])` repaints without the two-SkPath
+ * ping-pong. Only visible series allocate a path.
  */
 export function useMultiSeriesLinePaths(
   engine: MultiEngineState,
   padding: ChartPadding,
-): SharedValue<ReturnType<typeof Skia.Path.Make>[]> {
+): SharedValue<SkPath[]> {
+  const builders = usePathBuilders(MAX_MULTI_SERIES);
+
   const poolRef = useRef<{
-    a: SkPath[];
-    b: SkPath[];
-    tick: boolean;
+    empty: SkPath;
     ptsBuf: number[];
     scratch: ReturnType<typeof makeSplineScratch>;
   } | null>(null);
   if (poolRef.current === null) {
-    const a: SkPath[] = [];
-    const b: SkPath[] = [];
-    for (let i = 0; i < MAX_MULTI_SERIES; i++) {
-      a.push(Skia.Path.Make());
-      b.push(Skia.Path.Make());
-    }
-    // One point buffer + spline scratch, reused across slots (built sequentially)
-    // and across frames — no per-frame, per-series array allocation.
-    poolRef.current = { a, b, tick: false, ptsBuf: [] as number[], scratch: makeSplineScratch() };
+    poolRef.current = {
+      empty: Skia.Path.Make(),
+      ptsBuf: [] as number[],
+      scratch: makeSplineScratch(),
+    };
   }
 
   return useDerivedValue(() => {
     const pool = poolRef.current!;
-    pool.tick = !pool.tick;
-    const slots = pool.tick ? pool.a : pool.b;
+    const slots = builders.value;
     const s = engine.series.get();
     const displays = engine.displaySeriesValues.get();
-    const out: ReturnType<typeof Skia.Path.Make>[] = [];
+    const out: SkPath[] = [];
     for (let i = 0; i < MAX_MULTI_SERIES; i++) {
-      const path = slots[i];
-      path.reset();
       if (i >= s.length) {
-        out.push(path);
+        out.push(pool.empty);
         continue;
       }
       const pts = buildLinePoints(
@@ -66,10 +61,13 @@ export function useMultiSeriesLinePaths(
       );
       const n = pts.length >> 1;
       if (n >= 2) {
-        path.moveTo(pts[0], pts[1]);
-        drawSpline(path, pts, pool.scratch);
+        const b = slots[i];
+        b.moveTo(pts[0], pts[1]);
+        drawSpline(b, pts, pool.scratch);
+        out.push(b.detach());
+      } else {
+        out.push(pool.empty);
       }
-      out.push(path);
     }
     return out;
   });

--- a/packages/react-native-livechart/src/hooks/usePathBuilder.ts
+++ b/packages/react-native-livechart/src/hooks/usePathBuilder.ts
@@ -1,0 +1,42 @@
+import { Skia } from "@shopify/react-native-skia";
+import { useMemo } from "react";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
+
+/** A `Skia.PathBuilder` instance (typed without depending on a named export). */
+export type ReanimatedPathBuilder = ReturnType<typeof Skia.PathBuilder.Make>;
+
+/**
+ * A `Skia.PathBuilder` made accessible inside Reanimated worklets.
+ *
+ * Unlike `SkPath`, an `SkPathBuilder` is **not** a Reanimated-shareable host
+ * object: stashing one in a `useRef` and reading it from a `useDerivedValue`
+ * worklet yields `undefined`. Wrapping it in a `SharedValue` is the supported
+ * way to cross the JS→UI boundary, so the builder is created once on the JS
+ * thread and reused every frame on the UI thread.
+ *
+ * Per-frame usage in a worklet:
+ *
+ *   const b = builder.value;
+ *   b.moveTo(x, y); b.lineTo(...);   // emit verbs
+ *   return b.detach();               // fresh immutable SkPath; resets the builder
+ *
+ * `detach()` returns a new `SkPath` and resets the builder for the next frame,
+ * so the returned reference changes every frame and Reanimated notifies
+ * subscribers without the two-path ping-pong the mutable-`SkPath` pool needs.
+ */
+export function usePathBuilder(): SharedValue<ReanimatedPathBuilder> {
+  const builder = useMemo(() => Skia.PathBuilder.Make(), []);
+  return useSharedValue(builder);
+}
+
+/** Like {@link usePathBuilder} but a fixed-length array of builders (e.g. one per series). */
+export function usePathBuilders(
+  count: number,
+): SharedValue<ReanimatedPathBuilder[]> {
+  const builders = useMemo(() => {
+    const arr: ReanimatedPathBuilder[] = [];
+    for (let i = 0; i < count; i++) arr.push(Skia.PathBuilder.Make());
+    return arr;
+  }, [count]);
+  return useSharedValue(builders);
+}

--- a/packages/react-native-livechart/src/math/spline.ts
+++ b/packages/react-native-livechart/src/math/spline.ts
@@ -1,4 +1,3 @@
-import type { SkPath } from "@shopify/react-native-skia";
 import type { LiveChartPoint } from "../types";
 
 /**
@@ -33,7 +32,28 @@ export function makeSplineScratch(): SplineScratch {
  *
  * @see https://github.com/benjitaylor/liveline
  */
-export function drawSpline(path: SkPath, pts: number[], scratch?: SplineScratch) {
+/**
+ * Minimal structural sink for {@link drawSpline}: just the verb-emitting methods
+ * it calls. Both `SkPath` and `SkPathBuilder` satisfy it, so the spline can be
+ * built into either a mutable `SkPath` or a `Skia.PathBuilder`.
+ */
+export type SplinePathSink = {
+  lineTo: (x: number, y: number) => unknown;
+  cubicTo: (
+    c1x: number,
+    c1y: number,
+    c2x: number,
+    c2y: number,
+    x: number,
+    y: number,
+  ) => unknown;
+};
+
+export function drawSpline(
+  path: SplinePathSink,
+  pts: number[],
+  scratch?: SplineScratch,
+) {
   "worklet";
   const n = pts.length >> 1;
   if (n < 2) return;


### PR DESCRIPTION
**Stacked on #93** (needs Skia 2.6.4). Base will retarget to `main` once #93 merges.

## What

Replaces the **pooled mutable-`SkPath` + ping-pong** pattern with **`Skia.PathBuilder` reused via a `SharedValue`**, finalized with `detach()` each frame (new [`usePathBuilder`](packages/react-native-livechart/src/hooks/usePathBuilder.ts) / `usePathBuilders` helpers).

`detach()` returns a fresh immutable `SkPath` every frame, so the two-`SkPath` ping-pong that existed *only* to defeat Reanimated's value-equality short-circuit is gone — **net −150 lines**.

Migrated every per-frame builder: `useChartPaths`, `useMultiSeriesLinePaths`, `useCandlePaths`, `useBadge`, `ValueLineOverlay`, `XAxisOverlay`, `YAxisOverlay`, `MarkerOverlay`, `MultiSeriesValueLines`, `ReferenceLineOverlay`, plus the build-time paths in `markerAtlas`. `drawSpline` is widened to a structural `SplinePathSink` so it accepts a builder; the Jest Skia mock gains a `PathBuilder`.

## Why

`SkPath` is going **immutable** in Skia 3.0 ([path-migration guide](https://shopify.github.io/react-native-skia/docs/shapes/path-migration/)) — `moveTo`/`cubicTo`/`reset` on a rendered path will be removed. `PathBuilder` is the forward-compatible construction API. This is the migration the [`skia-paths` skill (#94)](https://github.com/brandtnewlabs/react-native-livechart/pull/94) describes.

## Gated on on-device profiling

Full method + numbers in [`docs/pathbuilder-perf.md`](docs/pathbuilder-perf.md). iPhone 17 Pro / iOS 26.4, multi-series scene, 90s runs:

| Variant | RSS (90s) | mean CPU | fps |
|---|---|---|---|
| Pooled SkPath + ping-pong (old) | flat ~440 MB | 36.9% | 60/60 |
| PathBuilder reused-via-SharedValue (**this PR**) | flat ~440 MB | 35.2% | 60/60 |

**Findings:** (1) per-frame allocation does **not** leak on 2.6.4 — every variant held flat RSS, contradicting the old pool docstring's premise; (2) reused-builder PathBuilder is **perf-equivalent** to the pool (within noise, same memory, 60fps); (3) **key constraint** — `SkPathBuilder` is *not* a Reanimated-shareable host object, so it must be reused through a `SharedValue`, not a `useRef` (a `useRef` builder throws `"Cannot convert undefined value to object"` inside the worklet). That's exactly what `usePathBuilder` encapsulates.

## Verification

- ✅ typecheck, lint, **699 tests**, coverage thresholds (`usePathBuilder.ts` 100%)
- ✅ On-device render confirmed for **line/fill/badge/value-line/grid/axes**, **candle bodies+wicks**, **multi-series**, **markers+atlas**, **reference lines/bands/off-axis/chevron**, and the **loading→line morph** — all on the iOS 26.4 simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)