### PR TITLE
feat: add topLabel/bottomLabel axis labels

### DIFF
--- a/app/demo/axes-grid.tsx
+++ b/app/demo/axes-grid.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
-import { LiveChart, LiveChartSeries } from "react-native-livechart";
+import { Text } from "react-native";
+import {
+  LiveChart,
+  LiveChartSeries,
+  type AxisLabelConfig,
+} from "react-native-livechart";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
-import { ChipRow } from "../../demo-lib/ChipRow";
+import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { ACCENT } from "../../demo-lib/shared";
+import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
@@ -34,6 +40,8 @@ export default function AxesGridScreen() {
   const [vis, setVis] = useState<AxisVis>("both");
   const [gap, setGap] = useState<GapPreset>("default");
   const [which, setWhich] = useState<ChartKind>("single");
+  const [highLow, setHighLow] = useState(false);
+  const [customLabel, setCustomLabel] = useState(false);
 
   const yOn = vis !== "noY" && vis !== "none";
   const xOn = vis !== "noX" && vis !== "none";
@@ -51,11 +59,24 @@ export default function AxesGridScreen() {
     historyRange: "1m",
   });
 
+  // Built-in high/low labels: the chart floats its current top / bottom Y-axis
+  // bound at each edge, formatted and updated on the UI thread — no hand-rolled
+  // animated text needed. A `render` escape hatch demos a fully custom element.
+  const customTop: AxisLabelConfig = {
+    render: () => <Text style={[demoStyles.scrubReadout, { marginBottom: 0 }]}>HIGH</Text>,
+  };
+  const customBottom: AxisLabelConfig = {
+    render: () => <Text style={[demoStyles.scrubReadout, { marginBottom: 0 }]}>LOW</Text>,
+  };
+
+  const topLabel = customLabel ? customTop : highLow ? true : undefined;
+  const bottomLabel = customLabel ? customBottom : highLow ? true : undefined;
+
   return (
     <DemoScreen
       title="Axes & grid"
       docs="guides/theming"
-      description="Hide Y, X, or both; axis minGap. Toggle single vs multi chart."
+      description="Hide Y, X, or both; axis minGap. Toggle single vs multi chart, and Robinhood-style high/low edge labels (built-in or a custom render)."
       chart={
         which === "single" ? (
           <LiveChart
@@ -66,6 +87,8 @@ export default function AxesGridScreen() {
             yAxis={yAxis}
             xAxis={xAxis}
             scrub
+            topLabel={topLabel}
+            bottomLabel={bottomLabel}
           />
         ) : (
           <LiveChartSeries
@@ -75,6 +98,8 @@ export default function AxesGridScreen() {
             yAxis={yAxis}
             xAxis={xAxis}
             scrub
+            topLabel={topLabel}
+            bottomLabel={bottomLabel}
           />
         )
       }
@@ -97,6 +122,18 @@ export default function AxesGridScreen() {
         value={gap}
         onChange={setGap}
       />
+      <ControlRow label="Axis labels">
+        <ToggleChip
+          label="Built-in high / low"
+          value={highLow}
+          onChange={setHighLow}
+        />
+        <ToggleChip
+          label="Custom render"
+          value={customLabel}
+          onChange={setCustomLabel}
+        />
+      </ControlRow>
     </DemoScreen>
   );
 }

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -19,6 +19,23 @@ accepts all the shared theming, axis, range, layout, and text props from
   Array of series definitions. Read on the UI thread. See [`SeriesConfig`](/api-reference/types).
 </ParamField>
 
+## Axis labels
+
+Shared with [`LiveChart`](/api-reference/livechart#axes-grid-range). Both
+default off.
+
+<ParamField body="topLabel" type="boolean | AxisLabelConfig" default="false">
+  Edge label at the plot's top. `true` shows the built-in value label — the
+  chart's current top Y-axis bound, updated each frame. Pass
+  [`AxisLabelConfig`](/api-reference/types#axislabelconfig) (`format` / `color` /
+  `position`) or `{ render }` for a custom element.
+</ParamField>
+
+<ParamField body="bottomLabel" type="boolean | AxisLabelConfig" default="false">
+  Edge label at the plot's bottom (the current bottom Y-axis bound), with the
+  same options as `topLabel`.
+</ParamField>
+
 ## Legend
 
 <ParamField body="legend" type="boolean | LegendConfig" default="true">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -152,6 +152,20 @@ provided; everything else has a default.
   Value-axis grid + labels.
 </ParamField>
 
+<ParamField body="topLabel" type="boolean | AxisLabelConfig" default="false">
+  Edge label floated at the plot's **top**. `true` shows the built-in value
+  label — the chart's current top Y-axis bound, formatted and updated each frame
+  (Robinhood-style high). Pass [`AxisLabelConfig`](/api-reference/types#axislabelconfig)
+  to set `format` / `color` / `position`, or `{ render }` to float a fully custom
+  element instead. See [Axis labels](/guides/theming#axis-edge-labels).
+</ParamField>
+
+<ParamField body="bottomLabel" type="boolean | AxisLabelConfig" default="false">
+  Edge label floated at the plot's **bottom**. `true` shows the built-in value
+  label — the chart's current bottom Y-axis bound (the low) — with the same
+  `AxisLabelConfig` knobs and `render` escape hatch as `topLabel`.
+</ParamField>
+
 <ParamField body="gridStyle" type="GridStyleConfig">
   Grid-line color / width / dash / opacity.
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -170,6 +170,13 @@ interface SelectionDotConfig {
 interface GridStyleConfig { color?: string; strokeWidth?: number; intervals?: number[]; opacity?: number }
 interface YAxisConfig { minGap?: number } // default 36
 interface XAxisConfig { minGap?: number } // default 60
+// Edge label (topLabel / bottomLabel). Default off — both opt-in.
+interface AxisLabelConfig {
+  format?: (v: number) => string; // built-in value formatter; defaults to formatValue
+  color?: string;                 // text color; defaults to palette.gridLabel (muted)
+  position?: "left" | "right";    // alignment within the plot width; default "right"
+  render?: () => React.ReactElement | null; // custom element; overrides the built-in value
+}
 interface ChartInsets { top?: number; right?: number; bottom?: number; left?: number }
 interface LeftEdgeFadeConfig { width?: number; startColor?: string; endColor?: string }
 
@@ -204,6 +211,17 @@ interface FontConfig {
   fontManager?: SkFontMgr | null;
 }
 ```
+
+## AxisLabelConfig
+
+Shape for the `topLabel` / `bottomLabel` props. Both are opt-in (default off).
+With `true`, the chart floats its current top (`topLabel`) / bottom
+(`bottomLabel`) Y-axis bound at that edge, formatted with `format` (falling back
+to the chart's `formatValue`) in `color` (falling back to the muted
+`palette.gridLabel`), aligned by `position`. The values track the live Y-axis
+range each frame on the UI thread. Set `render` to float a fully custom element
+at the edge instead of the built-in value. See
+[Axis labels](/guides/theming#axis-edge-labels).
 
 ## SelectionDotProps
 

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -114,6 +114,44 @@ The five namespaces:
 Pass `yAxis={false}` or `xAxis={false}` to hide an axis. `gridStyle.intervals` of `[]` renders
 solid grid lines.
 
+## Axis edge labels
+
+`topLabel` and `bottomLabel` float a value at the top / bottom edge of the plot — the
+Robinhood-style high/low readout. Pass `true` for the batteries-included label: the chart shows
+its current top (`topLabel`) and bottom (`bottomLabel`) Y-axis bound, formatted with the chart's
+`formatValue` and updated each frame on the UI thread.
+
+```tsx
+<LiveChart data={data} value={value} topLabel bottomLabel />
+```
+
+Both default off. Pass an [`AxisLabelConfig`](/api-reference/types#axislabelconfig) to tune the
+built-in label — `format`, `color`, and `position` (`"left"` | `"right"`, default `"right"`):
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  topLabel={{ color: "#22d3ee", position: "left" }}
+  bottomLabel={{ format: (v) => `$${v.toFixed(2)}` }}
+/>
+```
+
+For full control, the `render` escape hatch floats any element at the edge (it overrides the
+built-in value):
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  topLabel={{ render: () => <Text style={styles.highLabel}>High</Text> }}
+/>
+```
+
+The same props work on [`LiveChartSeries`](/api-reference/livechart-series#axis-labels), where the
+bounds track the combined range of the visible series. The labels are display-only
+(`pointerEvents="none"`), so they never block scrubbing.
+
 ## Fonts
 
 Chart text (axes, badges, tooltips) uses the `font` prop. Point it at a system family, or load a

--- a/packages/react-native-livechart/src/components/AxisLabelOverlay.tsx
+++ b/packages/react-native-livechart/src/components/AxisLabelOverlay.tsx
@@ -1,0 +1,133 @@
+import { TextInput, StyleSheet, View } from "react-native";
+import Animated, {
+  useAnimatedProps,
+  useDerivedValue,
+} from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
+
+import type { ResolvedAxisLabelConfig } from "../core/resolveConfig";
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+
+/** Editable={false} TextInput so its `text` prop can be animated on the UI thread. */
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+/**
+ * The batteries-included axis edge label — an animated RN text driven by a
+ * `SharedValue<number>` (the chart's current top / bottom Y-axis bound). The
+ * value updates each frame on the UI thread via `useDerivedValue` +
+ * `useAnimatedProps`, so the label tracks the live range without JS re-renders.
+ *
+ * Scoped into its own subcomponent so these hooks only run when the built-in
+ * label is active (not when a custom `render` is supplied).
+ */
+function BuiltInAxisValueLabel({
+  value,
+  format,
+  color,
+  position,
+}: {
+  value: SharedValue<number>;
+  format: (v: number) => string;
+  color: string;
+  position: "left" | "right";
+}) {
+  const text = useDerivedValue(() => format(value.get()));
+  const animatedProps = useAnimatedProps(() => {
+    const t = text.get();
+    return { text: t, defaultValue: t };
+  });
+  return (
+    <AnimatedTextInput
+      editable={false}
+      underlineColorAndroid="transparent"
+      style={{
+        color,
+        textAlign: position === "left" ? "left" : "right",
+        padding: 0,
+      }}
+      animatedProps={animatedProps}
+    />
+  );
+}
+
+/**
+ * React Native overlay (NOT Skia) floating axis edge labels over the Skia
+ * canvas — `topLabel` pinned to the plot's top edge and `bottomLabel` to its
+ * bottom edge (Robinhood-style high/low values).
+ *
+ * For each side: a resolved config with a `render` floats that custom element;
+ * otherwise the built-in {@link BuiltInAxisValueLabel} shows the chart's current
+ * `engine.displayMax` (top) / `engine.displayMin` (bottom) — the live Y-axis
+ * bounds — formatted with the config's `format` (falling back to the chart's
+ * `formatValue`) in the config `color` (falling back to `defaultColor`).
+ *
+ * Because the chart's `<View>` is the canvas size, the plot's top edge sits
+ * `padding.top` px from the top and its bottom edge `padding.bottom` px from
+ * the bottom — so positioning needs only the resolved padding (no live height,
+ * no SharedValues). `pointerEvents="none"` keeps the labels display-only so they
+ * never intercept the scrub pan gesture.
+ */
+export function AxisLabelOverlay({
+  topLabel,
+  bottomLabel,
+  engine,
+  formatValue,
+  defaultColor,
+  padding,
+}: {
+  topLabel: ResolvedAxisLabelConfig | null;
+  bottomLabel: ResolvedAxisLabelConfig | null;
+  engine: ChartEngineLayout;
+  formatValue: (v: number) => string;
+  defaultColor: string;
+  padding: ChartPadding;
+}) {
+  if (!topLabel && !bottomLabel) return null;
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      {topLabel && (
+        <View
+          style={{
+            position: "absolute",
+            top: padding.top,
+            left: padding.left,
+            right: padding.right,
+          }}
+        >
+          {topLabel.render ? (
+            topLabel.render()
+          ) : (
+            <BuiltInAxisValueLabel
+              value={engine.displayMax}
+              format={topLabel.format ?? formatValue}
+              color={topLabel.color ?? defaultColor}
+              position={topLabel.position}
+            />
+          )}
+        </View>
+      )}
+      {bottomLabel && (
+        <View
+          style={{
+            position: "absolute",
+            bottom: padding.bottom,
+            left: padding.left,
+            right: padding.right,
+          }}
+        >
+          {bottomLabel.render ? (
+            bottomLabel.render()
+          ) : (
+            <BuiltInAxisValueLabel
+              value={engine.displayMin}
+              format={bottomLabel.format ?? formatValue}
+              color={bottomLabel.color ?? defaultColor}
+              position={bottomLabel.position}
+            />
+          )}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -19,6 +19,7 @@ import {
 
 import { DEFAULT_ACCENT_COLOR } from "../constants";
 import {
+  resolveAxisLabel,
   resolveBadge,
   resolveDegen,
   resolveDot,
@@ -67,6 +68,7 @@ import {
   resolveTheme,
 } from "../theme";
 import type { LiveChartProps, Marker, TradeEvent } from "../types";
+import { AxisLabelOverlay } from "./AxisLabelOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
@@ -127,6 +129,8 @@ function useLiveChartController({
   // ── Overlays ────────────────────────────────────────────────────────────
   yAxis = true,
   xAxis = true,
+  topLabel,
+  bottomLabel,
   badge = true,
   momentum = true,
   pulse = true,
@@ -162,6 +166,8 @@ function useLiveChartController({
   // ── Resolve feature configs ────────────────────────────────────────────
   const yAxisCfg = resolveYAxis(yAxis);
   const xAxisCfg = resolveXAxis(xAxis);
+  const topLabelCfg = resolveAxisLabel(topLabel);
+  const bottomLabelCfg = resolveAxisLabel(bottomLabel);
   const badgeCfg = resolveBadge(badge);
   const scrubCfg = resolveScrub(scrub);
   const gradientCfg = isCandle ? null : resolveGradient(gradient);
@@ -490,6 +496,9 @@ function useLiveChartController({
     // selection dot: resolved config + fallback color (the chart line/accent color)
     selectionDot: selectionDotCfg,
     selectionColor: lineProp?.color ?? palette.line,
+    // RN axis edge labels (floated over the canvas as a sibling layer)
+    topLabelCfg,
+    bottomLabelCfg,
   };
 }
 
@@ -855,6 +864,10 @@ export function LiveChart(props: LiveChartProps) {
     leftEdgeFadeCfg,
     effectivePadding,
     engine,
+    palette,
+    formatValue,
+    topLabelCfg,
+    bottomLabelCfg,
   } = model;
 
   return (
@@ -888,6 +901,17 @@ export function LiveChart(props: LiveChartProps) {
               its left edge (the badge tracks the live value, not the scrub). */}
           <ChartBadgeLayer model={model} />
         </Canvas>
+
+        {/* RN labels floated over the canvas (sibling of <Canvas>, an RN view).
+            Pinned to the plot's top/bottom edges via the resolved padding. */}
+        <AxisLabelOverlay
+          topLabel={topLabelCfg}
+          bottomLabel={bottomLabelCfg}
+          engine={engine}
+          formatValue={formatValue}
+          defaultColor={palette.gridLabel}
+          padding={effectivePadding}
+        />
       </View>
     </GestureDetector>
   );

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -24,6 +24,7 @@ import {
   type SeriesLineStyle,
 } from "../core/multiSeriesLayout";
 import {
+  resolveAxisLabel,
   resolveDegen,
   resolveGridStyle,
   resolveLeftEdgeFade,
@@ -61,6 +62,7 @@ import {
   resolveTheme,
 } from "../theme";
 import type { LiveChartSeriesProps, Marker, SeriesConfig } from "../types";
+import { AxisLabelOverlay } from "./AxisLabelOverlay";
 import { CrosshairLine } from "./CrosshairLine";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
 import { LeftEdgeFade } from "./LeftEdgeFade";
@@ -122,6 +124,8 @@ function useLiveChartSeriesController({
   formatTime = defaultFormatTime,
   yAxis = true,
   xAxis = true,
+  topLabel,
+  bottomLabel,
   referenceLines,
   gridStyle,
   palette: paletteOverride,
@@ -146,6 +150,8 @@ function useLiveChartSeriesController({
   const markersActive = markers != null;
   const yAxisCfg = resolveYAxis(yAxis);
   const xAxisCfg = resolveXAxis(xAxis);
+  const topLabelCfg = resolveAxisLabel(topLabel);
+  const bottomLabelCfg = resolveAxisLabel(bottomLabel);
   const scrubCfg = resolveScrub(scrub);
   const scrubEnabled = scrubCfg !== null;
   const selectionDotCfg = resolveSelectionDot(selectionDot);
@@ -383,6 +389,9 @@ function useLiveChartSeriesController({
     // selection dot: resolved config + fallback color (the leading series' color)
     selectionDot: selectionDotCfg,
     selectionColor: lineColors[0],
+    // RN axis edge labels (floated over the canvas as a sibling layer)
+    topLabelCfg,
+    bottomLabelCfg,
   };
 }
 
@@ -603,6 +612,9 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     dotOuterRadius,
     selectionDot,
     selectionColor,
+    formatValue,
+    topLabelCfg,
+    bottomLabelCfg,
   } = model;
 
   // Extend the scrub dim past the plot's right edge to fully cover the series
@@ -674,6 +686,18 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 clips them (they track each series' live value, not the scrub). */}
             <SeriesValueLabelLayer model={model} />
           </Canvas>
+
+          {/* RN labels floated over the canvas (sibling of <Canvas>, an RN
+              view). Inside the canvas wrapper so its top/bottom edges align
+              with the plot area, not the legend row. */}
+          <AxisLabelOverlay
+            topLabel={topLabelCfg}
+            bottomLabel={bottomLabelCfg}
+            engine={engine}
+            formatValue={formatValue}
+            defaultColor={palette.gridLabel}
+            padding={effectivePadding}
+          />
         </View>
       </GestureDetector>
       {legendCfg.position === "bottom" ? legend : null}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -1,4 +1,5 @@
 import type {
+  AxisLabelConfig,
   BadgeConfig,
   BadgeVariant,
   DegenOptions,
@@ -26,7 +27,7 @@ import type {
   YAxisConfig,
 } from "../types";
 
-import type { ComponentType } from "react";
+import type { ComponentType, ReactElement } from "react";
 import type { SharedValue } from "react-native-reanimated";
 import {
   BADGE_METRICS_DEFAULTS,
@@ -55,6 +56,16 @@ export interface ResolvedBadgeConfig {
 
 export interface ResolvedYAxisConfig {
   minGap: number;
+}
+
+export interface ResolvedAxisLabelConfig {
+  /** undefined → use the chart's `formatValue` at render time. */
+  format?: (v: number) => string;
+  /** undefined → use the muted default label color at render time. */
+  color?: string;
+  position: "left" | "right";
+  /** When set, the built-in value label is replaced by this custom element. */
+  render?: () => ReactElement | null;
 }
 
 export interface ResolvedXAxisConfig {
@@ -223,6 +234,24 @@ export function resolveYAxis(
   prop: boolean | YAxisConfig | undefined,
 ): ResolvedYAxisConfig | null {
   return resolveToggle(prop, Y_AXIS_DEFAULTS, false);
+}
+
+const AXIS_LABEL_DEFAULTS: ResolvedAxisLabelConfig = {
+  format: undefined,
+  color: undefined,
+  position: "right",
+  render: undefined,
+};
+
+/**
+ * Resolves a `topLabel` / `bottomLabel` prop to a fully-typed config or null
+ * (no label). Opt-in, so `undefined`/`false` → null; `true` → the built-in
+ * value label with defaults; object → configured built-in (or a custom `render`).
+ */
+export function resolveAxisLabel(
+  prop: boolean | AxisLabelConfig | undefined,
+): ResolvedAxisLabelConfig | null {
+  return resolveToggle(prop, AXIS_LABEL_DEFAULTS, false);
 }
 
 const X_AXIS_DEFAULTS: ResolvedXAxisConfig = {

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -28,6 +28,7 @@ export { useTradeStream } from "./hooks/useTradeStream";
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type {
+  AxisLabelConfig,
   BadgeConfig,
   BadgeMetrics,
   BadgeVariant,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import type { ComponentType, ReactElement } from "react";
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
@@ -174,6 +174,24 @@ export interface BadgeConfig {
 export interface YAxisConfig {
   /** Minimum pixel gap between grid lines. Default `36`. */
   minGap?: number;
+}
+
+/**
+ * Axis edge label — the value floated at the plot's top or bottom edge
+ * (Robinhood-style high/low). Pass `topLabel`/`bottomLabel` as `true` for the
+ * batteries-included value label (the chart's current top/bottom Y-axis bound,
+ * updated each frame), an object to configure it, or `{ render }` to float a
+ * fully custom element instead.
+ */
+export interface AxisLabelConfig {
+  /** Formatter for the built-in value. Defaults to the chart's `formatValue`. */
+  format?: (v: number) => string;
+  /** Text color. Defaults to a muted label color (`palette.gridLabel`). */
+  color?: string;
+  /** Horizontal alignment within the plot width. Default `"right"`. */
+  position?: "left" | "right";
+  /** Full custom element, floated at the edge. Overrides the built-in value label. */
+  render?: () => ReactElement | null;
 }
 
 /** X-axis (time) configuration. */
@@ -750,6 +768,20 @@ export interface LiveChartCoreProps {
   yAxis?: boolean | YAxisConfig;
   /** X-axis time labels. `true` = defaults, `false` = hidden, or pass `XAxisConfig`. Default `true`. */
   xAxis?: boolean | XAxisConfig;
+  /**
+   * Label floated at the top edge of the plot area. `true` = the built-in value
+   * label showing the chart's current TOP Y-axis bound (updated each frame),
+   * `false`/omitted = none, or pass `AxisLabelConfig` to configure it (or supply
+   * a custom `render`). Default off.
+   */
+  topLabel?: boolean | AxisLabelConfig;
+  /**
+   * Label floated at the bottom edge of the plot area. `true` = the built-in
+   * value label showing the chart's current BOTTOM Y-axis bound (updated each
+   * frame), `false`/omitted = none, or pass `AxisLabelConfig` (or a custom
+   * `render`). Default off.
+   */
+  bottomLabel?: boolean | AxisLabelConfig;
   /** Reference lines / bands drawn into the chart. Supports all three `ReferenceLine` forms. */
   referenceLines?: ReferenceLine[];
   /** Per-instance grid-line styling. Pass an object to override color / width / dash / opacity. */

--- a/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { Text, TextInput } from "react-native";
+
+import { AxisLabelOverlay } from "../../src/components/AxisLabelOverlay";
+import type { ResolvedAxisLabelConfig } from "../../src/core/resolveConfig";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+
+/** A minimal engine stub: only displayMax/displayMin are read by the overlay. */
+function makeEngine(max = 120, min = 80): ChartEngineLayout {
+  const sv = <T,>(value: T) => ({ value, get: () => value }) as never;
+  return {
+    displayMax: sv(max),
+    displayMin: sv(min),
+    displayWindow: sv(30),
+    canvasWidth: sv(300),
+    canvasHeight: sv(200),
+    timestamp: sv(0),
+  };
+}
+
+const builtIn = (
+  over: Partial<ResolvedAxisLabelConfig> = {},
+): ResolvedAxisLabelConfig => ({ position: "right", ...over });
+
+const fmt = (v: number) => v.toFixed(2);
+
+describe("AxisLabelOverlay", () => {
+  it("renders the built-in top and bottom value labels without throwing", () => {
+    const screen = render(
+      <AxisLabelOverlay
+        topLabel={builtIn()}
+        bottomLabel={builtIn()}
+        engine={makeEngine()}
+        formatValue={fmt}
+        defaultColor="#888"
+        padding={DEFAULT_PADDING}
+      />,
+    );
+    // The built-in label mounts an (animated) TextInput node for each side.
+    expect(screen.UNSAFE_getAllByType(TextInput)).toHaveLength(2);
+  });
+
+  it("renders custom content when `render` is set", () => {
+    const screen = render(
+      <AxisLabelOverlay
+        topLabel={builtIn({ render: () => <Text>HIGH</Text> })}
+        bottomLabel={builtIn({ render: () => <Text>LOW</Text> })}
+        engine={makeEngine()}
+        formatValue={fmt}
+        defaultColor="#888"
+        padding={DEFAULT_PADDING}
+      />,
+    );
+    expect(screen.getByText("HIGH")).toBeTruthy();
+    expect(screen.getByText("LOW")).toBeTruthy();
+  });
+
+  it("returns null when both labels are null", () => {
+    const screen = render(
+      <AxisLabelOverlay
+        topLabel={null}
+        bottomLabel={null}
+        engine={makeEngine()}
+        formatValue={fmt}
+        defaultColor="#888"
+        padding={DEFAULT_PADDING}
+      />,
+    );
+    expect(screen.toJSON()).toBeNull();
+  });
+
+  it("renders only the top label when bottom is null", () => {
+    const screen = render(
+      <AxisLabelOverlay
+        topLabel={builtIn({ render: () => <Text>HIGH</Text> })}
+        bottomLabel={null}
+        engine={makeEngine()}
+        formatValue={fmt}
+        defaultColor="#888"
+        padding={DEFAULT_PADDING}
+      />,
+    );
+    expect(screen.getByText("HIGH")).toBeTruthy();
+    expect(screen.queryByText("LOW")).toBeNull();
+  });
+
+  it("renders only the bottom label when top is null", () => {
+    const screen = render(
+      <AxisLabelOverlay
+        topLabel={null}
+        bottomLabel={builtIn({ render: () => <Text>LOW</Text> })}
+        engine={makeEngine()}
+        formatValue={fmt}
+        defaultColor="#888"
+        padding={DEFAULT_PADDING}
+      />,
+    );
+    expect(screen.getByText("LOW")).toBeTruthy();
+    expect(screen.queryByText("HIGH")).toBeNull();
+  });
+});

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAxisLabel,
   resolveBadge,
   resolveDegen,
   resolveDot,
@@ -127,6 +128,47 @@ describe("resolveYAxis", () => {
 
   it("merges partial config with defaults", () => {
     expect(resolveYAxis({ minGap: 48 })).toEqual({ minGap: 48 });
+  });
+});
+
+// ─── resolveAxisLabel ──────────────────────────────────────────────────────────
+
+describe("resolveAxisLabel", () => {
+  it("returns null for undefined (opt-in, default off)", () => {
+    expect(resolveAxisLabel(undefined)).toBeNull();
+  });
+
+  it("returns null for false", () => {
+    expect(resolveAxisLabel(false)).toBeNull();
+  });
+
+  it("returns the built-in defaults for true", () => {
+    expect(resolveAxisLabel(true)).toEqual({
+      format: undefined,
+      color: undefined,
+      position: "right",
+      render: undefined,
+    });
+  });
+
+  it("merges partial config (color / position) with defaults", () => {
+    expect(resolveAxisLabel({ color: "#abc", position: "left" })).toEqual({
+      format: undefined,
+      color: "#abc",
+      position: "left",
+      render: undefined,
+    });
+  });
+
+  it("carries through a custom format and render escape hatch", () => {
+    const format = (v: number) => `$${v}`;
+    const render = () => null;
+    expect(resolveAxisLabel({ format, render })).toEqual({
+      format,
+      color: undefined,
+      position: "right",
+      render,
+    });
   });
 });
 


### PR DESCRIPTION
Floating high/low value labels over the canvas, using the library's boolean | Config idiom: topLabel?/bottomLabel?: boolean | AxisLabelConfig (default off). true renders a built-in animated label showing the chart's current top value (engine.displayMax) / bottom value (displayMin); config adds format/color/position knobs; render is a full custom escape hatch. Rendered by an RN AxisLabelOverlay (pointerEvents none) pinned to the plot edges via effectivePadding. Resolved via resolveAxisLabel; works on LiveChart + LiveChartSeries. Demo: axes-grid built-in + custom-render toggles. Docs: api-reference + theming guide.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>