### PR TITLE
fix(scrub-action): coordinate marker taps with the action tap

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -410,6 +410,22 @@ function useLiveChartController({
       }
     : undefined;
 
+  const markersActive = markers != null;
+  // `projected` is used internally by the hit-test gesture; the overlay
+  // self-projects, so we only need the gesture + hit-test here. Built BEFORE
+  // `useCrosshair` so the scrub-action tap can defer to a marker under the finger.
+  const { tapGesture: markerTapGesture, hitTest: markerHitTest } = useMarkers(
+    engine,
+    effectivePadding,
+    markersSV,
+    !isStatic && markersActive,
+    markerHitRadius,
+    onMarkerHover,
+    undefined, // seriesSV — single-series has none
+    engine.data, // anchor value-less markers to the line
+    !isStatic, // static: no marker-projection loop
+  );
+
   const crosshair = useCrosshair(
     engine,
     effectivePadding,
@@ -428,21 +444,7 @@ function useLiveChartController({
     scrubActionCfg,
     onScrubAction,
     metricsCfg.badge,
-  );
-
-  const markersActive = markers != null;
-  // `projected` is used internally by the hit-test gesture; the overlay
-  // self-projects, so we only need the gesture here.
-  const { tapGesture: markerTapGesture } = useMarkers(
-    engine,
-    effectivePadding,
-    markersSV,
-    !isStatic && markersActive,
-    markerHitRadius,
-    onMarkerHover,
-    undefined, // seriesSV — single-series has none
-    engine.data, // anchor value-less markers to the line
-    !isStatic, // static: no marker-projection loop
+    markersActive ? markerHitTest : undefined,
   );
 
   // Scrub-action composes a Tap (place/move the reticle, press the badge, dismiss)
@@ -454,8 +456,15 @@ function useLiveChartController({
       ? Gesture.Exclusive(crosshair.tapGesture, crosshair.gesture)
       : crosshair.gesture;
 
+  // With markers + scrub-action, the action tap and the marker tap must BOTH see
+  // each tap (Simultaneous): the action tap defers to a marker under the finger
+  // (via `markerHitTest`) so the marker tap selects it, and places the reticle on
+  // an empty tap. `Race` would cancel the loser and silently drop one of them.
+  // Without scrub-action there's only the pan, so `Race` stays correct.
   const rootGesture = markersActive
-    ? Gesture.Race(baseGesture, markerTapGesture)
+    ? scrubActionCfg !== null
+      ? Gesture.Simultaneous(baseGesture, markerTapGesture)
+      : Gesture.Race(baseGesture, markerTapGesture)
     : baseGesture;
 
   // ── Derived render values ──────────────────────────────────────────────

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -107,6 +107,12 @@ export function useCrosshair(
   onScrubAction?: (point: ScrubActionPoint) => void,
   /** Badge geometry (gutter margins / pad) for the action pill. */
   badgeMetrics: BadgeMetrics = BADGE_METRICS_DEFAULTS,
+  /**
+   * Worklet predicate: true when a tap at (x, y) lands on a marker. When markers
+   * coexist with scrub-action, the tap defers to the marker (no reticle placed)
+   * so the marker tap can select it. Omitted when there are no markers.
+   */
+  isMarkerHit?: (x: number, y: number) => boolean,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -511,6 +517,10 @@ export function useCrosshair(
         return;
       }
     }
+    // 2.5. Defer to a marker under the tap: when markers coexist, the tap fires
+    //      both this handler and the marker tap (Simultaneous) — yield so the
+    //      marker is selected instead of dropping/moving a reticle on top of it.
+    if (isMarkerHit !== undefined && isMarkerHit(e.x, e.y)) return;
     // 3. Place / move the reticle. Clear any in-progress live-scrub so its
     //    crosshair never shows behind the placed reticle.
     scrubActive.set(false);

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -32,7 +32,12 @@ export function useMarkers(
   lineData?: SharedValue<LiveChartPoint[]>,
   /** Static charts run no loops: register without starting. Default `true`. */
   autostart = true,
-): { projected: SharedValue<ProjectedMarker[]>; tapGesture: ReturnType<typeof Gesture.Tap> } {
+): {
+  projected: SharedValue<ProjectedMarker[]>;
+  tapGesture: ReturnType<typeof Gesture.Tap>;
+  /** Worklet hit-test: true when (x, y) lands on a projected marker. */
+  hitTest: (x: number, y: number) => boolean;
+} {
   const projected = useSharedValue<ProjectedMarker[]>([]);
   const cacheRef = useRef<{
     a: ProjectedMarker[];
@@ -94,5 +99,16 @@ export function useMarkers(
     },
   );
 
-  return { projected, tapGesture };
+  // Lets a coexisting gesture (e.g. the scrub-action tap) defer to a marker
+  // under the finger instead of acting on it.
+  const hitTest =
+    /* istanbul ignore next -- worklet, runs on the UI thread, not in Jest */ (
+      x: number,
+      y: number,
+    ) => {
+      "worklet";
+      return nearestMarkerIndex(projected.get(), x, y, hitRadius) >= 0;
+    };
+
+  return { projected, tapGesture, hitTest };
 }


### PR DESCRIPTION
When markers + scrubAction were both active, the marker tap and the
order-ticket action tap raced (Gesture.Race) with no coordination — both
recognise every tap, so the winner was threshold-dependent: a badge press
could be swallowed, or tapping a marker would drop a reticle instead of
selecting it.

Compose them with Gesture.Simultaneous so both fire, and have the action tap
defer (place nothing) when the tap lands on a marker — via a hit-test predicate
now exposed by useMarkers (built before useCrosshair so it's available). Plain
markers without scrubAction keep Race.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>