### PR TITLE
fix(markers): rasterize marker atlas at device-pixel ratio (#118)

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -105,6 +105,7 @@ jest.mock("@shopify/react-native-skia", () => {
     save: jest.fn(),
     restore: jest.fn(),
     translate: jest.fn(),
+    scale: jest.fn(),
     drawCircle: jest.fn(),
     drawText: jest.fn(),
     drawPath: jest.fn(),

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -6,6 +6,7 @@ import {
   type SkFont,
 } from "@shopify/react-native-skia";
 import { useMemo, useRef, useState } from "react";
+import { PixelRatio } from "react-native";
 import {
   useDerivedValue,
   useAnimatedReaction,
@@ -189,13 +190,19 @@ export function MarkerOverlay({
   }, [snapshot]);
   // Cells bake in resolved colors; include the palette fields they depend on.
   const paletteKey = `${palette.bgRgb.join(",")}|${palette.line}|${palette.refLine}|${palette.dotUp}|${palette.refLabel}`;
+  // Rasterize at the screen's device-pixel ratio so sprites stay crisp on
+  // retina canvases instead of being upscaled from a logical-sized texture.
+  const dpr = PixelRatio.get();
   const atlas = useMemo(
-    () => buildMarkerAtlas(snapshot, palette, font),
+    () => buildMarkerAtlas(snapshot, palette, font, dpr),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- appearanceKey/paletteKey capture the inputs that change cell pixels
-    [appearanceKey, paletteKey, font],
+    [appearanceKey, paletteKey, font, dpr],
   );
   const cells: Record<string, AtlasCell> = atlas.cells;
   const atlasImage = atlas.image;
+  // Inverse of the texture's device-pixel scale; shrinks each hi-res cell back
+  // to its logical on-canvas size in the per-frame blit.
+  const invScale = 1 / atlas.scale;
 
   // One pooled, ping-ponged projection buffer reused every frame (no per-frame
   // array allocation for the projection itself).
@@ -240,15 +247,16 @@ export function MarkerOverlay({
         if (isConnectorMarker(m)) continue;
         const cell = cells[markerAppearanceSig(m)];
         if (!cell) continue;
-        // Center the cell on the projected point (RSXform: scale 1, no rotation).
+        // Center the cell on the projected point. The cell's source rect is in
+        // device pixels, so scale by 1/dpr to land it at its logical size.
         transforms.push(
-          Skia.RSXform(1, 0, pt.x - cell.w / 2, pt.y - cell.h / 2),
+          Skia.RSXform(invScale, 0, pt.x - cell.w / 2, pt.y - cell.h / 2),
         );
         sprites.push(cell.rect);
       }
       return { transforms, sprites };
     },
-    [cells, markers, engine, padding, series, lineData],
+    [cells, invScale, markers, engine, padding, series, lineData],
   );
   const transforms = useDerivedValue(() => atlasData.get().transforms, [atlasData]);
   const sprites = useDerivedValue(() => atlasData.get().sprites, [atlasData]);

--- a/packages/react-native-livechart/src/draw/markerAtlas.ts
+++ b/packages/react-native-livechart/src/draw/markerAtlas.ts
@@ -74,7 +74,9 @@ export function markerAppearanceSig(m: Marker): string {
 
 /** One packed glyph in the atlas image: its source rect + box size. */
 export interface AtlasCell {
+  /** Source rect into the (hi-res) atlas texture, in **device** pixels. */
   rect: SkRect;
+  /** Logical (DPR-independent) cell width/height, used to center the blit. */
   w: number;
   h: number;
 }
@@ -84,9 +86,16 @@ export interface MarkerAtlas {
   image: SkImage | null;
   /** appearance-signature → cell. */
   cells: Record<string, AtlasCell>;
+  /**
+   * Device-pixel scale the texture was rasterized at. Cell `rect`s are in
+   * texture (device) pixels, while `w`/`h` stay in logical pixels — so the
+   * per-frame blit must apply an `RSXform` scale of `1 / scale` to map the
+   * hi-res cell back to its logical on-canvas size. See `buildMarkerAtlas`.
+   */
+  scale: number;
 }
 
-const EMPTY_ATLAS: MarkerAtlas = { image: null, cells: {} };
+const EMPTY_ATLAS: MarkerAtlas = { image: null, cells: {}, scale: 1 };
 
 function fillPaint(color: string): SkPaint {
   const p = Skia.Paint();
@@ -258,11 +267,18 @@ function cellSpec(m: Marker, palette: LiveChartPalette, font: SkFont): CellSpec 
  *
  * Connector kinds (see `isConnectorMarker`) are skipped — they render via a
  * self-projecting fallback component.
+ *
+ * The texture is rasterized at `scale` (the screen's device-pixel ratio) so the
+ * cells carry enough resolution to stay crisp when blitted onto a retina canvas
+ * — every glyph is recorded in logical coords then magnified by `scale`, and the
+ * per-frame `drawAtlas` shrinks it back with an `RSXform` scale of `1 / scale`.
+ * Without this the logical-sized texture is upscaled ~3× on iOS and looks blurry.
  */
 export function buildMarkerAtlas(
   markers: Marker[],
   palette: LiveChartPalette,
   font: SkFont,
+  scale = 1,
 ): MarkerAtlas {
   const seen = new Set<string>();
   const specs: { sig: string; spec: CellSpec }[] = [];
@@ -282,11 +298,16 @@ export function buildMarkerAtlas(
     totalW += specs[i].spec.w;
     if (specs[i].spec.h > maxH) maxH = specs[i].spec.h;
   }
+  // Logical packed size; the texture itself is `scale`× larger in each axis.
   const W = Math.max(1, Math.ceil(totalW));
   const H = Math.max(1, Math.ceil(maxH));
+  const texW = Math.max(1, Math.ceil(W * scale));
+  const texH = Math.max(1, Math.ceil(H * scale));
 
   const recorder = Skia.PictureRecorder();
-  const canvas = recorder.beginRecording(Skia.XYWHRect(0, 0, W, H));
+  const canvas = recorder.beginRecording(Skia.XYWHRect(0, 0, texW, texH));
+  // Magnify so glyphs drawn in logical coords fill the hi-res texture.
+  canvas.scale(scale, scale);
   const cells: Record<string, AtlasCell> = {};
   let x = 0;
   for (let i = 0; i < specs.length; i++) {
@@ -295,10 +316,15 @@ export function buildMarkerAtlas(
     canvas.translate(x, 0);
     spec.draw(canvas, spec.w / 2, H / 2);
     canvas.restore();
-    cells[sig] = { rect: Skia.XYWHRect(x, 0, spec.w, H), w: spec.w, h: H };
+    // Source rect indexes the device-pixel texture; w/h stay logical.
+    cells[sig] = {
+      rect: Skia.XYWHRect(x * scale, 0, spec.w * scale, texH),
+      w: spec.w,
+      h: H,
+    };
     x += spec.w;
   }
   const picture = recorder.finishRecordingAsPicture();
-  const image = drawAsImageFromPicture(picture, { width: W, height: H });
-  return { image, cells };
+  const image = drawAsImageFromPicture(picture, { width: texW, height: texH });
+  return { image, cells, scale };
 }

--- a/packages/react-native-livechart/tests/draw/markerAtlas.test.ts
+++ b/packages/react-native-livechart/tests/draw/markerAtlas.test.ts
@@ -100,6 +100,26 @@ describe("buildMarkerAtlas", () => {
     );
     expect(Object.keys(atlas.cells)).toHaveLength(2);
   });
+
+  it("defaults to a 1x texture (logical-sized cells)", () => {
+    const marker = m({ id: "t", kind: "trade" });
+    const atlas = buildMarkerAtlas([marker], palette, font);
+    const cell = atlas.cells[markerAppearanceSig(marker)];
+    expect(atlas.scale).toBe(1);
+    // At 1x the source rect equals the logical cell box.
+    expect(cell.rect.width).toBe(cell.w);
+  });
+
+  it("rasterizes at the given device-pixel ratio for crisp retina sprites", () => {
+    const marker = m({ id: "t", kind: "trade" });
+    const atlas = buildMarkerAtlas([marker], palette, font, 3);
+    const cell = atlas.cells[markerAppearanceSig(marker)];
+    expect(atlas.scale).toBe(3);
+    // The source rect lives in device pixels (3x the logical box) while w/h
+    // stay logical, so the per-frame blit can shrink it back with 1/scale.
+    expect(cell.rect.width).toBeCloseTo(cell.w * 3);
+    expect(cell.rect.height).toBeCloseTo(cell.h * 3);
+  });
 });
 
 describe("defaultMarkerColor", () => {


### PR DESCRIPTION
Markers were pre-rasterized into a Skia atlas at logical-pixel resolution,
then blitted at scale 1 via drawAtlas. On retina screens the small texture
was upscaled ~3x, so markers looked blurry while directly-drawn text and
lines stayed sharp.

Build the atlas at the screen's device-pixel ratio and shrink each cell back
during the per-frame blit:

- buildMarkerAtlas takes a `scale` arg (default 1); records glyphs in logical
coords under canvas.scale(scale) and emits a scale-x-larger texture. Cell
rects are stored in device pixels; w/h stay logical. MarkerAtlas now carries
`scale`.
- MarkerOverlay reads PixelRatio.get(), passes it through, and the per-frame
worklet emits RSXform(1/scale, ...) so hi-res cells land at logical size.
- jest-setup: add `scale` to the mock canvas.
- tests: assert 1x default and device-pixel-sized rects at scale 3.

Fixes #118

![image.png](https://app.graphite.com/user-attachments/assets/90911910-cdcb-4260-94b2-0dd383e5670a.png)



Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)