### PR TITLE
feat(line): support gradient stroke colors

### DIFF
--- a/app/demo/line.tsx
+++ b/app/demo/line.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
-import type { BadgeConfig, PulseConfig } from "react-native-livechart";
+import type {
+  BadgeConfig,
+  LineConfig,
+  PulseConfig,
+} from "react-native-livechart";
 import { LiveChart } from "react-native-livechart";
+import { StyleSheet, TextInput } from "react-native";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
@@ -11,6 +16,37 @@ import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 export const options = { title: "Line & area" };
 
 type BadgeMode = "on" | "off" | "left" | "minimal" | "noTail" | "customBg";
+
+type LineMode = "default" | "solid" | "gradient" | "tricolor" | "custom";
+
+const LINE_OPTIONS: { value: LineMode; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "solid", label: "Solid" },
+  { value: "gradient", label: "Gradient" },
+  { value: "tricolor", label: "3-color" },
+  { value: "custom", label: "Custom" },
+];
+
+function resolveLine(
+  mode: LineMode,
+  customColors: string[],
+): LineConfig | undefined {
+  switch (mode) {
+    case "solid":
+      return { color: "#ff6b6b" };
+    case "gradient":
+      return { colors: ["#ff6b6b", "#6b6bff"] };
+    case "tricolor":
+      return { colors: ["#ff6b6b", "#6bff6b", "#6b6bff"] };
+    case "custom": {
+      const valid = customColors.filter((c) => c.trim().length > 0);
+      if (valid.length < 2) return undefined;
+      return { colors: valid };
+    }
+    default:
+      return undefined;
+  }
+}
 
 function resolveBadge(mode: BadgeMode): boolean | BadgeConfig {
   switch (mode) {
@@ -57,6 +93,8 @@ const PULSE_OPTIONS: { value: PulseMode; label: string }[] = [
 export default function LineScreen() {
   const [badgeMode, setBadgeMode] = useState<BadgeMode>("on");
   const [pulseMode, setPulseMode] = useState<PulseMode>("on");
+  const [lineMode, setLineMode] = useState<LineMode>("default");
+  const [customColors, setCustomColors] = useState(["#ff6b6b", "#6bff6b"]);
   const [valueLine, setValueLine] = useState(true);
   const [showValue, setShowValue] = useState(false);
   const [valueMomentumColor, setValueMomentumColor] = useState(false);
@@ -84,6 +122,7 @@ export default function LineScreen() {
           value={value}
           accentColor={ACCENT}
           theme={APP_THEME}
+          line={resolveLine(lineMode, customColors)}
           badge={resolveBadge(badgeMode)}
           pulse={resolvePulse(pulseMode)}
           dot={{ show: dots, ring }}
@@ -100,6 +139,47 @@ export default function LineScreen() {
         value={badgeMode}
         onChange={setBadgeMode}
       />
+      <ChipRow
+        label="Line"
+        options={LINE_OPTIONS}
+        value={lineMode}
+        onChange={setLineMode}
+      />
+      {lineMode === "custom" && (
+        <ControlRow label="Gradient colors">
+          {customColors.map((c, i) => (
+            <TextInput
+              key={i}
+              style={styles.colorInput}
+              value={c}
+              onChangeText={(t) =>
+                setCustomColors((prev) => {
+                  const next = [...prev];
+                  next[i] = t;
+                  return next;
+                })
+              }
+              placeholder="#ff0000"
+              placeholderTextColor="#666"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          ))}
+          <TextInput
+            style={styles.colorInput}
+            value=""
+            onChangeText={(t) =>
+              t.trim().length > 0
+                ? setCustomColors((prev) => [...prev, t])
+                : undefined
+            }
+            placeholder="+ add color"
+            placeholderTextColor="#666"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </ControlRow>
+      )}
       <ChipRow
         label="Pulse"
         options={PULSE_OPTIONS}
@@ -132,3 +212,18 @@ export default function LineScreen() {
     </DemoScreen>
   );
 }
+
+const styles = StyleSheet.create({
+  colorInput: {
+    width: 100,
+    height: 36,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#333",
+    backgroundColor: "#1a1a1a",
+    color: "#eee",
+    fontSize: 13,
+    paddingHorizontal: 10,
+    fontFamily: "JetBrainsMono_400Regular",
+  },
+});

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -129,7 +129,7 @@ interface ScrubPointMulti extends ScrubPointCore {
 These are the option shapes accepted by the matching props.
 
 ```ts
-interface LineConfig { width?: number; color?: string }
+interface LineConfig { width?: number; color?: string; colors?: string[] }
 interface GradientConfig { topOpacity?: number; bottomOpacity?: number }
 interface BadgeConfig {
   variant?: "default" | "minimal";

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -289,7 +289,7 @@ function useLiveChartController({
   );
 
   // ── Per-frame derived values ───────────────────────────────────────────
-  const { layoutHeight, onLayout } = useCanvasLayout(engine);
+  const { layoutWidth, layoutHeight, onLayout } = useCanvasLayout(engine);
 
   const { linePath, fillPath } = useChartPaths(
     engine,
@@ -455,6 +455,7 @@ function useLiveChartController({
     gradientBottomColor,
     lineGroupOpacity,
     candleGroupOpacity,
+    layoutWidth,
     onLayout,
     linePath,
     fillPath,
@@ -527,6 +528,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     markersSV,
     emptyText,
     metricsCfg,
+    layoutWidth,
   } = model;
 
   return (
@@ -593,10 +595,18 @@ function ChartStack({ model }: { model: LiveChartModel }) {
           path={linePath}
           style="stroke"
           strokeWidth={strokeWidth}
-          color={lineProp?.color ?? palette.line}
           strokeCap="round"
           strokeJoin="round"
-        />
+          color={lineProp?.color ?? palette.line}
+        >
+          {lineProp?.colors?.length ? (
+            <LinearGradient
+              start={vec(0, 0)}
+              end={vec(layoutWidth, 0)}
+              colors={lineProp.colors}
+            />
+          ) : null}
+        </Path>
       </Group>
 
       {/* Candle bodies/wicks (fades in in candle mode) */}

--- a/packages/react-native-livechart/src/hooks/useCanvasLayout.ts
+++ b/packages/react-native-livechart/src/hooks/useCanvasLayout.ts
@@ -5,18 +5,20 @@ import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 
 /**
  * Track canvas dimensions via `onLayout` and sync them into engine shared values.
- * Returns `{ layoutHeight, onLayout }` — pass `onLayout` to the container View
- * and use `layoutHeight` for conditional rendering (e.g. minimum height guards).
+ * Returns `{ layoutWidth, layoutHeight, onLayout }` — pass `onLayout` to the
+ * container View and use dimensions for conditional rendering or gradient coordinates.
  */
 export function useCanvasLayout(engine: ChartEngineLayout) {
+  const [layoutWidth, setLayoutWidth] = useState(0);
   const [layoutHeight, setLayoutHeight] = useState(0);
 
   const onLayout = (e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
     engine.canvasWidth.set(width);
     engine.canvasHeight.set(height);
+    setLayoutWidth(width);
     setLayoutHeight(height);
   };
 
-  return { layoutHeight, onLayout } as const;
+  return { layoutWidth, layoutHeight, onLayout } as const;
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -142,6 +142,11 @@ export interface LineConfig {
   width?: number;
   /** Line color override. Defaults to palette-derived accent. */
   color?: string;
+  /**
+   * Two or more CSS color strings → horizontal gradient along the stroke
+   * (left → right). Takes precedence over `color` when set.
+   */
+  colors?: string[];
 }
 
 /** Area fill gradient beneath the chart line. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -106,6 +106,20 @@ describe("LiveChart", () => {
     render(<Harness line={{ width: 3, color: "#ff0000" }} />);
   });
 
+  it("accepts LineConfig with gradient colors", () => {
+    render(<Harness line={{ colors: ["#ff0000", "#0000ff"] }} />);
+  });
+
+  it("accepts LineConfig with empty colors array (no gradient)", () => {
+    render(<Harness line={{ colors: [] }} />);
+  });
+
+  it("accepts LineConfig with both color and colors", () => {
+    render(
+      <Harness line={{ color: "#ff0000", colors: ["#00ff00", "#0000ff"] }} />,
+    );
+  });
+
   it("accepts PulseConfig", () => {
     render(<Harness pulse={{ interval: 2000, maxRadius: 30 }} />);
   });

--- a/packages/react-native-livechart/tests/hooks/useCanvasLayout.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useCanvasLayout.test.tsx
@@ -28,6 +28,7 @@ describe("useCanvasLayout", () => {
       } as never);
     });
 
+    expect(result.current.layoutWidth).toBe(320);
     expect(result.current.layoutHeight).toBe(240);
     expect(engine.canvasWidth.value).toBe(320);
     expect(engine.canvasHeight.value).toBe(240);


### PR DESCRIPTION
## What

`LineConfig` gains a new **`colors?: string[]`** field — an array of CSS color
strings applied as a horizontal gradient along the chart line stroke
(left → right). The existing `color?: string` is unchanged, so this is a
**non-breaking, additive** change.

- `color: "#f00"` → solid color (unchanged behavior)
- `colors: ["#f00", "#00f"]` → two-or-more-stop gradient
- `colors` takes precedence over `color` when both are set
- Omit both → palette default (unchanged)

## Why

Charts often use gradient strokes to convey direction, momentum, or multi-zone
semantics (e.g. red → green for sentiment). This wasn't possible with the
solid-color-only `LineConfig.color`. Adding a separate `colors` field (rather
than widening `color` to `string[]`) keeps existing callers working and mirrors
the `GradientConfig.colors` API already used for the area fill.

## Usage

```tsx
// Solid red (unchanged)
<LiveChart line={{ color: "#ff0000" }} />

// Red → blue gradient
<LiveChart line={{ colors: ["#ff0000", "#0000ff"] }} />

// 3-color gradient
<LiveChart line={{ colors: ["#ff0000", "#00ff00", "#0000ff"] }} />

// Default (palette accent, unchanged)
<LiveChart />
```

## Changes

- `types.ts` — adds `LineConfig.colors?: string[]` (existing `color?: string`
  left untouched)
- `useCanvasLayout.ts` — exposes `layoutWidth` (plain React state) alongside
  `layoutHeight`, so the gradient end-point doesn't read a SharedValue during
  render
- `LiveChart.tsx` — renders a Skia `LinearGradient` child on the stroke `Path`
  when `colors` is non-empty, spanning `vec(0, 0) → vec(layoutWidth, 0)`
- `docs/api-reference/types.mdx` — documents the new `colors` field
- `LiveChart.test.tsx` / `useCanvasLayout.test.tsx` — tests for gradient colors,
  empty-array (no gradient), `color` + `colors` together, and `layoutWidth`
- `app/demo/line.tsx` — demo gains gradient presets and custom color inputs
