### PR TITLE
feat(line): threshold split — color the line above/below a live value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Threshold split** — `threshold?: ThresholdConfig` on `LiveChart` colors the
+  line **above vs. below a live value** (green above, red below by default). The
+  `value` is always a `SharedValue`, so the split tracks a moving benchmark on the
+  UI thread without re-rendering — break-even / average cost, VWAP, the previous
+  close, or a stablecoin peg. New exported types: `ThresholdConfig`,
+  `ThresholdLineConfig`. Single-series, line mode only.
+  - `aboveColor` / `belowColor` — stroke colors for the two halves (default the
+    palette's semantic up-green / down-red). The split is a vertical hard-stop
+    gradient on the line stroke; while set it supersedes `line.color` /
+    `line.colors` and segment recoloring for the main stroke.
+  - `fill` — tints the profit/loss band _between the line and the threshold_
+    toward the above/below colors. Independent of the baseline `gradient` fill, so
+    `gradient={false}` shows the band alone.
+  - `line` — a dashed marker line at the threshold. `true` draws the line only
+    (no text); a `ThresholdLineConfig` adds an opaque label **badge**, anchored
+    flush to the plot's left edge by default (`labelPosition`, or the right
+    gutter) and drawn on top of the line, with optional `showValue`.
+
+### Changed
+
+- The **left-edge fade** now softens only the background fills (grid, area
+  gradient, threshold band); the chart line and its overlays render above the fade
+  and stay crisp at the left edge instead of washing out.
+
 ## [3.4.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ High-performance **live** line and candlestick charts for React Native, built on
 - ⚡ **Momentum** detection and **degen** effects (particle bursts + shake on big swings)
 - 🏷️ **Trade markers** driven by a `SharedValue` trade stream
 - 🕔 **Segments** — label time ranges (after-hours, overnight, sessions) with scrub-focus: one color at rest, and scrubbing a segment keeps it full while the others de-emphasize
+- ⚖️ **Threshold split** — color the line green above / red below a live break-even, VWAP, or peg (always a `SharedValue`), with an optional profit/loss fill band and labelled marker line
 - 🎨 **Theming** with light/dark modes, an accent-driven `palette`, and `metrics` sizing/motion tokens
 - ⏳ **Loading** (breathing-line shell) and **paused** states out of the box
 - 🧵 **SharedValue-driven** rendering — history and live values stay on the UI thread

