### PR TITLE
perf: render degen particles via a single drawAtlas call

### DIFF
--- a/docs/guides/momentum-and-degen.mdx
+++ b/docs/guides/momentum-and-degen.mdx
@@ -72,6 +72,12 @@ Tune it with `DegenOptions`:
   bursts off **its own** dot, in that series' color, on its own upward momentum swing (per-outcome).
 </Note>
 
+<Tip>
+  Particle bursts render through a single batched Skia `drawAtlas` call: one white-circle sprite is
+  rasterized once, then every active particle is blitted with its own transform and color in that
+  one draw. So even dense bursts stay cheap. This is automatic — no API or config change.
+</Tip>
+
 ## Reacting to shake
 
 `onDegenShake` fires on the JS thread when a shake starts (unless `shake` is `false`) — useful

--- a/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
+++ b/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
@@ -1,99 +1,38 @@
-import { Circle, Group } from "@shopify/react-native-skia";
+import {
+  Atlas,
+  Skia,
+  type SkColor,
+  type SkRSXform,
+  type SkRect,
+} from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import { DEGEN_STRIDE } from "../constants";
+import {
+  buildParticleInstances,
+  buildParticleSprite,
+} from "../draw/particleAtlas";
+import { parseColorRgb } from "../theme";
 import type { LiveChartPalette } from "../types";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 
 type DegenPack = SharedValue<Float64Array<ArrayBuffer>>;
 
 /**
- * Renders one particle slot from the packed ring buffer.
- * Buffer layout per slot (stride = DEGEN_STRIDE = 8):
- *   [0] x, [1] y, [2] vx, [3] vy, [4] t0, [5] active, [6] size, [7] colorIndex
- * See `math/degenTick.ts` for the authoritative layout documentation.
+ * Renders the degen particle burst with a single `drawAtlas` call.
  *
- * Each particle stores a `colorIndex` (set at spawn) that selects its color
- * from `colorList`, so multi-series bursts render in their own series' color.
+ * Every active particle shares one pre-rasterized white-circle sprite and
+ * differs only in position, scale, color, and opacity — the ideal `drawAtlas`
+ * case. A single per-frame worklet projects the packed ring buffer (layout:
+ * `[x, y, vx, vy, t0, active, size, colorIndex]`, stride = DEGEN_STRIDE = 8;
+ * see `math/degenTick.ts`) into transforms + per-sprite colors, replacing the
+ * old O(slots × 4 derived values + 1 `<Circle>` each) fan-out with O(1) mappers
+ * and one draw.
+ *
+ * Per-particle color/opacity is baked into the sprite color (`rgba(r,g,b,a)`)
+ * and applied with the `"modulate"` blend mode, which multiplies the white
+ * sprite by each color — so a white AA circle becomes a soft, correctly-tinted,
+ * correctly-faded particle, visually equivalent to the old `<Circle color
+ * opacity>`.
  */
