### PR TITLE
fix(reference-line): index keys so duplicate-value badges don't collapse

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -693,9 +693,12 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         </Group>
       )}
 
-      {allRefLines.map((rl) => (
+      {/* Index keys: reference lines are a positional array and two may share
+          value + label (e.g. duplicate working orders at the same price), which a
+          content-derived key would collapse to one. */}
+      {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
-          key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
+          key={i}
           engine={engine}
           padding={effectivePadding}
           line={rl}
@@ -982,9 +985,9 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
   if (allRefLines.length === 0) return null;
   return (
     <Group transform={degenShakeTransform}>
-      {allRefLines.map((rl) => (
+      {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
-          key={`badge-${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
+          key={i}
           engine={engine}
           padding={effectivePadding}
           line={rl}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -448,9 +448,12 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         </Group>
       )}
 
-      {allRefLines.map((rl) => (
+      {/* Index keys: reference lines are a positional array and two may share
+          value + label (e.g. duplicate working orders at the same price), which a
+          content-derived key would collapse to one. */}
+      {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
-          key={`${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
+          key={i}
           engine={engine}
           padding={effectivePadding}
           line={rl}
@@ -604,9 +607,9 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
   if (allRefLines.length === 0) return null;
   return (
     <Group transform={degenShakeTransform}>
-      {allRefLines.map((rl) => (
+      {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
-          key={`badge-${rl.value ?? ""}:${rl.valueFrom ?? ""}:${rl.valueTo ?? ""}:${rl.from ?? ""}:${rl.to ?? ""}:${rl.label ?? ""}`}
+          key={i}
           engine={engine}
           padding={effectivePadding}
           line={rl}

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -110,6 +110,26 @@ describe("LiveChart", () => {
     render(<CandleHarness scrubAction onScrubAction={jest.fn()} />);
   });
 
+  it("does not collide React keys for duplicate-value reference lines", () => {
+    // Two working orders at the same price + label (reachable from the
+    // order-ticket flow) must each render — a content-derived key would
+    // collapse them and warn. Index keys keep them distinct.
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <Harness
+        referenceLines={[
+          { value: 50, label: "Limit buy", showValue: true, badge: { icon: "▲" } },
+          { value: 50, label: "Limit buy", showValue: true, badge: { icon: "▲" } },
+        ]}
+      />,
+    );
+    const keyWarning = errorSpy.mock.calls.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("same key")),
+    );
+    expect(keyWarning).toBe(false);
+    errorSpy.mockRestore();
+  });
+
   it("accepts custom formatters", () => {
     render(
       <Harness formatValue={(v) => v.toFixed(4)} formatTime={() => "x"} />,


### PR DESCRIPTION
ChartRefBadgeLayer / SeriesRefBadgeLayer and the base-pass maps keyed
reference lines by value+label, so two working orders at the same price +
side produced an identical React key — only one rendered, plus a console
warning. Reachable straight from the order-ticket flow. Key by array index.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>