### PR TITLE
feat: add static mode for cheap sparklines in lists

### DIFF
--- a/app/demo/sparklines.tsx
+++ b/app/demo/sparklines.tsx
@@ -1,0 +1,161 @@
+import { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { LiveChart, type LiveChartPoint } from "react-native-livechart";
+import { useSharedValue } from "react-native-reanimated";
+
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ACCENT, ACCENT_PRESETS } from "../../demo-lib/shared";
+import { APP_THEME, colors } from "../../demo-lib/theme";
+import { demoStyles } from "../../demo-lib/styles";
+
+export const options = { title: "Sparklines" };
+
+const CELL_COUNT = 24;
+const POINTS_PER_CELL = 40;
+const CELL_SPAN = 60; // seconds of history per sparkline
+
+/**
+ * Mulberry32 — a tiny, fast, deterministic PRNG. Seeded so every cell renders the
+ * same walk on every launch (no `Math.random`, no live feed).
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Deterministic seeded random walk: `count` points ending at `endTime`. */
+function seededWalk(seed: number, count: number, endTime: number): LiveChartPoint[] {
+  const rand = mulberry32(seed);
+  const out: LiveChartPoint[] = [];
+  let v = 50 + rand() * 50;
+  for (let i = 0; i < count; i++) {
+    v += (rand() - 0.48) * 6;
+    out.push({
+      time: endTime - CELL_SPAN + (i / (count - 1)) * CELL_SPAN,
+      value: v,
+    });
+  }
+  return out;
+}
+
+type CellSeed = {
+  id: number;
+  points: LiveChartPoint[];
+  last: number;
+  endTime: number;
+  color: string;
+};
+
+/**
+ * One static mini-chart. Wraps its fixed array in shared values (so the chart's
+ * UI-thread reads work) and frames it edge-to-edge with `timeWindow` +
+ * `nowOverride` (the historical-data-fill pattern). `static` disables every
+ * per-frame loop, so dozens of these cost almost nothing.
+ */
+function SparklineCell({ seed }: { seed: CellSeed }) {
+  const dataSV = useSharedValue<LiveChartPoint[]>(seed.points);
+  const valSV = useSharedValue(seed.last);
+  return (
+    <View style={styles.cell}>
+      <LiveChart
+        static
+        data={dataSV}
+        value={valSV}
+        accentColor={seed.color}
+        theme={APP_THEME}
+        timeWindow={CELL_SPAN}
+        nowOverride={seed.endTime}
+        windowBuffer={0}
+        line={{ width: 1.5 }}
+        badge={false}
+        yAxis={false}
+        xAxis={false}
+        scrub={false}
+        pulse={false}
+        dot={{ radius: 2.5, ring: false }}
+        leftEdgeFade={false}
+        style={styles.cellChart}
+      />
+    </View>
+  );
+}
+
+export default function SparklinesScreen() {
+  // Build the 24 fixed datasets once. `nowOverride` is pinned per-cell so the
+  // most recent point sits exactly at the right edge.
+  const seeds = useMemo<CellSeed[]>(() => {
+    const endTime = Date.now() / 1000;
+    return Array.from({ length: CELL_COUNT }, (_, i) => {
+      const points = seededWalk(i * 1000 + 7, POINTS_PER_CELL, endTime);
+      return {
+        id: i,
+        points,
+        last: points[points.length - 1].value,
+        endTime,
+        color: ACCENT_PRESETS[i % ACCENT_PRESETS.length],
+      };
+    });
+  }, []);
+
+  // Featured larger sparkline shown in the fixed chart slot above the grid.
+  const featuredData = useSharedValue<LiveChartPoint[]>(seeds[0].points);
+  const featuredValue = useSharedValue(seeds[0].last);
+
+  return (
+    <DemoScreen
+      title="Sparklines"
+      description="static — many mini-charts in a list with zero per-chart animation loops"
+      chart={
+        <LiveChart
+          static
+          data={featuredData}
+          value={featuredValue}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={CELL_SPAN}
+          nowOverride={seeds[0].endTime}
+          windowBuffer={0}
+          scrub={false}
+          pulse={false}
+        />
+      }
+    >
+      <Text style={demoStyles.sectionLabel}>{CELL_COUNT} static sparklines</Text>
+      <Text style={[demoStyles.chipText, { opacity: 0.6, marginBottom: 12 }]}>
+        Each cell renders once from a fixed seeded walk. No frame callback, no
+        pulse, no scrub, no entry animation — so a long list of them stays cheap.
+      </Text>
+      <View style={styles.grid}>
+        {seeds.map((seed) => (
+          <SparklineCell key={seed.id} seed={seed} />
+        ))}
+      </View>
+    </DemoScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+  },
+  cell: {
+    width: "48%",
+    height: 56,
+    marginBottom: 10,
+    borderRadius: 8,
+    overflow: "hidden",
+    backgroundColor: colors.chipBackground,
+  },
+  cellChart: {
+    flex: 1,
+    backgroundColor: "transparent",
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -52,6 +52,11 @@ const SECTIONS: DemoSection[] = [
         title: "Multi-series",
         blurb: "LiveChartSeries: per-series style, legend, dots, scrub.",
       },
+      {
+        href: "/demo/sparklines",
+        title: "Sparklines",
+        blurb: "Many static mini-charts in a list (no per-chart animation loop).",
+      },
     ],
   },
   {

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -182,6 +182,14 @@ provided; everything else has a default.
   Breathing-line loading shell until data is ready.
 </ParamField>
 
+<ParamField body="static" type="boolean" default="false">
+  Render once with no per-frame animation loops — engine, degen, trades, candles,
+  markers, pulse, and entry reveal are all disabled, and scrubbing is off. Keeps
+  many small charts cheap when you render a list or grid of sparklines. Frame the
+  data edge-to-edge with `timeWindow` + `nowOverride`. See the
+  [Sparklines guide](/guides/sparklines).
+</ParamField>
+
 <ParamField body="smoothing" type="number" default="0.08">
   Value-lerp speed (0 = frozen, 1 = instant).
 </ParamField>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,6 +51,7 @@
             "group": "Engine & data",
             "pages": [
               "guides/playback",
+              "guides/sparklines",
               "guides/states-and-formatting",
               "guides/transitions"
             ]

--- a/docs/guides/sparklines.mdx
+++ b/docs/guides/sparklines.mdx
@@ -1,0 +1,77 @@
+---
+title: Sparklines
+icon: "chart-simple"
+description: "Render many cheap, non-animated mini-charts in a list or grid with static mode."
+---
+
+`static` renders a `LiveChart` **once** with zero per-frame animation loops. The engine tick
+loop, the degen/trade/candle/marker callbacks, the pulse, and the entry reveal are all
+disabled, and scrubbing is off. That makes each instance cheap enough to put dozens of them in a
+scrolling list — a watchlist row, a token grid, a portfolio of sparklines.
+
+It mirrors `react-native-graph`'s `animated={false}`.
+
+## When to use it
+
+Reach for `static` when you're rendering **many** mini-charts at once and don't need them to
+animate or respond to touch. A single hero chart should stay live; a `FlatList` of forty
+thumbnails should be `static`.
+
+## A sparkline cell
+
+Strip the chrome you don't need in a thumbnail — badge, axes, pulse — and frame the data
+edge-to-edge:
+
+```tsx
+function SparklineCell({ history, lastValue, lastTime, span }) {
+  return (
+    <LiveChart
+      static
+      data={history}
+      value={lastValue}
+      timeWindow={span}
+      nowOverride={lastTime}
+      badge={false}
+      yAxis={false}
+      xAxis={false}
+      pulse={false}
+    />
+  );
+}
+```
+
+Drop it into a list or grid:
+
+```tsx
+<FlatList
+  data={tokens}
+  numColumns={2}
+  keyExtractor={(t) => t.id}
+  renderItem={({ item }) => (
+    <SparklineCell
+      history={item.history}
+      lastValue={item.lastValue}
+      lastTime={item.lastTime}
+      span={item.span}
+    />
+  )}
+/>
+```
+
+## Framing the data
+
+A static chart never scrolls, so you decide exactly what's on screen. Set `timeWindow` to the
+span you want to show and `nowOverride` to your dataset's last timestamp (unix seconds) so the
+window ends right at the latest point. This is the same approach as the
+[historical data fill](/guides/playback#historical-data-fill) pattern in the playback guide.
+
+## `static` vs `paused`
+
+They sound similar but do opposite things:
+
+- **`paused`** freezes a **live** chart — the tick loop keeps running, the value keeps buffering,
+  and resuming catches the window back up to real time. Use it for one interactive chart.
+- **`static`** removes the loops **entirely** — nothing animates and nothing recovers, because
+  there's nothing to recover. Use it for many instances at once.
+
+See the full prop list in the [`LiveChart` reference](/api-reference/livechart).

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -114,6 +114,8 @@ function useLiveChartController({
   timeWindow = 30,
   paused = false,
   loading = false,
+  // `static` is a reserved word — alias it so the destructure parses.
+  static: isStatic = false,
   smoothing = 0.08,
   exaggerate = false,
   nonNegative = false,
@@ -172,13 +174,17 @@ function useLiveChartController({
   const scrubCfg = resolveScrub(scrub);
   const gradientCfg = isCandle ? null : resolveGradient(gradient);
   const valueLineCfg = resolveValueLine(valueLine);
-  const pulseCfg = resolvePulse(pulse);
+  // Static charts run zero loops: force the pulse off so its `withRepeat`-driven
+  // ring never starts (the DotOverlay reads `pulseCfg`, so null = no pulse).
+  const pulseCfg = isStatic ? null : resolvePulse(pulse);
   const dotCfg = resolveDot(dot);
   const selectionDotCfg = resolveSelectionDot(selectionDot);
   // Outer footprint of the dot (color-filled radius plus the halo ring).
   const dotOuterRadius = dotCfg.radius + (dotCfg.ring?.width ?? 0);
   const gridStyleCfg = resolveGridStyle(gridStyle);
-  const degenCfg = resolveDegen(degen);
+  // Static charts run zero loops: force degen off so `useDegen`'s frame callback
+  // never starts (also passed `isStatic` below as a belt-and-braces autostart gate).
+  const degenCfg = isStatic ? null : resolveDegen(degen);
   const tradeStreamResolved = resolveTradeStream(tradeStream);
   const metricsCfg = resolveMetrics(metrics);
 
@@ -259,7 +265,7 @@ function useLiveChartController({
     candles,
   });
 
-  const reveal = useChartReveal(loading, hasData);
+  const reveal = useChartReveal(loading, hasData, isStatic);
 
   // After data clears, keep last snapshot until morphT finishes dropping (web parity).
   const { lineEngineData, candlesEngine, liveEngine } =
@@ -280,6 +286,7 @@ function useLiveChartController({
     value,
     timeWindow,
     paused,
+    static: isStatic,
     smoothing,
     adaptiveSpeedBoost: metricsCfg.motion.adaptiveSpeedBoost,
     exaggerate,
@@ -317,6 +324,7 @@ function useLiveChartController({
       candleWidth,
       isCandle,
       metricsCfg.candle,
+      !isStatic, // static: no candle-width lerp loop
     );
   const { dotX, dotY } = useLiveDot(engine, effectivePadding);
 
@@ -326,14 +334,15 @@ function useLiveChartController({
     engine,
     tradeStreamSV,
     effectivePadding,
-    tradeStreamResolved !== null,
+    !isStatic && tradeStreamResolved !== null,
+    !isStatic, // static: no trade-tape loop
   );
 
   const {
     pack: degenPack,
     packRevision: degenPackRevision,
     shakeTransform: degenShakeTransform,
-  } = useDegen(engine, dotX, dotY, momentumSV, degenCfg, onDegenShake);
+  } = useDegen(engine, dotX, dotY, momentumSV, degenCfg, onDegenShake, isStatic);
 
   // ── Overlay hooks ─────────────────────────────────────────────────────
   const { yAxisEntries } = useYAxis(
@@ -384,7 +393,8 @@ function useLiveChartController({
     formatValue,
     formatTime,
     skiaFont,
-    scrubCfg !== null,
+    // Static charts have an inert pan gesture — no scrub work on the UI thread.
+    !isStatic && scrubCfg !== null,
     onScrub,
     candleOpts,
     scrubCfg?.panGestureDelay ?? 0,
@@ -399,11 +409,12 @@ function useLiveChartController({
     engine,
     effectivePadding,
     markersSV,
-    markersActive,
+    !isStatic && markersActive,
     markerHitRadius,
     onMarkerHover,
     undefined, // seriesSV — single-series has none
     engine.data, // anchor value-less markers to the line
+    !isStatic, // static: no marker-projection loop
   );
 
   const rootGesture = markersActive

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -7,6 +7,7 @@
  */
 import { useState } from "react";
 import {
+  useAnimatedReaction,
   useDerivedValue,
   useFrameCallback,
   useSharedValue,
@@ -31,6 +32,12 @@ export interface EngineConfig {
   nowOverride?: number;
   windowBuffer?: number;
   paused?: boolean;
+  /**
+   * Loop-free render: settle the display state once (smoothing forced to 1, no
+   * per-frame frame callback) for many small charts in a list. See
+   * {@link LiveChartProps.static}.
+   */
+  static?: boolean;
   mode?: "line" | "candle";
   candles?: SharedValue<CandlePoint[]>;
   liveCandle?: SharedValue<CandlePoint | null>;
@@ -143,7 +150,11 @@ export function applyLiveChartEngineFrame(
 export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   // Low-frequency config → UI thread via useDerivedValue
   const timeWindow = useDerivedValue(() => config.timeWindow);
-  const smoothing = useDerivedValue(() => config.smoothing);
+  // Static charts snap to their target in one tick (smoothing=1), so the single
+  // settle reaction below produces the final state with no per-frame easing.
+  const smoothing = useDerivedValue(() =>
+    config.static ? 1 : config.smoothing,
+  );
   const adaptiveSpeedBoostSV = useDerivedValue(() => config.adaptiveSpeedBoost);
   const exaggerateSV = useDerivedValue(() => config.exaggerate ?? false);
   const referenceValue = useDerivedValue(() => config.referenceValue);
@@ -170,34 +181,74 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   // no useDerivedValue bridging, no closure serialization per tick.
   const { data, value, candles, liveCandle } = config;
 
+  // Static charts run zero per-frame loops. `isStaticSV` gates both the
+  // frame-callback autostart and the one-shot settle reaction below.
+  const isStaticSV = useDerivedValue(() => config.static ?? false);
+
+  // Single refs object shared by the frame callback and the settle reaction so
+  // they can never drift out of sync.
+  const frameRefs: EngineFrameRefs = {
+    data,
+    value,
+    displayValue,
+    displayMin,
+    displayMax,
+    displayWindow,
+    timestamp,
+    canvasWidth,
+    canvasHeight,
+    timeWindow,
+    smoothing,
+    adaptiveSpeedBoostSV,
+    exaggerateSV,
+    referenceValue,
+    referenceValues,
+    nonNegativeSV,
+    maxValueSV,
+    nowOverrideSV,
+    windowBufferSV,
+    pausedSV,
+    modeSV,
+    candles,
+    liveCandle,
+  };
+
+  // `autostart=false` registers the frame callback without running it — the live
+  // loop is fully inert in static mode (the invariant that makes this worth it).
   useFrameCallback((frameInfo) => {
     "worklet";
-    applyLiveChartEngineFrame(frameInfo, {
-      data,
-      value,
-      displayValue,
-      displayMin,
-      displayMax,
-      displayWindow,
-      timestamp,
-      canvasWidth,
-      canvasHeight,
-      timeWindow,
-      smoothing,
-      adaptiveSpeedBoostSV,
-      exaggerateSV,
-      referenceValue,
-      referenceValues,
-      nonNegativeSV,
-      maxValueSV,
-      nowOverrideSV,
-      windowBufferSV,
-      pausedSV,
-      modeSV,
-      candles,
-      liveCandle,
-    });
-  });
+    applyLiveChartEngineFrame(frameInfo, frameRefs);
+  }, !config.static);
+
+  // One-shot settle for static charts: the fingerprint changes when the canvas
+  // lays out (width 0→real) or the framing inputs change, and the handler runs a
+  // single snap tick (smoothing=1). Inert when not static — `prepare` returns a
+  // constant so it never fires.
+  useAnimatedReaction(
+    () => {
+      if (!isStaticSV.get()) return 0; // inert when not static — never changes
+      const d = data.get();
+      const n = d.length;
+      return [
+        n,
+        n ? d[0].time : 0,
+        n ? d[0].value : 0,
+        n ? d[n - 1].time : 0,
+        n ? d[n - 1].value : 0,
+        value.get(),
+        canvasWidth.get(),
+        canvasHeight.get(),
+        timeWindow.get(),
+      ].join(",");
+    },
+    (curr, prev) => {
+      if (!isStaticSV.get() || curr === prev) return;
+      applyLiveChartEngineFrame(
+        { timeSincePreviousFrame: MS_PER_FRAME_60FPS },
+        frameRefs,
+      );
+    },
+  );
 
   return {
     data,

--- a/packages/react-native-livechart/src/hooks/useCandlePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useCandlePaths.ts
@@ -29,6 +29,8 @@ export function useCandlePaths(
   candleWidthSecs: number,
   active: boolean,
   candleMetrics: CandleMetrics = CANDLE_METRICS_DEFAULTS,
+  /** Static charts run no loops: register without starting. Default `true`. */
+  autostart = true,
 ) {
   const targetCandleWidth = useDerivedValue(() => candleWidthSecs);
   const displayCandleWidth = useSharedValue(candleWidthSecs);
@@ -50,7 +52,7 @@ export function useCandlePaths(
         dt,
       ),
     );
-  });
+  }, autostart);
 
   /* istanbul ignore next -- worklet */
   const geometry = useDerivedValue(() => {

--- a/packages/react-native-livechart/src/hooks/useChartReveal.ts
+++ b/packages/react-native-livechart/src/hooks/useChartReveal.ts
@@ -58,6 +58,8 @@ export interface ChartRevealState {
 export function useChartReveal(
   loading: boolean,
   hasData: SharedValue<boolean>,
+  /** Static charts skip the entry ramp: morphT snaps to its target, no `withTiming`. */
+  isStatic = false,
 ): ChartRevealState {
   // Best-guess initial so the common case — a live chart that already has data
   // and isn't loading — paints fully revealed with no flash. The reaction below
@@ -71,13 +73,14 @@ export function useChartReveal(
 
   // The reaction reads presence/loading on the UI thread (a worklet, never during
   // render — so no Reanimated "reading `value` during render" warning), seeds the
-  // exact reveal state on its first run, then animates on later changes.
+  // exact reveal state on its first run, then animates on later changes. Static
+  // charts always snap (no `withTiming` ramp) so no entry animation ever runs.
   useAnimatedReaction(
     () => !isLoading.get() && hasData.get(),
     (chartVisible, prev) => {
       "worklet";
-      if (prev === null || prev === undefined) {
-        // First run: snap to the correct initial reveal state (no animation).
+      if (isStatic || prev === null || prev === undefined) {
+        // Static, or first run: snap to the correct reveal state (no animation).
         morphT.set(chartVisible ? 1 : 0);
         return;
       }
@@ -90,7 +93,7 @@ export function useChartReveal(
         );
       }
     },
-    [hasData],
+    [hasData, isStatic],
   );
 
   const isEmpty = useDerivedValue(() => !isLoading.get() && !hasData.get());

--- a/packages/react-native-livechart/src/hooks/useDegen.ts
+++ b/packages/react-native-livechart/src/hooks/useDegen.ts
@@ -20,6 +20,8 @@ export function useDegen(
   momentumSV: SharedValue<Momentum>,
   cfg: ResolvedDegenConfig | null,
   onShake?: (payload: DegenShakePayload) => void,
+  /** Static charts run no loops: register the frame callback without starting it. */
+  isStatic = false,
 ): {
   pack: SharedValue<Float64Array<ArrayBuffer>>;
   packRevision: SharedValue<number>;
@@ -248,6 +250,10 @@ export function useDegen(
       }
       prevActiveCount.set(activeCount);
     },
+    // Static charts register the callback but never start it, so no degen frame
+    // loop runs. Live charts keep the default (autostart) loop unchanged. The
+    // controller also forces `cfg` to null in static, so degen is doubly off.
+    !isStatic,
   );
 
   const shakeTransform = useDerivedValue(() => {

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -30,6 +30,8 @@ export function useMarkers(
   onMarkerHover?: (event: MarkerHoverEvent | null) => void,
   seriesSV?: SharedValue<SeriesConfig[]>,
   lineData?: SharedValue<LiveChartPoint[]>,
+  /** Static charts run no loops: register without starting. Default `true`. */
+  autostart = true,
 ): { projected: SharedValue<ProjectedMarker[]>; tapGesture: ReturnType<typeof Gesture.Tap> } {
   const projected = useSharedValue<ProjectedMarker[]>([]);
   const cacheRef = useRef<{
@@ -73,6 +75,7 @@ export function useMarkers(
       });
       projected.set(buf);
     },
+    autostart,
   );
 
   const tapGesture = Gesture.Tap().onEnd(

--- a/packages/react-native-livechart/src/hooks/useTradeStream.ts
+++ b/packages/react-native-livechart/src/hooks/useTradeStream.ts
@@ -25,6 +25,8 @@ export function useTradeStream(
   tradeStream: SharedValue<TradeEvent[]>,
   padding: ChartPadding,
   active: boolean,
+  /** Static charts run no loops: register without starting. Default `true`. */
+  autostart = true,
 ): SharedValue<TradeMarker[]> {
   const markers = useSharedValue<TradeMarker[]>([]);
   const state = useSharedValue<TradeStreamState>(createTradeStreamState());
@@ -58,6 +60,7 @@ export function useTradeStream(
       const chartH = chartBottom - chartTop;
       markers.set(projectLabels(s, chartTop, chartH));
     },
+    autostart,
   );
 
   return markers;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -893,6 +893,10 @@ export interface LiveChartProps extends LiveChartCoreProps {
   data: SharedValue<LiveChartPoint[]>;
   /** Latest live value for smooth interpolation between data updates. */
   value: SharedValue<number>;
+  /** Render once with no per-frame animation loop — for many small charts (sparklines)
+   *  in a list. Pulse/scrub/degen and the entry animation are disabled. Frame the data
+   *  with `timeWindow` + `nowOverride` (see the historical-data-fill pattern). */
+  static?: boolean;
   /** Called when the user scrubs the crosshair. `null` when scrub ends. */
   onScrub?: (point: ScrubPoint | null) => void;
   /**

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -182,4 +182,26 @@ describe("LiveChart", () => {
       nativeEvent: { layout: { width: 400, height: 300 } },
     });
   });
+
+  it("renders in static mode and lays out without throwing", () => {
+    const screen = render(
+      <Harness static timeWindow={30} nowOverride={1700000030} />,
+    );
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 200 } },
+    });
+  });
+
+  it("static gates off pulse, scrub, and degen even when requested", () => {
+    // The controller forces these features off in static; exercising the gating
+    // branches with all three explicitly enabled must still render cleanly.
+    const screen = render(
+      <Harness static pulse scrub degen nowOverride={1700000030} />,
+    );
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 200 } },
+    });
+  });
 });

--- a/packages/react-native-livechart/tests/staticMode.test.tsx
+++ b/packages/react-native-livechart/tests/staticMode.test.tsx
@@ -1,0 +1,102 @@
+import { render, renderHook } from "@testing-library/react-native";
+import React from "react";
+import { View } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+
+// Capture every `useFrameCallback(cb, autostart)` call's autostart flag so we can
+// assert that static charts register their loops inert (autostart === false).
+const frameCallbackCalls: Array<boolean | undefined> = [];
+jest.mock("react-native-reanimated", () => {
+  const actual = jest.requireActual("react-native-reanimated");
+  return {
+    ...actual,
+    useFrameCallback: jest.fn(
+      (cb: (info: unknown) => void, autostart?: boolean) => {
+        frameCallbackCalls.push(autostart);
+        return actual.useFrameCallback(cb, autostart);
+      },
+    ),
+  };
+});
+
+// Imported after the mock so they pick up the wrapped `useFrameCallback`.
+import { LiveChart } from "../src/components/LiveChart";
+import { useLiveChartEngine } from "../src/core/useLiveChartEngine";
+import type { LiveChartPoint } from "../src/types";
+
+beforeEach(() => {
+  frameCallbackCalls.length = 0;
+});
+
+describe("static mode — no per-frame loops", () => {
+  it("engine autostarts the frame callback when not static", () => {
+    renderHook(() => {
+      const data = useSharedValue([{ time: 1700000000, value: 1 }]);
+      const value = useSharedValue(1);
+      return useLiveChartEngine({ data, value, timeWindow: 30, smoothing: 0.08 });
+    });
+    // One frame callback (the engine), autostarted (the `!config.static` arg).
+    expect(frameCallbackCalls).toEqual([true]);
+  });
+
+  it("engine registers the frame callback inert when static", () => {
+    renderHook(() => {
+      const data = useSharedValue([{ time: 1700000000, value: 1 }]);
+      const value = useSharedValue(1);
+      return useLiveChartEngine({
+        data,
+        value,
+        timeWindow: 30,
+        smoothing: 0.08,
+        static: true,
+      });
+    });
+    expect(frameCallbackCalls).toEqual([false]);
+  });
+
+  it("disables every frame-callback loop when LiveChart is static", () => {
+    function Harness() {
+      const data = useSharedValue<LiveChartPoint[]>([
+        { time: 1700000000, value: 10 },
+        { time: 1700000030, value: 30 },
+      ]);
+      const value = useSharedValue(30);
+      return (
+        <LiveChart
+          static
+          data={data}
+          value={value}
+          timeWindow={30}
+          nowOverride={1700000030}
+        />
+      );
+    }
+    const screen = render(<Harness />);
+    const views = screen.UNSAFE_getAllByType(View);
+    // Lay out the canvas so the chart fully wires up.
+    // (No assertions needed on layout — just exercising the render path.)
+    screen.rerender(<Harness />);
+    expect(views.length).toBeGreaterThan(0);
+    // Both the engine and useDegen register a frame callback; in static mode
+    // every one must be inert (autostart false) — that is the core invariant.
+    expect(frameCallbackCalls.length).toBeGreaterThanOrEqual(2);
+    expect(frameCallbackCalls.every((autostart) => autostart === false)).toBe(
+      true,
+    );
+  });
+
+  it("autostarts LiveChart frame-callback loops when not static", () => {
+    function Harness() {
+      const data = useSharedValue<LiveChartPoint[]>([
+        { time: 1700000000, value: 10 },
+      ]);
+      const value = useSharedValue(10);
+      return <LiveChart data={data} value={value} />;
+    }
+    render(<Harness />);
+    // The live engine autostarts (true). useDegen's callback defaults to
+    // autostart when not static; at minimum the engine's loop must be live.
+    expect(frameCallbackCalls).toContain(true);
+    expect(frameCallbackCalls).not.toContain(false);
+  });
+});

--- a/packages/react-native-livechart/tests/useLiveChartEngine.test.tsx
+++ b/packages/react-native-livechart/tests/useLiveChartEngine.test.tsx
@@ -65,4 +65,64 @@ describe("useLiveChartEngine", () => {
     });
     expect(result.current.displayMin.value).toBeDefined();
   });
+
+  it("does not throw rendering a static engine", () => {
+    // Smoke test: the static path adds a one-shot settle reaction; ensure the
+    // hook mounts cleanly (autostart wiring is asserted in the frame-callback
+    // mock test, the settle math in the smoothing=1 snap test below).
+    const { result } = renderHook(() => {
+      const data = useSharedValue([
+        { time: 1700000000, value: 10 },
+        { time: 1700000030, value: 30 },
+      ]);
+      const value = useSharedValue(30);
+      return useLiveChartEngine({
+        data,
+        value,
+        timeWindow: 30,
+        smoothing: 0.08,
+        static: true,
+        nowOverride: 1700000030,
+      });
+    });
+    expect(result.current.displayMin.value).toBeDefined();
+  });
+
+  it("snaps the display state in one tick at smoothing=1 (the static settle)", () => {
+    // The static settle reaction runs `applyLiveChartEngineFrame` once with
+    // smoothing forced to 1, which must reach the final state immediately.
+    const sv = {
+      data: {
+        value: [
+          { time: 1700000000, value: 10 },
+          { time: 1700000030, value: 30 },
+        ],
+      },
+      value: { value: 30 },
+      displayValue: { value: 0 },
+      displayMin: { value: 0 },
+      displayMax: { value: 1 },
+      displayWindow: { value: 30 },
+      timestamp: { value: 1700000030 },
+      canvasWidth: { value: 300 },
+      canvasHeight: { value: 120 },
+      timeWindow: { value: 30 },
+      smoothing: { value: 1 },
+      exaggerateSV: { value: false },
+      referenceValue: { value: undefined as number | undefined },
+      nowOverrideSV: { value: 1700000030 },
+      windowBufferSV: { value: 0 },
+      pausedSV: { value: false },
+      modeSV: { value: "line" as const },
+    };
+    applyLiveChartEngineFrame(
+      { timeSincePreviousFrame: 16.67 },
+      sv as unknown as EngineFrameRefs,
+    );
+    // Snap-to-target: the live value lands exactly on its target in one call,
+    // and the Y-range brackets the data.
+    expect(sv.displayValue.value).toBe(30);
+    expect(sv.displayMin.value).toBeLessThanOrEqual(10);
+    expect(sv.displayMax.value).toBeGreaterThanOrEqual(30);
+  });
 });


### PR DESCRIPTION
static?: boolean on LiveChart renders once with zero per-frame loops, so a list of many mini-charts is viable (historical-data-fill already covers single-chart static framing; this adds the no-loop performance path). Engine: smoothing forced to 1 + useFrameCallback autostart=false + a one-shot useAnimatedReaction that snaps display state on data/layout change. All five frame callbacks (engine, degen, trade-stream, candle-paths, markers) and the entry reveal/withTiming are gated inert when static; pulse and scrub are forced off. Live path is byte-for-byte unchanged (new autostart params default to true). Demo: new sparklines screen renders a 24-cell grid of seeded static minis.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>