### PR TITLE
feat: add onGestureStart/onGestureEnd scrub callbacks

### DIFF
--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -1,4 +1,4 @@
-import { TextInput } from "react-native";
+import { Text, TextInput } from "react-native";
 
 import { useState } from "react";
 import { formatTime, LiveChart } from "react-native-livechart";
@@ -48,6 +48,11 @@ export default function ScrubbingScreen() {
   const [styledTooltip, setStyledTooltip] = useState(false);
   const [dimOpacity, setDimOpacity] = useState(0.3);
   const [holdToScrub, setHoldToScrub] = useState(false);
+  // onGestureStart/onGestureEnd are JS-thread callbacks, so plain React state
+  // is fine here (they fire once per gesture, not once per pointer move).
+  const [gestureState, setGestureState] = useState<"idle" | "scrubbing…">(
+    "idle",
+  );
   // Press-and-hold delay: lets a quick horizontal swipe pass through to a
   // navigator's swipe-back gesture instead of scrubbing.
   const panGestureDelay = holdToScrub ? 250 : 0;
@@ -114,6 +119,8 @@ export default function ScrubbingScreen() {
           theme={APP_THEME}
           timeWindow={windowSecs}
           scrub={scrub}
+          onGestureStart={() => setGestureState("scrubbing…")}
+          onGestureEnd={() => setGestureState("idle")}
           onScrub={(point) => {
             "worklet";
             if (point === null) {
@@ -132,6 +139,8 @@ export default function ScrubbingScreen() {
         />
       }
     >
+      <Text style={demoStyles.scrubReadout}>Gesture: {gestureState}</Text>
+
       <AnimatedTextInput
         editable={false}
         multiline

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -51,6 +51,16 @@ accepts all the shared theming, axis, range, layout, and text props from
   Includes a per-series value array. See [Scrubbing](/guides/scrubbing).
 </ParamField>
 
+<ParamField body="onGestureStart" type="() => void">
+  JS-thread callback fired once when the user starts scrubbing. Respects
+  `scrub.panGestureDelay` (it fires when the pan activates, not on first touch).
+</ParamField>
+
+<ParamField body="onGestureEnd" type="() => void">
+  JS-thread callback fired once when the user stops scrubbing. Fires only if a
+  scrub actually started — a tap that never activates emits neither callback.
+</ParamField>
+
 ## Degen
 
 <ParamField body="degen" type="boolean | DegenOptions">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -124,6 +124,16 @@ provided; everything else has a default.
   Fires while scrubbing; `null` when it ends.
 </ParamField>
 
+<ParamField body="onGestureStart" type="() => void">
+  JS-thread callback fired once when the user starts scrubbing. Respects
+  `scrub.panGestureDelay` (it fires when the pan activates, not on first touch).
+</ParamField>
+
+<ParamField body="onGestureEnd" type="() => void">
+  JS-thread callback fired once when the user stops scrubbing. Fires only if a
+  scrub actually started — a tap that never activates emits neither callback.
+</ParamField>
+
 ## Axes, grid & range
 
 <ParamField body="xAxis" type="boolean | XAxisConfig" default="true">

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -84,6 +84,32 @@ thread**, so you can call React `setState` directly:
 />
 ```
 
+## Gesture lifecycle (`onGestureStart` / `onGestureEnd`)
+
+`onGestureStart` and `onGestureEnd` fire once at the edges of a scrub — on both `LiveChart` and
+`LiveChartSeries`. Unlike `onScrub`, they're plain **JS-thread** functions (not worklets), so a
+regular `useState` is fine:
+
+```tsx
+import { useState } from "react";
+
+const [scrubbing, setScrubbing] = useState(false);
+
+<LiveChart
+  data={data}
+  value={value}
+  onGestureStart={() => setScrubbing(true)}
+  onGestureEnd={() => setScrubbing(false)}
+/>;
+```
+
+`onGestureStart` fires when the pan **activates** — so it respects `scrub.panGestureDelay` and only
+fires once the press-and-hold threshold is met. `onGestureEnd` fires only if a scrub actually
+started; a quick tap that never activates emits neither callback.
+
+They pair well with side effects you want to bracket around an interaction — fire a haptic on start,
+or pause a live feed while the user inspects history and resume it on end.
+
 ## Multi-series scrub (worklet)
 
 For `LiveChartSeries`, `onScrub` is a **worklet** that runs on the UI thread each frame with a

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -147,6 +147,8 @@ function useLiveChartController({
 
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
+  onGestureStart,
+  onGestureEnd,
   onDegenShake,
 }: LiveChartProps) {
   const emptyTradeStream = useSharedValue<TradeEvent[]>([]);
@@ -377,6 +379,8 @@ function useLiveChartController({
     onScrub,
     candleOpts,
     scrubCfg?.panGestureDelay ?? 0,
+    onGestureStart,
+    onGestureEnd,
   );
 
   const markersActive = markers != null;

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -127,6 +127,8 @@ function useLiveChartSeriesController({
   metrics,
   scrub = true,
   onScrub,
+  onGestureStart,
+  onGestureEnd,
   onSeriesToggle,
   dot: dotProp,
   legend: legendProp,
@@ -307,6 +309,8 @@ function useLiveChartSeriesController({
     scrubEnabled,
     onScrub,
     scrubCfg?.panGestureDelay ?? 0,
+    onGestureStart,
+    onGestureEnd,
   );
 
   // `projected` is used internally by the hit-test gesture; the overlay

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -57,9 +57,14 @@ export function useCrosshair(
   candleOpts?: CrosshairCandleOpts,
   /** Press-and-hold delay (ms) before scrubbing activates. 0 = immediate. */
   panGestureDelay = 0,
+  onGestureStart?: () => void,
+  onGestureEnd?: () => void,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
+  // Tracks whether the active scrub phase actually began, so a tap that never
+  // activates doesn't emit a spurious onGestureEnd.
+  const gestureStarted = useSharedValue(false);
 
   const scrubTime = useDerivedValue(() =>
     computeScrubTime(
@@ -165,7 +170,19 @@ export function useCrosshair(
     onScrub?.(null);
   }
 
+  /* istanbul ignore next */
+  function handleGestureStart() {
+    onGestureStart?.();
+  }
+
+  /* istanbul ignore next */
+  function handleGestureEnd() {
+    onGestureEnd?.();
+  }
+
   const hasOnScrub = onScrub != null;
+  const hasOnGestureStart = onGestureStart != null;
+  const hasOnGestureEnd = onGestureEnd != null;
 
   useAnimatedReaction(
     () => {
@@ -229,6 +246,8 @@ export function useCrosshair(
         if (!enabled) return;
         scrubX.set(e.x);
         scrubActive.set(true);
+        gestureStarted.set(true);
+        if (hasOnGestureStart) scheduleOnRN(handleGestureStart);
       },
     )
     .onUpdate(
@@ -243,6 +262,10 @@ export function useCrosshair(
         "worklet";
         scrubActive.set(false);
         if (hasOnScrub) scheduleOnRN(handleScrubEnd);
+        if (gestureStarted.get()) {
+          gestureStarted.set(false);
+          if (hasOnGestureEnd) scheduleOnRN(handleGestureEnd);
+        }
       },
     );
 

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -5,6 +5,7 @@ import {
   useDerivedValue,
   useSharedValue,
 } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 import { type ChartPadding } from "../draw/line";
 import type { ScrubPointMulti } from "../types";
@@ -30,9 +31,14 @@ export function useCrosshairSeries(
   onScrub?: (point: ScrubPointMulti | null) => void,
   /** Press-and-hold delay (ms) before scrubbing activates. 0 = immediate. */
   panGestureDelay = 0,
+  onGestureStart?: () => void,
+  onGestureEnd?: () => void,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
+  // Tracks whether the active scrub phase actually began, so a tap that never
+  // activates doesn't emit a spurious onGestureEnd.
+  const gestureStarted = useSharedValue(false);
 
   const scrubTime = useDerivedValue(() =>
     computeScrubTime(
@@ -64,7 +70,19 @@ export function useCrosshairSeries(
 
   const tooltipLayout = useSharedValue(HIDDEN_TOOLTIP);
 
+  /* istanbul ignore next */
+  function handleGestureStart() {
+    onGestureStart?.();
+  }
+
+  /* istanbul ignore next */
+  function handleGestureEnd() {
+    onGestureEnd?.();
+  }
+
   const hasOnScrub = onScrub != null;
+  const hasOnGestureStart = onGestureStart != null;
+  const hasOnGestureEnd = onGestureEnd != null;
 
   useAnimatedReaction(
     () => {
@@ -136,6 +154,8 @@ export function useCrosshairSeries(
         if (!enabled) return;
         scrubX.set(e.x);
         scrubActive.set(true);
+        gestureStarted.set(true);
+        if (hasOnGestureStart) scheduleOnRN(handleGestureStart);
       },
     )
     .onUpdate(
@@ -149,6 +169,10 @@ export function useCrosshairSeries(
       /* istanbul ignore next */ () => {
         "worklet";
         scrubActive.set(false);
+        if (gestureStarted.get()) {
+          gestureStarted.set(false);
+          if (hasOnGestureEnd) scheduleOnRN(handleGestureEnd);
+        }
       },
     );
 

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -737,6 +737,10 @@ export interface LiveChartCoreProps {
   accessibilityRole?: "image" | "none" | "adjustable" | "summary";
   /** Crosshair scrubbing on hover/drag. `true` = defaults, `false` = disabled, or pass `ScrubConfig`. Default `true`. */
   scrub?: boolean | ScrubConfig;
+  /** Called once when the user starts scrubbing/panning the chart. */
+  onGestureStart?: () => void;
+  /** Called once when the user stops scrubbing/panning the chart. */
+  onGestureEnd?: () => void;
   /**
    * Fade out chart content on the left (destination-out style). `true` = defaults, `false` = off,
    * or pass `LeftEdgeFadeConfig`. Default `true`.

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -462,6 +462,34 @@ describe("useCrosshair (hook)", () => {
     expect(result.current.scrubActive.value).toBe(false);
   });
 
+  it("accepts onGestureStart/onGestureEnd and still returns a gesture", () => {
+    const onGestureStart = jest.fn();
+    const onGestureEnd = jest.fn();
+    const engine = makeEngine();
+    const { result } = renderHook(() =>
+      useCrosshair(
+        engine,
+        padding,
+        palette,
+        formatValue,
+        formatTime,
+        font,
+        true,
+        undefined, // onScrub
+        undefined, // candleOpts
+        0, // panGestureDelay
+        onGestureStart,
+        onGestureEnd,
+      ),
+    );
+    expect(result.current.gesture).toBeDefined();
+    expect(result.current.scrubActive.value).toBe(false);
+    // Callbacks fire only from the UI-thread gesture worklets (istanbul-ignored),
+    // so nothing is invoked at render time.
+    expect(onGestureStart).not.toHaveBeenCalled();
+    expect(onGestureEnd).not.toHaveBeenCalled();
+  });
+
   it("uses Android pan minDistance when Platform.OS is android", () => {
     const prev = Platform.OS;
     Object.defineProperty(Platform, "OS", {

--- a/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
@@ -325,6 +325,40 @@ describe("useCrosshairSeries (hook)", () => {
     expect(result.current.scrubActive.value).toBe(false);
   });
 
+  it("accepts onGestureStart/onGestureEnd and still returns a gesture", () => {
+    const onGestureStart = jest.fn();
+    const onGestureEnd = jest.fn();
+    const engine = makeEngine({
+      series: {
+        value: [
+          {
+            id: "a",
+            data: [{ time: 1_700_000_000, value: 5 }],
+            value: 5,
+            color: "#00f",
+          },
+        ],
+      },
+    });
+    const { result } = renderHook(() =>
+      useCrosshairSeries(
+        engine,
+        padding,
+        true,
+        undefined, // onScrub
+        0, // panGestureDelay
+        onGestureStart,
+        onGestureEnd,
+      ),
+    );
+    expect(result.current.gesture).toBeDefined();
+    expect(result.current.scrubActive.value).toBe(false);
+    // Callbacks fire only from the UI-thread gesture worklets (istanbul-ignored),
+    // so nothing is invoked at render time.
+    expect(onGestureStart).not.toHaveBeenCalled();
+    expect(onGestureEnd).not.toHaveBeenCalled();
+  });
+
   it("uses Android pan minDistance when Platform.OS is android", () => {
     const prev = Platform.OS;
     Object.defineProperty(Platform, "OS", {


### PR DESCRIPTION
Mirrors react-native-graph's gesture callbacks. Fires once when scrubbing starts (pan onStart, after the enabled guard) and once when it ends (onFinalize), guarded by a gestureStarted flag so taps that never activate don't emit a spurious end. Added to LiveChartCoreProps so both LiveChart and LiveChartSeries expose them; threaded through useCrosshair and useCrosshairSeries. Demo: scrubbing screen shows live gesture state.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>