### PR TITLE
feat(scrub): customizable tooltips for LiveChart (#119)

### DIFF
--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -1,11 +1,13 @@
-import { Text, TextInput } from "react-native";
+import { StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Circle, Group } from "@shopify/react-native-skia";
 import { useState } from "react";
 import {
   formatTime,
   LiveChart,
+  type ScrubConfig,
   type SelectionDotProps,
+  type TooltipRenderProps,
 } from "react-native-livechart";
 import Animated, {
   useAnimatedProps,
@@ -29,6 +31,23 @@ const SCRUB_OPTIONS: { value: ScrubMode; label: string }[] = [
   { value: "off", label: "Off" },
   { value: "on", label: "On + tooltip" },
   { value: "noTooltip", label: "On, no tooltip" },
+];
+
+type TooltipPlacement = NonNullable<ScrubConfig["tooltipPlacement"]>;
+
+// Placement applies to BOTH the built-in pill and a custom `renderTooltip` —
+// the chart positions either one on the UI thread per `tooltipPlacement`.
+const PLACEMENT_OPTIONS: { value: TooltipPlacement; label: string }[] = [
+  { value: "side", label: "Side" },
+  { value: "top", label: "Top" },
+  { value: "bottom", label: "Bottom" },
+];
+
+// Gap between the tooltip and the plot edge it's pinned to (`tooltipMargin`).
+const MARGIN_OPTIONS: { value: number; label: string }[] = [
+  { value: 8, label: "8" },
+  { value: 24, label: "24" },
+  { value: 48, label: "48" },
 ];
 
 type DisplayMode = "line" | "candle";
@@ -68,10 +87,39 @@ function RingSelectionDot({ x, y, opacity, size }: SelectionDotProps) {
   );
 }
 
+// A fully custom tooltip (`renderTooltip`): a brand-blue pill with white date
+// text. The chart floats it over the canvas and positions it on the UI thread;
+// the date is an animated TextInput bound to `timeStr`, so movement AND text
+// both update on the UI thread — no JS re-render while scrubbing. Works the same
+// under hold-to-scrub (the overlay is `pointerEvents="box-none"`, so the pan
+// gesture and its `panGestureDelay` are unaffected). Line mode only.
+function BlueTooltip({ timeStr }: TooltipRenderProps) {
+  const animatedProps = useAnimatedProps(() => {
+    const t = timeStr.get();
+    return { text: t, defaultValue: t };
+  });
+  return (
+    <View style={styles.blueTip}>
+      <AnimatedTextInput
+        editable={false}
+        underlineColorAndroid="transparent"
+        style={styles.blueTipText}
+        animatedProps={animatedProps}
+      />
+    </View>
+  );
+}
+
 export default function ScrubbingScreen() {
   const [scrubMode, setScrubMode] = useState<ScrubMode>("on");
   const [displayMode, setDisplayMode] = useState<DisplayMode>("line");
   const [styledTooltip, setStyledTooltip] = useState(false);
+  const [customTooltip, setCustomTooltip] = useState(false);
+  const [tooltipPlacement, setTooltipPlacement] =
+    useState<TooltipPlacement>("side");
+  const [tooltipMargin, setTooltipMargin] = useState(8);
+  const [dateOnly, setDateOnly] = useState(false);
+  const [roundedTip, setRoundedTip] = useState(false);
   const [dimOpacity, setDimOpacity] = useState(0.3);
   const [dotMode, setDotMode] = useState<DotMode>("default");
   const [holdToScrub, setHoldToScrub] = useState(false);
@@ -112,22 +160,29 @@ export default function ScrubbingScreen() {
     maxPoints: 6000,
   });
 
-  const scrub =
+  const scrub: ScrubConfig | boolean =
     scrubMode === "off"
       ? false
-      : scrubMode === "noTooltip"
-        ? { tooltip: false, dimOpacity, panGestureDelay }
-        : styledTooltip
-          ? {
-              tooltip: true,
-              dimOpacity,
-              panGestureDelay,
-              tooltipBackground: "#1e293b",
-              tooltipColor: "#fbbf24",
-              tooltipBorderColor: "#fbbf24",
-              crosshairLineColor: "#fbbf24",
-            }
-          : { tooltip: true, dimOpacity, panGestureDelay };
+      : {
+          tooltip: scrubMode !== "noTooltip",
+          dimOpacity,
+          panGestureDelay,
+          // Tooltip layout knobs — apply to the built-in pill and the custom
+          // render alike (placement + margin position either one).
+          tooltipPlacement,
+          tooltipMargin,
+          tooltipShowValue: !dateOnly,
+          tooltipBorderRadius: roundedTip ? 16 : 5,
+          // The "Styled" toggle recolors the built-in pill + crosshair line.
+          ...(styledTooltip
+            ? {
+                tooltipBackground: "#1e293b",
+                tooltipColor: "#fbbf24",
+                tooltipBorderColor: "#fbbf24",
+                crosshairLineColor: "#fbbf24",
+              }
+            : {}),
+        };
 
   // The `boolean | SelectionDotConfig` idiom: `true` = built-in dot, `false` =
   // hidden, a config tweaks size/color/ring, and `{ component }` swaps in a
@@ -158,6 +213,10 @@ export default function ScrubbingScreen() {
           theme={APP_THEME}
           timeWindow={windowSecs}
           scrub={scrub}
+          // Custom tooltip is line-mode only; candle keeps its OHLC stack.
+          renderTooltip={
+            customTooltip && displayMode === "line" ? BlueTooltip : undefined
+          }
           selectionDot={selectionDot}
           onGestureStart={() => setGestureState("scrubbing…")}
           onGestureEnd={() => setGestureState("idle")}
@@ -198,6 +257,38 @@ export default function ScrubbingScreen() {
         onChange={setScrubMode}
       />
       <ChipRow
+        label="Tooltip placement"
+        options={PLACEMENT_OPTIONS}
+        value={tooltipPlacement}
+        onChange={setTooltipPlacement}
+      />
+      <ChipRow
+        label="Tooltip margin (edge gap)"
+        options={MARGIN_OPTIONS}
+        value={tooltipMargin}
+        onChange={setTooltipMargin}
+      />
+      <ControlRow label="Tooltip">
+        {/* Date-only + rounded restyle the built-in pill; Custom render swaps in
+            a brand-blue RN pill. Placement/margin apply to the custom one too. */}
+        <ToggleChip label="Date only" value={dateOnly} onChange={setDateOnly} />
+        <ToggleChip
+          label="Rounded"
+          value={roundedTip}
+          onChange={setRoundedTip}
+        />
+        <ToggleChip
+          label="Styled"
+          value={styledTooltip}
+          onChange={setStyledTooltip}
+        />
+        <ToggleChip
+          label="Custom render"
+          value={customTooltip}
+          onChange={setCustomTooltip}
+        />
+      </ControlRow>
+      <ChipRow
         label="Trailing fade (dimOpacity)"
         options={DIM_OPTIONS}
         value={dimOpacity}
@@ -209,12 +300,7 @@ export default function ScrubbingScreen() {
         value={dotMode}
         onChange={setDotMode}
       />
-      <ControlRow>
-        <ToggleChip
-          label="Styled tooltip"
-          value={styledTooltip}
-          onChange={setStyledTooltip}
-        />
+      <ControlRow label="Gesture">
         <ToggleChip
           label="Hold to scrub (250ms)"
           value={holdToScrub}
@@ -231,3 +317,22 @@ export default function ScrubbingScreen() {
     </DemoScreen>
   );
 }
+
+const styles = StyleSheet.create({
+  blueTip: {
+    borderRadius: 10,
+    backgroundColor: ACCENT,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  blueTipText: {
+    // Fixed width: the TextInput is measured once at mount; UI-thread text
+    // updates don't re-trigger a layout pass, so an auto-width pill would clip.
+    width: 72,
+    textAlign: "center",
+    color: "#fff",
+    fontSize: 13,
+    padding: 0,
+    fontFamily: "JetBrainsMono_400Regular",
+  },
+});

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -123,6 +123,18 @@ provided; everything else has a default.
   [Custom marker rendering](/guides/markers-and-references#custom-marker-rendering).
 </ParamField>
 
+<ParamField body="renderTooltip" type="(ctx: TooltipRenderProps) => ReactElement | null">
+  Render a fully custom scrub tooltip as a **React Native** element instead of the
+  built-in pill — the same idea as `renderMarker`. The chart floats it over the
+  canvas and positions it on the UI thread (per `scrub.tooltipPlacement`); you own
+  the chrome (border radius/color, background are plain RN styles) and content. Bind
+  the [`TooltipRenderProps`](/api-reference/types#tooltiprenderprops) `SharedValue`s
+  to animated text so the value/date update on the UI thread too — smooth, unlike
+  rebuilding the tooltip from the JS-thread `onScrub`. Return `null`/`undefined` to
+  fall back to the built-in pill. **Line mode only** (candle keeps its OHLC stack).
+  See [Custom tooltip](/guides/scrubbing#custom-tooltip-rendertooltip).
+</ParamField>
+
 <ParamField body="referenceLines" type="ReferenceLine[]">
   Reference lines / bands (horizontal line, value band, or time band).
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -213,6 +213,10 @@ interface ScrubConfig {
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;
+  tooltipBorderRadius?: number; // pill corner radius; default 5
+  tooltipPlacement?: "side" | "top" | "bottom"; // default "side" (offset/flip); top/bottom center over the line
+  tooltipMargin?: number; // gap (px) to the pinned plot edge (top for side/top, bottom for bottom); default 8
+  tooltipShowValue?: boolean; tooltipShowTime?: boolean; // default both true; drop a row (e.g. date-only)
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0
 }
 // Order-ticket mode (scrubAction). Opt-in — default off.
@@ -307,6 +311,25 @@ interface SelectionDotProps {
   opacity: SharedValue<number>; // crosshair fade opacity (0..1), already ramped
   color: string;                // resolved dot color (line / series accent)
   size: number;                 // suggested dot radius in px
+}
+```
+
+## TooltipRenderProps
+
+Context passed to a custom `renderTooltip` — the fully custom scrub tooltip. The element you
+return is a React Native view the chart floats over
+the canvas and positions on the UI thread (per `scrub.tooltipPlacement`). Every live field is a
+`SharedValue`, so bind them to animated text (e.g. an `Animated.createAnimatedComponent(TextInput)`
+driven by `useAnimatedProps`) and both movement **and** text stay on the UI thread — no JS
+re-render while scrubbing. See [Custom tooltip](/guides/scrubbing#custom-tooltip-rendertooltip).
+
+```ts
+interface TooltipRenderProps {
+  value: SharedValue<number | null>; // interpolated value under the crosshair
+  time: SharedValue<number>;         // window time (unix seconds) under the crosshair
+  valueStr: SharedValue<string>;     // value formatted with the chart's formatValue
+  timeStr: SharedValue<string>;      // time formatted with the chart's formatTime
+  active: SharedValue<boolean>;      // whether scrubbing is active
 }
 ```
 

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -31,6 +31,97 @@ Disable it with `scrub={false}`, or configure the crosshair and tooltip:
 />
 ```
 
+## Customizing the tooltip
+
+The default pill shows the value on the first row and the time on the second, offset to the side of
+the crosshair. Reshape it with `ScrubConfig` knobs — no custom rendering required:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  scrub={{
+    tooltipPlacement: "top",     // "side" (default) | "top" | "bottom"
+    tooltipShowValue: false,     // drop the value row → date-only pill
+    tooltipBorderRadius: 12,     // pill corner radius; default 5
+    tooltipBackground: "#1e293b",
+    tooltipColor: "#e2e8f0",
+    tooltipBorderColor: "#334155",
+  }}
+/>
+```
+
+- **`tooltipPlacement`** — `"side"` (default) offsets the pill to the right of the scrub line and
+  flips it left near the right edge. `"top"` / `"bottom"` center it horizontally over the line,
+  clamped into the plot and pinned to the plot's top or bottom.
+- **`tooltipMargin`** — the gap (px) between the pill and the plot edge it's pinned to (the top for
+  `"side"` / `"top"`, the bottom for `"bottom"`). Default `8`. Applies to a custom `renderTooltip` too.
+- **`tooltipShowValue` / `tooltipShowTime`** — both default `true`. Drop a row to show just the date
+  (`tooltipShowValue: false`) or just the value. Turning both off keeps the time row.
+- **`tooltipBorderRadius`**, **`tooltipBackground`**, **`tooltipColor`**, **`tooltipBorderColor`** —
+  the pill's shape and colors.
+
+## Custom tooltip (`renderTooltip`)
+
+For full control — your own layout, blur, or any non-Skia view — pass `renderTooltip`. It's the same
+idea as [`renderMarker`](/guides/markers-and-references#custom-marker-rendering): return a **React
+Native** element and the chart floats it over the canvas, positioning it on the UI thread (honoring
+`tooltipPlacement`). When set, it replaces the built-in pill entirely.
+
+The catch the JS-thread `onScrub` can't solve: the value/date change every frame while scrubbing, so
+rebuilding the tooltip in React lags. `renderTooltip` receives the live fields as
+[`SharedValue`s](/api-reference/types#tooltiprenderprops) — bind them to an animated `TextInput`
+(`useAnimatedProps`) and both the position **and** the text update on the UI thread, with no
+re-renders.
+
+```tsx
+import { View, TextInput, StyleSheet } from "react-native";
+import Animated, { useAnimatedProps } from "react-native-reanimated";
+import type { TooltipRenderProps } from "react-native-livechart";
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+function BlueTooltip({ timeStr }: TooltipRenderProps) {
+  // Animate the date text on the UI thread — no JS re-render while scrubbing.
+  const animatedProps = useAnimatedProps(() => {
+    const t = timeStr.get();
+    return { text: t, defaultValue: t };
+  });
+  return (
+    <View style={styles.pill}>
+      <AnimatedTextInput editable={false} style={styles.text} animatedProps={animatedProps} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    borderRadius: 10,
+    backgroundColor: "#3323E6",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  // Fixed width: the TextInput is measured once at mount, and UI-thread text
+  // updates don't re-trigger a layout pass — an auto-width pill would clip.
+  // Use a monospace font (or `tabular-nums`) so every digit is the same width
+  // and the value never outgrows the fixed pill as it changes.
+  text: {
+    width: 72,
+    textAlign: "center",
+    color: "#fff",
+    fontSize: 13,
+    padding: 0,
+    fontVariant: ["tabular-nums"],
+  },
+});
+
+<LiveChart data={data} value={value} scrub renderTooltip={BlueTooltip} />;
+```
+
+`renderTooltip` is **line mode only** — candle charts keep their built-in OHLC stack. Return
+`null`/`undefined` to fall back to the default pill (e.g. only customize in certain states). The
+`tooltip*` style props above are ignored while a custom tooltip is active, since you own the chrome.
+
 ## Trailing fade (`dimOpacity`)
 
 While scrubbing, the chart content to the **right** of the crosshair (the "future") is faded so the

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -15,8 +15,6 @@ import type { ResolvedSelectionDotConfig } from "../core/resolveConfig";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import { SelectionDotSlot } from "./SelectionDot";
 
-const TOOLTIP_RADIUS = 5;
-
 export function CrosshairOverlay({
   scrubX,
   crosshairOpacity,
@@ -39,6 +37,9 @@ export function CrosshairOverlay({
   tooltipBackground,
   tooltipColor,
   tooltipBorderColor,
+  tooltipBorderRadius = 5,
+  tooltipShowValue = true,
+  tooltipShowTime = true,
 }: {
   scrubX: SharedValue<number>;
   crosshairOpacity: SharedValue<number>;
@@ -78,6 +79,12 @@ export function CrosshairOverlay({
   tooltipBackground?: string;
   tooltipColor?: string;
   tooltipBorderColor?: string;
+  /** Tooltip pill corner radius in px. Default 5. */
+  tooltipBorderRadius?: number;
+  /** Draw the value row of the default tooltip body. Default true. */
+  tooltipShowValue?: boolean;
+  /** Draw the time row of the default tooltip body. Default true. */
+  tooltipShowTime?: boolean;
 }) {
   // Explicit dependency arrays: with React Compiler enabled, Reanimated's
   // auto-detected worklet dependencies can change array size between renders
@@ -181,7 +188,7 @@ export function CrosshairOverlay({
             y={tipY}
             width={tipW}
             height={tipH}
-            r={TOOLTIP_RADIUS}
+            r={tooltipBorderRadius}
             color={tooltipBackground ?? palette.tooltipBg}
           />
 
@@ -190,7 +197,7 @@ export function CrosshairOverlay({
             y={tipY}
             width={tipW}
             height={tipH}
-            r={TOOLTIP_RADIUS}
+            r={tooltipBorderRadius}
             color={tooltipBorderColor ?? palette.tooltipBorder}
             style="stroke"
             strokeWidth={1}
@@ -199,20 +206,24 @@ export function CrosshairOverlay({
           {children ??
             renderTooltip?.() ?? (
               <Group>
-                <SkiaText
-                  x={valueTextX}
-                  y={line1Y}
-                  text={valueStr}
-                  font={font}
-                  color={tooltipColor ?? palette.tooltipText}
-                />
-                <SkiaText
-                  x={timeTextX}
-                  y={line2Y}
-                  text={timeStr}
-                  font={font}
-                  color={palette.gridLabel}
-                />
+                {tooltipShowValue && (
+                  <SkiaText
+                    x={valueTextX}
+                    y={line1Y}
+                    text={valueStr}
+                    font={font}
+                    color={tooltipColor ?? palette.tooltipText}
+                  />
+                )}
+                {tooltipShowTime && (
+                  <SkiaText
+                    x={timeTextX}
+                    y={tooltipShowValue ? line2Y : line1Y}
+                    text={timeStr}
+                    font={font}
+                    color={palette.gridLabel}
+                  />
+                )}
               </Group>
             )}
         </>

--- a/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
@@ -1,0 +1,135 @@
+import { StyleSheet, View, type LayoutChangeEvent } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import type { TooltipLayout } from "../hooks/crosshairShared";
+import type { TooltipRenderProps } from "../types";
+
+// Mirror the Skia tooltip's offsets (see crosshairShared.ts) so a custom pill
+// lines up with where the built-in one would sit. The vertical edge gap is
+// configurable via `scrub.tooltipMargin` (passed as `margin`).
+const OFFSET_X = 12;
+const EDGE_GAP = 4;
+
+/**
+ * React Native overlay (NOT Skia) that floats a custom `renderTooltip` element
+ * over the Skia canvas while scrubbing. A sibling of `<Canvas>` — like
+ * {@link AxisLabelOverlay} and `CustomMarkerOverlay` — so the element can be any
+ * RN view (e.g. a glass `BlurView`) and stays crisp at native resolution.
+ *
+ * The element is positioned entirely on the UI thread: a `useAnimatedStyle`
+ * transform tracks `scrubX` + the resolved `tooltipPlacement`, measuring the
+ * element's own size via `onLayout` so it can flip/clamp/center correctly — so
+ * movement stays smooth without JS re-renders, unlike rebuilding the tooltip
+ * from the JS-thread `onScrub`. The consumer binds the {@link TooltipRenderProps}
+ * SharedValues to animated text for the value/date to update on the UI thread.
+ *
+ * `pointerEvents="box-none"` lets the scrub pan gesture pass through the empty
+ * area (and any non-interactive tooltip body) while still allowing an
+ * interactive leaf inside the custom element to be tapped.
+ */
+export function CustomTooltipOverlay({
+  renderTooltip,
+  scrubX,
+  scrubValue,
+  scrubTime,
+  scrubActive,
+  crosshairOpacity,
+  tooltipLayout,
+  engine,
+  padding,
+  placement,
+  margin = 8,
+}: {
+  renderTooltip: (ctx: TooltipRenderProps) => React.ReactElement | null | undefined;
+  scrubX: SharedValue<number>;
+  scrubValue: SharedValue<number | null>;
+  scrubTime: SharedValue<number>;
+  scrubActive: SharedValue<boolean>;
+  crosshairOpacity: SharedValue<number>;
+  tooltipLayout: SharedValue<TooltipLayout>;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  placement: "side" | "top" | "bottom";
+  /** Gap (px) between the pill and the plot edge it's pinned to. Default 8. */
+  margin?: number;
+}) {
+  // Formatted strings come ready-made off the layout (formatted UI-side in
+  // computeTooltipLayout), so consumers don't need a worklet-safe formatter.
+  const valueStr = useDerivedValue(() => tooltipLayout.get().valueStr);
+  const timeStr = useDerivedValue(() => tooltipLayout.get().timeStr);
+
+  const ctx: TooltipRenderProps = {
+    value: scrubValue,
+    time: scrubTime,
+    valueStr,
+    timeStr,
+    active: scrubActive,
+  };
+  const element = renderTooltip(ctx);
+
+  // Measured element size, so the transform can flip/center/clamp the pill.
+  const size = useSharedValue({ width: 0, height: 0 });
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    size.value = { width, height };
+  };
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const active = scrubActive.get();
+    const sx = scrubX.get();
+    const cw = engine.canvasWidth.get();
+    const ch = engine.canvasHeight.get();
+    const s = size.get();
+    const rightEdge = cw - padding.right;
+
+    let x: number;
+    let y: number;
+    if (placement === "side") {
+      x = sx + OFFSET_X;
+      if (x + s.width > rightEdge - EDGE_GAP) x = sx - s.width - OFFSET_X;
+      y = padding.top + margin;
+    } else {
+      const leftBound = padding.left + EDGE_GAP;
+      const rightBound = rightEdge - EDGE_GAP - s.width;
+      x = Math.min(
+        Math.max(sx - s.width / 2, leftBound),
+        Math.max(leftBound, rightBound),
+      );
+      y =
+        placement === "top"
+          ? padding.top + margin
+          : ch - padding.bottom - margin - s.height;
+    }
+
+    return {
+      opacity: active ? crosshairOpacity.get() : 0,
+      transform: [{ translateX: x }, { translateY: y }],
+    };
+  });
+
+  if (element == null) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      <Animated.View
+        pointerEvents="box-none"
+        onLayout={onLayout}
+        style={[styles.anchor, animatedStyle]}
+      >
+        {element}
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // top/left 0 + transform so the measured element can be placed precisely.
+  anchor: { position: "absolute", top: 0, left: 0 },
+});

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -87,6 +87,7 @@ import {
 } from "./ThresholdLineOverlay";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
 import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
+import { CustomTooltipOverlay } from "./CustomTooltipOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
@@ -201,6 +202,7 @@ function useLiveChartController({
   onMarkerHover,
   markerHitRadius = 16,
   renderMarker,
+  renderTooltip,
   leftEdgeFade = true,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
@@ -532,6 +534,10 @@ function useLiveChartController({
     onScrubAction,
     metricsCfg.badge,
     markersActive || refPressActive ? deferTapHit : undefined,
+    scrubCfg?.tooltipPlacement ?? "side",
+    scrubCfg?.tooltipShowValue ?? true,
+    scrubCfg?.tooltipShowTime ?? true,
+    scrubCfg?.tooltipMargin ?? 8,
   );
 
   // Scrub-action composes a Tap (place/move the reticle, press the badge, dismiss)
@@ -685,6 +691,7 @@ function useLiveChartController({
     markersActive,
     markersSV,
     renderMarker,
+    renderTooltip,
     // selection dot: resolved config + fallback color (the chart line/accent color)
     selectionDot: selectionDotCfg,
     selectionColor: lineProp?.color ?? palette.line,
@@ -1060,7 +1067,13 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
     dotOuterRadius,
     selectionDot,
     selectionColor,
+    renderTooltip,
   } = model;
+
+  // A custom line-mode tooltip is an RN overlay (sibling of <Canvas>), so the
+  // default Skia pill is suppressed here while it's active. Candle keeps its
+  // built-in OHLC stack (renderTooltip is ignored in candle mode).
+  const customTooltipActive = !isCandle && renderTooltip != null;
 
   if (!tradeStreamResolved && !scrubCfg) return null;
 
@@ -1094,7 +1107,7 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
           padding={effectivePadding}
           palette={palette}
           font={skiaFont}
-          showTooltip={scrubCfg.tooltip}
+          showTooltip={scrubCfg.tooltip && !customTooltipActive}
           selectionDot={selectionDot}
           selectionY={crosshair.scrubDotY}
           scrubActive={crosshair.scrubActive}
@@ -1106,6 +1119,9 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
           tooltipBackground={scrubCfg.tooltipBackground}
           tooltipColor={scrubCfg.tooltipColor}
           tooltipBorderColor={scrubCfg.tooltipBorderColor}
+          tooltipBorderRadius={scrubCfg.tooltipBorderRadius}
+          tooltipShowValue={scrubCfg.tooltipShowValue}
+          tooltipShowTime={scrubCfg.tooltipShowTime}
         >
           {/* Candle charts render a multi-line OHLC tooltip; the line
               chart falls back to CrosshairOverlay's default value/time
@@ -1259,6 +1275,10 @@ export function LiveChart(props: LiveChartProps) {
     markersActive,
     markersSV,
     renderMarker,
+    renderTooltip,
+    scrubCfg,
+    crosshair,
+    isCandle,
   } = model;
 
   return (
@@ -1324,6 +1344,24 @@ export function LiveChart(props: LiveChartProps) {
             engine={engine}
             padding={effectivePadding}
             lineData={engine.data}
+          />
+        )}
+
+        {/* Custom scrub tooltip — an RN view floated over the canvas (non-Skia),
+            positioned on the UI thread. Sibling of <Canvas>. Line mode only. */}
+        {scrubCfg && renderTooltip && !isCandle && (
+          <CustomTooltipOverlay
+            renderTooltip={renderTooltip}
+            scrubX={crosshair.scrubX}
+            scrubValue={crosshair.scrubValue}
+            scrubTime={crosshair.scrubTime}
+            scrubActive={crosshair.scrubActive}
+            crosshairOpacity={crosshair.crosshairOpacity}
+            tooltipLayout={crosshair.tooltipLayout}
+            engine={engine}
+            padding={effectivePadding}
+            placement={scrubCfg.tooltipPlacement}
+            margin={scrubCfg.tooltipMargin}
           />
         )}
       </View>

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -89,6 +89,16 @@ export interface ResolvedScrubConfig {
   tooltipColor: string | undefined;
   /** undefined → palette.tooltipBorder */
   tooltipBorderColor: string | undefined;
+  /** Tooltip pill corner radius in px. */
+  tooltipBorderRadius: number;
+  /** Where the tooltip pill sits relative to the scrub line. */
+  tooltipPlacement: "side" | "top" | "bottom";
+  /** Gap (px) between the tooltip and the plot edge it's pinned to. */
+  tooltipMargin: number;
+  /** Show the value row in the default tooltip body. */
+  tooltipShowValue: boolean;
+  /** Show the time row in the default tooltip body. */
+  tooltipShowTime: boolean;
   /** Press-and-hold delay (ms) before scrubbing activates. 0 = immediate. */
   panGestureDelay: number;
 }
@@ -357,6 +367,11 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltipBackground: undefined,
   tooltipColor: undefined,
   tooltipBorderColor: undefined,
+  tooltipBorderRadius: 5,
+  tooltipPlacement: "side",
+  tooltipMargin: 8,
+  tooltipShowValue: true,
+  tooltipShowTime: true,
   panGestureDelay: 0,
 };
 

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -190,6 +190,18 @@ export function computeTooltipLayout(
    *  every frame, and `measureText` shapes text each call (a real cost,
    *  especially in the simulator). Falls back to `measureText` when 0. */
   monoCharWidth = 0,
+  /** Where the pill sits relative to the scrub line. `"side"` offsets it right
+   *  (flipping left near the edge); `"top"`/`"bottom"` center it over the line,
+   *  clamped into the plot and pinned to the plot's top/bottom. */
+  placement: "side" | "top" | "bottom" = "side",
+  /** Render the value row. */
+  showValue = true,
+  /** Render the time row. */
+  showTime = true,
+  /** Canvas height in px — needed to pin `"bottom"` placement. */
+  canvasHeight = 0,
+  /** Gap in px between the pill and the plot edge it's pinned to. */
+  margin = TOOLTIP_TOP_MARGIN,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || scrubValue === null) return HIDDEN_TOOLTIP;
@@ -199,9 +211,19 @@ export function computeTooltipLayout(
   const valueStr = formatValue(v);
   const timeStr = formatTime(t);
 
+  // Content toggles: pick which rows render. Guard both-off → keep the time row.
+  let sv = showValue;
+  let st = showTime;
+  let rowCount = (sv ? 1 : 0) + (st ? 1 : 0);
+  if (rowCount === 0) {
+    st = true;
+    rowCount = 1;
+  }
+
   const fm = font.getMetrics();
   const lineH = -fm.ascent + fm.descent;
-  const totalH = TOOLTIP_PAD_Y * 2 + lineH * 2 + TOOLTIP_LINE_GAP;
+  const totalH =
+    TOOLTIP_PAD_Y * 2 + lineH * rowCount + TOOLTIP_LINE_GAP * (rowCount - 1);
 
   const valueW =
     monoCharWidth > 0
@@ -211,19 +233,39 @@ export function computeTooltipLayout(
     monoCharWidth > 0
       ? timeStr.length * monoCharWidth
       : measureFontTextWidth(font, timeStr);
-  const contentW = Math.max(valueW, timeW);
+  // Only the visible rows contribute to the pill width.
+  const contentW = Math.max(sv ? valueW : 0, st ? timeW : 0);
   const pillW = contentW + TOOLTIP_PAD_X * 2;
 
   const rightEdge = canvasWidth - padding.right;
 
-  let pillX = scrubX + TOOLTIP_OFFSET_X;
-  if (pillX + pillW > rightEdge - TOOLTIP_EDGE_GAP) {
-    pillX = scrubX - pillW - TOOLTIP_OFFSET_X;
+  let pillX: number;
+  let pillY: number;
+  if (placement === "side") {
+    pillX = scrubX + TOOLTIP_OFFSET_X;
+    if (pillX + pillW > rightEdge - TOOLTIP_EDGE_GAP) {
+      pillX = scrubX - pillW - TOOLTIP_OFFSET_X;
+    }
+    pillY = padding.top + margin;
+  } else {
+    // Centered horizontally over the scrub line, clamped into the plot.
+    const leftBound = padding.left + TOOLTIP_EDGE_GAP;
+    const rightBound = rightEdge - TOOLTIP_EDGE_GAP - pillW;
+    pillX = Math.min(
+      Math.max(scrubX - pillW / 2, leftBound),
+      Math.max(leftBound, rightBound),
+    );
+    pillY =
+      placement === "top"
+        ? padding.top + margin
+        : canvasHeight - padding.bottom - margin - totalH;
   }
-  const pillY = padding.top + TOOLTIP_TOP_MARGIN;
 
-  const line1Y = pillY + TOOLTIP_PAD_Y - fm.ascent;
-  const line2Y = line1Y + lineH + TOOLTIP_LINE_GAP;
+  // line1Y = first rendered row's baseline; line2Y = second (when both shown).
+  // The overlay maps value→line1Y and time→(showValue ? line2Y : line1Y).
+  const firstBaseline = pillY + TOOLTIP_PAD_Y - fm.ascent;
+  const line1Y = firstBaseline;
+  const line2Y = firstBaseline + lineH + TOOLTIP_LINE_GAP;
 
   const valueTextX = pillX + TOOLTIP_PAD_X + (contentW - valueW) / 2;
   const timeTextX = pillX + TOOLTIP_PAD_X + (contentW - timeW) / 2;
@@ -618,6 +660,11 @@ export function deriveCrosshairTooltipSingle(
   formatTime: (t: number) => string,
   font: SkFont,
   monoCharWidth = 0,
+  placement: "side" | "top" | "bottom" = "side",
+  showValue = true,
+  showTime = true,
+  canvasHeight = 0,
+  margin = TOOLTIP_TOP_MARGIN,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || scrubTime < 0) return HIDDEN_TOOLTIP;
@@ -632,5 +679,10 @@ export function deriveCrosshairTooltipSingle(
     formatTime,
     font,
     monoCharWidth,
+    placement,
+    showValue,
+    showTime,
+    canvasHeight,
+    margin,
   );
 }

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -129,6 +129,14 @@ export function useCrosshair(
    * Omitted when nothing coexists.
    */
   deferTapHit?: (x: number, y: number) => boolean,
+  /** Where the tooltip pill sits relative to the scrub line. Default `"side"`. */
+  tooltipPlacement: "side" | "top" | "bottom" = "side",
+  /** Render the value row in the default tooltip. Default `true`. */
+  tooltipShowValue = true,
+  /** Render the time row in the default tooltip. Default `true`. */
+  tooltipShowTime = true,
+  /** Gap (px) between the tooltip and the plot edge it's pinned to. Default `8`. */
+  tooltipMargin = 8,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -247,6 +255,11 @@ export function useCrosshair(
       formatTime,
       font,
       monoCharWidth,
+      tooltipPlacement,
+      tooltipShowValue,
+      tooltipShowTime,
+      engine.canvasHeight.get(),
+      tooltipMargin,
     );
   });
 

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -79,6 +79,7 @@ export type {
   ThemeMode,
   ThresholdConfig,
   ThresholdLineConfig,
+  TooltipRenderProps,
   TradeEvent,
   ValueLineConfig,
   XAxisConfig,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -378,6 +378,27 @@ export interface ScrubConfig {
   tooltipColor?: string;
   /** Tooltip pill border color. Omit to use theme `tooltipBorder`. */
   tooltipBorderColor?: string;
+  /** Tooltip pill corner radius in px. Default `5`. */
+  tooltipBorderRadius?: number;
+  /**
+   * Where the tooltip pill sits relative to the vertical scrub line.
+   * `"side"` (default) offsets it to the right of the line and flips left near
+   * the right edge. `"top"` / `"bottom"` center it horizontally over the line,
+   * clamped into the plot and pinned to the plot's top or bottom. This also
+   * drives a custom {@link LiveChartProps.renderTooltip} so it gets the same
+   * placement for free.
+   */
+  tooltipPlacement?: "side" | "top" | "bottom";
+  /**
+   * Gap in px between the tooltip and the plot edge it's pinned to — the top for
+   * `"side"`/`"top"`, the bottom for `"bottom"`. Applies to the built-in pill and
+   * a custom {@link LiveChartProps.renderTooltip}. Default `8`.
+   */
+  tooltipMargin?: number;
+  /** Show the value row in the default tooltip body. Default `true`. */
+  tooltipShowValue?: boolean;
+  /** Show the time row in the default tooltip body. Default `true`. */
+  tooltipShowTime?: boolean;
   /**
    * Press-and-hold delay in milliseconds before scrubbing activates — think of
    * it as "press and hold to scrub." During the delay the pan is not captured,
@@ -471,6 +492,28 @@ export interface SelectionDotProps {
   color: string;
   /** Suggested dot radius in px. */
   size: number;
+}
+
+/**
+ * Context passed to a custom {@link LiveChartProps.renderTooltip}. The element
+ * you return is a React Native view that the chart floats over the canvas and
+ * positions on the UI thread (per `scrub.tooltipPlacement`) — so movement stays
+ * smooth without JS re-renders, unlike rebuilding the tooltip from the JS-thread
+ * `onScrub` callback. Bind the SharedValues here to animated text (e.g. an
+ * `Animated.createAnimatedComponent(TextInput)` driven by `useAnimatedProps`)
+ * for the value/date to update on the UI thread too.
+ */
+export interface TooltipRenderProps {
+  /** Interpolated value under the crosshair; `null` when none. */
+  value: SharedValue<number | null>;
+  /** Window time (unix seconds) under the crosshair. */
+  time: SharedValue<number>;
+  /** Value formatted with the chart's `formatValue` (computed UI-side). */
+  valueStr: SharedValue<string>;
+  /** Time formatted with the chart's `formatTime` (computed UI-side). */
+  timeStr: SharedValue<string>;
+  /** Whether scrubbing is currently active. */
+  active: SharedValue<boolean>;
 }
 
 /** Outer ring drawn around the built-in selection dot (the subtle halo). */
@@ -1025,6 +1068,20 @@ export interface LiveChartCoreProps {
    * glyph entirely (no double-draw).
    */
   renderMarker?: (marker: Marker) => ReactElement | null | undefined;
+  /**
+   * Render a fully custom scrub tooltip as a **React Native** element instead of
+   * the built-in pill — the same idea as `renderMarker`. The chart floats the
+   * returned element over the canvas and positions it on the UI thread per
+   * `scrub.tooltipPlacement` (so it stays smooth, unlike rebuilding the tooltip
+   * from the JS-thread `onScrub`). You own the chrome (border radius/color,
+   * background are plain RN styles) and content — bind the {@link
+   * TooltipRenderProps} SharedValues to animated text for the value/date.
+   *
+   * Return `null`/`undefined` to fall back to the built-in pill. Replaces the
+   * default pill entirely while active. Single-series **line mode only** —
+   * ignored in candle mode (the OHLC stack owns the tooltip there).
+   */
+  renderTooltip?: (ctx: TooltipRenderProps) => ReactElement | null | undefined;
   /**
    * Override individual resolved-palette keys on top of the palette derived from
    * `accentColor` + `theme`. Only the keys you set are replaced.

--- a/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { Text } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+
+import { CustomTooltipOverlay } from "../../src/components/CustomTooltipOverlay";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import type { TooltipLayout } from "../../src/hooks/crosshairShared";
+import type { TooltipRenderProps } from "../../src/types";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+function engine(): ChartEngineLayout {
+  return withSharedValueAccessors({
+    displayMin: { value: 0 },
+    displayMax: { value: 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: 300 },
+    timestamp: { value: 1000 },
+    data: { value: [] },
+  }) as unknown as ChartEngineLayout;
+}
+
+const LAYOUT: TooltipLayout = {
+  x: 110,
+  y: 20,
+  w: 80,
+  h: 40,
+  valueStr: "42.00",
+  timeStr: "12:00:00",
+  valueTextX: 115,
+  timeTextX: 115,
+  line1Y: 30,
+  line2Y: 45,
+  stackedLines: undefined,
+};
+
+function Fixture({
+  renderTooltip,
+  placement = "side",
+}: {
+  renderTooltip: (ctx: TooltipRenderProps) => React.ReactElement | null | undefined;
+  placement?: "side" | "top" | "bottom";
+}) {
+  const scrubX = useSharedValue(100);
+  const scrubValue = useSharedValue<number | null>(42);
+  const scrubTime = useSharedValue(985);
+  const scrubActive = useSharedValue(true);
+  const crosshairOpacity = useSharedValue(1);
+  const tooltipLayout = useSharedValue<TooltipLayout>(LAYOUT);
+  return (
+    <CustomTooltipOverlay
+      renderTooltip={renderTooltip}
+      scrubX={scrubX}
+      scrubValue={scrubValue}
+      scrubTime={scrubTime}
+      scrubActive={scrubActive}
+      crosshairOpacity={crosshairOpacity}
+      tooltipLayout={tooltipLayout}
+      engine={engine()}
+      padding={DEFAULT_PADDING}
+      placement={placement}
+    />
+  );
+}
+
+describe("CustomTooltipOverlay", () => {
+  it("floats the consumer's element over the canvas", () => {
+    const { getByTestId } = render(
+      <Fixture renderTooltip={() => <Text testID="custom-tip">tip</Text>} />,
+    );
+    expect(getByTestId("custom-tip")).toBeTruthy();
+  });
+
+  it("measures the element via onLayout without throwing", () => {
+    const { getByTestId } = render(
+      <Fixture renderTooltip={() => <Text testID="custom-tip">tip</Text>} />,
+    );
+    // Drive an onLayout so the size-measurement branch executes.
+    fireEvent(getByTestId("custom-tip").parent!, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 80, height: 40 } },
+    });
+    expect(getByTestId("custom-tip")).toBeTruthy();
+  });
+
+  it("renders nothing when renderTooltip returns null", () => {
+    const { toJSON } = render(<Fixture renderTooltip={() => null} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("exposes the scrub state as SharedValues in the context", () => {
+    let captured: TooltipRenderProps | undefined;
+    render(
+      <Fixture
+        renderTooltip={(ctx) => {
+          captured = ctx;
+          return <Text testID="tip">{ctx.valueStr.get()}</Text>;
+        }}
+      />,
+    );
+    expect(captured).toBeDefined();
+    // Live bits are SharedValues (not snapshots) so animated text stays smooth.
+    expect(typeof captured!.value.get).toBe("function");
+    expect(typeof captured!.timeStr.get).toBe("function");
+    expect(captured!.valueStr.get()).toBe("42.00");
+    expect(captured!.timeStr.get()).toBe("12:00:00");
+  });
+
+  it("positions for top/bottom placement without error", () => {
+    const top = render(
+      <Fixture
+        placement="top"
+        renderTooltip={() => <Text testID="tip-top">tip</Text>}
+      />,
+    );
+    expect(top.getByTestId("tip-top")).toBeTruthy();
+
+    const bottom = render(
+      <Fixture
+        placement="bottom"
+        renderTooltip={() => <Text testID="tip-bottom">tip</Text>}
+      />,
+    );
+    expect(bottom.getByTestId("tip-bottom")).toBeTruthy();
+  });
+});

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -405,6 +405,46 @@ describe("CrosshairOverlay", () => {
     render(<Fixture />);
   });
 
+  it("omits the value row when tooltipShowValue is false (date-only)", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(1);
+      const tooltipLayout = useSharedValue<TooltipLayout>({
+        x: 110,
+        y: 20,
+        w: 80,
+        h: 24,
+        valueStr: "42.00",
+        timeStr: "12:00:00",
+        valueTextX: 115,
+        timeTextX: 115,
+        line1Y: 30,
+        line2Y: 45,
+        stackedLines: undefined,
+      });
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          showTooltip
+          tooltipShowValue={false}
+          tooltipBorderRadius={9}
+        />
+      );
+    }
+    const { toJSON } = render(<Fixture />);
+    const tree = JSON.stringify(toJSON());
+    // Value row dropped, time row kept; custom radius applied to the pill.
+    expect(tree).not.toContain("42.00");
+    expect(tree).toContain("12:00:00");
+    expect(tree).toContain('"r":9');
+  });
+
   it("renders stacked multi-series tooltip lines", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -314,6 +314,183 @@ describe("computeTooltipLayout", () => {
     expect(layout.valueTextX).toBeGreaterThanOrEqual(layout.x);
     expect(layout.valueTextX).toBeLessThan(layout.x + layout.w);
   });
+
+  it("placement 'top' centers the pill over the scrub line and pins it to the top", () => {
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8, // mono advance → deterministic width
+      "top",
+    );
+    // Centered horizontally over scrubX (200), pinned to padding.top + 8 = 20.
+    expect(layout.x + layout.w / 2).toBeCloseTo(200);
+    expect(layout.y).toBe(padding.top + 8);
+  });
+
+  it("placement 'bottom' pins the pill to the plot's bottom", () => {
+    const canvasHeight = 300;
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "bottom",
+      true,
+      true,
+      canvasHeight,
+    );
+    // Bottom edge sits canvasHeight - padding.bottom - 8 from the top.
+    expect(layout.y + layout.h).toBe(canvasHeight - padding.bottom - 8);
+  });
+
+  it("honors a custom margin for the pinned edge gap", () => {
+    const top = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "top",
+      true,
+      true,
+      300,
+      24, // margin
+    );
+    expect(top.y).toBe(padding.top + 24);
+
+    const bottom = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "bottom",
+      true,
+      true,
+      300,
+      24,
+    );
+    expect(bottom.y + bottom.h).toBe(300 - padding.bottom - 24);
+  });
+
+  it("placement 'top'/'bottom' clamps the centered pill into the plot at the edges", () => {
+    const left = computeTooltipLayout(
+      true,
+      0,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "top",
+    );
+    expect(left.x).toBeGreaterThanOrEqual(padding.left + 4);
+
+    const right = computeTooltipLayout(
+      true,
+      400,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "bottom",
+      true,
+      true,
+      300,
+    );
+    expect(right.x + right.w).toBeLessThanOrEqual(400 - padding.right - 4);
+  });
+
+  it("drops the value row when showValue is false (date-only, single-row height)", () => {
+    const layout = computeTooltipLayout(
+      true,
+      50,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "side",
+      false, // showValue
+      true, // showTime
+    );
+    // Single row: height = PAD_Y*2 + lineH = 12 + 12 = 24; sized by the time row.
+    expect(layout.h).toBe(24);
+    expect(layout.w).toBe(layout.timeStr.length * 8 + 16);
+  });
+
+  it("drops the time row when showTime is false (single row sized by value)", () => {
+    const layout = computeTooltipLayout(
+      true,
+      50,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "side",
+      true,
+      false, // showTime
+    );
+    expect(layout.h).toBe(24);
+    expect(layout.w).toBe(layout.valueStr.length * 8 + 16);
+  });
+
+  it("falls back to the time row when both content rows are off", () => {
+    const layout = computeTooltipLayout(
+      true,
+      50,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "side",
+      false,
+      false,
+    );
+    expect(layout.h).toBe(24);
+    expect(layout.w).toBe(layout.timeStr.length * 8 + 16);
+  });
 });
 
 describe("computeTooltipLayoutMulti", () => {

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -190,6 +190,11 @@ describe("resolveScrub", () => {
     expect(resolveScrub(true)).toEqual({
       tooltip: true,
       dimOpacity: 0.3,
+      tooltipBorderRadius: 5,
+      tooltipPlacement: "side",
+      tooltipMargin: 8,
+      tooltipShowValue: true,
+      tooltipShowTime: true,
       panGestureDelay: 0,
     });
   });
@@ -198,6 +203,11 @@ describe("resolveScrub", () => {
     expect(resolveScrub({ tooltip: false })).toEqual({
       tooltip: false,
       dimOpacity: 0.3,
+      tooltipBorderRadius: 5,
+      tooltipPlacement: "side",
+      tooltipMargin: 8,
+      tooltipShowValue: true,
+      tooltipShowTime: true,
       panGestureDelay: 0,
     });
   });
@@ -206,6 +216,11 @@ describe("resolveScrub", () => {
     expect(resolveScrub({ dimOpacity: 0.5 })).toEqual({
       tooltip: true,
       dimOpacity: 0.5,
+      tooltipBorderRadius: 5,
+      tooltipPlacement: "side",
+      tooltipMargin: 8,
+      tooltipShowValue: true,
+      tooltipShowTime: true,
       panGestureDelay: 0,
     });
   });
@@ -214,7 +229,40 @@ describe("resolveScrub", () => {
     expect(resolveScrub({ panGestureDelay: 300 })).toEqual({
       tooltip: true,
       dimOpacity: 0.3,
+      tooltipBorderRadius: 5,
+      tooltipPlacement: "side",
+      tooltipMargin: 8,
+      tooltipShowValue: true,
+      tooltipShowTime: true,
       panGestureDelay: 300,
+    });
+  });
+
+  it("carries a custom tooltipBorderRadius", () => {
+    expect(resolveScrub({ tooltipBorderRadius: 12 })).toMatchObject({
+      tooltipBorderRadius: 12,
+      tooltipPlacement: "side",
+    });
+  });
+
+  it("carries a tooltipPlacement override", () => {
+    expect(resolveScrub({ tooltipPlacement: "bottom" })).toMatchObject({
+      tooltipPlacement: "bottom",
+      tooltipBorderRadius: 5,
+    });
+  });
+
+  it("carries a custom tooltipMargin (edge gap)", () => {
+    expect(resolveScrub({ tooltipMargin: 24 })).toMatchObject({
+      tooltipMargin: 24,
+      tooltipPlacement: "side",
+    });
+  });
+
+  it("can drop the value row (date-only tooltip)", () => {
+    expect(resolveScrub({ tooltipShowValue: false })).toMatchObject({
+      tooltipShowValue: false,
+      tooltipShowTime: true,
     });
   });
 });


### PR DESCRIPTION
Closes #119

Adds two complementary ways to customize the single-series `LiveChart` scrub tooltip — an **adjustable config** path and a **custom render prop** — following the established `renderMarker` (3.6.0) pattern.

## Adjustable config (`ScrubConfig`)
| Prop | Default | Effect |
| --- | --- | --- |
| `tooltipPlacement` | `"side"` | `"side"` offsets the pill to the right of the scrub line (flips at the edge); `"top"`/`"bottom"` center it over the line, pinned to the plot edge |
| `tooltipMargin` | `8` | Gap (px) between the pill and the plot edge it's pinned to |
| `tooltipShowValue` / `tooltipShowTime` | `true` | Drop a row — e.g. a date-only tooltip |
| `tooltipBorderRadius` | `5` | Pill corner radius |

(`tooltipBackground` / `tooltipColor` / `tooltipBorderColor` already existed.)

## Custom render prop (`renderTooltip`)
`renderTooltip?: (ctx: TooltipRenderProps) => ReactElement | null` — a **React Native** element the chart floats over the canvas and positions on the UI thread (per `tooltipPlacement`), the same idea as `renderMarker`. It receives the live scrub state as **SharedValues**, so the value/date can be bound to animated text (`useAnimatedProps`) and update on the UI thread — fixing the JS-thread `onScrub` lag/tearing the reporter described. Line mode only (candle keeps its OHLC stack).

```tsx
<LiveChart
  data={data}
  value={value}
  scrub={{ tooltipPlacement: "top", tooltipMargin: 24 }}
  renderTooltip={BlueTooltip}
/>
```

## Implementation
- New `CustomTooltipOverlay` (RN overlay, sibling of `<Canvas>`, mirrors `CustomMarkerOverlay`/`AxisLabelOverlay`).
- Config threaded through `computeTooltipLayout` (worklet) → `useCrosshair` → `LiveChart`; `TooltipRenderProps` exported from the barrel.
- `LiveChartSeries` is out of scope (it uses per-series value labels, not a pill).

## Demo & docs
- The **Scrubbing** demo gains placement / margin chip rows + Date-only / Rounded / Styled / Custom-render toggles (all composable, line + candle, hold-to-scrub).
- Updated the scrubbing guide, `livechart`, and `types` API references.

## Tests
- `resolveScrub` defaults + merge cases; `computeTooltipLayout` placement / margin / content-toggle cases; `CrosshairOverlay` content toggles + radius; new `CustomTooltipOverlay` precedence tests.
- `npm run verify` green (typecheck + lint + 929 tests); coverage thresholds hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)