### PR TITLE
fix(scrub-action): keep the locked price stable as the axis rescales

### DIFF
--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -136,7 +136,10 @@ export function useCrosshair(
   // lock gestures are only wired by the controller when `scrubAction` is set.
   const lockActive = useSharedValue(false);
   const lockX = useSharedValue(-1);
-  const lockY = useSharedValue(-1);
+  // The chosen PRICE is the source of truth (frozen on place/drag); the reticle's
+  // screen Y is re-derived from it each frame (see `lockY` below) so the level
+  // tracks the price as the axis rescales instead of drifting under a fixed pixel.
+  const lockPriceValue = useSharedValue<number | null>(null);
   const hasScrubAction = scrubAction != null;
   const hasOnScrubAction = onScrubAction != null;
   const dismissOnTapOutside = scrubAction?.dismissOnTapOutside ?? false;
@@ -244,20 +247,35 @@ export function useCrosshair(
   });
 
   // ── Scrub-action lock derivations ──────────────────────────────────────────
-  // Chosen price = value at the locked reticle Y (a free level, NOT the line
-  // value at X), optionally snapped. Null until a reticle is placed.
+  // Reported price = the frozen chosen price, optionally snapped. Independent of
+  // the display range (the point of freezing it), so the badge readout and the
+  // onScrubAction payload stay stable while the chart auto-rescales. Null until a
+  // reticle is placed.
   /* istanbul ignore next -- worklet (locked branch only runs on the UI thread) */
   const lockPrice = useDerivedValue(() => {
     if (!lockActive.get()) return null;
-    const v = computeValueAtY(
-      lockY.get(),
+    const p = lockPriceValue.get();
+    return p === null ? null : snapPrice(p, snapIncrement);
+  });
+
+  // Screen Y of the locked level, DERIVED from the frozen price each frame so the
+  // line + badge track the chosen price as displayMin/Max move (rather than the
+  // price drifting under a pixel-fixed reticle). Pins to the plot edge when the
+  // price scrolls out of the visible range; -1 until placed / laid out.
+  /* istanbul ignore next -- worklet (locked branch only runs on the UI thread) */
+  const lockY = useDerivedValue(() => {
+    const p = lockPriceValue.get();
+    const ch = engine.canvasHeight.get();
+    if (p === null || ch - padding.top - padding.bottom <= 0) return -1;
+    const y = computeScrubDotY(
+      p,
       engine.displayMin.get(),
       engine.displayMax.get(),
-      engine.canvasHeight.get(),
+      ch,
       padding.top,
       padding.bottom,
     );
-    return v === null ? null : snapPrice(v, snapIncrement);
+    return clampPlotY(y, padding.top, ch, padding.bottom);
   });
 
   const lockTime = useDerivedValue(() =>
@@ -447,9 +465,19 @@ export function useCrosshair(
           lockX.set(
             clampPlotX(e.x, padding.left, engine.canvasWidth.get(), padding.right),
           );
-          lockY.set(
-            clampPlotY(e.y, padding.top, engine.canvasHeight.get(), padding.bottom),
-          );
+          // Freeze the chosen price (value at the pointer Y); the line's Y is
+          // re-derived from it so the level stays put in PRICE as the axis rescales.
+          {
+            const p = computeValueAtY(
+              e.y,
+              engine.displayMin.get(),
+              engine.displayMax.get(),
+              engine.canvasHeight.get(),
+              padding.top,
+              padding.bottom,
+            );
+            if (p !== null) lockPriceValue.set(p);
+          }
           return;
         }
         scrubX.set(e.x);
@@ -466,9 +494,19 @@ export function useCrosshair(
           lockX.set(
             clampPlotX(e.x, padding.left, engine.canvasWidth.get(), padding.right),
           );
-          lockY.set(
-            clampPlotY(e.y, padding.top, engine.canvasHeight.get(), padding.bottom),
-          );
+          // Freeze the chosen price (value at the pointer Y); the line's Y is
+          // re-derived from it so the level stays put in PRICE as the axis rescales.
+          {
+            const p = computeValueAtY(
+              e.y,
+              engine.displayMin.get(),
+              engine.displayMax.get(),
+              engine.canvasHeight.get(),
+              padding.top,
+              padding.bottom,
+            );
+            if (p !== null) lockPriceValue.set(p);
+          }
           return;
         }
         scrubX.set(e.x);
@@ -547,9 +585,18 @@ export function useCrosshair(
     lockX.set(
       clampPlotX(e.x, padding.left, engine.canvasWidth.get(), padding.right),
     );
-    lockY.set(
-      clampPlotY(e.y, padding.top, engine.canvasHeight.get(), padding.bottom),
+    // Freeze the chosen price at the tap Y; the line's Y derives from it (see
+    // `lockY`). No-op until the canvas is laid out (price === null).
+    const placedPrice = computeValueAtY(
+      e.y,
+      engine.displayMin.get(),
+      engine.displayMax.get(),
+      engine.canvasHeight.get(),
+      padding.top,
+      padding.bottom,
     );
+    if (placedPrice === null) return;
+    lockPriceValue.set(placedPrice);
     lockActive.set(true);
   };
 

--- a/packages/react-native-livechart/tests/hooks/crosshairShared.test.ts
+++ b/packages/react-native-livechart/tests/hooks/crosshairShared.test.ts
@@ -49,6 +49,24 @@ describe("computeValueAtY", () => {
     const y = computeScrubDotY(v, 0, 100, 300, 12, 28);
     expect(computeValueAtY(y, 0, 100, 300, 12, 28)).toBeCloseTo(v);
   });
+
+  it("price-stable lock: a frozen price keeps its value while its Y tracks the range", () => {
+    // Old (buggy) model derived the price from a FIXED pixel each frame, so the
+    // reported price drifted as the axis rescaled:
+    const pixelY = 150;
+    const drift1 = computeValueAtY(pixelY, 0, 100, 300, 12, 28);
+    const drift2 = computeValueAtY(pixelY, 20, 120, 300, 12, 28);
+    expect(drift2).not.toBeCloseTo(drift1 as number); // the drift the fix removes
+
+    // New model freezes the price once (the source of truth) and re-derives the
+    // line's Y from it: the value stays constant, the line moves to keep tracking
+    // that price as displayMin/Max shift.
+    const frozen = drift1 as number;
+    const yUnchanged = computeScrubDotY(frozen, 0, 100, 300, 12, 28);
+    const yShifted = computeScrubDotY(frozen, 20, 120, 300, 12, 28);
+    expect(yUnchanged).toBeCloseTo(pixelY); // same range → same pixel
+    expect(yShifted).not.toBeCloseTo(yUnchanged); // shifted range → line moves
+  });
 });
 
 describe("snapPrice", () => {


### PR DESCRIPTION
The reticle was pixel-locked (lockY) and the price was re-derived from that
fixed pixel every frame, so a placed level's reported price drifted as the live
chart auto-rescaled — the badge readout and onScrubAction payload depended on
the axis scaling at press time, not the price the user placed.

Make the chosen price the source of truth: freeze value-at-Y on place/drag into
lockPriceValue, derive the reported price (snapped) from it — now independent of
the display range — and re-derive the on-screen lockY from it each frame via
computeScrubDotY, so the level line tracks the chosen price (pinning to the plot
edge when it scrolls out of the visible range). lockY becomes a derived value.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>