### PR TITLE
feat(reference-line): onReferenceLinePress — tap a working-order badge

### DIFF
--- a/app/demo/scrub-action.tsx
+++ b/app/demo/scrub-action.tsx
@@ -48,6 +48,9 @@ export default function ScrubActionScreen() {
     side: "buy" | "sell";
     price: number;
   } | null>(null);
+  // The working order whose line was tapped (index into `orders`); opens the
+  // cancel sheet. null when no order is selected.
+  const [cancelIdx, setCancelIdx] = useState<number | null>(null);
 
   const emptyCandles = useSharedValue<CandlePoint[]>([]);
   const nullLive = useSharedValue<CandlePoint | null>(null);
@@ -75,6 +78,17 @@ export default function ScrubActionScreen() {
     if (pending) setOrders((prev) => [...prev, pending]);
     setPending(null);
   };
+
+  // onReferenceLinePress fires when a working-order badge is tapped. `index` is
+  // the order's position in `referenceLines` (= `orders`, same order), so it maps
+  // straight back to the order to cancel.
+  const cancelOrder = () => {
+    if (cancelIdx !== null) {
+      setOrders((prev) => prev.filter((_, i) => i !== cancelIdx));
+    }
+    setCancelIdx(null);
+  };
+  const cancelTarget = cancelIdx !== null ? orders[cancelIdx] : undefined;
 
   const referenceLines: ReferenceLine[] = orders.map((o) => {
     const color = o.side === "buy" ? "#16a34a" : "#dc2626";
@@ -105,7 +119,7 @@ export default function ScrubActionScreen() {
   return (
     <DemoScreen
       title="Order ticket"
-      description="scrubAction: tap to drop a price reticle, drag to adjust, press the + badge to place a limit order. Confirmed orders become working-order reference lines."
+      description="scrubAction: tap to drop a price reticle, drag to adjust, press the + badge to place a limit order. Confirmed orders become working-order lines — tap an order's badge to cancel it."
       chart={
         <LiveChart
           data={data}
@@ -128,6 +142,8 @@ export default function ScrubActionScreen() {
             timeBadge: showTime,
           }}
           onScrubAction={onScrubAction}
+          // Tap a working-order badge to manage it — here, open a cancel sheet.
+          onReferenceLinePress={(_line, index) => setCancelIdx(index)}
         />
       }
     >
@@ -195,6 +211,39 @@ export default function ScrubActionScreen() {
                 <Text style={styles.sheetConfirmText}>
                   Place {pending?.side === "buy" ? "buy" : "sell"}
                 </Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* Cancel sheet, opened by tapping a working-order badge (onReferenceLinePress). */}
+      <Modal
+        visible={cancelTarget !== undefined}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setCancelIdx(null)}
+      >
+        <Pressable style={styles.backdrop} onPress={() => setCancelIdx(null)}>
+          <Pressable style={styles.sheet}>
+            <Text style={styles.sheetTitle}>
+              Cancel {cancelTarget?.side === "buy" ? "limit buy" : "limit sell"}?
+            </Text>
+            <Text style={styles.sheetPrice}>
+              @ ${cancelTarget?.price.toFixed(2)}
+            </Text>
+            <View style={styles.sheetRow}>
+              <Pressable
+                style={[styles.sheetButton, styles.sheetCancel]}
+                onPress={() => setCancelIdx(null)}
+              >
+                <Text style={styles.sheetCancelText}>Keep</Text>
+              </Pressable>
+              <Pressable
+                style={[styles.sheetButton, { backgroundColor: "#dc2626" }]}
+                onPress={cancelOrder}
+              >
+                <Text style={styles.sheetConfirmText}>Cancel order</Text>
               </Pressable>
             </View>
           </Pressable>

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -52,6 +52,7 @@ import { useDegen } from "../hooks/useDegen";
 import { useLiveChartHasData } from "../hooks/useLiveChartHasData";
 import { useLiveDot } from "../hooks/useLiveDot";
 import { useMarkers } from "../hooks/useMarkers";
+import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
 import { useMomentum } from "../hooks/useMomentum";
 import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
@@ -163,6 +164,7 @@ function useLiveChartController({
   // ── Callbacks ───────────────────────────────────────────────────────────
   onScrub,
   onScrubAction,
+  onReferenceLinePress,
   onGestureStart,
   onGestureEnd,
   onDegenShake,
@@ -426,6 +428,30 @@ function useLiveChartController({
     !isStatic, // static: no marker-projection loop
   );
 
+  // Pressable reference-line badges (working orders / alerts). Built before
+  // `useCrosshair` so the scrub-action tap can defer to a badge under the finger.
+  const refPressActive = onReferenceLinePress != null && allRefLines.length > 0;
+  const { tapGesture: refLineTapGesture, hitTest: refLineHitTest } =
+    useReferenceLinePress(
+      engine,
+      effectivePadding,
+      allRefLines,
+      skiaFont,
+      formatValue,
+      !isStatic && refPressActive,
+      markerHitRadius,
+      onReferenceLinePress,
+    );
+
+  // Combined "defer" hit-test for the scrub-action place-tap: yield to a marker or
+  // a pressable badge under the finger so the tap is routed there instead of
+  // dropping a reticle. (Both hit-tests return false when their feature is off.)
+  /* istanbul ignore next -- worklet runs on the UI thread, not in Jest */
+  const deferTapHit = (x: number, y: number): boolean => {
+    "worklet";
+    return markerHitTest(x, y) || refLineHitTest(x, y);
+  };
+
   const crosshair = useCrosshair(
     engine,
     effectivePadding,
@@ -444,7 +470,7 @@ function useLiveChartController({
     scrubActionCfg,
     onScrubAction,
     metricsCfg.badge,
-    markersActive ? markerHitTest : undefined,
+    markersActive || refPressActive ? deferTapHit : undefined,
   );
 
   // Scrub-action composes a Tap (place/move the reticle, press the badge, dismiss)
@@ -456,16 +482,29 @@ function useLiveChartController({
       ? Gesture.Exclusive(crosshair.tapGesture, crosshair.gesture)
       : crosshair.gesture;
 
-  // With markers + scrub-action, the action tap and the marker tap must BOTH see
-  // each tap (Simultaneous): the action tap defers to a marker under the finger
-  // (via `markerHitTest`) so the marker tap selects it, and places the reticle on
-  // an empty tap. `Race` would cancel the loser and silently drop one of them.
-  // Without scrub-action there's only the pan, so `Race` stays correct.
-  const rootGesture = markersActive
-    ? scrubActionCfg !== null
-      ? Gesture.Simultaneous(baseGesture, markerTapGesture)
-      : Gesture.Race(baseGesture, markerTapGesture)
-    : baseGesture;
+  // Overlay taps that hit-test discrete targets (marker dots, reference-line
+  // badges). They must all see each tap, so they're combined with `Simultaneous`
+  // (not `Race`, which cancels the loser and would drop one). The scrub-action
+  // action tap defers to them via `deferTapHit`, so a tap on an overlay is routed
+  // there instead of placing a reticle.
+  const overlayTaps = [
+    markersActive ? markerTapGesture : null,
+    refPressActive ? refLineTapGesture : null,
+  ].filter((g): g is NonNullable<typeof g> => g !== null);
+
+  let rootGesture = baseGesture;
+  if (overlayTaps.length > 0) {
+    const tapGroup =
+      overlayTaps.length === 1
+        ? overlayTaps[0]
+        : Gesture.Simultaneous(overlayTaps[0], overlayTaps[1]);
+    // With scrub-action the action tap shares the gesture space with the overlay
+    // taps (Simultaneous); without it the pan only needs to race the tap group.
+    rootGesture =
+      scrubActionCfg !== null
+        ? Gesture.Simultaneous(baseGesture, tapGroup)
+        : Gesture.Race(baseGesture, tapGroup);
+  }
 
   // ── Derived render values ──────────────────────────────────────────────
   const {

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -120,11 +120,12 @@ export function useCrosshair(
   /** Badge geometry (gutter margins / pad) for the action pill. */
   badgeMetrics: BadgeMetrics = BADGE_METRICS_DEFAULTS,
   /**
-   * Worklet predicate: true when a tap at (x, y) lands on a marker. When markers
-   * coexist with scrub-action, the tap defers to the marker (no reticle placed)
-   * so the marker tap can select it. Omitted when there are no markers.
+   * Worklet predicate: true when a tap at (x, y) lands on another interactive
+   * overlay (a marker, or a pressable reference-line badge). The scrub-action tap
+   * defers to it (no reticle placed) so that overlay's tap handler can act.
+   * Omitted when nothing coexists.
    */
-  isMarkerHit?: (x: number, y: number) => boolean,
+  deferTapHit?: (x: number, y: number) => boolean,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -575,10 +576,10 @@ export function useCrosshair(
         return;
       }
     }
-    // 2.5. Defer to a marker under the tap: when markers coexist, the tap fires
-    //      both this handler and the marker tap (Simultaneous) — yield so the
-    //      marker is selected instead of dropping/moving a reticle on top of it.
-    if (isMarkerHit !== undefined && isMarkerHit(e.x, e.y)) return;
+    // 2.5. Defer to a marker / reference-line badge under the tap: when one
+    //      coexists, the tap fires both this handler and that overlay's tap
+    //      (Simultaneous) — yield so it acts instead of dropping a reticle on top.
+    if (deferTapHit !== undefined && deferTapHit(e.x, e.y)) return;
     // 3. Place / move the reticle. Clear any in-progress live-scrub so its
     //    crosshair never shows behind the placed reticle.
     scrubActive.set(false);

--- a/packages/react-native-livechart/src/hooks/useReferenceLine.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLine.ts
@@ -78,6 +78,8 @@ const BADGE_GAP = 4;
 const BADGE_CHEV_W = 8;
 /** Pill inset from the pinned plot edge, in px. */
 const BADGE_EDGE_INSET = 2;
+/** Vertical padding inside the pill (matches ReferenceLineOverlay's BADGE_PILL_PAD_Y). */
+const BADGE_PILL_PAD_Y = 3;
 
 interface BadgeGeometry {
   pillX: number;
@@ -166,6 +168,91 @@ function badgeGeometry(
   }
 
   return { pillX, pillW, iconX, textX, chevronCx, connStart, connEnd };
+}
+
+/** Resolved badge text for a Form-A line (in-range tag or off-axis pin). */
+function referenceBadgeText(
+  line: ReferenceLine,
+  badge: ReturnType<typeof resolveReferenceBadge> & object,
+  v: number,
+  formatValue: (value: number) => string,
+  offAxis: boolean,
+): string {
+  "worklet";
+  if (!badge.showText) return "";
+  if (offAxis && badge.legacyText) {
+    const word = line.offAxisBadgeLabel ?? line.label;
+    return word ? `${word}: ${formatValue(v)}` : formatValue(v);
+  }
+  if (line.showValue && line.label) return `${line.label} ${formatValue(v)}`;
+  return line.label ?? formatValue(v);
+}
+
+/** Axis-aligned screen rect of a reference-line badge pill (the press hit-target). */
+export interface ReferenceBadgeRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Screen-space pill rect for a Form-A reference line's **badge**, or `null` when
+ * the line has no pressable badge (no `badge`/`offAxisBadge`, not a value line, a
+ * legacy off-axis badge while in range, or the canvas isn't laid out / range is
+ * degenerate). Shares `badgeGeometry` + the edge classification with
+ * {@link useReferenceLine}, so the hit-target tracks the rendered pill exactly.
+ * Pure worklet — used by {@link useReferenceLinePress} for tap hit-testing.
+ */
+export function computeReferenceBadgeRect(
+  line: ReferenceLine,
+  canvasWidth: number,
+  canvasHeight: number,
+  padding: ChartPadding,
+  dMin: number,
+  dMax: number,
+  font: SkFont,
+  formatValue: (value: number) => string,
+): ReferenceBadgeRect | null {
+  "worklet";
+  const badge = resolveReferenceBadge(line);
+  if (!badge) return null;
+  if (referenceLineForm(line) !== "line" || line.value === undefined) return null;
+  if (canvasWidth === 0 || canvasHeight === 0) return null;
+
+  const chartTop = padding.top;
+  const chartBottom = canvasHeight - padding.bottom;
+  const chartH = chartBottom - chartTop;
+  const valRange = dMax - dMin;
+  if (chartH <= 0 || valRange <= 0) return null;
+
+  const x1 = padding.left;
+  const x2 = canvasWidth - padding.right;
+  const v = line.value;
+  const edge = classifyReferenceEdge(v, dMin, dMax);
+
+  let y: number;
+  let hasChevron: boolean;
+  if (edge !== "in") {
+    // Off-screen: pinned to the nearest edge with a chevron.
+    hasChevron = true;
+    y =
+      edge === "above"
+        ? chartTop + OFF_AXIS_EDGE_INSET
+        : chartBottom - OFF_AXIS_EDGE_INSET;
+  } else {
+    // In range: a legacy off-axis-only badge shows no pill here → not pressable.
+    if (!badge.inRange) return null;
+    hasChevron = false;
+    y = chartTop + ((dMax - v) / valRange) * chartH;
+  }
+
+  const text = referenceBadgeText(line, badge, v, formatValue, edge !== "in");
+  const g = badgeGeometry(badge.position, badge.icon, text, hasChevron, x1, x2, font);
+  const fm = font.getMetrics();
+  const pillH = fm.descent - fm.ascent + BADGE_PILL_PAD_Y * 2;
+  // The pill is vertically centered on the line's y (see ReferenceLineOverlay).
+  return { x: g.pillX, y: y - pillH / 2, w: g.pillW, h: pillH };
 }
 
 /**
@@ -293,18 +380,7 @@ export function useReferenceLine(
       const clampedY = above
         ? chartTop + OFF_AXIS_EDGE_INSET
         : chartBottom - OFF_AXIS_EDGE_INSET;
-      let text = "";
-      if (badge.showText) {
-        if (badge.legacyText) {
-          const word = line.offAxisBadgeLabel ?? line.label;
-          text = word ? `${word}: ${formatValue(v)}` : formatValue(v);
-        } else {
-          text = line.label ?? formatValue(v);
-          if (line.showValue && line.label) {
-            text = `${line.label} ${formatValue(v)}`;
-          }
-        }
-      }
+      const text = referenceBadgeText(line, badge, v, formatValue, true);
       const g = badgeGeometry(badge.position, badge.icon, text, true, x1, x2, font);
       return {
         ...INVISIBLE,
@@ -333,13 +409,7 @@ export function useReferenceLine(
 
     // In-range pill badge (the `badge` config, not the legacy off-axis-only flag).
     if (badge && badge.inRange) {
-      let text = "";
-      if (badge.showText) {
-        text = line.label ?? formatValue(v);
-        if (line.showValue && line.label) {
-          text = `${line.label} ${formatValue(v)}`;
-        }
-      }
+      const text = referenceBadgeText(line, badge, v, formatValue, false);
       const g = badgeGeometry(badge.position, badge.icon, text, false, x1, x2, font);
       return {
         ...INVISIBLE,

--- a/packages/react-native-livechart/src/hooks/useReferenceLinePress.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLinePress.ts
@@ -1,0 +1,92 @@
+import type { SkFont } from "@shopify/react-native-skia";
+import { Gesture } from "react-native-gesture-handler";
+import { useDerivedValue } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import type { ReferenceLine } from "../types";
+import { pointInRect } from "./crosshairShared";
+import {
+  computeReferenceBadgeRect,
+  type ReferenceBadgeRect,
+} from "./useReferenceLine";
+
+/**
+ * Builds a tap gesture that hit-tests a chart's reference-line **badges** (the
+ * pill tags for working orders / alerts / targets) and fires `onPress(line,
+ * index)` when one is tapped. Mirrors {@link useMarkers}: badge rects are
+ * projected to screen each frame on the UI thread (so they track the rescaling
+ * axis exactly like the rendered pills), and the gesture hit-tests against them.
+ *
+ * Also returns a `hitTest` worklet so a coexisting gesture (the scrub-action tap)
+ * can defer to a badge under the finger instead of acting on it. Only badge-tagged
+ * Form-A (value) lines are pressable; everything else projects to `null`.
+ */
+export function useReferenceLinePress(
+  engine: ChartEngineLayout,
+  padding: ChartPadding,
+  lines: ReferenceLine[],
+  font: SkFont,
+  formatValue: (v: number) => string,
+  active: boolean,
+  /** Touch-target inflation around each pill, in px. */
+  hitSlop: number,
+  onPress?: (line: ReferenceLine, index: number) => void,
+): {
+  tapGesture: ReturnType<typeof Gesture.Tap>;
+  hitTest: (x: number, y: number) => boolean;
+} {
+  // Per-frame badge hit-rects, index-aligned with `lines` (null = no pressable
+  // badge / off-screen / not laid out). Recomputed on the UI thread.
+  /* istanbul ignore next -- worklet runs on the UI thread, not in Jest */
+  const rects = useDerivedValue<(ReferenceBadgeRect | null)[]>(() => {
+    if (!active || lines.length === 0) return [];
+    const w = engine.canvasWidth.value;
+    const h = engine.canvasHeight.value;
+    const dMin = engine.displayMin.value;
+    const dMax = engine.displayMax.value;
+    const out: (ReferenceBadgeRect | null)[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      out.push(
+        computeReferenceBadgeRect(lines[i], w, h, padding, dMin, dMax, font, formatValue),
+      );
+    }
+    return out;
+  });
+
+  // Topmost badge under (x, y), or -1. Last drawn = last in the array = topmost.
+  /* istanbul ignore next -- worklet, runs on the UI thread */
+  const indexAt = (x: number, y: number): number => {
+    "worklet";
+    const rs = rects.value;
+    for (let i = rs.length - 1; i >= 0; i--) {
+      const r = rs[i];
+      if (r && pointInRect(x, y, r, hitSlop)) return i;
+    }
+    return -1;
+  };
+
+  /* istanbul ignore next -- worklet, runs on the UI thread */
+  const hitTest = (x: number, y: number): boolean => {
+    "worklet";
+    return indexAt(x, y) >= 0;
+  };
+
+  /* istanbul ignore next -- runs only via scheduleOnRN from the UI-thread tap */
+  function emitPress(index: number) {
+    onPress?.(lines[index], index);
+  }
+
+  /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+  const tapGesture = Gesture.Tap()
+    .maxDuration(250)
+    .onEnd((e, success) => {
+      "worklet";
+      if (!active || !success) return;
+      const i = indexAt(e.x, e.y);
+      if (i >= 0) scheduleOnRN(emitPress, i);
+    });
+
+  return { tapGesture, hitTest };
+}

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1081,6 +1081,16 @@ export interface LiveChartProps extends LiveChartCoreProps {
    */
   onScrubAction?: (point: ScrubActionPoint) => void;
   /**
+   * Called on the JS thread when the user taps a reference line's **badge** — the
+   * pill tag drawn for a working order / alert / target (a `ReferenceLine` with a
+   * {@link ReferenceLine.badge}). Receives the tapped line and its index in the
+   * `referenceLines` array, e.g. to open a cancel/edit sheet for that order. Only
+   * badge-tagged Form-A (value) lines are pressable — a plain line has no discrete
+   * hit target. Coexists with `scrub`/`scrubAction`/`markers` (a tap on a badge is
+   * routed here, not to reticle placement). Single-series only.
+   */
+  onReferenceLinePress?: (line: ReferenceLine, index: number) => void;
+  /**
    * Called on the JS thread when degen chart shake starts (momentum swing with shake enabled).
    * Not called when `degen` is off or `DegenOptions.shake` is `false`.
    */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -130,6 +130,40 @@ describe("LiveChart", () => {
     errorSpy.mockRestore();
   });
 
+  it("supports onReferenceLinePress on a badged reference line", () => {
+    const onReferenceLinePress = jest.fn();
+    render(
+      <Harness
+        referenceLines={[
+          { value: 50, label: "Limit buy", showValue: true, badge: { icon: "+" } },
+        ]}
+        onReferenceLinePress={onReferenceLinePress}
+      />,
+    );
+    // Fires only from the UI-thread tap worklet (istanbul-ignored under Jest).
+    expect(onReferenceLinePress).not.toHaveBeenCalled();
+  });
+
+  it("composes reference-line press with markers and scrubAction", () => {
+    function ComboHarness() {
+      const data = useSharedValue([{ time: 1700000000, value: 50 }]);
+      const value = useSharedValue(50);
+      const markers = useSharedValue<Marker[]>([]);
+      return (
+        <LiveChart
+          data={data}
+          value={value}
+          scrubAction
+          markers={markers}
+          referenceLines={[{ value: 50, badge: { icon: "+" } }]}
+          onReferenceLinePress={jest.fn()}
+          onScrubAction={jest.fn()}
+        />
+      );
+    }
+    render(<ComboHarness />);
+  });
+
   it("accepts custom formatters", () => {
     render(
       <Harness formatValue={(v) => v.toFixed(4)} formatTime={() => "x"} />,

--- a/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
@@ -1,7 +1,10 @@
 import { DEFAULT_PADDING } from "../../src/draw/line";
 import type { EngineState } from "../../src/core/useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
-import { useReferenceLine } from "../../src/hooks/useReferenceLine";
+import {
+  computeReferenceBadgeRect,
+  useReferenceLine,
+} from "../../src/hooks/useReferenceLine";
 
 const font = {
   getSize: () => 12,
@@ -396,5 +399,49 @@ describe("useReferenceLine", () => {
     expect(l.badge).toBe(true);
     expect(l.chevronUp).toBe(true);
     expect(l.chevronCx).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("computeReferenceBadgeRect", () => {
+  // PADDING top=12 bottom=28 → chartTop=12, chartH=260 (canvasHeight 300).
+  // pillH = descent - ascent + 2*3 = 2.4 + 9.6 + 6 = 18; pill centered on the line y.
+  const call = (line: Parameters<typeof useReferenceLine>[2]) =>
+    computeReferenceBadgeRect(line!, 400, 300, PADDING, 0, 100, font, fmt);
+
+  it("returns null for a line with no badge", () => {
+    expect(call({ value: 50 })).toBeNull();
+  });
+
+  it("returns null for a band (only Form-A value lines are pressable)", () => {
+    expect(call({ valueFrom: 20, valueTo: 60, badge: true })).toBeNull();
+    expect(call({ from: 10, to: 20, badge: true })).toBeNull();
+  });
+
+  it("returns null when the canvas is not laid out", () => {
+    expect(
+      computeReferenceBadgeRect({ value: 50, badge: true }, 0, 0, PADDING, 0, 100, font, fmt),
+    ).toBeNull();
+  });
+
+  it("returns null for a legacy off-axis badge while in range (no pill shown)", () => {
+    expect(call({ value: 50, offAxisBadge: true })).toBeNull();
+  });
+
+  it("returns the pill rect for an in-range badge, centered on the line y", () => {
+    const r = call({ value: 50, badge: true })!;
+    expect(r).not.toBeNull();
+    // y = 12 + ((100-50)/100)*260 = 142; pill (h=18) centered → top = 133.
+    expect(r.h).toBe(18);
+    expect(r.y).toBeCloseTo(133);
+    // Left-pinned pill at x1 + BADGE_EDGE_INSET = 14; width = "50.00"(35) + 2*pad(12).
+    expect(r.x).toBeCloseTo(14);
+    expect(r.w).toBeCloseTo(35 + 12);
+  });
+
+  it("pins the rect to the top edge for an off-screen (above) badge", () => {
+    const r = call({ value: 150, badge: true })!;
+    expect(r).not.toBeNull();
+    // Off-axis above → y = chartTop + 12 = 24; centered pill top = 15.
+    expect(r.y).toBeCloseTo(15);
   });
 });


### PR DESCRIPTION
Add an onReferenceLinePress(line, index) callback to LiveChart: tapping a
reference line's pill badge (a working order / alert / target) fires it on the
JS thread — e.g. to open a cancel/edit sheet.

- computeReferenceBadgeRect: pure worklet returning a badge's screen pill rect.
  Shares badgeGeometry + edge classification with useReferenceLine (via a new
  referenceBadgeText helper), so the hit-target tracks the rendered pill exactly.
- useReferenceLinePress: projects badge rects each frame and builds a tap gesture
  (mirrors useMarkers); also exposes a hitTest so the scrub-action tap defers to
  a badge under the finger.
- Gesture composition: overlay taps (markers + badges) combine with Simultaneous
  so each tap reaches every hit-tester; the scrub-action place-tap defers to both
  via a combined deferTapHit (generalized from isMarkerHit).
- Demo (scrub-action): tap a working-order badge to open a cancel sheet.

Only badge-tagged Form-A value lines are pressable; single-series only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>