### PR TITLE
fix(xaxis): tie tick cadence to target window, not the animating one (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - 2026-06-15
+
+### Fixed
+
+- **X-axis tick cadence no longer depends on the time window you came from**
+  (`LiveChart` and `LiveChartSeries`). Changing `timeWindow` between values —
+  e.g. `24h` → `1h` — could settle the axis on a coarser tick interval (one fewer
+  tick) than selecting that window directly, and switching from a much larger
+  window down to a small one could leave only a single tick. Tick selection read
+  the *animating* window, which eases asymptotically toward the target and settles
+  just above or below it, landing in the neighbouring interval bucket depending on
+  the direction of approach. Tick selection now reads the target `timeWindow`, so
+  the cadence is stable and independent of the prior window; labels still animate
+  smoothly via the easing window.
+  ([#126](https://github.com/brandtnewlabs/react-native-livechart/issues/126))
+
 ## [3.8.0] - 2026-06-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -17929,7 +17929,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.1.0",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -68,5 +68,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -47,7 +47,17 @@ export interface EngineConfig {
 export interface ChartEngineLayout {
   displayMin: SharedValue<number>;
   displayMax: SharedValue<number>;
+  /** Animating window (lerps toward {@link timeWindow}); use for positioning. */
   displayWindow: SharedValue<number>;
+  /**
+   * The target window from props — the exact value `displayWindow` eases toward.
+   * Tick *selection* (which X-axis labels exist) must read this, not
+   * `displayWindow`: the lerp is asymptotic and never reaches the target, so it
+   * settles just above or just below it depending on the prior window. Bucketing
+   * that off-by-epsilon value (e.g. via `niceTimeInterval`) would otherwise make
+   * the tick cadence depend on where you came from. See issue #126.
+   */
+  timeWindow: SharedValue<number>;
   canvasWidth: SharedValue<number>;
   canvasHeight: SharedValue<number>;
   timestamp: SharedValue<number>;
@@ -257,6 +267,7 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
     displayMin,
     displayMax,
     displayWindow,
+    timeWindow,
     canvasWidth,
     canvasHeight,
     timestamp,

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -211,6 +211,7 @@ export function useLiveChartSeriesEngine(
     displayMin,
     displayMax,
     displayWindow,
+    timeWindow,
     canvasWidth,
     canvasHeight,
     timestamp,

--- a/packages/react-native-livechart/src/hooks/useXAxis.ts
+++ b/packages/react-native-livechart/src/hooks/useXAxis.ts
@@ -88,8 +88,16 @@ export function useXAxis(
     if (w === 0 || h === 0) return [] as XAxisEntry[];
 
     const now = engine.timestamp.get();
+    // `displayWindow` animates toward `timeWindow`; it positions the labels so
+    // the zoom slides smoothly. `targetWindow` is the settled destination and
+    // decides *which* labels exist — see the note on ChartEngineLayout.timeWindow
+    // and issue #126. Reading the animating window for selection makes the tick
+    // cadence depend on the prior window (the asymptotic lerp lands just off the
+    // `niceTimeInterval` bucket boundary, which the round window values sit on).
     const windowSecs = engine.displayWindow.get();
+    const targetWindow = engine.timeWindow.get();
     const winStart = now - windowSecs;
+    const targetWinStart = now - targetWindow;
 
     const chartLeft = padding.left;
     const chartRight = w - padding.right;
@@ -99,15 +107,19 @@ export function useXAxis(
 
     const fadeZone = 50;
 
-    // Pick interval from window duration
-    const targetPxPerSec = chartW / windowSecs;
-    let interval = niceTimeInterval(windowSecs);
-    while (interval * targetPxPerSec < 60 && interval < windowSecs) {
+    // Pick interval from the *target* window duration so the cadence is stable
+    // and independent of the window we're animating from.
+    const targetPxPerSec = chartW / targetWindow;
+    let interval = niceTimeInterval(targetWindow);
+    while (interval * targetPxPerSec < 60 && interval < targetWindow) {
       interval *= 2;
     }
 
-    // Generate target label keys (plain array, no Set — worklet-safe)
-    const firstTime = Math.ceil((winStart - interval) / interval) * interval;
+    // Generate target label keys (plain array, no Set — worklet-safe). Anchored
+    // to the target window so the set is destination-stable; positioning below
+    // still uses the animating `winStart`/`windowSecs` for a smooth transition.
+    const firstTime =
+      Math.ceil((targetWinStart - interval) / interval) * interval;
     const targetKeys: number[] = [];
     for (
       let t = firstTime;

--- a/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
@@ -14,6 +14,7 @@ function makeEngine(max = 120, min = 80): ChartEngineLayout {
     displayMax: sv(max),
     displayMin: sv(min),
     displayWindow: sv(30),
+    timeWindow: sv(30),
     canvasWidth: sv(300),
     canvasHeight: sv(200),
     timestamp: sv(0),

--- a/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
@@ -48,6 +48,7 @@ function EngineHarness({
   const displayMinSV = useSharedValue(displayMin);
   const displayMaxSV = useSharedValue(displayMax);
   const displayWindowSV = useSharedValue(30);
+  const timeWindowSV = useSharedValue(30);
   const canvasWidthSV = useSharedValue(canvasWidth);
   const canvasHeightSV = useSharedValue(canvasHeight);
   const timestampSV = useSharedValue(1_700_000_000);
@@ -62,6 +63,7 @@ function EngineHarness({
     displayMin: displayMinSV,
     displayMax: displayMaxSV,
     displayWindow: displayWindowSV,
+    timeWindow: timeWindowSV,
     canvasWidth: canvasWidthSV,
     canvasHeight: canvasHeightSV,
     timestamp: timestampSV,

--- a/packages/react-native-livechart/tests/hooks/useXAxis.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useXAxis.test.tsx
@@ -15,7 +15,15 @@ const font = {
   }),
 } as never;
 
-function makeEngine(w: number, h: number, windowSecs: number): EngineState {
+function makeEngine(
+  w: number,
+  h: number,
+  windowSecs: number,
+  // The settled target window. Defaults to `windowSecs` so callers get a
+  // fully-settled engine; the regression test below passes a different
+  // `displayWindow` to simulate mid-animation / asymptotic-settle states.
+  targetSecs: number = windowSecs,
+): EngineState {
   return withSharedValueAccessors({
     data: { value: [] },
     value: { value: 1 },
@@ -23,10 +31,21 @@ function makeEngine(w: number, h: number, windowSecs: number): EngineState {
     displayMin: { value: 0 },
     displayMax: { value: 10 },
     displayWindow: { value: windowSecs },
+    timeWindow: { value: targetSecs },
     canvasWidth: { value: w },
     canvasHeight: { value: h },
     timestamp: { value: 1700000000 },
   }) as unknown as EngineState;
+}
+
+/** Sorted set of label texts currently rendered — the X-axis tick "cadence". */
+function tickLabels(eng: EngineState): string[] {
+  const { result } = renderHook(() =>
+    useXAxis(eng, DEFAULT_PADDING, (t) => `t${Math.round(t)}`, font),
+  );
+  return result.current.xAxisEntries.value
+    .map((e) => e.label)
+    .sort();
 }
 
 describe("useXAxis", () => {
@@ -60,6 +79,25 @@ describe("useXAxis", () => {
       ),
     );
     expect(result.current.xAxisEntries.value.length).toBeGreaterThan(0);
+  });
+
+  // Regression for #126: the tick cadence must depend on the *target* window,
+  // not the window we animated from. `displayWindow` is an asymptotic lerp that
+  // settles just above the target when coming from a larger window (e.g. 24h →
+  // 1h) and just below it from a smaller one (1m → 1h). Those off-by-epsilon
+  // values land on opposite sides of a `niceTimeInterval` bucket boundary (the
+  // round window values sit exactly on the boundaries), so the old code that
+  // bucketed `displayWindow` produced a different number of ticks per path.
+  it("tick cadence is independent of the window animated from (#126)", () => {
+    const direct = tickLabels(makeEngine(400, 200, 3600, 3600));
+    // Settled from above (came from 24h): displayWindow rests just over target.
+    const fromAbove = tickLabels(makeEngine(400, 200, 3600.001, 3600));
+    // Settled from below (came from 1m): displayWindow rests just under target.
+    const fromBelow = tickLabels(makeEngine(400, 200, 3599.999, 3600));
+
+    expect(fromAbove).toEqual(direct);
+    expect(fromBelow).toEqual(direct);
+    expect(direct.length).toBeGreaterThan(2);
   });
 
   it("widens interval until label spacing target met", () => {


### PR DESCRIPTION
## Summary

Fixes #126 — the X-axis tick cadence depended on which time window you switched *from*. Selecting `1h` directly (from `1m`) showed ~20-min spacing, but going `24h → 1h` settled on ~30-min spacing (one fewer tick); large → small jumps (the reporter's `1Y → 1D`) could leave a single tick.

## Root cause

This is a library bug, not a demo issue — the Playground just sets `timeWindow` normally.

`useXAxis` derived the tick interval by bucketing the **animating** `displayWindow` through `niceTimeInterval`. `displayWindow` is an exponential lerp toward the target that **never reaches it** — coming from a larger window it settles at `target + ε`, from a smaller one at `target − ε`. `niceTimeInterval`'s bucket boundaries (`≤ 3600`, `≤ 14400`, `≤ 86400`, …) sit *exactly* on the round window values, so that epsilon decided the bucket — permanently, in whichever direction you approached from.

## Fix

Decouple *which* ticks exist from *where* they're drawn:

- **Selection** (interval, keys) now reads the exact target `timeWindow` → cadence is destination-stable and path-independent.
- **Positioning** still uses the animating `displayWindow` → the zoom still slides smoothly.

`timeWindow` is now exposed on the shared `ChartEngineLayout`, so both `LiveChart` and `LiveChartSeries` are fixed. This also removes the mid-transition churn where intermediate window sizes spawned/discarded interim-interval labels.

## Verification

- **Unit:** new regression test in `useXAxis.test.tsx` asserts identical tick labels whether `displayWindow` settles just above or just below the target. It fails on the old code (`30-min` vs `20-min`) and passes now.
- **Device (iOS 26.4 sim):** `1h` direct and `1h` after `24h` now render an identical axis (`14:20 / 14:40 / 15:00`, 20-min spacing) and stay stable across a 7s settle; `24h → 1m` settles cleanly too.
- `npm run verify` green: typecheck + lint + 931 tests.

## Release

Bundles the `v3.8.1` patch release (version bump + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
