### PR TITLE
feat(examples): Robinhood tokenized-stock showcase + linear/edgy line options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0] - 2026-06-15
+
+### Added
+
+- **Line shape controls** (single-series `LiveChart`) — new `LineConfig` fields for
+  angular, hard-edged lines:
+  - `curve?: "monotone" | "linear"` — `"monotone"` (default) keeps the smooth
+    cubic; `"linear"` draws straight segments between points. Applies to the area
+    fill too, so the gradient follows the same straight path.
+  - `join?: "round" | "miter" | "bevel"` — corner join between segments.
+    `"round"` (default) softens peaks; `"miter"` gives sharp, angular peaks;
+    `"bevel"` flattens them.
+  - `cap?: "round" | "butt" | "square"` — stroke cap at the line's start/end.
+  - Pair `curve: "linear"` + `join: "miter"` + `cap: "butt"` for a fully
+    hard-edged line (see the new `app/showcase/robinhood.tsx` tokenized-stock
+    showcase).
+
 ## [3.7.0] - 2026-06-14
 
 ### Added

--- a/app/showcase/robinhood.tsx
+++ b/app/showcase/robinhood.tsx
@@ -1,0 +1,463 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useState } from "react";
+import {
+  type DimensionValue,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type ViewStyle,
+} from "react-native";
+import {
+  type ChartSegment,
+  LiveChart,
+  type LiveChartPoint,
+  type ScrubPoint,
+  type TooltipRenderProps,
+} from "react-native-livechart";
+import Animated, {
+  type SharedValue,
+  useAnimatedProps,
+  useAnimatedReaction,
+  useSharedValue,
+} from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+/**
+ * Robinhood (EU) — tokenized-stock detail recreation.
+ *
+ * Same skeleton philosophy as Fomo: everything but the chart and the live price
+ * readout is a grey placeholder. The chart matches Robinhood's: a clean, thin,
+ * hard-edged (miter joins) line on pure black with NO grid / fill / glow / dot,
+ * framed as a fixed 1-week historical view. The only chart interaction is the
+ * scrub dim-split — the line stays full colour up to the crosshair and the part
+ * past it drops to a strong fade — plus a plain date/time tooltip.
+ *
+ * To add another app, copy this file to `app/showcase/<id>.tsx` and register it
+ * in `demo-lib/examples.ts`.
+ */
+
+const C = {
+  bg: "#000000",
+  green: "#4FE05A",
+  red: "#FF5247",
+  text: "#FFFFFF",
+  muted: "rgba(255,255,255,0.5)",
+  skeleton: "rgba(255,255,255,0.08)",
+  skeletonStrong: "rgba(255,255,255,0.14)",
+  hairline: "rgba(255,255,255,0.1)",
+  crosshair: "rgba(255,255,255,0.45)",
+} as const;
+
+const FONT_BOLD = "PlusJakartaSans_700Bold";
+const FONT_SEMIBOLD = "PlusJakartaSans_600SemiBold";
+const FONT_MEDIUM = "PlusJakartaSans_500Medium";
+
+const START_PRICE = 113; // a week ago; drifts up/down to "now" within a few %.
+const SPAN_SECS = 7 * 24 * 3600; // 1 week (the selected "1W" timeframe)
+const POINT_COUNT = 180;
+const CHANGE_LABEL = "Letzte Woche";
+
+// German formatting to match the screenshots: "119,03 $" and "5,19 %".
+const PRICE_FMT = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+const PCT_FMT = new Intl.NumberFormat("de-DE", {
+  style: "percent",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+// "HH:MM, D Mon" for the scrub tooltip (German month abbreviations, each 3 chars).
+const MONTHS_DE = "JanFebMärAprMaiJunJulAugSepOktNovDez";
+function formatStamp(t: number) {
+  "worklet";
+  const d = new Date(t * 1000);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const m = d.getMonth();
+  return `${hh}:${mm}, ${d.getDate()} ${MONTHS_DE.slice(m * 3, m * 3 + 3)}`;
+}
+
+/** A fixed week of edgy prices — small steps so the change stays realistic (~few %). */
+function seedWeek(endTime: number) {
+  const start = endTime - SPAN_SECS;
+  const points: LiveChartPoint[] = [];
+  let v = START_PRICE;
+  for (let i = 0; i < POINT_COUNT; i++) {
+    const time = start + (i / (POINT_COUNT - 1)) * SPAN_SECS;
+    v += (Math.random() - 0.5) * 1.3; // small, frequent reversals → sharp zigzags
+    points.push({ time, value: v });
+  }
+  return {
+    points,
+    open: points[0].value,
+    last: points[points.length - 1].value,
+    now: endTime,
+  };
+}
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+/** Scrub tooltip — plain centred text floated at the top of the plot (no pill). */
+function RobinhoodTooltip({ timeStr }: TooltipRenderProps) {
+  const animatedProps = useAnimatedProps(() => {
+    const t = timeStr.get();
+    return { text: t, defaultValue: t };
+  });
+  return (
+    <AnimatedTextInput
+      editable={false}
+      underlineColorAndroid="transparent"
+      style={styles.tipText}
+      animatedProps={animatedProps}
+    />
+  );
+}
+
+/** Grey placeholder block (bar or, with `r = h/2`, a circle). */
+function Sk({
+  w,
+  h,
+  r = 6,
+  strong,
+  style,
+}: {
+  w?: DimensionValue;
+  h: number;
+  r?: number;
+  strong?: boolean;
+  style?: ViewStyle;
+}) {
+  return (
+    <View
+      style={[
+        {
+          width: w,
+          height: h,
+          borderRadius: r,
+          backgroundColor: strong ? C.skeletonStrong : C.skeleton,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+/**
+ * Price (white) + change readout. Shows the week's close at rest, the crosshair
+ * value while scrubbing; change is vs the week open, and the period suffix hides
+ * while scrubbing — matching the screenshots.
+ */
+function RobinhoodPriceReadout({
+  value,
+  baseline,
+  initial,
+  scrubbing,
+}: {
+  value: SharedValue<number>;
+  baseline: number;
+  initial: number;
+  scrubbing: SharedValue<boolean>;
+}) {
+  const [raw, setRaw] = useState(initial);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+
+  useAnimatedReaction(
+    () => value.get(),
+    (cur, prev) => {
+      if (cur !== prev && Number.isFinite(cur)) runOnJS(setRaw)(cur);
+    },
+  );
+  useAnimatedReaction(
+    () => scrubbing.get(),
+    (s, prev) => {
+      if (s !== prev) runOnJS(setIsScrubbing)(s);
+    },
+  );
+
+  const delta = raw - baseline;
+  const up = delta >= 0;
+  const changeColor = up ? C.green : C.red;
+  const pct = baseline !== 0 ? delta / baseline : 0;
+
+  return (
+    <View>
+      <Text style={styles.price}>{PRICE_FMT.format(raw)}</Text>
+      <View style={styles.changeRow}>
+        <Text style={[styles.change, { color: changeColor }]}>
+          {up ? "▲" : "▼"} {PRICE_FMT.format(Math.abs(delta))} (
+          {PCT_FMT.format(Math.abs(pct))})
+        </Text>
+        {!isScrubbing ? (
+          <Text style={styles.changeSuffix}> {CHANGE_LABEL}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+/** One fake bottom tab icon. */
+function TabIcon({ name }: { name: keyof typeof Ionicons.glyphMap }) {
+  return <Ionicons name={name} size={24} color={C.skeletonStrong} />;
+}
+
+export default function RobinhoodShowcase() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  // Fixed historical week — seeded once. `nowOverride` + `timeWindow` pin the
+  // frame (no live scroll), like a real 1W view.
+  const [seed] = useState(() => seedWeek(Date.now() / 1000));
+  const data = useSharedValue<LiveChartPoint[]>(seed.points);
+  const value = useSharedValue(seed.last);
+
+  // Readout follows the week's close, or the crosshair value while scrubbing.
+  const isScrubbing = useSharedValue(false);
+  const displayValue = useSharedValue(seed.last);
+
+  const trendDown = seed.last < seed.open;
+  const trendColor = trendDown ? C.red : C.green;
+
+  // Robinhood "segments on scroll" — the documented `segments` scrub-focus model:
+  // three equal sessions, no dividers. At rest the line is one colour; scrubbing
+  // into a session keeps it full and fades the OTHER segments. With no dividers the
+  // fade has to carry it, so the off-segments drop hard (the focused one pops).
+  const muted = trendDown ? "rgba(255,82,71,0.2)" : "rgba(79,224,90,0.2)";
+  const segStart = seed.now - SPAN_SECS;
+  const t1 = segStart + SPAN_SECS / 3;
+  const t2 = segStart + (2 * SPAN_SECS) / 3;
+  const segments: ChartSegment[] = [
+    { to: t1, mutedColor: muted },
+    { from: t1, to: t2, mutedColor: muted },
+    { from: t2, mutedColor: muted },
+  ];
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <StatusBar style="light" />
+
+      {/* ── Header: back + centred symbol skeleton + add */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={styles.headerSide}
+          accessibilityRole="button"
+          accessibilityLabel="Back to Examples"
+        >
+          <Ionicons name="chevron-back" size={26} color={C.green} />
+        </Pressable>
+        <View style={styles.headerCenter}>
+          <Sk w={84} h={13} />
+          <Sk w={44} h={9} style={{ marginTop: 5 }} />
+        </View>
+        <View style={[styles.headerSide, { alignItems: "flex-end" }]}>
+          <Ionicons name="add-circle-outline" size={28} color={C.green} />
+        </View>
+      </View>
+
+      {/* ── Symbol + Token badge (grey) */}
+      <View style={styles.symbolRow}>
+        <Sk w={62} h={16} strong />
+        <Sk w={78} h={26} r={13} />
+      </View>
+
+      {/* ── Fund name (grey, two lines) */}
+      <View style={styles.nameBlock}>
+        <Sk w="82%" h={20} style={{ marginBottom: 7 }} />
+        <Sk w="64%" h={20} />
+      </View>
+
+      {/* ── Price + change */}
+      <View style={styles.priceBlock}>
+        <RobinhoodPriceReadout
+          value={displayValue}
+          baseline={seed.open}
+          initial={seed.last}
+          scrubbing={isScrubbing}
+        />
+        {/* bid / ask (Geldkurs · Briefkurs) — grey */}
+        <Sk w="62%" h={12} style={{ marginTop: 10 }} />
+      </View>
+
+      {/* ── Hero chart: clean hard-edged line + scrub dim-split + date tooltip */}
+      <View style={styles.chartWrap}>
+        <LiveChart
+          data={data}
+          value={value}
+          theme="dark"
+          accentColor={trendColor}
+          // Thin + fully hard-edged: `curve: "linear"` draws straight segments (no
+          // spline smoothing), miter joins keep peaks as sharp points (0 corner
+          // radius), butt caps keep the ends flat. No rounding anywhere.
+          line={{
+            color: trendColor,
+            width: 1.4,
+            curve: "linear",
+            join: "miter",
+            cap: "butt",
+          }}
+          segments={segments}
+          dot={false}
+          pulse={false}
+          gradient={false}
+          badge={false}
+          valueLine={false}
+          momentum={false}
+          yAxis={false}
+          xAxis={false}
+          insets={{ left: 0, right: 0, top: 24, bottom: 24 }}
+          timeWindow={SPAN_SECS}
+          nowOverride={seed.now}
+          windowBuffer={0}
+          formatTime={formatStamp}
+          renderTooltip={RobinhoodTooltip}
+          selectionDot={{ size: 4, color: trendColor, ring: { width: 2 } }}
+          scrub={{
+            tooltipPlacement: "top",
+            crosshairLineColor: C.crosshair,
+            // De-emphasis is handled by `segments` (scrub-focus), not dimOpacity.
+          }}
+          onScrub={(point: ScrubPoint | null) => {
+            "worklet";
+            if (point === null) {
+              isScrubbing.set(false);
+              displayValue.set(value.get());
+              return;
+            }
+            isScrubbing.set(true);
+            displayValue.set(point.value);
+          }}
+        />
+      </View>
+
+      {/* ── Timeframe selector (grey pills) */}
+      <View style={styles.timeframes}>
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <Sk key={i} h={26} r={8} strong={i === 1} style={styles.tfChip} />
+        ))}
+      </View>
+
+      {/* ── "Übersicht" + description (grey) */}
+      <View style={styles.overview}>
+        <Sk w={120} h={22} strong />
+        <Sk w="92%" h={13} style={{ marginTop: 16 }} />
+        <Sk w="88%" h={13} style={{ marginTop: 9 }} />
+        <Sk w="48%" h={13} style={{ marginTop: 9 }} />
+      </View>
+
+      <View style={{ flex: 1 }} />
+
+      {/* ── Fake bottom tab bar */}
+      <View style={[styles.tabBar, { paddingBottom: insets.bottom + 6 }]}>
+        <TabIcon name="trending-up-outline" />
+        <TabIcon name="cube-outline" />
+        <TabIcon name="sync-circle-outline" />
+        <TabIcon name="search-outline" />
+        <TabIcon name="person-outline" />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: C.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    height: 44,
+  },
+  headerSide: {
+    width: 40,
+    justifyContent: "center",
+  },
+  headerCenter: {
+    flex: 1,
+    alignItems: "center",
+  },
+  symbolRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 20,
+    marginTop: 10,
+  },
+  nameBlock: {
+    paddingHorizontal: 20,
+    marginTop: 16,
+  },
+  priceBlock: {
+    paddingHorizontal: 20,
+    marginTop: 12,
+  },
+  price: {
+    color: C.text,
+    fontSize: 34,
+    fontFamily: FONT_BOLD,
+    letterSpacing: -0.5,
+    fontVariant: ["tabular-nums"],
+  },
+  changeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 6,
+  },
+  change: {
+    fontSize: 14,
+    fontFamily: FONT_SEMIBOLD,
+    fontVariant: ["tabular-nums"],
+  },
+  changeSuffix: {
+    color: C.muted,
+    fontSize: 14,
+    fontFamily: FONT_MEDIUM,
+  },
+  chartWrap: {
+    height: 320,
+    marginTop: 10,
+  },
+  timeframes: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 20,
+    marginTop: 8,
+  },
+  tfChip: {
+    flex: 1,
+  },
+  overview: {
+    paddingHorizontal: 20,
+    marginTop: 28,
+  },
+  tabBar: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+    paddingTop: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: C.hairline,
+  },
+  tipText: {
+    // Fixed width (measured once) — wide enough for "20:00, 11 Jun" at this size.
+    width: 156,
+    textAlign: "center",
+    color: "rgba(255,255,255,0.6)",
+    fontSize: 15,
+    fontFamily: FONT_MEDIUM,
+    fontVariant: ["tabular-nums"],
+    padding: 0,
+  },
+});

--- a/demo-lib/examples.ts
+++ b/demo-lib/examples.ts
@@ -39,9 +39,10 @@ export const EXAMPLES: ExampleEntry[] = [
   {
     id: "robinhood",
     title: "Robinhood",
-    tagline: "Portfolio hero chart with timeframe scrubbing",
-    accent: "#00C805",
-    status: "soon",
+    tagline: "Tokenized-stock detail — edgy line + scrub dim-split",
+    accent: "#4FE05A",
+    href: "/showcase/robinhood",
+    status: "ready",
   },
   {
     id: "coinbase",

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -42,7 +42,11 @@ provided; everything else has a default.
 ## Line, fill & tip
 
 <ParamField body="line" type="LineConfig">
-  Main line styling: `width`, `color`.
+  Main line styling: `width`, `color`, plus shape controls — `curve`
+  (`"monotone"` smooth default | `"linear"` straight segments), `join`
+  (`"round"` | `"miter"` | `"bevel"`), and `cap` (`"round"` | `"butt"` |
+  `"square"`). Pair `curve: "linear"` with `join: "miter"` + `cap: "butt"` for a
+  fully hard-edged ("edgy") line.
 </ParamField>
 
 <ParamField body="gradient" type="boolean | GradientConfig" default="true">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -173,7 +173,17 @@ interface ScrubActionPoint {
 These are the option shapes accepted by the matching props.
 
 ```ts
-interface LineConfig { width?: number; color?: string; colors?: string[] }
+interface LineConfig {
+  width?: number;   // stroke width in px; default 2
+  color?: string;   // line color override; defaults to palette accent
+  colors?: string[];// per-point gradient stops (left → right); wins over color
+  curve?: "monotone" | "linear"; // point interpolation; default "monotone"
+                    //   (smooth cubic). "linear" = straight segments / hard-edged.
+  join?: "round" | "miter" | "bevel"; // corner join; default "round".
+                    //   "miter" = sharp/angular peaks, "bevel" = flattened.
+  cap?: "round" | "butt" | "square";  // start/end cap; default "round".
+                    //   pair "butt" + join "miter" for a fully hard-edged line.
+}
 interface GradientConfig {
   topOpacity?: number;    // accent-derived top fill opacity
   bottomOpacity?: number; // accent-derived bottom fill opacity

--- a/docs/guides/line-and-area.mdx
+++ b/docs/guides/line-and-area.mdx
@@ -40,6 +40,36 @@ Override the stroke with the `line` prop, and the area fill with `gradient`:
 
 Pass `gradient={false}` to remove the area fill entirely.
 
+### Curve & edges
+
+By default the line is a smooth monotone cubic with rounded joins and caps. For an
+angular, hard-edged look — think the Robinhood tokenized-stock style — switch the
+interpolation to `linear` and sharpen the corners:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  line={{
+    width: 1.4,
+    curve: "linear", // straight segments instead of the smooth spline
+    join: "miter",   // sharp, angular peaks (no corner rounding)
+    cap: "butt",     // flat line ends
+  }}
+/>
+```
+
+`curve` (`"monotone"` | `"linear"`), `join` (`"round"` | `"miter"` | `"bevel"`),
+and `cap` (`"round"` | `"butt"` | `"square"`) are independent — e.g. keep the
+smooth curve but flatten the ends with `cap: "butt"`. `curve: "linear"` applies to
+the area fill as well, so the gradient follows the same straight segments.
+
+<Note>
+  **Live example:**
+  [`app/showcase/robinhood.tsx`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/showcase/robinhood.tsx)
+  pairs all three for a fully hard-edged line.
+</Note>
+
 ## Badge, dot, and value line
 
 By default the chart draws a value badge at the tip, a pulsing live dot, and (optionally) a

--- a/package-lock.json
+++ b/package-lock.json
@@ -17929,7 +17929,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.1.0",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -68,5 +68,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "3.7.0"
+  "version": "3.8.0"
 }

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -402,6 +402,8 @@ function useLiveChartController({
     reveal.morphT,
     // Only build the band path when the fill is actually on.
     thresholdCfg?.fill ? thresholdGeom.lineY : undefined,
+    // Straight polyline instead of the monotone cubic when line.curve === "linear".
+    lineProp?.curve === "linear",
   );
   const { upBodiesPath, downBodiesPath, upWicksPath, downWicksPath } =
     useCandlePaths(
@@ -902,8 +904,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
           path={linePath}
           style="stroke"
           strokeWidth={strokeWidth}
-          strokeCap="round"
-          strokeJoin="round"
+          strokeCap={lineProp?.cap ?? "round"}
+          strokeJoin={lineProp?.join ?? "round"}
           color={lineProp?.color ?? palette.line}
         >
           {thresholdCfg && thresholdStrokeColors ? (

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -25,6 +25,8 @@ export function useChartPaths(
   /** When set, also build `thresholdFillPath` — the band between the line and this
    *  pixel-Y, closed at the threshold instead of the chart baseline. */
   thresholdY?: SharedValue<number>,
+  /** Draw the line/fill as a straight polyline instead of the monotone cubic. */
+  linear = false,
 ) {
   const lineBuilder = usePathBuilder();
   const fillBuilder = usePathBuilder();
@@ -90,7 +92,7 @@ export function useChartPaths(
     if (n < 2) return cache.emptyPath;
     const b = lineBuilder.value;
     b.moveTo(pts[0], pts[1]);
-    drawSpline(b, pts, cache.scratch);
+    drawSpline(b, pts, cache.scratch, linear);
     return b.detach();
   });
 
@@ -101,7 +103,7 @@ export function useChartPaths(
     if (n < 2) return cache.emptyPath;
     const b = fillBuilder.value;
     b.moveTo(pts[0], pts[1]);
-    drawSpline(b, pts, cache.scratch);
+    drawSpline(b, pts, cache.scratch, linear);
     const bottom = engine.canvasHeight.get() - padding.bottom;
     b.lineTo(pts[(n - 1) * 2], bottom);
     b.lineTo(pts[0], bottom);
@@ -122,7 +124,7 @@ export function useChartPaths(
     if (n < 2 || !Number.isFinite(yT)) return cache.emptyPath;
     const b = thresholdFillBuilder.value;
     b.moveTo(pts[0], pts[1]);
-    drawSpline(b, pts, cache.scratch);
+    drawSpline(b, pts, cache.scratch, linear);
     b.lineTo(pts[(n - 1) * 2], yT);
     b.lineTo(pts[0], yT);
     b.close();

--- a/packages/react-native-livechart/src/math/spline.ts
+++ b/packages/react-native-livechart/src/math/spline.ts
@@ -53,10 +53,17 @@ export function drawSpline(
   path: SplinePathSink,
   pts: number[],
   scratch?: SplineScratch,
+  /** Straight polyline (`lineTo` per point) instead of the monotone cubic — an
+   *  angular, hard-edged line. The caller has already `moveTo`'d point 0. */
+  linear = false,
 ) {
   "worklet";
   const n = pts.length >> 1;
   if (n < 2) return;
+  if (linear) {
+    for (let i = 1; i < n; i++) path.lineTo(pts[i * 2], pts[i * 2 + 1]);
+    return;
+  }
   if (n === 2) {
     path.lineTo(pts[2], pts[3]);
     return;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -232,6 +232,12 @@ export interface ValueLineConfig {
 export interface LineConfig {
   /** Stroke width of the main line in pixels. Default `2`. */
   width?: number;
+  /**
+   * Interpolation between points. `"monotone"` (default) draws a smooth monotone
+   * cubic; `"linear"` draws straight segments for an angular, hard-edged line —
+   * pair with `join: "miter"` + `cap: "butt"` for true sharp corners (no rounding).
+   */
+  curve?: "monotone" | "linear";
   /** Line color override. Defaults to palette-derived accent. */
   color?: string;
   /**
@@ -239,6 +245,17 @@ export interface LineConfig {
    * (left → right). Takes precedence over `color` when set.
    */
   colors?: string[];
+  /**
+   * Stroke line-join — how corners between segments render. `"round"` (default)
+   * softens every peak; `"miter"` gives sharp, angular ("edgy") peaks; `"bevel"`
+   * flattens them.
+   */
+  join?: "round" | "miter" | "bevel";
+  /**
+   * Stroke line-cap at the path's start/end. `"round"` (default) | `"butt"` |
+   * `"square"`. Pair `"butt"` with `join: "miter"` for a fully hard-edged line.
+   */
+  cap?: "round" | "butt" | "square";
 }
 
 /**

--- a/packages/react-native-livechart/tests/math/spline.test.ts
+++ b/packages/react-native-livechart/tests/math/spline.test.ts
@@ -30,6 +30,14 @@ describe("drawSpline", () => {
     expect(path.cubicTo).toHaveBeenCalled();
   });
 
+  it("draws straight segments (lineTo per point) when linear", () => {
+    const path = makePath();
+    drawSpline(path as never, [0, 0, 5, 5, 10, 0], undefined, true);
+    expect(path.lineTo).toHaveBeenCalledWith(5, 5);
+    expect(path.lineTo).toHaveBeenCalledWith(10, 0);
+    expect(path.cubicTo).not.toHaveBeenCalled();
+  });
+
   it("handles zero delta x (flat vertical segment)", () => {
     const path = makePath();
     drawSpline(path as never, [0, 0, 0, 10, 10, 10]);


### PR DESCRIPTION
## Robinhood showcase

A faithful recreation of Robinhood (EU)'s tokenized-stock detail screen — the second example for the Examples tab — plus the `LineConfig` options it needs for a hard-edged line.

> 📚 Stacked on #123 (Examples tab + Fomo). Review/merge that first.

### Example — `app/showcase/robinhood.tsx`
- Fixed **1-week historical** view (`nowOverride` + `timeWindow`) on pure black; same skeleton-chrome philosophy as Fomo, with the live price readout and the German "Letzte Woche" change.
- **Session segments** (the documented `segments` scrub-focus model): at rest the line is one colour; scrubbing a third keeps it full and fades the others.
- **Thin, angular line** — 1.4px, straight segments, miter joins, butt caps; custom plain-text date tooltip via `renderTooltip`.

### Library — `LineConfig` additions
General-purpose, but required here to get the angular line:
- **`curve: "monotone" | "linear"`** — `"linear"` draws straight `lineTo` segments instead of the monotone cubic spline (`drawSpline` gains a linear mode, threaded through `useChartPaths`). This is what actually makes the line angular — a stroke join can't sharpen a curve.
- **`join` / `cap`** — expose the stroke line-join / line-cap (were hardcoded `"round"`); `join: "miter"` + `cap: "butt"` give true 0-radius corners.
- New test covers the linear spline branch.

> ⚠️ The `LineConfig` additions are new public API — they want a **CHANGELOG entry + minor version bump** at release time (happy to do that separately).

Verified on the iOS simulator (including zooming the line at full resolution to confirm the 0-radius corners) and via `npm run verify` + `build:lib` (75 suites / 930 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
