### PR TITLE
fix(reference-line): center the icon ink in pill badges

### DIFF
--- a/app/demo/scrub-action.tsx
+++ b/app/demo/scrub-action.tsx
@@ -92,7 +92,7 @@ export default function ScrubActionScreen() {
       // Pill badge with a directional icon (and optional text). Left-pinned with a
       // connector to the right edge; gains a chevron once it scrolls off-screen.
       badge: {
-        icon: o.side === "buy" ? "▲" : "▼",
+        icon: o.side === "buy" ? "+" : "−",
         text: !orderIconOnly,
         background:
           o.side === "buy" ? "rgba(22,163,74,0.15)" : "rgba(220,38,38,0.15)",

--- a/packages/react-native-livechart/src/hooks/useReferenceLine.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLine.ts
@@ -103,7 +103,13 @@ function badgeGeometry(
   font: SkFont,
 ): BadgeGeometry {
   "worklet";
-  const iconW = icon ? measureFontTextWidth(font, icon) : 0;
+  // Measure the icon's visual bounds (not just width): `SkiaText` draws from the
+  // pen origin, so the glyph's left side-bearing (`bounds.x`) must be subtracted
+  // to land the ink in its slot. Without this an asymmetric glyph (a ▼ triangle,
+  // a "+"/"−") sits off-center in an icon-only pill. Mirrors the action-badge
+  // price-pill centering in computeActionBadgeLayout.
+  const iconBounds = icon ? font.measureText(icon) : null;
+  const iconW = iconBounds ? iconBounds.width : 0;
   const textW = text ? measureFontTextWidth(font, text) : 0;
 
   let contentW = 0;
@@ -136,7 +142,9 @@ function badgeGeometry(
   }
   let iconX = -1;
   if (icon) {
-    iconX = cursor;
+    // Pen origin compensates the left side-bearing so the ink starts at `cursor`
+    // (and is centered in an icon-only pill, whose width is iconW + 2*padX).
+    iconX = cursor - (iconBounds ? iconBounds.x : 0);
     cursor += iconW + BADGE_GAP;
   }
   const textX = text ? cursor : -1;

--- a/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
@@ -358,6 +358,35 @@ describe("useReferenceLine", () => {
     expect(l.labelX).toBe(-1);
   });
 
+  it("centers the icon ink in an icon-only pill (compensates the side-bearing)", () => {
+    // A font where every glyph carries a 3px left side-bearing. SkiaText draws
+    // from the pen origin, so the layout must pull `iconX` back by the bearing to
+    // keep the ink centered in the pill.
+    const bearing = 3;
+    const bearingFont = {
+      getSize: () => 12,
+      measureText: (s: string) => ({ x: bearing, y: 0, width: s.length * 7, height: 12 }),
+      getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+    } as never;
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, badge: { icon: "+", text: false } },
+        fmt,
+        bearingFont,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.icon).toBe("+");
+    const inkW = "+".length * 7;
+    const inkLeft = l.iconX + bearing; // SkiaText ink starts at origin + bearing
+    // Ink left lands at the pill's content edge (pillX + BADGE_PAD_X = 6)...
+    expect(inkLeft).toBeCloseTo(l.pillX + 6);
+    // ...so the ink is centered in the pill.
+    expect(inkLeft + inkW / 2).toBeCloseTo(l.pillX + l.pillW / 2);
+  });
+
   it("pins the badge to the edge with a chevron when off-screen", () => {
     const { result } = renderHook(() =>
       useReferenceLine(engine(), PADDING, { value: 150, badge: true }, fmt, font),


### PR DESCRIPTION
An icon-only badge sized its pill to the glyph's ink width but drew the glyph at
the pen origin, so the left side-bearing pushed the ink off-center (a ▼/▲ or
'+'/'−' sat left of center). Measure the icon's visual bounds in badgeGeometry
and pull the pen origin back by bounds.x — mirroring the action-badge price
centering — so the ink lands centered in the pill.

Demo (scrub-action): use '+' for buy and '−' for sell working orders instead of
▲/▼ — reads more naturally as add/reduce and shows off the centering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>