### PR TITLE
ci(codeql): suppress the worklet-directive false positive

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: CodeQL config
+
+# Reanimated/Skia worklets use a `"worklet"` directive prologue
+# (https://docs.swmansion.com/react-native-reanimated/). CodeQL's
+# js/unknown-directive query flags it as a misspelled directive, which is a
+# false positive here. Exclude that one query; keep the rest of
+# security-and-quality.
+query-filters:
+  - exclude:
+      id: js/unknown-directive

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL's js/unknown-directive query flags Reanimated/Skia "worklet" prologue
directives as misspelled directives — a false positive across this codebase. Add
a CodeQL config that excludes just that query (keeping the rest of
security-and-quality) and wire it into the analysis workflow via config-file.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>