--- a/app/demo/threshold.tsx
+++ b/app/demo/threshold.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { useSharedValue } from "react-native-reanimated";
+import { LiveChart } from "react-native-livechart";
+
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Threshold split" };
+
+const START = 100;
+
+type EntryLevel = "start" | "high" | "low";
+const ENTRY_LEVELS: Record<EntryLevel, number> = {
+  start: START,
+  high: START * 1.03,
+  low: START * 0.97,
+};
+
+export default function ThresholdScreen() {
+  const [fill, setFill] = useState(true);
+  const [markerLine, setMarkerLine] = useState(true);
+  const [label, setLabel] = useState(true);
+  const [showValue, setShowValue] = useState(true);
+  const [labelSide, setLabelSide] = useState<"left" | "right">("left");
+  const [colorMode, setColorMode] = useState<"default" | "custom">("default");
+  const [entry, setEntry] = useState<EntryLevel>("start");
+
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    startValue: START,
+    // Dense seed so the line weaves above/below the break-even from frame one.
+    historySpanSeconds: 40,
+    historyRange: "1m",
+  });
+
+  // The split value is ALWAYS a SharedValue — here a fixed break-even / entry
+  // price. Updating it with `.set()` moves the split live on the UI thread with
+  // no re-render; a real app would point this at average cost, VWAP, or the
+  // previous close.
+  const breakEven = useSharedValue(START);
+
+  const setEntryLevel = (next: EntryLevel) => {
+    setEntry(next);
+    breakEven.set(ENTRY_LEVELS[next]);
+  };
+
+  const customColors =
+    colorMode === "custom"
+      ? { aboveColor: "#14b8a6", belowColor: "#f97316" }
+      : {};
+
+  return (
+    <DemoScreen
+      title="Threshold split"
+      docs="api-reference/livechart"
+      description="threshold — green above / red below a live break-even, with a P/L fill band + marker line"
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          gradient={false}
+          threshold={{
+            value: breakEven,
+            ...customColors,
+            fill,
+            // `true` → dashed line only (no text/badge); object → labelled badge.
+            line: markerLine
+              ? label
+                ? { label: "Break-even", showValue, labelPosition: labelSide }
+                : true
+              : false,
+          }}
+          scrub={false}
+        />
+      }
+    >
+      <ControlRow label="Threshold">
+        <ToggleChip label="Fill band" value={fill} onChange={setFill} />
+        <ToggleChip
+          label="Marker line"
+          value={markerLine}
+          onChange={setMarkerLine}
+        />
+        <ToggleChip label="Label" value={label} onChange={setLabel} />
+        <ToggleChip
+          label="Show value"
+          value={showValue}
+          onChange={setShowValue}
+        />
+      </ControlRow>
+
+      <ChipRow
+        label="Label side"
+        options={[
+          { value: "left", label: "Left" },
+          { value: "right", label: "Right" },
+        ]}
+        value={labelSide}
+        onChange={setLabelSide}
+      />
+
+      <ChipRow
+        label="Colors"
+        options={[
+          { value: "default", label: "Green / Red" },
+          { value: "custom", label: "Teal / Orange" },
+        ]}
+        value={colorMode}
+        onChange={setColorMode}
+      />
+
+      <ChipRow
+        label="Break-even level"
+        options={[
+          { value: "start", label: "At start" },
+          { value: "high", label: "+3%" },
+          { value: "low", label: "−3%" },
+        ]}
+        value={entry}
+        onChange={setEntryLevel}
+      />
+    </DemoScreen>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -98,6 +98,11 @@ const SECTIONS: DemoSection[] = [
         blurb: "referenceLines: lines, value/time bands, off-axis badge.",
       },
       {
+        href: "/demo/threshold",
+        title: "Threshold split",
+        blurb: "threshold: green above / red below a live break-even — split stroke, P/L fill band, marker line.",
+      },
+      {
         href: "/demo/segments",
         title: "Segments",
         blurb: "segments: after-hours / overnight sessions — scrub-focus line recolor, divider + label.",

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -126,6 +126,17 @@ provided; everything else has a default.
   [`ChartSegment`](/api-reference/types#chartsegment). Single-series only.
 </ParamField>
 
+<ParamField body="threshold" type="ThresholdConfig">
+  Color the line above vs. below a live threshold value — green above, red below
+  by default. The `value` is **always** a `SharedValue`, so the split tracks a
+  live benchmark (break-even / average cost, VWAP, previous close, a peg) on the
+  UI thread without re-rendering. Optionally adds a tinted profit/loss `fill` band
+  and a dashed marker `line`. Supersedes `line.color`/`colors` and segment
+  recoloring for the main stroke while set. See
+  [`ThresholdConfig`](/api-reference/types#thresholdconfig). Single-series,
+  line mode only.
+</ParamField>
+
 ## Scrubbing
 
 <ParamField body="scrub" type="boolean | ScrubConfig" default="true">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -182,6 +182,21 @@ interface GradientConfig {
   positions?: number[];   // optional stop positions (0..1, ascending), same
                           //   length as colors; ignored if the lengths differ
 }
+interface ThresholdConfig {
+  value: SharedValue<number>; // the split value (Y-axis units), always live
+  aboveColor?: string;        // stroke at/above value; default palette up-green
+  belowColor?: string;        // stroke below value;    default palette down-red
+  fill?: boolean;             // tint the line↔value band (profit/loss); default false
+  line?: boolean | ThresholdLineConfig; // dashed marker line at value; default off
+}
+interface ThresholdLineConfig {
+  label?: string;                    // label text, e.g. "Break-even"
+  labelPosition?: "left" | "right";  // "left" = inside plot (clear of y-axis); default "left"
+  color?: string;                    // line + label color; default palette refLine/refLabel
+  intervals?: [number, number];      // dash pattern; default [4, 4]
+  strokeWidth?: number;              // default 1
+  showValue?: boolean;               // append the formatted value to the label; default false
+}
 interface BadgeConfig {
   variant?: "default" | "minimal";
   tail?: boolean;

--- a/docs/guides/markers-and-references.mdx
+++ b/docs/guides/markers-and-references.mdx
@@ -127,6 +127,59 @@ referenceLines={[
 `text: false` (icon-only), and `background` / `borderColor` / `radius`. It supersedes the legacy
 `offAxisBadge` (still supported), which only appears once the value is off-screen and takes no icon.
 
+## Threshold split
+
+Where a reference line is a *static* annotation, `threshold` colors the line itself
+**above vs. below a live value** — green above, red below by default. The threshold
+is **always** a `SharedValue`, so the split tracks a moving benchmark on the UI
+thread without re-rendering: break-even / average cost, VWAP, the previous close, or
+a stablecoin peg. Single-series `LiveChart`, line mode.
+
+```tsx
+import { useSharedValue } from "react-native-reanimated";
+import { LiveChart } from "react-native-livechart";
+
+const breakEven = useSharedValue(100); // move it live with breakEven.set(...)
+
+<LiveChart data={data} value={value} threshold={{ value: breakEven }} />;
+```
+
+A bare `{ value }` splits the **stroke** at the threshold (palette green above, red
+below; override with `aboveColor` / `belowColor`). Two opt-in extras share the same
+`SharedValue`:
+
+- **`fill`** — tints the area *between the line and the threshold* (the profit/loss
+  band) toward the above/below colors. It's independent of the baseline `gradient`
+  fill, so set `gradient={false}` for the band alone.
+- **`line`** — a dashed marker line at the threshold. `true` draws just the line;
+  pass a `ThresholdLineConfig` to add a label badge.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  gradient={false}
+  threshold={{
+    value: breakEven,
+    aboveColor: "#16a34a",
+    belowColor: "#dc2626",
+    fill: true,
+    // object → labelled badge; `line: true` → marker line only (no text/badge)
+    line: { label: "Break-even", showValue: true },
+  }}
+/>;
+```
+
+The label renders as an opaque **badge** anchored flush to the plot's left edge
+(`labelPosition: "left"`, the default — clear of the y-axis labels) or the right
+gutter, and is drawn on top of the line so it's never painted over. While a
+threshold is set it supersedes `line.color` / `line.colors` and segment recoloring
+for the main stroke.
+
+See [`ThresholdConfig`](/api-reference/types#thresholdconfig) for every field, and
+[`app/demo/threshold.tsx`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/demo/threshold.tsx)
+for a live example.
+
 ## Segments
 
 `segments` labels time ranges of the line — pre-market / regular / after-hours

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -31,11 +31,13 @@ import {
   resolveScrub,
   resolveScrubAction,
   resolveSelectionDot,
+  resolveThreshold,
   resolveTradeStream,
   resolveValueLine,
   resolveXAxis,
   resolveYAxis,
 } from "../core/resolveConfig";
+import type { ResolvedThresholdConfig } from "../core/resolveConfig";
 import { resolveSegment } from "../core/resolveSegment";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
 import { pulseRadialOutset } from "../draw/line";
@@ -57,6 +59,7 @@ import { useModeBlend } from "../hooks/useModeBlend";
 import { useMomentum } from "../hooks/useMomentum";
 import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
 import { useSingleChartReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
+import { useThreshold } from "../hooks/useThreshold";
 import { useTradeStream } from "../hooks/useTradeStream";
 import { useXAxis } from "../hooks/useXAxis";
 import { useYAxis } from "../hooks/useYAxis";
@@ -69,9 +72,19 @@ import { collectReferenceValues } from "../math/referenceLines";
 import {
   applyPaletteOverride,
   leftEdgeFadeColorsFromBgRgb,
+  parseColorRgb,
   resolveTheme,
 } from "../theme";
-import type { LiveChartProps, Marker, TradeEvent } from "../types";
+import type {
+  LiveChartPalette,
+  LiveChartProps,
+  Marker,
+  TradeEvent,
+} from "../types";
+import {
+  ThresholdBadgeOverlay,
+  ThresholdLineOverlay,
+} from "./ThresholdLineOverlay";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
@@ -89,6 +102,32 @@ import { TradeStreamOverlay } from "./TradeStreamOverlay";
 import { ValueLineOverlay } from "./ValueLineOverlay";
 import { XAxisOverlay } from "./XAxisOverlay";
 import { YAxisOverlay } from "./YAxisOverlay";
+
+/** Translucent fill alpha for the threshold profit/loss band. */
+const THRESHOLD_FILL_OPACITY = 0.16;
+
+/**
+ * Color stops for the threshold's hard-split vertical gradient. Both arrays pair
+ * with the `[0, t, t, 1]` split positions: index 0–1 paint above the split,
+ * 2–3 below. `stroke` is full-strength; `fill` is the same hues at
+ * {@link THRESHOLD_FILL_OPACITY} for the band. Defaults to the palette's semantic
+ * up-green / down-red when colors are omitted.
+ */
+function thresholdStops(
+  cfg: ResolvedThresholdConfig,
+  palette: LiveChartPalette,
+): { stroke: string[]; fill: string[] } {
+  const above = cfg.aboveColor ?? palette.candleUp;
+  const below = cfg.belowColor ?? palette.candleDown;
+  const [ar, ag, ab] = parseColorRgb(above);
+  const [br, bg, bb] = parseColorRgb(below);
+  const aboveFill = `rgba(${ar}, ${ag}, ${ab}, ${THRESHOLD_FILL_OPACITY})`;
+  const belowFill = `rgba(${br}, ${bg}, ${bb}, ${THRESHOLD_FILL_OPACITY})`;
+  return {
+    stroke: [above, above, below, below],
+    fill: [aboveFill, aboveFill, belowFill, belowFill],
+  };
+}
 
 /**
  * Resolves props → configs → theme/layout → engine → per-frame derived values and
@@ -148,6 +187,7 @@ function useLiveChartController({
   valueMomentumColor = false,
   referenceLines,
   segments,
+  threshold,
   gridStyle,
   palette: paletteOverride,
   metrics,
@@ -173,6 +213,9 @@ function useLiveChartController({
   const tradeStreamSV = tradeStream ?? emptyTradeStream;
   const emptyMarkers = useSharedValue<Marker[]>([]);
   const markersSV = markers ?? emptyMarkers;
+  // Stand-in threshold value so `useThreshold` can be called unconditionally
+  // (hooks can't be); the geometry is ignored when no threshold is configured.
+  const emptyThresholdValue = useSharedValue(0);
   const isCandle = mode === "candle";
 
   // ── Resolve feature configs ────────────────────────────────────────────
@@ -185,6 +228,9 @@ function useLiveChartController({
   // Static charts run no gestures, so scrub-action (tap/drag to lock a price) is off.
   const scrubActionCfg = isStatic ? null : resolveScrubAction(scrubAction);
   const gradientCfg = isCandle ? null : resolveGradient(gradient);
+  // Threshold split is a line-mode feature (candle bodies carry their own up/down
+  // colors), so it's inert in candle mode — same as the area gradient.
+  const thresholdCfg = isCandle ? null : resolveThreshold(threshold);
   const valueLineCfg = resolveValueLine(valueLine);
   // Static charts run zero loops: force the pulse off so its `withRepeat`-driven
   // ring never starts (the DotOverlay reads `pulseCfg`, so null = no pulse).
@@ -335,10 +381,23 @@ function useLiveChartController({
   // ── Per-frame derived values ───────────────────────────────────────────
   const { layoutWidth, layoutHeight, onLayout } = useCanvasLayout(engine);
 
-  const { linePath, fillPath } = useChartPaths(
+  // Threshold split geometry (shared by stroke gradient, fill band, marker line).
+  // Called unconditionally with a stand-in value when no threshold is set.
+  const thresholdGeom = useThreshold(
+    engine,
+    effectivePadding,
+    thresholdCfg?.value ?? emptyThresholdValue,
+  );
+  const thresholdStopColors = thresholdCfg
+    ? thresholdStops(thresholdCfg, palette)
+    : null;
+
+  const { linePath, fillPath, thresholdFillPath } = useChartPaths(
     engine,
     effectivePadding,
     reveal.morphT,
+    // Only build the band path when the fill is actually on.
+    thresholdCfg?.fill ? thresholdGeom.lineY : undefined,
   );
   const { upBodiesPath, downBodiesPath, upWicksPath, downWicksPath } =
     useCandlePaths(
@@ -576,6 +635,10 @@ function useLiveChartController({
     resolvedSegments,
     hasRecolorSegments,
     segmentGradient,
+    thresholdCfg,
+    thresholdGeom,
+    thresholdStrokeColors: thresholdStopColors?.stroke ?? null,
+    thresholdFillColors: thresholdStopColors?.fill ?? null,
     badgeUsesRightGutter,
     // theme / layout / fonts
     palette,
@@ -599,6 +662,7 @@ function useLiveChartController({
     onLayout,
     linePath,
     fillPath,
+    thresholdFillPath,
     upBodiesPath,
     downBodiesPath,
     upWicksPath,
@@ -629,10 +693,13 @@ function useLiveChartController({
 
 type LiveChartModel = ReturnType<typeof useLiveChartController>;
 
-/** Main shaken chart stack: grid, fill, line/candles, axes, badge, dot, degen,
- *  markers, and the loading/empty art. The live value text is a separate layer
- *  (ChartValueOverlay) so it sits above the left-edge fade. */
-function ChartStack({ model }: { model: LiveChartModel }) {
+/**
+ * Background fills drawn BENEATH the left-edge fade: the y-axis grid, the area
+ * gradient, and the threshold profit/loss band. Split out from `ChartStack` so
+ * the fade's `dstOut` only softens the fills — the line and everything above it
+ * (drawn in `ChartStack`, after the fade) stay crisp at the left edge.
+ */
+function ChartFillLayer({ model }: { model: LiveChartModel }) {
   const {
     degenShakeTransform,
     yAxisCfg,
@@ -645,41 +712,16 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     badgeUsesRightGutter,
     badgeCfg,
     gridStyleCfg,
+    metricsCfg,
     gradientCfg,
     fillPath,
     gradientEnd,
     gradientColors,
     gradientPositions,
-    valueLineCfg,
-    dotY,
-    allRefLines,
-    resolvedSegments,
-    hasRecolorSegments,
-    segmentGradient,
-    formatValue,
-    lineGroupOpacity,
-    linePath,
-    strokeWidth,
-    lineProp,
-    candleGroupOpacity,
-    upWicksPath,
-    downWicksPath,
-    upBodiesPath,
-    downBodiesPath,
-    xAxisCfg,
-    xAxisEntries,
-    dotX,
-    liveDotOpacity,
-    pulseCfg,
-    dotCfg,
-    degenCfg,
-    degenPack,
-    degenPackRevision,
-    markersActive,
-    markersSV,
-    emptyText,
-    metricsCfg,
-    layoutWidth,
+    thresholdCfg,
+    thresholdGeom,
+    thresholdFillPath,
+    thresholdFillColors,
   } = model;
 
   return (
@@ -715,6 +757,75 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         </Group>
       )}
 
+      {/* Threshold profit/loss band — the area between the line and the threshold,
+          hard-split at the threshold Y into the above/below colors. Independent of
+          the baseline area fill above (set `gradient={false}` for the band alone). */}
+      {thresholdCfg?.fill && thresholdFillColors && (
+        <Group opacity={reveal.fillOpacity}>
+          <Path path={thresholdFillPath} style="fill">
+            <LinearGradient
+              start={vec(0, 0)}
+              end={thresholdGeom.gradientEnd}
+              colors={thresholdFillColors}
+              positions={thresholdGeom.splitPositions}
+            />
+          </Path>
+        </Group>
+      )}
+    </Group>
+  );
+}
+
+/** Main shaken chart stack drawn ABOVE the left-edge fade so the line stays crisp:
+ *  segment dividers, value/reference lines, the line/candles, axes, dot, degen,
+ *  markers, and the loading/empty art. Background fills are in `ChartFillLayer`
+ *  (below the fade); the live value text is `ChartValueOverlay` (above the fade). */
+function ChartStack({ model }: { model: LiveChartModel }) {
+  const {
+    degenShakeTransform,
+    reveal,
+    engine,
+    effectivePadding,
+    palette,
+    skiaFont,
+    badgeCfg,
+    valueLineCfg,
+    dotY,
+    allRefLines,
+    resolvedSegments,
+    hasRecolorSegments,
+    segmentGradient,
+    thresholdCfg,
+    thresholdGeom,
+    thresholdStrokeColors,
+    formatValue,
+    lineGroupOpacity,
+    linePath,
+    strokeWidth,
+    lineProp,
+    candleGroupOpacity,
+    upWicksPath,
+    downWicksPath,
+    upBodiesPath,
+    downBodiesPath,
+    xAxisCfg,
+    xAxisEntries,
+    dotX,
+    liveDotOpacity,
+    pulseCfg,
+    dotCfg,
+    degenCfg,
+    degenPack,
+    degenPackRevision,
+    markersActive,
+    markersSV,
+    emptyText,
+    metricsCfg,
+    layoutWidth,
+  } = model;
+
+  return (
+    <Group transform={degenShakeTransform}>
       {/* Segment dividers + labels (behind the line). The scrub-focus emphasis is
           painted on the line stroke itself, below — this overlay draws no fill. */}
       {resolvedSegments.map((seg, i) => (
@@ -756,6 +867,21 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         />
       ))}
 
+      {/* Threshold marker line + label (behind the chart line). */}
+      {thresholdCfg?.line && (
+        <ThresholdLineOverlay
+          engine={engine}
+          padding={effectivePadding}
+          lineY={thresholdGeom.lineY}
+          visible={thresholdGeom.visible}
+          value={thresholdCfg.value}
+          cfg={thresholdCfg.line}
+          palette={palette}
+          font={skiaFont}
+          formatValue={formatValue}
+        />
+      )}
+
       {/* Chart line (fades out in candle mode). When segments recolor the line, a
           full-width gradient paints the base color outside segments and each
           segment's color within — so the line itself is recolored/faded (alpha in
@@ -769,7 +895,16 @@ function ChartStack({ model }: { model: LiveChartModel }) {
           strokeJoin="round"
           color={lineProp?.color ?? palette.line}
         >
-          {hasRecolorSegments ? (
+          {thresholdCfg && thresholdStrokeColors ? (
+            // Vertical hard split at the threshold Y — supersedes line.colors and
+            // segment recoloring for the stroke while a threshold is set.
+            <LinearGradient
+              start={vec(0, 0)}
+              end={thresholdGeom.gradientEnd}
+              colors={thresholdStrokeColors}
+              positions={thresholdGeom.splitPositions}
+            />
+          ) : hasRecolorSegments ? (
             <LinearGradient
               start={vec(0, 0)}
               end={segmentGradient.gradientEnd}
@@ -865,7 +1000,24 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         </Group>
       )}
 
-      {/* Loading / empty state — before left-edge fade so the squiggle/empty art fades like the chart */}
+      {/* Threshold label badge — on top of the line/dot/markers so it's never
+          painted over (the dashed marker line itself stays behind the line, above). */}
+      {thresholdCfg?.line && (
+        <ThresholdBadgeOverlay
+          engine={engine}
+          padding={effectivePadding}
+          lineY={thresholdGeom.lineY}
+          visible={thresholdGeom.visible}
+          value={thresholdCfg.value}
+          cfg={thresholdCfg.line}
+          palette={palette}
+          font={skiaFont}
+          formatValue={formatValue}
+        />
+      )}
+
+      {/* Loading / empty state — drawn with the line stack (above the fade) so the
+          squiggle/empty art stays crisp, consistent with the line. */}
       <LoadingOverlay
         engine={engine}
         padding={effectivePadding}
@@ -1111,8 +1263,10 @@ export function LiveChart(props: LiveChartProps) {
         accessibilityRole={accessibilityRole}
       >
         <Canvas style={{ flex: 1 }}>
-          {/* Shaken chart stack — left-edge fade is a sibling below so dstOut runs in canvas space */}
-          <ChartStack model={model} />
+          {/* Background fills first, then the left-edge fade (a canvas-space sibling
+              so dstOut blends correctly), then the line stack on top — so the fade
+              softens only the fills and the line stays crisp at the left edge. */}
+          <ChartFillLayer model={model} />
 
           {leftEdgeFadeCfg && (
             <LeftEdgeFade
@@ -1123,6 +1277,9 @@ export function LiveChart(props: LiveChartProps) {
               engine={engine}
             />
           )}
+
+          {/* Line stack above the fade so the line stays crisp at the left edge. */}
+          <ChartStack model={model} />
 
           {/* Reference-line badges + labels above the fade so they stay crisp. */}
           <ChartRefBadgeLayer model={model} />

--- a/packages/react-native-livechart/src/components/ThresholdLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ThresholdLineOverlay.tsx
@@ -1,0 +1,172 @@
+import {
+  DashPathEffect,
+  Group,
+  Path,
+  RoundedRect,
+  Text as SkiaText,
+  type SkFont,
+} from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { ResolvedThresholdLineConfig } from "../core/resolveConfig";
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { usePathBuilder } from "../hooks/usePathBuilder";
+import { measureFontTextWidth } from "../lib/measureFontTextWidth";
+import type { LiveChartPalette } from "../types";
+
+/** Padding inside the marker badge pill, in px (mirrors `ReferenceLineOverlay`). */
+const BADGE_PAD_X = 6;
+const BADGE_PAD_Y = 3;
+const BADGE_RADIUS = 5;
+/** Inset from the canvas edge — small so the badge sits as flush to the edge as possible. */
+const BADGE_EDGE_INSET = 2;
+
+interface ThresholdMarkerProps {
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  lineY: SharedValue<number>;
+  visible: SharedValue<boolean>;
+  value: SharedValue<number>;
+  cfg: ResolvedThresholdLineConfig;
+  palette: LiveChartPalette;
+  font: SkFont;
+  formatValue: (v: number) => string;
+}
+
+/**
+ * The dashed horizontal marker line at a live threshold value, tracking a
+ * `SharedValue` pixel-Y on the UI thread. Drawn **behind** the chart line so the
+ * data line stays the focus; the label badge ({@link ThresholdBadgeOverlay}) is
+ * a separate layer drawn on top. Hidden when the threshold is off-screen.
+ */
+export function ThresholdLineOverlay({
+  engine,
+  padding,
+  lineY,
+  visible,
+  cfg,
+  palette,
+}: ThresholdMarkerProps) {
+  const lineColor = cfg.color ?? palette.refLine;
+  const { strokeWidth, intervals } = cfg;
+
+  const builder = usePathBuilder();
+
+  const linePath = useDerivedValue(() => {
+    const b = builder.value;
+    if (visible.get()) {
+      const y = lineY.get();
+      b.moveTo(padding.left, y);
+      b.lineTo(engine.canvasWidth.get() - padding.right, y);
+    }
+    return b.detach();
+  });
+
+  const opacity = useDerivedValue(() => (visible.get() ? 1 : 0));
+
+  return (
+    <Group opacity={opacity}>
+      <Path
+        path={linePath}
+        style="stroke"
+        strokeWidth={strokeWidth}
+        color={lineColor}
+      >
+        <DashPathEffect intervals={intervals} />
+      </Path>
+    </Group>
+  );
+}
+
+/**
+ * The threshold's label as an opaque badge pill (rounded background + colored
+ * border, like `ReferenceLineOverlay`'s off-axis badge). Drawn **on top** of the
+ * chart line so the label is never painted over, and anchored hard to the plot's
+ * left edge by default (clear of the y-axis labels + live badge) or the right
+ * gutter. Renders nothing when there is no label and no `showValue`.
+ */
+export function ThresholdBadgeOverlay({
+  engine,
+  padding,
+  lineY,
+  visible,
+  value,
+  cfg,
+  palette,
+  font,
+  formatValue,
+}: ThresholdMarkerProps) {
+  const { label, labelPosition, showValue } = cfg;
+  const badgeBackground = palette.tooltipBg;
+  const badgeBorderColor = cfg.color ?? palette.refLine;
+  const labelColor = cfg.color ?? palette.refLabel;
+
+  // Font metrics are stable → read once (getMetrics allocates + crosses JSI).
+  const { fontAscent, baselineOffset, pillH } = (() => {
+    const fm = font.getMetrics();
+    return {
+      fontAscent: fm.ascent,
+      baselineOffset: (fm.ascent + fm.descent) / 2,
+      pillH: fm.descent - fm.ascent + BADGE_PAD_Y * 2,
+    };
+  })();
+
+  const opacity = useDerivedValue(() => (visible.get() ? 1 : 0));
+
+  const labelText = useDerivedValue(() => {
+    if (showValue) {
+      const v = formatValue(value.get());
+      return label ? `${label} ${v}` : v;
+    }
+    return label ?? "";
+  });
+
+  const pillW = useDerivedValue(
+    () => measureFontTextWidth(font, labelText.get()) + BADGE_PAD_X * 2,
+  );
+  // Left: flush to the canvas edge. Right: flush to the right plot edge.
+  const pillX = useDerivedValue(() =>
+    labelPosition === "right"
+      ? engine.canvasWidth.get() - padding.right - BADGE_EDGE_INSET - pillW.get()
+      : BADGE_EDGE_INSET,
+  );
+  const pillY = useDerivedValue(
+    () => lineY.get() - baselineOffset + fontAscent - BADGE_PAD_Y,
+  );
+  const labelX = useDerivedValue(() => pillX.get() + BADGE_PAD_X);
+  const labelY = useDerivedValue(() => lineY.get() - baselineOffset);
+
+  // No label and no value → nothing to draw (hooks above still run, in order).
+  if (label === undefined && !showValue) return null;
+
+  return (
+    <Group opacity={opacity}>
+      <RoundedRect
+        x={pillX}
+        y={pillY}
+        width={pillW}
+        height={pillH}
+        r={BADGE_RADIUS}
+        color={badgeBackground}
+      />
+      <RoundedRect
+        x={pillX}
+        y={pillY}
+        width={pillW}
+        height={pillH}
+        r={BADGE_RADIUS}
+        color={badgeBorderColor}
+        style="stroke"
+        strokeWidth={1}
+      />
+      <SkiaText
+        x={labelX}
+        y={labelY}
+        text={labelText}
+        font={font}
+        color={labelColor}
+      />
+    </Group>
+  );
+}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -22,6 +22,8 @@ import type {
   SelectionDotConfig,
   SelectionDotProps,
   SelectionDotRingConfig,
+  ThresholdConfig,
+  ThresholdLineConfig,
   TradeEvent,
   ValueLineConfig,
   XAxisConfig,
@@ -222,6 +224,66 @@ export function resolveValueLine(
   prop: boolean | ValueLineConfig | undefined,
 ): ResolvedValueLineConfig | null {
   return resolveToggle(prop, VALUE_LINE_DEFAULTS, false);
+}
+
+export interface ResolvedThresholdLineConfig {
+  /** undefined → no label. */
+  label: string | undefined;
+  /** Label side; `"left"` sits inside the plot (clear of the y-axis gutter). */
+  labelPosition: "left" | "right";
+  /** undefined → use palette.refLine (line) / palette.refLabel (label) at render time. */
+  color: string | undefined;
+  intervals: [number, number];
+  strokeWidth: number;
+  showValue: boolean;
+}
+
+export interface ResolvedThresholdConfig {
+  /** The live split value (Y-axis units). Read on the UI thread each frame. */
+  value: SharedValue<number>;
+  /** undefined → use palette.candleUp (up-green) at render time. */
+  aboveColor: string | undefined;
+  /** undefined → use palette.candleDown (down-red) at render time. */
+  belowColor: string | undefined;
+  fill: boolean;
+  line: ResolvedThresholdLineConfig | null;
+}
+
+const THRESHOLD_LINE_DEFAULTS: ResolvedThresholdLineConfig = {
+  label: undefined,
+  labelPosition: "left",
+  color: undefined,
+  intervals: [4, 4],
+  strokeWidth: 1,
+  showValue: false,
+};
+
+/**
+ * Resolves the `threshold.line` sub-prop to a config or null (no marker line).
+ * `true` → dashed defaults, object → merged, falsy/undefined → null.
+ */
+export function resolveThresholdLine(
+  prop: boolean | ThresholdLineConfig | undefined,
+): ResolvedThresholdLineConfig | null {
+  return resolveToggle(prop, THRESHOLD_LINE_DEFAULTS, false);
+}
+
+/**
+ * Resolves the `threshold` prop to a fully-typed config or null (disabled).
+ * Presence-gated (like `referenceLines`/`markers`): the required `value`
+ * SharedValue means there is no boolean form — a config object enables it.
+ */
+export function resolveThreshold(
+  prop: ThresholdConfig | undefined,
+): ResolvedThresholdConfig | null {
+  if (!prop) return null;
+  return {
+    value: prop.value,
+    aboveColor: prop.aboveColor,
+    belowColor: prop.belowColor,
+    fill: prop.fill ?? false,
+    line: resolveThresholdLine(prop.line),
+  };
 }
 
 const BADGE_DEFAULTS: ResolvedBadgeConfig = {

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -22,9 +22,13 @@ export function useChartPaths(
   engine: SingleEngineState,
   padding: ChartPadding,
   morphT?: SharedValue<number>,
+  /** When set, also build `thresholdFillPath` — the band between the line and this
+   *  pixel-Y, closed at the threshold instead of the chart baseline. */
+  thresholdY?: SharedValue<number>,
 ) {
   const lineBuilder = usePathBuilder();
   const fillBuilder = usePathBuilder();
+  const thresholdFillBuilder = usePathBuilder();
 
   const cacheRef = useRef<{
     emptyPath: SkPath;
@@ -105,5 +109,25 @@ export function useChartPaths(
     return b.detach();
   });
 
-  return { linePath, fillPath } as const;
+  // Threshold-anchored fill: the same spline, closed at `thresholdY` instead of the
+  // baseline, so the band lies between the line and the threshold (the profit/loss
+  // area). Painted with the hard-split vertical gradient, the part above the split
+  // shows the above-color and the part below shows the below-color.
+  const thresholdFillPath = useDerivedValue(() => {
+    const cache = cacheRef.current!;
+    if (!thresholdY) return cache.emptyPath;
+    const yT = thresholdY.get();
+    const pts = flatPts.get();
+    const n = pts.length >> 1;
+    if (n < 2 || !Number.isFinite(yT)) return cache.emptyPath;
+    const b = thresholdFillBuilder.value;
+    b.moveTo(pts[0], pts[1]);
+    drawSpline(b, pts, cache.scratch);
+    b.lineTo(pts[(n - 1) * 2], yT);
+    b.lineTo(pts[0], yT);
+    b.close();
+    return b.detach();
+  });
+
+  return { linePath, fillPath, thresholdFillPath } as const;
 }

--- a/packages/react-native-livechart/src/hooks/useThreshold.ts
+++ b/packages/react-native-livechart/src/hooks/useThreshold.ts
@@ -1,0 +1,63 @@
+import { vec } from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import {
+  thresholdLineY,
+  thresholdSplitPositions,
+  thresholdVisible,
+} from "../math/threshold";
+
+export interface ThresholdGeometry {
+  /** Threshold pixel-Y within the canvas, or NaN before layout / degenerate range. */
+  lineY: SharedValue<number>;
+  /** Whether the threshold sits within the plot area (drives marker-line opacity). */
+  visible: SharedValue<boolean>;
+  /** Vertical gradient end vector, `vec(0, canvasHeight)` — shared by stroke + fill. */
+  gradientEnd: SharedValue<ReturnType<typeof vec>>;
+  /** `[0, t, t, 1]` stop positions for the hard-split gradient — shared by stroke + fill. */
+  splitPositions: SharedValue<number[]>;
+}
+
+/**
+ * Per-frame screen geometry for the threshold split, shared by the stroke
+ * gradient, the profit/loss fill band, and the dashed marker line. Reads the live
+ * threshold value + engine Y-range on the UI thread; the math lives in
+ * `math/threshold` so it stays unit-testable without Reanimated.
+ */
+export function useThreshold(
+  engine: ChartEngineLayout,
+  padding: ChartPadding,
+  value: SharedValue<number>,
+): ThresholdGeometry {
+  const lineY = useDerivedValue(() =>
+    thresholdLineY(
+      value.get(),
+      engine.displayMin.get(),
+      engine.displayMax.get(),
+      engine.canvasHeight.get(),
+      padding.top,
+      padding.bottom,
+    ),
+  );
+
+  const visible = useDerivedValue(() =>
+    thresholdVisible(
+      lineY.get(),
+      engine.canvasHeight.get(),
+      padding.top,
+      padding.bottom,
+    ),
+  );
+
+  const splitPositions = useDerivedValue(() =>
+    thresholdSplitPositions(lineY.get(), engine.canvasHeight.get()),
+  );
+
+  const gradientEnd = useDerivedValue(() =>
+    vec(0, Math.max(1, engine.canvasHeight.get())),
+  );
+
+  return { lineY, visible, gradientEnd, splitPositions };
+}

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -77,6 +77,8 @@ export type {
   SelectionDotRingConfig,
   SeriesConfig,
   ThemeMode,
+  ThresholdConfig,
+  ThresholdLineConfig,
   TradeEvent,
   ValueLineConfig,
   XAxisConfig,

--- a/packages/react-native-livechart/src/math/threshold.ts
+++ b/packages/react-native-livechart/src/math/threshold.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure, worklet-safe geometry for the threshold split ({@link ThresholdConfig}).
+ * No SharedValues and no hooks — these are unit-tested directly; `useThreshold`
+ * wires the live SharedValues into them.
+ */
+
+/**
+ * Pixel Y of a threshold value within the plot. Mirrors the line path's value→Y
+ * mapping in `buildLinePoints` (`top + (max - v) / range * chartH`). Returns NaN
+ * when the canvas hasn't laid out yet or the value range is degenerate, so the
+ * line/fill/marker callers can cull instead of drawing at a bogus position.
+ */
+export function thresholdLineY(
+  value: number,
+  displayMin: number,
+  displayMax: number,
+  canvasHeight: number,
+  paddingTop: number,
+  paddingBottom: number,
+): number {
+  "worklet";
+  const range = displayMax - displayMin;
+  const chartH = canvasHeight - paddingTop - paddingBottom;
+  if (canvasHeight <= 0 || range <= 0 || chartH <= 0) return NaN;
+  return paddingTop + ((displayMax - value) / range) * chartH;
+}
+
+/** True when the threshold's Y sits within the plot area (i.e. on-screen). */
+export function thresholdVisible(
+  lineY: number,
+  canvasHeight: number,
+  paddingTop: number,
+  paddingBottom: number,
+): boolean {
+  "worklet";
+  if (!Number.isFinite(lineY) || canvasHeight <= 0) return false;
+  return lineY >= paddingTop && lineY <= canvasHeight - paddingBottom;
+}
+
+/**
+ * Stop positions for the vertical hard-split gradient, paired with the 4-stop
+ * color array `[above, above, below, below]`: `[0, t, t, 1]`, where `t` is the
+ * threshold's fraction down the full canvas (the gradient vector spans
+ * `0 → canvasHeight`), clamped to `[0, 1]`.
+ *
+ * - `t ≤ 0` (threshold above everything) → `[0, 0, 0, 1]` → solid below-color.
+ * - `t ≥ 1` (threshold below everything) → `[0, 1, 1, 1]` → solid above-color.
+ */
+export function thresholdSplitPositions(
+  lineY: number,
+  canvasHeight: number,
+): number[] {
+  "worklet";
+  if (canvasHeight <= 0 || !Number.isFinite(lineY)) return [0, 1, 1, 1];
+  let t = lineY / canvasHeight;
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  return [0, t, t, 1];
+}

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -241,6 +241,61 @@ export interface LineConfig {
   colors?: string[];
 }
 
+/**
+ * Color the line above vs. below a live threshold value — green above, red below
+ * by default. The threshold is **always** a `SharedValue` so it can track a live
+ * benchmark (break-even / average cost, VWAP, previous close, a peg) on the UI
+ * thread without re-rendering. Drives a hard-split line stroke and, optionally, a
+ * tinted profit/loss fill band and a dashed marker line at the threshold.
+ *
+ * The split stroke supersedes `LineConfig.color`/`colors` and segment recoloring
+ * for the main line while a threshold is set.
+ */
+export interface ThresholdConfig {
+  /**
+   * The split value, in Y-axis (price) units. A `SharedValue` — update it with
+   * `.set()` and the split tracks live on the UI thread (break-even, VWAP, the
+   * previous close, a peg, …).
+   */
+  value: SharedValue<number>;
+  /** Stroke color where the line is at/above `value`. Default: palette up-green (`candleUp`). */
+  aboveColor?: string;
+  /** Stroke color where the line is below `value`. Default: palette down-red (`candleDown`). */
+  belowColor?: string;
+  /**
+   * Tint the area between the line and `value` (the profit/loss band) toward the
+   * above/below colors. Independent of the baseline `gradient` fill — set
+   * `gradient={false}` for the threshold band alone. Default `false`.
+   */
+  fill?: boolean;
+  /**
+   * Dashed marker line + optional gutter label at the threshold. `true` → a dashed
+   * line in the palette reference color; object → styled; omit/`false` → none.
+   * Default off.
+   */
+  line?: boolean | ThresholdLineConfig;
+}
+
+/** Dashed marker line drawn at a {@link ThresholdConfig} value. */
+export interface ThresholdLineConfig {
+  /** Label text, e.g. `"Break-even"`. */
+  label?: string;
+  /**
+   * Label side. `"left"` sits just inside the plot at the line's left edge —
+   * clear of the y-axis labels and the live badge; `"right"` uses the right
+   * gutter like a legacy reference line (may overlap y-axis labels). Default `"left"`.
+   */
+  labelPosition?: "left" | "right";
+  /** Line + label color. Defaults to palette `refLine` / `refLabel`. */
+  color?: string;
+  /** Dash pattern `[dashLength, gapLength]` in pixels. Default `[4, 4]`. */
+  intervals?: [number, number];
+  /** Line thickness in pixels. Default `1`. */
+  strokeWidth?: number;
+  /** Append the formatted threshold value to the label. Default `false`. */
+  showValue?: boolean;
+}
+
 /** Area fill gradient beneath the chart line. */
 export interface GradientConfig {
   /** Opacity at the top of the gradient (near the line). Default `0.35`. */
@@ -1034,6 +1089,12 @@ export interface LiveChartProps extends LiveChartCoreProps {
    * `mutedColors`). Optional dashed `divider` + `label` mark a segment's edge.
    */
   segments?: ChartSegment[];
+  /**
+   * Color the line above vs. below a live threshold value (break-even / average
+   * cost, VWAP, previous close, a peg). Always a `SharedValue` so the split tracks
+   * live on the UI thread. See {@link ThresholdConfig}.
+   */
+  threshold?: ThresholdConfig;
   /** Render the live value as a large text overlay in the top-left. Default `false`. */
   showValue?: boolean;
   /** Tint the `showValue` text by momentum (green up / red down). Default `false`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -8,6 +8,7 @@ import type {
   CandlePoint,
   LiveChartProps,
   Marker,
+  ThresholdConfig,
   TradeEvent,
 } from "../src/types";
 
@@ -49,6 +50,34 @@ function CandleHarness(props: Partial<LiveChartProps>) {
       {...props}
     />
   );
+}
+
+function ThresholdHarness({
+  thresholdValue = 0.5,
+  thresholdExtra,
+  ...props
+}: Partial<LiveChartProps> & {
+  thresholdValue?: number;
+  thresholdExtra?: Omit<ThresholdConfig, "value">;
+}) {
+  const data = useSharedValue([{ time: 1700000000, value: 50 }]);
+  const value = useSharedValue(50);
+  const thr = useSharedValue(thresholdValue);
+  return (
+    <LiveChart
+      data={data}
+      value={value}
+      threshold={{ value: thr, ...thresholdExtra }}
+      {...props}
+    />
+  );
+}
+
+function layoutFirst(screen: ReturnType<typeof render>) {
+  const views = screen.UNSAFE_getAllByType(View);
+  fireEvent(views[0], "layout", {
+    nativeEvent: { layout: { width: 400, height: 300 } },
+  });
 }
 
 describe("LiveChart", () => {
@@ -261,6 +290,46 @@ describe("LiveChart", () => {
       <Harness
         referenceLines={[{ value: 40, strokeWidth: 2, color: "#ff0000" }]}
       />,
+    );
+  });
+
+  it("colors the line above/below a threshold (palette defaults)", () => {
+    layoutFirst(render(<ThresholdHarness thresholdValue={0.5} />));
+  });
+
+  it("renders the threshold fill band + dashed labelled marker line", () => {
+    layoutFirst(
+      render(
+        <ThresholdHarness
+          thresholdValue={0.5}
+          gradient={false}
+          thresholdExtra={{
+            aboveColor: "#00ff00",
+            belowColor: "#ff0000",
+            fill: true,
+            line: { label: "Break-even", showValue: true, strokeWidth: 2 },
+          }}
+        />,
+      ),
+    );
+  });
+
+  it("accepts a bare dashed marker line (no label)", () => {
+    layoutFirst(
+      render(
+        <ThresholdHarness thresholdValue={0.5} thresholdExtra={{ line: true }} />,
+      ),
+    );
+  });
+
+  it("hides the marker line when the threshold is off-screen", () => {
+    layoutFirst(
+      render(
+        <ThresholdHarness
+          thresholdValue={50}
+          thresholdExtra={{ fill: true, line: { showValue: true } }}
+        />,
+      ),
     );
   });
 

--- a/packages/react-native-livechart/tests/components/ThresholdLineOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ThresholdLineOverlay.test.tsx
@@ -1,0 +1,120 @@
+import { render } from "@testing-library/react-native";
+
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import type { ResolvedThresholdLineConfig } from "../../src/core/resolveConfig";
+import {
+  ThresholdBadgeOverlay,
+  ThresholdLineOverlay,
+} from "../../src/components/ThresholdLineOverlay";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import { resolveTheme } from "../../src/theme";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+const font = {
+  getSize: () => 12,
+  measureText: (s: string) => ({ x: 0, y: 0, width: s.length * 7, height: 12 }),
+  getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+} as never;
+
+const palette = resolveTheme("#3b82f6", "dark");
+
+function engine(): ChartEngineLayout {
+  return withSharedValueAccessors({
+    displayMin: { value: 0 },
+    displayMax: { value: 10 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: 300 },
+    timestamp: { value: 1700000000 },
+  }) as unknown as ChartEngineLayout;
+}
+
+const LINE_DEFAULTS: ResolvedThresholdLineConfig = {
+  label: undefined,
+  labelPosition: "left",
+  color: undefined,
+  intervals: [4, 4],
+  strokeWidth: 1,
+  showValue: false,
+};
+
+function sv<T>(value: T) {
+  return withSharedValueAccessors({ v: { value } }).v as unknown as {
+    value: T;
+    get: () => T;
+    set: (n: T) => void;
+  };
+}
+
+function props(
+  cfg: ResolvedThresholdLineConfig,
+  overrides?: { lineY?: number; visible?: boolean; value?: number },
+) {
+  return {
+    engine: engine(),
+    padding: DEFAULT_PADDING,
+    lineY: sv(overrides?.lineY ?? 150) as never,
+    visible: sv(overrides?.visible ?? true) as never,
+    value: sv(overrides?.value ?? 5) as never,
+    cfg,
+    palette,
+    font,
+    formatValue: (v: number) => v.toFixed(2),
+  };
+}
+
+describe("ThresholdLineOverlay (dashed line)", () => {
+  it("draws the dashed line when visible", () => {
+    render(<ThresholdLineOverlay {...props(LINE_DEFAULTS)} />);
+  });
+
+  it("emits no segment while hidden", () => {
+    render(
+      <ThresholdLineOverlay
+        {...props(LINE_DEFAULTS, { visible: false, lineY: NaN })}
+      />,
+    );
+  });
+});
+
+describe("ThresholdBadgeOverlay", () => {
+  it("draws the pill + appended value label (left, default)", () => {
+    render(
+      <ThresholdBadgeOverlay
+        {...props({ ...LINE_DEFAULTS, label: "Break-even", showValue: true })}
+      />,
+    );
+  });
+
+  it("shows only the formatted value when showValue has no label", () => {
+    render(
+      <ThresholdBadgeOverlay
+        {...props({ ...LINE_DEFAULTS, showValue: true, color: "#0f0" })}
+      />,
+    );
+  });
+
+  it("right-aligns the pill in the gutter when configured", () => {
+    render(
+      <ThresholdBadgeOverlay
+        {...props({ ...LINE_DEFAULTS, label: "Entry", labelPosition: "right" })}
+      />,
+    );
+  });
+
+  it("renders nothing when there is no label and no value", () => {
+    const { toJSON } = render(<ThresholdBadgeOverlay {...props(LINE_DEFAULTS)} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("stays hidden (opacity 0) when the threshold is off-screen", () => {
+    render(
+      <ThresholdBadgeOverlay
+        {...props(
+          { ...LINE_DEFAULTS, label: "Break-even" },
+          { visible: false, lineY: NaN },
+        )}
+      />,
+    );
+  });
+});

--- a/packages/react-native-livechart/tests/math/threshold.test.ts
+++ b/packages/react-native-livechart/tests/math/threshold.test.ts
@@ -1,0 +1,80 @@
+import {
+  thresholdLineY,
+  thresholdSplitPositions,
+  thresholdVisible,
+} from "../../src/math/threshold";
+
+// Common geometry: 300px canvas, 12px top inset, 28px bottom inset → 260px plot.
+const H = 300;
+const TOP = 12;
+const BOT = 28;
+const CHART_H = H - TOP - BOT; // 260
+
+describe("thresholdLineY", () => {
+  it("maps a mid-range value to the matching plot Y", () => {
+    // value 50 of [0,100] → halfway down the plot.
+    expect(thresholdLineY(50, 0, 100, H, TOP, BOT)).toBeCloseTo(
+      TOP + 0.5 * CHART_H,
+    );
+  });
+
+  it("maps the max value to the plot top, the min to the plot bottom", () => {
+    expect(thresholdLineY(100, 0, 100, H, TOP, BOT)).toBeCloseTo(TOP);
+    expect(thresholdLineY(0, 0, 100, H, TOP, BOT)).toBeCloseTo(H - BOT);
+  });
+
+  it("projects an out-of-range value to an off-plot (but finite) Y", () => {
+    const y = thresholdLineY(150, 0, 100, H, TOP, BOT);
+    expect(Number.isFinite(y)).toBe(true);
+    expect(y).toBeLessThan(TOP);
+  });
+
+  it("returns NaN before layout (height 0)", () => {
+    expect(thresholdLineY(50, 0, 100, 0, TOP, BOT)).toBeNaN();
+  });
+
+  it("returns NaN for a degenerate value range", () => {
+    expect(thresholdLineY(50, 50, 50, H, TOP, BOT)).toBeNaN();
+  });
+
+  it("returns NaN when insets exceed the canvas height", () => {
+    expect(thresholdLineY(50, 0, 100, 30, TOP, BOT)).toBeNaN();
+  });
+});
+
+describe("thresholdVisible", () => {
+  it("is true within the plot, false above / below it", () => {
+    expect(thresholdVisible(TOP + 100, H, TOP, BOT)).toBe(true);
+    expect(thresholdVisible(TOP - 1, H, TOP, BOT)).toBe(false);
+    expect(thresholdVisible(H - BOT + 1, H, TOP, BOT)).toBe(false);
+  });
+
+  it("is inclusive of the plot edges", () => {
+    expect(thresholdVisible(TOP, H, TOP, BOT)).toBe(true);
+    expect(thresholdVisible(H - BOT, H, TOP, BOT)).toBe(true);
+  });
+
+  it("is false for NaN or an un-laid-out canvas", () => {
+    expect(thresholdVisible(NaN, H, TOP, BOT)).toBe(false);
+    expect(thresholdVisible(100, 0, TOP, BOT)).toBe(false);
+  });
+});
+
+describe("thresholdSplitPositions", () => {
+  it("places the hard stop at the threshold's canvas fraction", () => {
+    expect(thresholdSplitPositions(150, H)).toEqual([0, 0.5, 0.5, 1]);
+  });
+
+  it("clamps to all-below when the threshold is above the canvas", () => {
+    expect(thresholdSplitPositions(-20, H)).toEqual([0, 0, 0, 1]);
+  });
+
+  it("clamps to all-above when the threshold is below the canvas", () => {
+    expect(thresholdSplitPositions(H + 20, H)).toEqual([0, 1, 1, 1]);
+  });
+
+  it("falls back to a valid ascending array for NaN / height 0", () => {
+    expect(thresholdSplitPositions(NaN, H)).toEqual([0, 1, 1, 1]);
+    expect(thresholdSplitPositions(150, 0)).toEqual([0, 1, 1, 1]);
+  });
+});

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -16,6 +16,8 @@ import {
   resolveScrubAction,
   resolveSelectionDot,
   resolveSelectionDotRing,
+  resolveThreshold,
+  resolveThresholdLine,
   resolveTradeStream,
   resolveValueLine,
   resolveXAxis,
@@ -1001,5 +1003,110 @@ describe("resolveMetrics", () => {
       gapFadeWidth: 30,
     });
     expect(m.badge).toEqual(BADGE_METRICS_DEFAULTS);
+  });
+});
+
+// ─── resolveThreshold ─────────────────────────────────────────────────────────
+
+describe("resolveThresholdLine", () => {
+  it("returns null for undefined / false", () => {
+    expect(resolveThresholdLine(undefined)).toBeNull();
+    expect(resolveThresholdLine(false)).toBeNull();
+  });
+
+  it("returns dashed defaults for true (label on the left)", () => {
+    expect(resolveThresholdLine(true)).toEqual({
+      label: undefined,
+      labelPosition: "left",
+      color: undefined,
+      intervals: [4, 4],
+      strokeWidth: 1,
+      showValue: false,
+    });
+  });
+
+  it("merges an object over the defaults (incl. labelPosition)", () => {
+    expect(
+      resolveThresholdLine({
+        label: "Break-even",
+        labelPosition: "right",
+        color: "#0f0",
+        intervals: [6, 3],
+        strokeWidth: 2,
+        showValue: true,
+      }),
+    ).toEqual({
+      label: "Break-even",
+      labelPosition: "right",
+      color: "#0f0",
+      intervals: [6, 3],
+      strokeWidth: 2,
+      showValue: true,
+    });
+  });
+});
+
+describe("resolveThreshold", () => {
+  // resolveThreshold passes `value` through untouched — a sentinel is enough.
+  const value = {
+    sentinel: true,
+  } as unknown as import("react-native-reanimated").SharedValue<number>;
+
+  it("returns null when no threshold is set", () => {
+    expect(resolveThreshold(undefined)).toBeNull();
+  });
+
+  it("fills defaults (no colors, no fill, no line) for a bare value", () => {
+    const r = resolveThreshold({ value });
+    expect(r).toEqual({
+      value,
+      aboveColor: undefined,
+      belowColor: undefined,
+      fill: false,
+      line: null,
+    });
+    // Identity of the SharedValue must be preserved (read on the UI thread).
+    expect(r?.value).toBe(value);
+  });
+
+  it("passes through above/below colors and fill", () => {
+    expect(
+      resolveThreshold({
+        value,
+        aboveColor: "#0f0",
+        belowColor: "#f00",
+        fill: true,
+      }),
+    ).toEqual({
+      value,
+      aboveColor: "#0f0",
+      belowColor: "#f00",
+      fill: true,
+      line: null,
+    });
+  });
+
+  it("resolves the line sub-config (true → dashed defaults)", () => {
+    const r = resolveThreshold({ value, line: true });
+    expect(r?.line).toEqual({
+      label: undefined,
+      labelPosition: "left",
+      color: undefined,
+      intervals: [4, 4],
+      strokeWidth: 1,
+      showValue: false,
+    });
+  });
+
+  it("resolves a configured line + keeps line null when disabled", () => {
+    expect(resolveThreshold({ value, line: { label: "VWAP" } })?.line).toEqual({
+      label: "VWAP",
+      labelPosition: "left",
+      color: undefined,
+      intervals: [4, 4],
+      strokeWidth: 1,
+      showValue: false,
+    });
+    expect(resolveThreshold({ value, line: false })?.line).toBeNull();
   });
 });


### PR DESCRIPTION
## What

`threshold?: ThresholdConfig` on `LiveChart` colors the line **green above / red below a live value** — break-even / average cost, VWAP, the previous close, or a stablecoin peg. The `value` is **always** a `SharedValue`, so the split tracks live on the UI thread with no re-render.

```tsx
const breakEven = useSharedValue(100); // move it with breakEven.set(...)

// stroke split only (palette green above / red below)
<LiveChart data={data} value={value} threshold={{ value: breakEven }} />

// full: custom colors + P/L fill band + labelled marker line
<LiveChart
  data={data} value={value} gradient={false}
  threshold={{
    value: breakEven,
    aboveColor: "#16a34a", belowColor: "#dc2626",
    fill: true,
    line: { label: "Break-even", showValue: true }, // `line: true` → line only, no badge
  }}
/>
```

## Config

- **`value`** (required `SharedValue<number>`) — the split level.
- **`aboveColor` / `belowColor`** — default to the palette's semantic up-green / down-red.
- **`fill`** — tints the profit/loss band _between the line and the threshold_. Independent of the baseline `gradient` fill, so `gradient={false}` shows the band alone.
- **`line`** — `true` draws a dashed marker line only (no text); a `ThresholdLineConfig` adds an opaque label **badge** (`labelPosition` `"left"` default / `"right"`, plus `showValue`, `color`, `intervals`, `strokeWidth`).

## How

- **Stroke** — a vertical hard-stop `LinearGradient` on the line `Path`, split position derived per-frame from the threshold + display range (reuses the gradient-child pattern from #97 — no clip, no double-draw). Supersedes `line.color`/`colors` and segment recoloring for the stroke while set.
- **Fill band** — a threshold-anchored fill path in `useChartPaths`, painted with the same hard-split gradient.
- **Marker** — split into a dashed line (drawn _behind_ the data line) and a badge (drawn _on top_, mirroring `ReferenceLineOverlay`'s pill), both tracking a `SharedValue` Y.
- Pure geometry lives in `math/threshold.ts` (100% covered); the hook only wires SharedValues.

## Also changed

- The **left-edge fade** now softens only the background fills (grid, area gradient, threshold band). The chart line and its overlays render above the fade and stay crisp at the left edge instead of washing out. Affects all charts.

## Tests & docs

- New `math/threshold.test.ts` + `components/ThresholdLineOverlay.test.tsx`; extended `resolveConfig` + `LiveChart` tests. Coverage thresholds hold (branches ≥ 90, funcs/lines/statements ≥ 95).
- Docs: `livechart.mdx` prop, `types.mdx` shapes, a **Threshold split** section in the markers-and-references guide, a README feature bullet, and a CHANGELOG `[Unreleased]` entry.
- New demo screen `app/demo/threshold.tsx` (toggles for fill / marker line / label / show value, plus label side / colors / break-even level). Verified on the iOS 26.4 simulator.

New exported types: `ThresholdConfig`, `ThresholdLineConfig`. Single-series, line mode. Additive / non-breaking — a clean **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
