### PR TITLE
feat: support custom multi-color gradient fill (gradientFillColors)

### DIFF
--- a/app/demo/theming.tsx
+++ b/app/demo/theming.tsx
@@ -32,12 +32,20 @@ const THEME_OPTIONS: { value: "dark" | "light"; label: string }[] = [
 
 const ACCENT_OPTIONS = ACCENT_PRESETS.map((c) => ({ value: c, label: c }));
 
-type GradientMode = "on" | "off" | "custom";
+type GradientMode = "on" | "off" | "custom" | "multi";
 
 const GRADIENT_OPTIONS: { value: GradientMode; label: string }[] = [
   { value: "on", label: "On" },
   { value: "off", label: "Off" },
   { value: "custom", label: "Custom opacity" },
+  { value: "multi", label: "Multi-color" },
+];
+
+/** A 3-stop area fill (accent → violet → transparent). */
+const MULTI_GRADIENT_COLORS = [
+  "rgba(51,35,230,0.45)",
+  "rgba(168,85,247,0.25)",
+  "rgba(168,85,247,0)",
 ];
 
 const FONT_SIZE_OPTIONS = FONT_SIZES.map((s) => ({
@@ -61,6 +69,7 @@ export default function ThemingScreen() {
   const [accent, setAccent] = useState(ACCENT_PRESETS[0]);
   const [gradientOn, setGradientOn] = useState(true);
   const [gradientCfg, setGradientCfg] = useState(false);
+  const [gradientMulti, setGradientMulti] = useState(false);
   const [lineWide, setLineWide] = useState(false);
   const [lineColor, setLineColor] = useState(false);
   const [fontSize, setFontSize] = useState(11);
@@ -73,12 +82,15 @@ export default function ThemingScreen() {
 
   const gradientMode: GradientMode = !gradientOn
     ? "off"
-    : gradientCfg
-      ? "custom"
-      : "on";
+    : gradientMulti
+      ? "multi"
+      : gradientCfg
+        ? "custom"
+        : "on";
   const setGradientMode = (mode: GradientMode) => {
     setGradientOn(mode !== "off");
     setGradientCfg(mode === "custom");
+    setGradientMulti(mode === "multi");
   };
 
   const { data, value } = useSimulatedChartData({
@@ -103,7 +115,11 @@ export default function ThemingScreen() {
           accentColor={accent}
           theme={theme}
           gradient={
-            gradientCfg ? { topOpacity: 0.5, bottomOpacity: 0.05 } : gradientOn
+            gradientMulti
+              ? { colors: MULTI_GRADIENT_COLORS }
+              : gradientCfg
+                ? { topOpacity: 0.5, bottomOpacity: 0.05 }
+                : gradientOn
           }
           line={
             lineWide || lineColor

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -46,7 +46,9 @@ provided; everything else has a default.
 </ParamField>
 
 <ParamField body="gradient" type="boolean | GradientConfig" default="true">
-  Area fill under the line.
+  Area fill under the line. Pass a `GradientConfig` with `colors` (≥ 2 stops, top
+  → bottom) for a custom multi-color fill; otherwise the fill is derived from the
+  accent color.
 </ParamField>
 
 <ParamField body="badge" type="boolean | BadgeConfig" default="true">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -130,7 +130,14 @@ These are the option shapes accepted by the matching props.
 
 ```ts
 interface LineConfig { width?: number; color?: string }
-interface GradientConfig { topOpacity?: number; bottomOpacity?: number }
+interface GradientConfig {
+  topOpacity?: number;    // accent-derived top fill opacity
+  bottomOpacity?: number; // accent-derived bottom fill opacity
+  colors?: string[];      // explicit gradient stops (top → bottom), ≥ 2 entries;
+                          //   overrides topOpacity/bottomOpacity when provided
+  positions?: number[];   // optional stop positions (0..1, ascending), same
+                          //   length as colors; ignored if the lengths differ
+}
 interface BadgeConfig {
   variant?: "default" | "minimal";
   tail?: boolean;

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -49,6 +49,24 @@ Common keys include `line`, `fillTop` / `fillBottom`, `gridLine` / `gridLabel`,
 `crosshairLine`, and `tooltipBg` / `tooltipText`. See the [types reference](/api-reference/types)
 for the full `LiveChartPalette`.
 
+## Gradient fill
+
+The area under the line is filled with a gradient. By default it's derived from the accent color
+(`gradient.topOpacity` / `gradient.bottomOpacity`). For full control, pass explicit `colors` (top →
+bottom, at least two stops):
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  gradient={{ colors: ["rgba(51,35,230,0.45)", "rgba(168,85,247,0.25)", "rgba(168,85,247,0)"] }}
+/>
+```
+
+Omitting `colors` falls back to the accent-derived top/bottom opacity. Custom `colors` are
+single-series only — multi-series lines have no area fill. See the [`GradientConfig`
+reference](/api-reference/types) for `positions` and the opacity fields.
+
 ## Sizing and motion tokens
 
 Where `palette` controls _color_, `metrics` controls _shape_ (badge geometry, candle bounds) and

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -410,6 +410,8 @@ function useLiveChartController({
     gradientEnd,
     gradientTopColor,
     gradientBottomColor,
+    gradientColors,
+    gradientPositions,
   } = useChartColors(
     palette,
     gradientCfg,
@@ -460,6 +462,8 @@ function useLiveChartController({
     gradientEnd,
     gradientTopColor,
     gradientBottomColor,
+    gradientColors,
+    gradientPositions,
     lineGroupOpacity,
     candleGroupOpacity,
     onLayout,
@@ -510,8 +514,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     gradientCfg,
     fillPath,
     gradientEnd,
-    gradientTopColor,
-    gradientBottomColor,
+    gradientColors,
+    gradientPositions,
     valueLineCfg,
     dotY,
     allRefLines,
@@ -565,7 +569,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
             <LinearGradient
               start={vec(0, effectivePadding.top)}
               end={vec(0, gradientEnd)}
-              colors={[gradientTopColor, gradientBottomColor]}
+              colors={gradientColors}
+              positions={gradientPositions}
             />
           </Path>
         </Group>

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -84,6 +84,10 @@ export interface ResolvedGradientConfig {
   topOpacity: number | undefined;
   /** undefined → use palette.fillBottom (transparent) at render time */
   bottomOpacity: number | undefined;
+  /** Explicit color stops (top → bottom); overrides the opacity stops. */
+  colors: string[] | undefined;
+  /** Stop positions (0..1) matching `colors` length. */
+  positions: number[] | undefined;
 }
 
 export interface ResolvedPulseConfig {
@@ -259,6 +263,8 @@ export function resolveScrub(
 const GRADIENT_DEFAULTS: ResolvedGradientConfig = {
   topOpacity: undefined,
   bottomOpacity: undefined,
+  colors: undefined,
+  positions: undefined,
 };
 
 /**

--- a/packages/react-native-livechart/src/hooks/useChartColors.ts
+++ b/packages/react-native-livechart/src/hooks/useChartColors.ts
@@ -12,6 +12,11 @@ export interface ChartColors {
   gradientTopColor: string;
   /** Bottom gradient stop — custom opacity or palette default. */
   gradientBottomColor: string;
+  /** Gradient color stops (top → bottom). Custom `colors` when provided, else the
+   *  2-stop `[gradientTopColor, gradientBottomColor]` fallback. */
+  gradientColors: string[];
+  /** Stop positions matching `gradientColors`, or undefined for even spacing. */
+  gradientPositions: number[] | undefined;
 }
 
 /**
@@ -39,10 +44,24 @@ export function useChartColors(
       ? `rgba(${r}, ${g}, ${b}, ${gradientCfg.bottomOpacity})`
       : palette.fillBottom;
 
+  const customColors = gradientCfg?.colors;
+  const hasCustomColors = Array.isArray(customColors) && customColors.length >= 2;
+  const gradientColors = hasCustomColors
+    ? customColors
+    : [gradientTopColor, gradientBottomColor];
+  const gradientPositions =
+    hasCustomColors &&
+    gradientCfg?.positions !== undefined &&
+    gradientCfg.positions.length === customColors.length
+      ? gradientCfg.positions
+      : undefined;
+
   return {
     backgroundColor,
     gradientEnd,
     gradientTopColor,
     gradientBottomColor,
+    gradientColors,
+    gradientPositions,
   };
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -151,6 +151,11 @@ export interface GradientConfig {
   topOpacity?: number;
   /** Opacity at the bottom of the gradient. Default `0`. */
   bottomOpacity?: number;
+  /** Explicit gradient color stops (top → bottom) for the area fill. Overrides
+   *  topOpacity/bottomOpacity when provided. Must have at least 2 entries. */
+  colors?: string[];
+  /** Optional stop positions (0..1, ascending) matching `colors` length. */
+  positions?: number[];
 }
 
 /** Value badge pill configuration. */

--- a/packages/react-native-livechart/tests/hooks/useChartColors.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useChartColors.test.ts
@@ -25,7 +25,12 @@ describe("useChartColors", () => {
     const { result } = renderHook(() =>
       useChartColors(
         palette,
-        { topOpacity: undefined, bottomOpacity: undefined },
+        {
+          topOpacity: undefined,
+          bottomOpacity: undefined,
+          colors: undefined,
+          positions: undefined,
+        },
         "#3b82f6",
         300,
         DEFAULT_PADDING,
@@ -39,7 +44,12 @@ describe("useChartColors", () => {
     const { result } = renderHook(() =>
       useChartColors(
         palette,
-        { topOpacity: 0.5, bottomOpacity: undefined },
+        {
+          topOpacity: 0.5,
+          bottomOpacity: undefined,
+          colors: undefined,
+          positions: undefined,
+        },
         "#3b82f6",
         300,
         DEFAULT_PADDING,
@@ -53,7 +63,12 @@ describe("useChartColors", () => {
     const { result } = renderHook(() =>
       useChartColors(
         palette,
-        { topOpacity: undefined, bottomOpacity: 0.05 },
+        {
+          topOpacity: undefined,
+          bottomOpacity: 0.05,
+          colors: undefined,
+          positions: undefined,
+        },
         "#3b82f6",
         300,
         DEFAULT_PADDING,
@@ -68,5 +83,96 @@ describe("useChartColors", () => {
       useChartColors(palette, null, "#3b82f6", 0, DEFAULT_PADDING),
     );
     expect(result.current.gradientEnd).toBe(1);
+  });
+
+  it("falls back to a 2-stop gradient array when no custom colors", () => {
+    const { result } = renderHook(() =>
+      useChartColors(palette, null, "#3b82f6", 300, DEFAULT_PADDING),
+    );
+    expect(result.current.gradientColors).toEqual([
+      result.current.gradientTopColor,
+      result.current.gradientBottomColor,
+    ]);
+    expect(result.current.gradientPositions).toBeUndefined();
+  });
+
+  it("uses custom multi-color stops when colors has ≥2 entries", () => {
+    const colors = ["rgba(51,35,230,0.45)", "rgba(168,85,247,0.25)", "rgba(0,0,0,0)"];
+    const { result } = renderHook(() =>
+      useChartColors(
+        palette,
+        {
+          topOpacity: undefined,
+          bottomOpacity: undefined,
+          colors,
+          positions: undefined,
+        },
+        "#3b82f6",
+        300,
+        DEFAULT_PADDING,
+      ),
+    );
+    expect(result.current.gradientColors).toBe(colors);
+    expect(result.current.gradientPositions).toBeUndefined();
+  });
+
+  it("ignores a single-entry colors array (falls back to 2-stop)", () => {
+    const { result } = renderHook(() =>
+      useChartColors(
+        palette,
+        {
+          topOpacity: undefined,
+          bottomOpacity: undefined,
+          colors: ["rgba(51,35,230,0.45)"],
+          positions: undefined,
+        },
+        "#3b82f6",
+        300,
+        DEFAULT_PADDING,
+      ),
+    );
+    expect(result.current.gradientColors).toEqual([
+      result.current.gradientTopColor,
+      result.current.gradientBottomColor,
+    ]);
+  });
+
+  it("keeps positions when their length matches colors", () => {
+    const colors = ["#fff", "#000"];
+    const positions = [0, 1];
+    const { result } = renderHook(() =>
+      useChartColors(
+        palette,
+        {
+          topOpacity: undefined,
+          bottomOpacity: undefined,
+          colors,
+          positions,
+        },
+        "#3b82f6",
+        300,
+        DEFAULT_PADDING,
+      ),
+    );
+    expect(result.current.gradientColors).toBe(colors);
+    expect(result.current.gradientPositions).toBe(positions);
+  });
+
+  it("drops positions when their length does not match colors", () => {
+    const { result } = renderHook(() =>
+      useChartColors(
+        palette,
+        {
+          topOpacity: undefined,
+          bottomOpacity: undefined,
+          colors: ["#fff", "#888", "#000"],
+          positions: [0, 1],
+        },
+        "#3b82f6",
+        300,
+        DEFAULT_PADDING,
+      ),
+    );
+    expect(result.current.gradientPositions).toBeUndefined();
   });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -268,6 +268,8 @@ describe("resolveGradient", () => {
     expect(resolveGradient(true)).toEqual({
       topOpacity: undefined,
       bottomOpacity: undefined,
+      colors: undefined,
+      positions: undefined,
     });
   });
 
@@ -275,6 +277,8 @@ describe("resolveGradient", () => {
     expect(resolveGradient({ topOpacity: 0.25 })).toEqual({
       topOpacity: 0.25,
       bottomOpacity: undefined,
+      colors: undefined,
+      positions: undefined,
     });
   });
 
@@ -282,6 +286,38 @@ describe("resolveGradient", () => {
     expect(resolveGradient({ topOpacity: 0.3, bottomOpacity: 0.05 })).toEqual({
       topOpacity: 0.3,
       bottomOpacity: 0.05,
+      colors: undefined,
+      positions: undefined,
+    });
+  });
+
+  it("preserves explicit color stops", () => {
+    const colors = ["rgba(0,0,0,0.4)", "rgba(0,0,0,0.1)", "rgba(0,0,0,0)"];
+    expect(resolveGradient({ colors })).toEqual({
+      topOpacity: undefined,
+      bottomOpacity: undefined,
+      colors,
+      positions: undefined,
+    });
+  });
+
+  it("preserves color stops with positions", () => {
+    const colors = ["#fff", "#000"];
+    const positions = [0, 1];
+    expect(resolveGradient({ colors, positions })).toEqual({
+      topOpacity: undefined,
+      bottomOpacity: undefined,
+      colors,
+      positions,
+    });
+  });
+
+  it("leaves colors/positions undefined for an opacity-only object", () => {
+    expect(resolveGradient({ topOpacity: 0.5 })).toEqual({
+      topOpacity: 0.5,
+      bottomOpacity: undefined,
+      colors: undefined,
+      positions: undefined,
     });
   });
 });


### PR DESCRIPTION
GradientConfig gains colors?: string[] (+ optional positions?: number[]), mirroring react-native-graph's gradientFillColors. useChartcolors returns a gradientColors array (the custom stops when >= 2 are given, else the existing 2-stop top/bottom fallback) and gradientPositions (kept only when length matches). LiveChart's fill LinearGradient consumes both. Single-series only — multi-series render no area fill. Demo: theming screen adds a Multi-color gradient option.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>