### PR TITLE
fix(scrub-action): drop dead monoCharWidth param from action badge

### DIFF
--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -378,8 +378,9 @@ export function deriveScrubValueSingle(
  * (see {@link pointInRect}). When not locked / not laid out / both empty, returns
  * {@link HIDDEN_ACTION_BADGE}.
  *
- * Text widths are sized by character count × `monoCharWidth` (the chart font is
- * monospace), so this stays a cheap per-frame worklet with no `measureText`.
+ * The price text is sized to its actual visual bounds via `font.measureText`
+ * (run only while a reticle is shown) so the readout stays exactly centered —
+ * see the inline note on `priceTextX` below.
  */
 export interface ActionBadgeLayout {
   /** Union hit rect (icon button + price pill). */
@@ -445,8 +446,6 @@ export function computeActionBadgeLayout(
   marginEdge: number,
   padX: number,
   padY: number,
-  /** Monospace advance width; sizes text by length (see {@link computeTooltipLayout}). */
-  monoCharWidth = 0,
 ): ActionBadgeLayout {
   "worklet";
   if (!locked || canvasWidth <= 0) return HIDDEN_ACTION_BADGE;
@@ -475,8 +474,8 @@ export function computeActionBadgeLayout(
     // bearing; this lands the visual center exactly on the pill center.
     //
     // This measures the actual string each frame rather than estimating from a
-    // per-char width (`monoCharWidth`). A uniform width over-reserves for prices
-    // with narrow glyphs ("1", "."), which visibly de-centers the readout — and
+    // per-char monospace width. A uniform width over-reserves for prices with
+    // narrow glyphs ("1", "."), which visibly de-centers the readout — and
     // exact centering matters more here than shaving the per-frame `measureText`,
     // which profiling put at ~4% of one core on the simulator (transient, only
     // while a reticle is shown). See the price-pill centering tests.

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -281,7 +281,6 @@ export function useCrosshair(
       badgeMetrics.marginEdge,
       badgeMetrics.padX,
       badgeMetrics.padY,
-      monoCharWidth,
     );
   });
 

--- a/packages/react-native-livechart/tests/components/ScrubActionOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ScrubActionOverlay.test.tsx
@@ -70,13 +70,12 @@ describe("ScrubActionOverlay", () => {
       4,
       10,
       3,
-      7,
     );
     render(<Fixture active badge={badge} />);
   });
 
   it("renders the icon-less branch when icon is empty", () => {
-    const badge = computeActionBadgeLayout(true, 150, "64.20", "", 400, 360, font, 4, 10, 3, 7);
+    const badge = computeActionBadgeLayout(true, 150, "64.20", "", 400, 360, font, 4, 10, 3);
     render(
       <ScrubActionOverlay
         lockActive={{ value: true } as never}
@@ -97,7 +96,7 @@ describe("ScrubActionOverlay", () => {
   });
 
   it("renders the optional x-axis time badge when provided", () => {
-    const badge = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 360, font, 4, 10, 3, 7);
+    const badge = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 360, font, 4, 10, 3);
     const time = computeTimeBadgeLayout(true, 200, "13:00", 400, 291, font, 10, 3, 4);
     render(
       <ScrubActionOverlay
@@ -116,7 +115,7 @@ describe("ScrubActionOverlay", () => {
   });
 
   it("honors color overrides", () => {
-    const badge = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 360, font, 4, 10, 3, 7);
+    const badge = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 360, font, 4, 10, 3);
     render(
       <ScrubActionOverlay
         lockActive={{ value: true } as never}

--- a/packages/react-native-livechart/tests/hooks/crosshairShared.test.ts
+++ b/packages/react-native-livechart/tests/hooks/crosshairShared.test.ts
@@ -67,17 +67,17 @@ describe("snapPrice", () => {
 
 describe("computeActionBadgeLayout", () => {
   it("is hidden when not locked", () => {
-    const l = computeActionBadgeLayout(false, 100, "64.20", "+", 400, 360, font, 4, 10, 3, 7);
+    const l = computeActionBadgeLayout(false, 100, "64.20", "+", 400, 360, font, 4, 10, 3);
     expect(l.visible).toBe(false);
   });
 
   it("is hidden when the canvas is not laid out", () => {
-    const l = computeActionBadgeLayout(true, 100, "64.20", "+", 0, 0, font, 4, 10, 3, 7);
+    const l = computeActionBadgeLayout(true, 100, "64.20", "+", 0, 0, font, 4, 10, 3);
     expect(l.visible).toBe(false);
   });
 
   it("lays out a circular icon button + a right-anchored price pill, text centered", () => {
-    const l = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 320, font, 4, 10, 3, 7);
+    const l = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 320, font, 4, 10, 3);
     expect(l.visible).toBe(true);
     expect(l.hasIcon).toBe(true);
     expect(l.hasPrice).toBe(true);
@@ -100,7 +100,7 @@ describe("computeActionBadgeLayout", () => {
   });
 
   it("anchors an icon-only badge to the plot edge (attached to the line)", () => {
-    const l = computeActionBadgeLayout(true, 150, "", "+", 400, 320, font, 4, 10, 3, 7);
+    const l = computeActionBadgeLayout(true, 150, "", "+", 400, 320, font, 4, 10, 3);
     expect(l.visible).toBe(true);
     expect(l.hasIcon).toBe(true);
     expect(l.hasPrice).toBe(false);
@@ -113,12 +113,12 @@ describe("computeActionBadgeLayout", () => {
   });
 
   it("is hidden when both icon and price are empty", () => {
-    const l = computeActionBadgeLayout(true, 150, "", "", 400, 360, font, 4, 10, 3, 7);
+    const l = computeActionBadgeLayout(true, 150, "", "", 400, 360, font, 4, 10, 3);
     expect(l.visible).toBe(false);
   });
 
-  it("falls back to measureText sizing when monoCharWidth is 0", () => {
-    const l = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 360, font, 4, 10, 3, 0);
+  it("sizes the price pill from the text's measured width", () => {
+    const l = computeActionBadgeLayout(true, 150, "64.20", "+", 400, 360, font, 4, 10, 3);
     expect(l.visible).toBe(true);
     expect(l.w).toBeGreaterThan(0);
   });


### PR DESCRIPTION
computeActionBadgeLayout took a monoCharWidth arg it never used — it sizes
the price pill via font.measureText for exact ink-centering. Remove the dead
parameter, the wasted arg at the useCrosshair call site, and the JSDoc claim
that it avoids measureText (which contradicted the implementation).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>