-function DegenSlot({
-  index,
-  pack,
-  packRevision,
-  engine,
-  particleBurstDurationSec,
-  particleOpacity,
-  colorList,
-}: {
-  index: number;
-  pack: DegenPack;
-  packRevision: SharedValue<number>;
-  engine: ChartEngineLayout;
-  particleBurstDurationSec: number;
-  particleOpacity: number;
-  colorList: string[];
-}) {
-  const base = index * DEGEN_STRIDE;
-
-  /* istanbul ignore next -- useDerivedValue worklet runs on UI thread, not in Jest */
-  const cx = useDerivedValue(() => {
-    const rev = packRevision.value;
-    const buf = pack.value;
-    const active = buf[base + 5];
-    if (!(rev >= 0) || !(active > 0.5)) return -9999;
-    return buf[base + 0];
-  });
-
-  /* istanbul ignore next -- worklet */
-  const cy = useDerivedValue(() => {
-    const rev = packRevision.value;
-    const buf = pack.value;
-    const active = buf[base + 5];
-    if (!(rev >= 0) || !(active > 0.5)) return -9999;
-    return buf[base + 1];
-  });
-
-  /* istanbul ignore next -- worklet */
-  const r = useDerivedValue(() => {
-    const rev = packRevision.value;
-    const buf = pack.value;
-    const active = buf[base + 5];
-    if (!(rev >= 0) || !(active > 0.5)) return 0;
-    const now = engine.timestamp.value;
-    const dt = now - buf[base + 4];
-    if (dt < 0) return 0;
-    const life = Math.max(0, 1 - dt / particleBurstDurationSec);
-    const size = buf[base + 6] || 1;
-    return size * (0.5 + life * 0.5);
-  });
-
-  /* istanbul ignore next -- worklet */
-  const opacity = useDerivedValue(() => {
-    const rev = packRevision.value;
-    const buf = pack.value;
-    const active = buf[base + 5];
-    if (!(rev >= 0) || !(active > 0.5)) return 0;
-    const now = engine.timestamp.value;
-    const dt = now - buf[base + 4];
-    if (dt < 0) return 0;
-    const life = Math.max(0, 1 - dt / particleBurstDurationSec);
-    return life * particleOpacity;
-  });
-
-  /* istanbul ignore next -- worklet */
-  const color = useDerivedValue(() => {
-    // Read packRevision so this re-runs each frame — the pack buffer is mutated
-    // in place (stable reference), so without this the color would freeze at the
-    // mount-time colorIndex (0) for every particle.
-    const rev = packRevision.value;
-    const buf = pack.value;
-    if (!(rev >= 0)) return colorList[0];
-    const idx = Math.max(0, Math.floor(buf[base + 7]));
-    return colorList[idx % colorList.length];
-  });
-
-  return <Circle cx={cx} cy={cy} r={r} color={color} opacity={opacity} />;
-}
-
 export function DegenParticlesOverlay({
   pack,
   packRevision,
@@ -115,27 +54,72 @@ export function DegenParticlesOverlay({
 }) {
   /* istanbul ignore next -- branch depends on render-time props */
   const colorList = colors && colors.length > 0 ? colors : [palette.line];
-  // Fixed-size persistent slot pool. Each <DegenSlot> renders whatever particle
-  // currently occupies slot `i` (read from `pack` by index), and particles cycle
-  // through the slots over time. The pool is positional — slot `i` always renders
-  // ring-buffer index `i`, and the list only grows/shrinks at the tail, never
-  // reorders — so each slot has a permanent identity. Key by that stable per-slot
-  // id (`particle-slot-<i>`) rather than the bare array index.
-  const slotKeys = Array.from(
-    { length: particleSlotCount },
-    (_, i) => `particle-slot-${i}`,
-  );
-  const slots = slotKeys.map((slotKey, i) => (
-    <DegenSlot
-      key={slotKey}
-      index={i}
-      pack={pack}
-      packRevision={packRevision}
-      engine={engine}
-      particleBurstDurationSec={particleBurstDurationSec}
-      particleOpacity={particleOpacity}
-      colorList={colorList}
+
+  // White-circle sprite has no per-render inputs; React Compiler memoizes it.
+  const sprite = buildParticleSprite();
+
+  // Pre-parse the color list to [r,g,b] tuples so the per-frame worklet never
+  // parses arbitrary color strings (only formats `rgba(...)`). React Compiler
+  // memoizes this on `colorList`.
+  const colorRgb = colorList.map((c) => parseColorRgb(c));
+
+  // Single per-frame worklet. Reads `packRevision` so it re-runs each frame
+  // while a burst is alive (the pack buffer is mutated in place, so its
+  // reference is stable and wouldn't otherwise re-notify).
+  const atlasData = useDerivedValue(() => {
+    const rev = packRevision.get();
+    const transforms: SkRSXform[] = [];
+    const sprites: SkRect[] = [];
+    const colorsOut: SkColor[] = [];
+    if (rev >= 0) {
+      const instances = buildParticleInstances(
+        pack.get(),
+        particleSlotCount,
+        engine.timestamp.get(),
+        particleBurstDurationSec,
+        particleOpacity,
+        sprite.radius,
+      );
+      const half = sprite.size / 2;
+      for (let i = 0; i < instances.length; i++) {
+        const inst = instances[i];
+        // Center the scaled sprite on (x, y); RSXform has no rotation.
+        transforms.push(
+          Skia.RSXform(
+            inst.scale,
+            0,
+            inst.x - inst.scale * half,
+            inst.y - inst.scale * half,
+          ),
+        );
+        sprites.push(Skia.XYWHRect(0, 0, sprite.size, sprite.size));
+        const [r, g, b] = colorRgb[inst.colorIndex % colorRgb.length];
+        colorsOut.push(Skia.Color(`rgba(${r}, ${g}, ${b}, ${inst.alpha})`));
+      }
+    }
+    return { transforms, sprites, colors: colorsOut };
+  }, [
+    pack,
+    packRevision,
+    engine,
+    particleSlotCount,
+    particleBurstDurationSec,
+    particleOpacity,
+    sprite,
+    colorRgb,
+  ]);
+
+  const transforms = useDerivedValue(() => atlasData.get().transforms, [atlasData]);
+  const sprites = useDerivedValue(() => atlasData.get().sprites, [atlasData]);
+  const atlasColors = useDerivedValue(() => atlasData.get().colors, [atlasData]);
+
+  return (
+    <Atlas
+      image={sprite.image}
+      sprites={sprites}
+      transforms={transforms}
+      colors={atlasColors}
+      colorBlendMode="modulate"
     />
-  ));
-  return <Group>{slots}</Group>;
+  );
 }

--- a/packages/react-native-livechart/src/draw/particleAtlas.ts
+++ b/packages/react-native-livechart/src/draw/particleAtlas.ts
@@ -1,0 +1,95 @@
+import {
+  Skia,
+  PaintStyle,
+  drawAsImageFromPicture,
+  type SkImage,
+} from "@shopify/react-native-skia";
+import { DEGEN_STRIDE } from "../constants";
+
+/** Reference radius of the rasterized white circle sprite (px). */
+const SPRITE_RADIUS = 16;
+/** Anti-alias breathing room baked around the circle so it never clips. */
+const SPRITE_MARGIN = 2;
+
+/** A rasterized white-circle sprite + its geometry. */
+export interface ParticleSprite {
+  image: SkImage | null;
+  /** Side length of the square sprite box (px). */
+  size: number;
+  /** Radius of the white circle inside the box (px). */
+  radius: number;
+}
+
+/**
+ * Rasterize ONE anti-aliased **white** filled circle into a square sprite, once
+ * (NOT per frame). Drawing it white lets each particle's per-sprite color
+ * modulate (multiply) the texture to its own tint + alpha via `drawAtlas`.
+ *
+ * Mirrors the PictureRecorder pattern in `markerAtlas.ts`.
+ */
+export function buildParticleSprite(): ParticleSprite {
+  const R = SPRITE_RADIUS;
+  const S = 2 * (R + SPRITE_MARGIN);
+  const paint = Skia.Paint();
+  paint.setAntiAlias(true);
+  paint.setColor(Skia.Color("#ffffff"));
+  paint.setStyle(PaintStyle.Fill);
+
+  const recorder = Skia.PictureRecorder();
+  const canvas = recorder.beginRecording(Skia.XYWHRect(0, 0, S, S));
+  canvas.drawCircle(S / 2, S / 2, R, paint);
+  const picture = recorder.finishRecordingAsPicture();
+  const image = drawAsImageFromPicture(picture, { width: S, height: S });
+  return { image, size: S, radius: R };
+}
+
+/** One particle ready to blit: world position + per-sprite scale/alpha/color. */
+export interface ParticleInstance {
+  x: number;
+  y: number;
+  scale: number;
+  alpha: number;
+  colorIndex: number;
+}
+
+/**
+ * Pure, worklet-safe projection of the packed particle ring buffer into render
+ * instances. No Skia — plain numbers only — so it's directly unit-testable.
+ *
+ * Preserves the exact size/opacity formulas the old per-slot `<Circle>` used:
+ *   life  = max(0, 1 - (now - t0) / burstDur)   (skip if dt = now - t0 < 0)
+ *   r     = size * (0.5 + life * 0.5),  size = buf[base+6] || 1
+ *   scale = r / spriteRadius
+ *   alpha = life * particleOpacity
+ * Inactive (active <= 0.5), pre-spawn (dt < 0) and fully-faded (life <= 0)
+ * slots are skipped.
+ */
+export function buildParticleInstances(
+  buf: Float64Array,
+  slots: number,
+  now: number,
+  burstDur: number,
+  particleOpacity: number,
+  spriteRadius: number,
+): ParticleInstance[] {
+  "worklet";
+  const out: ParticleInstance[] = [];
+  for (let i = 0; i < slots; i++) {
+    const base = i * DEGEN_STRIDE;
+    if (!(buf[base + 5] > 0.5)) continue;
+    const dt = now - buf[base + 4];
+    if (dt < 0) continue;
+    const life = Math.max(0, 1 - dt / burstDur);
+    if (life <= 0) continue;
+    const size = buf[base + 6] || 1;
+    const r = size * (0.5 + life * 0.5);
+    out.push({
+      x: buf[base + 0],
+      y: buf[base + 1],
+      scale: r / spriteRadius,
+      alpha: life * particleOpacity,
+      colorIndex: Math.max(0, Math.floor(buf[base + 7])),
+    });
+  }
+  return out;
+}

--- a/packages/react-native-livechart/tests/components/DegenParticlesOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/DegenParticlesOverlay.test.tsx
@@ -1,0 +1,100 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { useSharedValue } from "react-native-reanimated";
+import { DEGEN_STRIDE } from "../../src/constants";
+import { DegenParticlesOverlay } from "../../src/components/DegenParticlesOverlay";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { resolveTheme } from "../../src/theme";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+const palette = resolveTheme("#3b82f6", "dark");
+
+function engine(now: number): ChartEngineLayout {
+  return withSharedValueAccessors({
+    displayMin: { value: 0 },
+    displayMax: { value: 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: 300 },
+    timestamp: { value: now },
+  }) as unknown as ChartEngineLayout;
+}
+
+const SLOTS = 8;
+
+/** Buffer with `count` active particles spawned at t0=0. */
+function packBuffer(count: number): Float64Array<ArrayBuffer> {
+  const buf = new Float64Array(SLOTS * DEGEN_STRIDE);
+  for (let i = 0; i < count; i++) {
+    const b = i * DEGEN_STRIDE;
+    buf[b + 0] = 100 + i * 5; // x
+    buf[b + 1] = 150; // y
+    buf[b + 4] = 0; // t0
+    buf[b + 5] = 1; // active
+    buf[b + 6] = 2; // size
+    buf[b + 7] = i; // colorIndex
+  }
+  return buf;
+}
+
+describe("DegenParticlesOverlay", () => {
+  it("renders the atlas for an active-particle burst", () => {
+    function Fixture() {
+      const pack = useSharedValue<Float64Array<ArrayBuffer>>(packBuffer(4));
+      const packRevision = useSharedValue(1);
+      return (
+        <DegenParticlesOverlay
+          pack={pack}
+          packRevision={packRevision}
+          engine={engine(0.3)}
+          palette={palette}
+          particleSlotCount={SLOTS}
+          particleBurstDurationSec={1}
+          particleOpacity={0.8}
+          colors={["#16a34a", "#dc2626"]}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("renders without throwing for an empty (no active particles) buffer", () => {
+    function Fixture() {
+      const pack = useSharedValue<Float64Array<ArrayBuffer>>(packBuffer(0));
+      const packRevision = useSharedValue(0);
+      return (
+        <DegenParticlesOverlay
+          pack={pack}
+          packRevision={packRevision}
+          engine={engine(0)}
+          palette={palette}
+          particleSlotCount={SLOTS}
+          particleBurstDurationSec={1}
+          particleOpacity={0.8}
+          colors={null}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("emits nothing while uninitialized (packRevision < 0)", () => {
+    function Fixture() {
+      const pack = useSharedValue<Float64Array<ArrayBuffer>>(packBuffer(4));
+      const packRevision = useSharedValue(-1);
+      return (
+        <DegenParticlesOverlay
+          pack={pack}
+          packRevision={packRevision}
+          engine={engine(0.3)}
+          palette={palette}
+          particleSlotCount={SLOTS}
+          particleBurstDurationSec={1}
+          particleOpacity={0.8}
+          colors={["#16a34a"]}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+});

--- a/packages/react-native-livechart/tests/draw/particleAtlas.test.ts
+++ b/packages/react-native-livechart/tests/draw/particleAtlas.test.ts
@@ -1,0 +1,109 @@
+import { DEGEN_STRIDE } from "../../src/constants";
+import {
+  buildParticleInstances,
+  buildParticleSprite,
+} from "../../src/draw/particleAtlas";
+
+/** Write one active particle into slot `i` of a fresh buffer. */
+function bufWith(
+  i: number,
+  slots: number,
+  fields: { x?: number; y?: number; t0?: number; size?: number; colorIndex?: number },
+): Float64Array {
+  const buf = new Float64Array(slots * DEGEN_STRIDE);
+  const b = i * DEGEN_STRIDE;
+  buf[b + 0] = fields.x ?? 0;
+  buf[b + 1] = fields.y ?? 0;
+  buf[b + 4] = fields.t0 ?? 0;
+  buf[b + 5] = 1; // active
+  buf[b + 6] = fields.size ?? 1;
+  buf[b + 7] = fields.colorIndex ?? 0;
+  return buf;
+}
+
+describe("buildParticleInstances", () => {
+  const burstDur = 1.0;
+  const particleOpacity = 0.8;
+  const spriteRadius = 16;
+
+  it("computes scale = r/spriteRadius and alpha = life*particleOpacity", () => {
+    // t0=0, now=0.5 → dt=0.5, life=0.5; size=4 → r = 4*(0.5+0.25) = 3.
+    const buf = bufWith(0, 4, { x: 100, y: 200, t0: 0, size: 4 });
+    const out = buildParticleInstances(
+      buf,
+      4,
+      0.5,
+      burstDur,
+      particleOpacity,
+      spriteRadius,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].x).toBe(100);
+    expect(out[0].y).toBe(200);
+    expect(out[0].scale).toBeCloseTo(3 / spriteRadius, 6);
+    expect(out[0].alpha).toBeCloseTo(0.5 * particleOpacity, 6);
+  });
+
+  it("defaults size to 1 when the slot's size field is 0", () => {
+    const buf = bufWith(0, 2, { t0: 0, size: 0 });
+    // dt=0 → life=1 → r = 1*(0.5+0.5) = 1.
+    const out = buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius);
+    expect(out[0].scale).toBeCloseTo(1 / spriteRadius, 6);
+  });
+
+  it("skips inactive slots", () => {
+    const buf = bufWith(0, 2, { t0: 0, size: 2 });
+    buf[5] = 0; // mark inactive
+    const out = buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius);
+    expect(out).toHaveLength(0);
+  });
+
+  it("skips pre-spawn particles (dt < 0)", () => {
+    const buf = bufWith(0, 2, { t0: 10, size: 2 });
+    const out = buildParticleInstances(buf, 2, 5, burstDur, 1, spriteRadius);
+    expect(out).toHaveLength(0);
+  });
+
+  it("skips fully-expired particles (life <= 0)", () => {
+    const buf = bufWith(0, 2, { t0: 0, size: 2 });
+    // dt = burstDur → life = 0.
+    const out = buildParticleInstances(buf, 2, burstDur, burstDur, 1, spriteRadius);
+    expect(out).toHaveLength(0);
+  });
+
+  it("passes colorIndex through (floored, clamped to >= 0)", () => {
+    const buf = bufWith(0, 2, { t0: 0, size: 2, colorIndex: 3.9 });
+    const out = buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius);
+    expect(out[0].colorIndex).toBe(3);
+  });
+
+  it("counts multiple active particles", () => {
+    const buf = new Float64Array(3 * DEGEN_STRIDE);
+    for (let i = 0; i < 3; i++) {
+      const b = i * DEGEN_STRIDE;
+      buf[b + 4] = 0; // t0
+      buf[b + 5] = 1; // active
+      buf[b + 6] = 2; // size
+      buf[b + 7] = i; // colorIndex
+    }
+    const out = buildParticleInstances(buf, 3, 0.2, burstDur, 1, spriteRadius);
+    expect(out).toHaveLength(3);
+    expect(out.map((p) => p.colorIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("returns an empty array when there are no slots", () => {
+    expect(
+      buildParticleInstances(new Float64Array(0), 0, 0, burstDur, 1, spriteRadius),
+    ).toEqual([]);
+  });
+});
+
+describe("buildParticleSprite", () => {
+  it("returns an image plus matching box size and radius", () => {
+    const sprite = buildParticleSprite();
+    expect(sprite.image).toBeDefined();
+    expect(sprite.radius).toBe(16);
+    // Box = 2 * (radius + margin), margin = 2.
+    expect(sprite.size).toBe(2 * (16 + 2));
+  });
+});


### PR DESCRIPTION
Replaces the per-particle fan-out (~60 DegenSlot components, each 4 useDerivedValue worklets -> a Circle = ~240 worklets + 60 nodes/frame) with one pre-rasterized white-circle sprite, one batched worklet, and one <Atlas>. Per-particle color+opacity is baked into rgba() and applied via colorBlendMode=modulate. New particleAtlas.ts holds the sprite builder + a pure, unit-tested buildParticleInstances projector. The simulation (degenTick.ts) and the size/opacity/color formulas are unchanged, so visual output matches. Mirrors the existing marker drawAtlas pattern.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>