### PR TITLE
feat(markers): renderMarker — custom RN element per marker

### DIFF
--- a/app/demo/markers.tsx
+++ b/app/demo/markers.tsx
@@ -1,5 +1,6 @@
+import { BlurView } from "expo-blur";
 import { useEffect, useRef, useState } from "react";
-import { Text } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import { LiveChart, type Marker } from "react-native-livechart";
 import { useSharedValue } from "react-native-reanimated";
 
@@ -39,10 +40,33 @@ function makeMarker(id: string, time: number, side: Side): Marker {
   };
 }
 
+/**
+ * Custom-rendered marker: an iOS-style "glass" badge built from an `expo-blur`
+ * `<BlurView>` — a NON-Skia native view that the Skia canvas can't draw. This is
+ * exactly what `renderMarker` unlocks: the chart floats it over the canvas,
+ * pinned to the marker's live position, crisp at native resolution.
+ */
+function GlassMarker({ side }: { side: Side }) {
+  const color = side === "buy" ? BUY_COLOR : SELL_COLOR;
+  return (
+    <BlurView
+      intensity={28}
+      tint={APP_THEME === "dark" ? "dark" : "light"}
+      style={glass.badge}
+    >
+      <View style={[glass.dot, { backgroundColor: color }]} />
+      <Text style={[glass.text, { color }]}>
+        {side === "buy" ? "BUY" : "SELL"}
+      </Text>
+    </BlurView>
+  );
+}
+
 export default function MarkersScreen() {
   const [auto, setAuto] = useState(true);
   const [hover, setHover] = useState("Tap a marker");
   const [streamOn, setStreamOn] = useState(false);
+  const [custom, setCustom] = useState(false);
   const [vol, setVol] = useState<(typeof VOLATILITY_MODES)[number]>("normal");
 
   const { data, value, tradeStream } = useSimulatedChartData({
@@ -106,6 +130,15 @@ export default function MarkersScreen() {
           timeWindow={WINDOW}
           markers={markers}
           markerHitRadius={22}
+          renderMarker={
+            custom
+              ? (m) => (
+                  <GlassMarker
+                    side={(m.data as { side?: Side })?.side ?? "buy"}
+                  />
+                )
+              : undefined
+          }
           tradeStream={streamOn ? tradeStream : undefined}
           onMarkerHover={(e) => {
             const side = (e?.marker.data as { side?: Side } | undefined)?.side;
@@ -137,6 +170,15 @@ export default function MarkersScreen() {
         line at its time.
       </Text>
 
+      <ControlRow label="Custom render">
+        <ToggleChip label="renderMarker" value={custom} onChange={setCustom} />
+      </ControlRow>
+      <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+        `renderMarker` floats your own RN element at each marker — here a real
+        expo-blur `BlurView` glass badge, the kind of non-Skia view the canvas
+        can&apos;t draw.
+      </Text>
+
       <ControlRow label="Trade stream">
         <ToggleChip label="tradeStream" value={streamOn} onChange={setStreamOn} />
       </ControlRow>
@@ -149,3 +191,24 @@ export default function MarkersScreen() {
     </DemoScreen>
   );
 }
+
+const glass = StyleSheet.create({
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    // Hairline rim sells the "glass" edge; overflow clips the blur to the pill.
+    borderColor: APP_THEME === "dark" ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.12)",
+    overflow: "hidden",
+  },
+  dot: { width: 6, height: 6, borderRadius: 3 },
+  text: {
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+});

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -112,6 +112,17 @@ provided; everything else has a default.
   Tap hit-test radius in px.
 </ParamField>
 
+<ParamField body="renderMarker" type="(marker: Marker) => ReactElement | null">
+  Render a marker as a custom **React Native** element instead of a built-in Skia
+  glyph — e.g. an `expo-blur` glass badge or any non-Skia view. Return an element
+  to float it, auto-centered, at the marker's live `(time, value)` position
+  (tracked on the UI thread); return `null`/`undefined` to keep the built-in
+  glyph. Custom-rendered markers skip the atlas (no double-draw) and stay crisp at
+  native resolution. Use sparingly — each is its own animated view, whereas
+  built-in glyphs batch into one draw call. See
+  [Custom marker rendering](/guides/markers-and-references#custom-marker-rendering).
+</ParamField>
+
 <ParamField body="referenceLines" type="ReferenceLine[]">
   Reference lines / bands (horizontal line, value band, or time band).
 </ParamField>

--- a/docs/guides/markers-and-references.mdx
+++ b/docs/guides/markers-and-references.mdx
@@ -56,6 +56,45 @@ single-series chart, omitting `value` anchors the marker to the line at `time` (
 `data`); in multi-series, set `seriesId` to anchor to that series' line. So for a marker that should
 always sit on the line, just give it a `time` and `kind`.
 
+### Custom marker rendering
+
+Built-in glyphs are drawn into the Skia canvas. When you need something the canvas **can't** draw —
+a native `BlurView` glass badge, a gradient pill, an animated component — pass `renderMarker`. Return
+a **React Native** element to float it, auto-centered, at the marker's live `(time, value)` position
+(tracked on the UI thread); return `null`/`undefined` to keep the built-in glyph for that marker.
+
+```tsx
+import { BlurView } from "expo-blur";
+
+<LiveChart
+  data={data}
+  value={value}
+  markers={markers}
+  renderMarker={(marker) => {
+    const side = (marker.data as { side?: "buy" | "sell" })?.side;
+    if (!side) return null; // fall back to the built-in glyph
+    return (
+      <BlurView intensity={28} tint="light" style={styles.glassBadge}>
+        <Text style={{ color: side === "buy" ? "#16a34a" : "#dc2626" }}>
+          {side === "buy" ? "BUY" : "SELL"}
+        </Text>
+      </BlurView>
+    );
+  }}
+/>;
+```
+
+Custom-rendered markers are floated as RN views over the canvas, so they render **crisp at native
+resolution** (and skip the marker atlas entirely — no glyph drawn behind them). Taps still fire
+`onMarkerHover` via the marker hit-test. `expo-blur` is the consumer's choice — `renderMarker`
+accepts any element, and the library takes no extra dependency.
+
+<Note>
+  Use `renderMarker` for a handful of special markers, not hundreds of high-frequency ones: each
+  custom marker is its own animated view + projection, whereas built-in glyphs batch into a single
+  draw call. Works the same on `LiveChart` and `LiveChartSeries`.
+</Note>
+
 ## Trade stream
 
 For trade-fill markers specifically, feed a `SharedValue<TradeEvent[]>`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@shopify/react-native-skia": "2.6.4",
         "@types/jest": "29.5.14",
         "expo": "~54.0.35",
+        "expo-blur": "~15.0.8",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.12",
         "expo-haptics": "~15.0.8",
@@ -8632,6 +8633,17 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-blur": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
+      "integrity": "sha512-rWyE1NBRZEu9WD+X+5l7gyPRszw7n12cW3IRNAb5i6KFzaBp8cxqT5oeaphJapqURvcqhkOZn2k5EtBSbsuU7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@shopify/react-native-skia": "2.6.4",
     "@types/jest": "29.5.14",
     "expo": "~54.0.35",
+    "expo-blur": "~15.0.8",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.12",
     "expo-haptics": "~15.0.8",

--- a/packages/react-native-livechart/src/components/CustomMarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomMarkerOverlay.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import { StyleSheet, View, type LayoutChangeEvent } from "react-native";
+import Animated, {
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { markersSignature, projectPoint } from "../math/markers";
+import type { LiveChartPoint, Marker, SeriesConfig } from "../types";
+
+/**
+ * One custom-rendered marker: a React Native element floated over the canvas and
+ * pinned to the marker's live `(time, value)` position. Each glyph projects its
+ * OWN marker every frame (mirrors `ConnectorGlyph`) so reordering the array can't
+ * make it flash another marker's spot, and the transform runs on the UI thread —
+ * no JS re-render as the chart scrolls/rescales.
+ *
+ * The element is auto-centered on the point: its size is measured via `onLayout`
+ * into a SharedValue, and the animated transform offsets by half that size.
+ * `pointerEvents="box-none"` lets empty space fall through to the scrub gesture
+ * while still allowing an interactive leaf inside the custom element to be tapped.
+ */
+function CustomMarkerView({
+  marker,
+  element,
+  engine,
+  padding,
+  seriesSV,
+  lineDataSV,
+}: {
+  marker: Marker;
+  element: React.ReactElement;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  seriesSV?: SharedValue<SeriesConfig[]>;
+  lineDataSV?: SharedValue<LiveChartPoint[]>;
+}) {
+  const time = marker.time;
+  const value = marker.value;
+  const seriesId = marker.seriesId;
+
+  const layout = useDerivedValue(() =>
+    projectPoint(time, value, seriesId, {
+      canvasWidth: engine.canvasWidth.get(),
+      canvasHeight: engine.canvasHeight.get(),
+      padTop: padding.top,
+      padBottom: padding.bottom,
+      padLeft: padding.left,
+      padRight: padding.right,
+      timestamp: engine.timestamp.get(),
+      displayWindow: engine.displayWindow.get(),
+      displayMin: engine.displayMin.get(),
+      displayMax: engine.displayMax.get(),
+      series: seriesSV?.get(),
+      lineData: lineDataSV?.get(),
+    }),
+  );
+
+  // Measured element size, so the transform can center it on the point.
+  const size = useSharedValue({ width: 0, height: 0 });
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    size.value = { width, height };
+  };
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const l = layout.get();
+    const s = size.get();
+    return {
+      opacity: l.visible ? 1 : 0,
+      transform: [
+        { translateX: l.x - s.width / 2 },
+        { translateY: l.y - s.height / 2 },
+      ],
+    };
+  });
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      onLayout={onLayout}
+      style={[styles.anchor, animatedStyle]}
+    >
+      {element}
+    </Animated.View>
+  );
+}
+
+/**
+ * React Native overlay (NOT Skia) that floats `renderMarker` elements over the
+ * Skia canvas, one per marker the consumer chooses to customize. Rendered as a
+ * sibling of `<Canvas>` (like {@link AxisLabelOverlay}) so the elements can be
+ * any RN view — including non-Skia effects (e.g. a glass `BlurView`) — and stay
+ * crisp at native resolution instead of being rasterized into the marker atlas.
+ *
+ * The set of markers is mirrored to JS state via `markersSignature` (same as
+ * `MarkerOverlay`); `renderMarker` is then called per marker on the JS thread.
+ * Markers it returns an element for are excluded from the Skia atlas upstream, so
+ * there's no double-draw.
+ */
+export function CustomMarkerOverlay({
+  markers,
+  renderMarker,
+  engine,
+  padding,
+  series,
+  lineData,
+}: {
+  markers: SharedValue<Marker[]>;
+  renderMarker: (marker: Marker) => React.ReactElement | null | undefined;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  /** Multi-series data, used to anchor markers by `seriesId`. */
+  series?: SharedValue<SeriesConfig[]>;
+  /** Single-series line data; anchors markers that omit `value`. */
+  lineData?: SharedValue<LiveChartPoint[]>;
+}) {
+  const [snapshot, setSnapshot] = useState<Marker[]>(() => markers.get().slice());
+
+  const pull = () => {
+    setSnapshot(markers.get().slice());
+  };
+
+  useAnimatedReaction(
+    () => markersSignature(markers.get()),
+    /* istanbul ignore next -- scheduleOnRN from UI-thread reaction */
+    (sig, prev) => {
+      if (sig !== prev) scheduleOnRN(pull);
+    },
+    [markers, pull],
+  );
+
+  // Resolve each marker's custom element once per snapshot on the JS thread.
+  const custom: { marker: Marker; element: React.ReactElement }[] = [];
+  for (let i = 0; i < snapshot.length; i++) {
+    const m = snapshot[i];
+    const element = renderMarker(m);
+    if (element != null) custom.push({ marker: m, element });
+  }
+  if (custom.length === 0) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      {custom.map(({ marker, element }) => (
+        <CustomMarkerView
+          key={marker.id}
+          marker={marker}
+          element={element}
+          engine={engine}
+          padding={padding}
+          seriesSV={series}
+          lineDataSV={lineData}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // top/left 0 + translate so the measured element can be centered on the point.
+  anchor: { position: "absolute", top: 0, left: 0 },
+});

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -86,6 +86,7 @@ import {
   ThresholdLineOverlay,
 } from "./ThresholdLineOverlay";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
+import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
@@ -199,6 +200,7 @@ function useLiveChartController({
   markers,
   onMarkerHover,
   markerHitRadius = 16,
+  renderMarker,
   leftEdgeFade = true,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
@@ -682,6 +684,7 @@ function useLiveChartController({
     rootGesture,
     markersActive,
     markersSV,
+    renderMarker,
     // selection dot: resolved config + fallback color (the chart line/accent color)
     selectionDot: selectionDotCfg,
     selectionColor: lineProp?.color ?? palette.line,
@@ -819,6 +822,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     degenPackRevision,
     markersActive,
     markersSV,
+    renderMarker,
     emptyText,
     metricsCfg,
     layoutWidth,
@@ -996,6 +1000,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
             palette={palette}
             font={skiaFont}
             lineData={engine.data}
+            renderMarker={renderMarker}
           />
         </Group>
       )}
@@ -1251,6 +1256,9 @@ export function LiveChart(props: LiveChartProps) {
     formatValue,
     topLabelCfg,
     bottomLabelCfg,
+    markersActive,
+    markersSV,
+    renderMarker,
   } = model;
 
   return (
@@ -1306,6 +1314,18 @@ export function LiveChart(props: LiveChartProps) {
           defaultColor={palette.gridLabel}
           padding={effectivePadding}
         />
+
+        {/* Custom-rendered markers — RN views floated over the canvas (non-Skia),
+            pinned to each marker's live position. Sibling of <Canvas>. */}
+        {markersActive && renderMarker && (
+          <CustomMarkerOverlay
+            markers={markersSV}
+            renderMarker={renderMarker}
+            engine={engine}
+            padding={effectivePadding}
+            lineData={engine.data}
+          />
+        )}
       </View>
     </GestureDetector>
   );

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -63,6 +63,7 @@ import {
 } from "../theme";
 import type { LiveChartSeriesProps, Marker, SeriesConfig } from "../types";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
+import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
 import { CrosshairLine } from "./CrosshairLine";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
 import { LeftEdgeFade } from "./LeftEdgeFade";
@@ -143,6 +144,7 @@ function useLiveChartSeriesController({
   markers,
   onMarkerHover,
   markerHitRadius = 16,
+  renderMarker,
   leftEdgeFade = true,
 }: LiveChartSeriesProps) {
   const emptyMarkers = useSharedValue<Marker[]>([]);
@@ -386,6 +388,7 @@ function useLiveChartSeriesController({
     rootGesture,
     markersActive,
     markersSV,
+    renderMarker,
     // selection dot: resolved config + fallback color (the leading series' color)
     selectionDot: selectionDotCfg,
     selectionColor: lineColors[0],
@@ -426,6 +429,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     degenPackRevision,
     markersActive,
     markersSV,
+    renderMarker,
     series,
     emptyText,
     metricsCfg,
@@ -541,6 +545,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
             palette={palette}
             font={skiaFont}
             series={series}
+            renderMarker={renderMarker}
           />
         </Group>
       )}
@@ -649,6 +654,9 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     formatValue,
     topLabelCfg,
     bottomLabelCfg,
+    markersActive,
+    markersSV,
+    renderMarker,
   } = model;
 
   // Extend the scrub dim past the plot's right edge to fully cover the series
@@ -735,6 +743,18 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
             defaultColor={palette.gridLabel}
             padding={effectivePadding}
           />
+
+          {/* Custom-rendered markers — RN views floated over the canvas
+              (non-Skia), pinned to each marker's live position. */}
+          {markersActive && renderMarker && (
+            <CustomMarkerOverlay
+              markers={markersSV}
+              renderMarker={renderMarker}
+              engine={engine}
+              padding={effectivePadding}
+              series={series}
+            />
+          )}
         </View>
       </GestureDetector>
       {legendCfg.position === "bottom" ? legend : null}

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -148,6 +148,7 @@ export function MarkerOverlay({
   font,
   series,
   lineData,
+  renderMarker,
 }: {
   markers: SharedValue<Marker[]>;
   engine: ChartEngineLayout;
@@ -158,6 +159,12 @@ export function MarkerOverlay({
   series?: SharedValue<SeriesConfig[]>;
   /** Single-series line data; anchors markers that omit `value`. */
   lineData?: SharedValue<LiveChartPoint[]>;
+  /**
+   * When provided, markers it returns an element for are rendered as RN views by
+   * `CustomMarkerOverlay` instead — so they're excluded from the atlas here to
+   * avoid a (blurry) glyph drawn behind the custom element.
+   */
+  renderMarker?: (marker: Marker) => unknown;
 }) {
   // Seed from the current markers at mount; the reaction below keeps it in sync.
   const [snapshot, setSnapshot] = useState<Marker[]>(() => markers.get().slice());
@@ -177,6 +184,24 @@ export function MarkerOverlay({
     [markers, pull],
   );
 
+  // Ids of markers the consumer renders as custom RN views (CustomMarkerOverlay).
+  // Stabilized via a string key so an inline `renderMarker` that returns the same
+  // set doesn't churn `customIds`' identity (which the per-frame worklet captures).
+  const customKey = useMemo(() => {
+    if (!renderMarker) return "";
+    let k = "";
+    for (let i = 0; i < snapshot.length; i++) {
+      const m = snapshot[i];
+      if (renderMarker(m) != null) k += `${m.id}\x1f`;
+    }
+    return k;
+  }, [snapshot, renderMarker]);
+  const customIds = useMemo<Record<string, true>>(() => {
+    const o: Record<string, true> = {};
+    for (const id of customKey.split("\x1f")) if (id) o[id] = true;
+    return o;
+  }, [customKey]);
+
   // Rebuild the atlas image only when the set of distinct appearances or the
   // theme/font changes — never per frame. `markersSignature` already drives the
   // snapshot, so this useMemo re-runs at most at the snapshot cadence.
@@ -184,17 +209,18 @@ export function MarkerOverlay({
     const sigs = new Set<string>();
     for (let i = 0; i < snapshot.length; i++) {
       const m = snapshot[i];
-      if (!isConnectorMarker(m)) sigs.add(markerAppearanceSig(m));
+      if (!isConnectorMarker(m) && !customIds[m.id])
+        sigs.add(markerAppearanceSig(m));
     }
     return Array.from(sigs).sort().join("\x1e");
-  }, [snapshot]);
+  }, [snapshot, customIds]);
   // Cells bake in resolved colors; include the palette fields they depend on.
   const paletteKey = `${palette.bgRgb.join(",")}|${palette.line}|${palette.refLine}|${palette.dotUp}|${palette.refLabel}`;
   // Rasterize at the screen's device-pixel ratio so sprites stay crisp on
   // retina canvases instead of being upscaled from a logical-sized texture.
   const dpr = PixelRatio.get();
   const atlas = useMemo(
-    () => buildMarkerAtlas(snapshot, palette, font, dpr),
+    () => buildMarkerAtlas(snapshot.filter((m) => !customIds[m.id]), palette, font, dpr),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- appearanceKey/paletteKey capture the inputs that change cell pixels
     [appearanceKey, paletteKey, font, dpr],
   );
@@ -245,6 +271,8 @@ export function MarkerOverlay({
         if (!pt.visible) continue;
         const m = ms[i];
         if (isConnectorMarker(m)) continue;
+        // Custom-rendered markers are floated as RN views, not drawn here.
+        if (customIds[m.id]) continue;
         const cell = cells[markerAppearanceSig(m)];
         if (!cell) continue;
         // Center the cell on the projected point. The cell's source rect is in
@@ -256,7 +284,7 @@ export function MarkerOverlay({
       }
       return { transforms, sprites };
     },
-    [cells, invScale, markers, engine, padding, series, lineData],
+    [cells, customIds, invScale, markers, engine, padding, series, lineData],
   );
   const transforms = useDerivedValue(() => atlasData.get().transforms, [atlasData]);
   const sprites = useDerivedValue(() => atlasData.get().sprites, [atlasData]);

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1012,6 +1012,20 @@ export interface LiveChartCoreProps {
   /** Tap hit-test radius in px. Default `16` (≈ 44px touch target with the glyph). */
   markerHitRadius?: number;
   /**
+   * Render a marker as a custom **React Native** element instead of a built-in
+   * Skia glyph — e.g. an `expo-blur` glass badge or any non-Skia view that the
+   * canvas can't draw. Return an element to float it, auto-centered, at the
+   * marker's live `(time, value)` position (tracked on the UI thread); return
+   * `null`/`undefined` to keep the built-in atlas glyph for that marker.
+   *
+   * The element is rendered as an RN view layered over the canvas, so it is
+   * crisp at native resolution. Use it sparingly (a handful of special markers):
+   * each custom marker is its own animated view + projection, whereas built-in
+   * glyphs batch into a single draw call. Custom-rendered markers skip the atlas
+   * glyph entirely (no double-draw).
+   */
+  renderMarker?: (marker: Marker) => ReactElement | null | undefined;
+  /**
    * Override individual resolved-palette keys on top of the palette derived from
    * `accentColor` + `theme`. Only the keys you set are replaced.
    */

--- a/packages/react-native-livechart/tests/components/CustomMarkerOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomMarkerOverlay.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { Text, View } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { CustomMarkerOverlay } from "../../src/components/CustomMarkerOverlay";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import type { LiveChartPoint, Marker, SeriesConfig } from "../../src/types";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+function engine(): ChartEngineLayout {
+  return withSharedValueAccessors({
+    displayMin: { value: 0 },
+    displayMax: { value: 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: 300 },
+    timestamp: { value: 1000 },
+  }) as unknown as ChartEngineLayout;
+}
+
+const MARKERS: Marker[] = [
+  { id: "a", time: 999, kind: "trade", value: 50 },
+  { id: "b", time: 998, kind: "boost", value: 55 },
+];
+
+describe("CustomMarkerOverlay", () => {
+  it("floats a custom element for each marker renderMarker handles", () => {
+    function Fixture() {
+      const markers = useSharedValue<Marker[]>(MARKERS);
+      const lineData = useSharedValue<LiveChartPoint[]>([]);
+      return (
+        <CustomMarkerOverlay
+          markers={markers}
+          renderMarker={(m) => <Text testID={`cm-${m.id}`}>{m.id}</Text>}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          lineData={lineData}
+        />
+      );
+    }
+    const { getByTestId } = render(<Fixture />);
+    expect(getByTestId("cm-a")).toBeTruthy();
+    expect(getByTestId("cm-b")).toBeTruthy();
+  });
+
+  it("renders nothing when renderMarker opts out of every marker", () => {
+    function Fixture() {
+      const markers = useSharedValue<Marker[]>(MARKERS);
+      return (
+        <CustomMarkerOverlay
+          markers={markers}
+          // Returns null for all → no custom views, component renders null.
+          renderMarker={() => null}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+        />
+      );
+    }
+    const { queryByTestId, toJSON } = render(<Fixture />);
+    expect(queryByTestId("cm-a")).toBeNull();
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders only the markers renderMarker returns an element for", () => {
+    function Fixture() {
+      const markers = useSharedValue<Marker[]>(MARKERS);
+      return (
+        <CustomMarkerOverlay
+          markers={markers}
+          renderMarker={(m) =>
+            m.kind === "trade" ? <Text testID={`cm-${m.id}`}>{m.id}</Text> : null
+          }
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+        />
+      );
+    }
+    const { getByTestId, queryByTestId } = render(<Fixture />);
+    expect(getByTestId("cm-a")).toBeTruthy(); // trade → custom
+    expect(queryByTestId("cm-b")).toBeNull(); // boost → falls back to glyph
+  });
+
+  it("centers via onLayout without throwing (measures element size)", () => {
+    function Fixture() {
+      const markers = useSharedValue<Marker[]>([MARKERS[0]]);
+      return (
+        <CustomMarkerOverlay
+          markers={markers}
+          renderMarker={(m) => (
+            <View testID={`cm-${m.id}`} style={{ width: 24, height: 24 }} />
+          )}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+        />
+      );
+    }
+    const { getByTestId } = render(<Fixture />);
+    // Drive an onLayout so the centering branch (size measurement) executes.
+    fireEvent(getByTestId("cm-a").parent!, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 24, height: 24 } },
+    });
+    expect(getByTestId("cm-a")).toBeTruthy();
+  });
+
+  it("anchors a custom marker to a series by seriesId", () => {
+    function Fixture() {
+      const markers = useSharedValue<Marker[]>([
+        { id: "s", time: 990, kind: "winner", seriesId: "a" },
+      ]);
+      const series = useSharedValue<SeriesConfig[]>([
+        {
+          id: "a",
+          value: 0,
+          data: [
+            { time: 980, value: 20 },
+            { time: 1000, value: 40 },
+          ],
+        },
+      ]);
+      return (
+        <CustomMarkerOverlay
+          markers={markers}
+          renderMarker={(m) => <Text testID={`cm-${m.id}`}>{m.id}</Text>}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          series={series}
+        />
+      );
+    }
+    const { getByTestId } = render(<Fixture />);
+    expect(getByTestId("cm-s")).toBeTruthy();
+  });
+});

--- a/packages/react-native-livechart/tests/components/MarkerOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/MarkerOverlay.test.tsx
@@ -114,6 +114,27 @@ describe("MarkerOverlay", () => {
     render(<Fixture />);
   });
 
+  it("excludes custom-rendered markers from the atlas (renderMarker)", () => {
+    function Fixture() {
+      const markers = useSharedValue<Marker[]>([
+        { id: "atlas", time: 999, kind: "trade", value: 50 },
+        { id: "custom", time: 998, kind: "winner", value: 55 },
+      ]);
+      return (
+        <MarkerOverlay
+          markers={markers}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          // Custom-render the winner; the trade still draws via the atlas.
+          renderMarker={(m) => (m.id === "custom" ? <></> : null)}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
   it("anchors a marker to a series by seriesId", () => {
     function Fixture() {
       const markers = useSharedValue<Marker[]>([


### PR DESCRIPTION
## Summary

Implements the custom-render idea from #118 — a chart-level **`renderMarker`** prop on `LiveChart` and `LiveChartSeries`:

```tsx
renderMarker?: (marker: Marker) => ReactElement | null | undefined
```

Return an element to float your own **React Native** view at a marker's live `(time, value)` position; return `null`/`undefined` to keep the built-in Skia glyph. This lets consumers drop in non-Skia elements the canvas can't draw — e.g. an `expo-blur` `BlurView` glass badge — rendered crisp at native resolution (and sidestepping the marker-atlas rasterization for those markers).

## How it works

- **New `CustomMarkerOverlay`** — an RN overlay floated as a sibling of `<Canvas>` (the same pattern as `AxisLabelOverlay`). Each custom marker is an `Animated.View` whose transform is driven by the same `projectPoint` projection the Skia markers use, so it tracks scroll/rescale on the UI thread with no JS re-render, and auto-centers via `onLayout`. `pointerEvents="box-none"` keeps the scrub gesture working; taps still fire `onMarkerHover` via the existing marker hit-test.
- **No double-draw** — `MarkerOverlay` excludes custom-rendered markers from the atlas (by id, stabilized so an inline `renderMarker` doesn't churn the per-frame worklet).
- **Chart-level, not per-marker** — keeps `SharedValue<Marker[]>` pure data (no function crossing the JS↔UI boundary); the projection worklet only ever reads primitive anchor fields.

## Demo

The Markers screen gains a `renderMarker` toggle showing a real `expo-blur` `BlurView` glass badge. `expo-blur` is added to the **example app only** — the library itself takes no new dependency.

## Testing

- `npm run verify` passes: typecheck + lint + **912 tests** (new `CustomMarkerOverlay.test.tsx` + a `MarkerOverlay` atlas-skip test), coverage thresholds met.
- Verified on device: the BlurView glass markers track the line and render crisply (needs a native rebuild since `expo-blur` is a native module).

## Notes

- New backward-compatible API — no existing behavior changes (a **minor** release).
- `ios/`/`android/` are gitignored (prebuild workflow), so the pod changes aren't part of this diff.

Closes #118 (the custom-render follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
