### PR TITLE
feat(scrub): dashed crosshair option + Backpack showcase (v3.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2026-06-15
+
+### Added
+
+- **`scrub.crosshairDash` dashes the vertical scrub crosshair line** (`LiveChart`
+  and `LiveChartSeries`). `true` applies a default `[4, 4]` dash; an array sets
+  explicit Skia dash intervals `[on, off, …]` in px. Omit (or `false`) keeps the
+  solid line, so existing charts are unchanged.
+
 ## [3.8.2] - 2026-06-15
 
 ### Fixed

--- a/app/showcase/backpack.tsx
+++ b/app/showcase/backpack.tsx
@@ -1,0 +1,615 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useState } from "react";
+import {
+  type DimensionValue,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type ViewStyle,
+} from "react-native";
+import {
+  LiveChart,
+  type ScrubPoint,
+  type TooltipRenderProps,
+} from "react-native-livechart";
+import Animated, {
+  Easing,
+  interpolateColor,
+  type SharedValue,
+  useAnimatedProps,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+/**
+ * Backpack — token-detail recreation (light theme).
+ *
+ * Same skeleton philosophy as the other showcases (Fomo / Robinhood): everything
+ * but the chart and the live price readout is a grey placeholder, so focus stays
+ * on LiveChart and the ticking numbers. The only "real" pieces are the back
+ * button, the `LiveChart`, and `BackpackPriceReadout` (price + change).
+ *
+ * The chart matches Backpack's: a thin, hard-edged (linear + miter) green line on
+ * a WHITE background with NO grid / fill, a soft pulsing live dot at the leading
+ * edge, and a live-scrolling 1H window. The scrub draws a top time label + a
+ * crosshair and dims the "future" (everything right of the crosshair) via the
+ * documented `dimOpacity` split — exactly the second screenshot.
+ *
+ * To add another app, copy this file to `app/showcase/<id>.tsx` and register it
+ * in `demo-lib/examples.ts`.
+ */
+
+// ── Backpack palette (scoped — light surface).
+const C = {
+  bg: "#FFFFFF",
+  green: "#1FC85C",
+  red: "#FF4D4D",
+  text: "#0A0A0A",
+  muted: "rgba(0,0,0,0.45)",
+  skeleton: "rgba(0,0,0,0.06)",
+  skeletonStrong: "rgba(0,0,0,0.11)",
+  hairline: "rgba(0,0,0,0.08)",
+  crosshair: "rgba(0,0,0,0.28)",
+} as const;
+
+const FONT_BOLD = "PlusJakartaSans_700Bold";
+const FONT_SEMIBOLD = "PlusJakartaSans_600SemiBold";
+const FONT_MEDIUM = "PlusJakartaSans_500Medium";
+
+// Seed/start price. The change % is measured against the live window-open value
+// (computed in BackpackShowcase) so it stays realistic as the feed runs.
+const START_PRICE = 0.45059;
+
+// Chart geometry. A short ~90s "LIVE" window so the chart visibly scrolls (the
+// dot pushes in at the right and the line drifts left), framed as the "1H" tab.
+// `historyRange: "1m"` seeds ~1 point/sec so the window fills edge-to-edge (a
+// plain `historySpanSeconds` would inherit the 60s default step and seed nearly
+// empty — see the candle-seed-density note).
+const WINDOW_SECS = 90;
+const CHANGE_LABEL = "1h"; // the period the % readout covers (the selected tab)
+const CHART_HEIGHT = 248;
+
+// Built once (constructing Intl.NumberFormat per render is slow). 5 dp currency
+// renders the sub-dollar price as "$0.45059".
+const PRICE_FMT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 5,
+  maximumFractionDigits: 5,
+});
+
+// "9:12:07.531 PM" — 12-hour clock, no leading zero on the hour, down to the
+// millisecond (the live feed ticks sub-second, so ms distinguishes points).
+function formatStamp(t: number) {
+  "worklet";
+  const d = new Date(t * 1000);
+  let h = d.getHours();
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  const ms = String(d.getMilliseconds()).padStart(3, "0");
+  const ampm = h >= 12 ? "PM" : "AM";
+  h = h % 12;
+  if (h === 0) h = 12;
+  return `${h}:${m}:${s}.${ms} ${ampm}`;
+}
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+/**
+ * Scrub tooltip — plain centred grey text floated at the top of the plot (no
+ * pill), matching Backpack's "9:12 PM" label. Bound to the `timeStr` SharedValue
+ * so it updates on the UI thread while scrubbing (no JS re-render per move).
+ */
+function BackpackTooltip({ timeStr }: TooltipRenderProps) {
+  const animatedProps = useAnimatedProps(() => {
+    const t = timeStr.get();
+    return { text: t, defaultValue: t };
+  });
+  return (
+    <AnimatedTextInput
+      editable={false}
+      underlineColorAndroid="transparent"
+      style={styles.tipText}
+      animatedProps={animatedProps}
+    />
+  );
+}
+
+/** Grey placeholder block (bar or, with `r = h/2`, a circle). */
+function Sk({
+  w,
+  h,
+  r = 6,
+  strong,
+  style,
+}: {
+  w?: DimensionValue;
+  h: number;
+  r?: number;
+  strong?: boolean;
+  style?: ViewStyle;
+}) {
+  return (
+    <View
+      style={[
+        {
+          width: w,
+          height: h,
+          borderRadius: r,
+          backgroundColor: strong ? C.skeletonStrong : C.skeleton,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+/** Tiny candlestick glyph for the (decorative, line-mode) chart-type toggle. */
+function CandleGlyph() {
+  return (
+    <View style={styles.glyph}>
+      <View style={styles.glyphCandle}>
+        <View style={[styles.glyphWick, { backgroundColor: C.skeletonStrong }]} />
+        <View
+          style={[
+            styles.glyphBody,
+            { backgroundColor: C.skeletonStrong, height: 9, marginTop: -3 },
+          ]}
+        />
+      </View>
+      <View style={styles.glyphCandle}>
+        <View style={[styles.glyphWick, { backgroundColor: C.skeletonStrong }]} />
+        <View
+          style={[
+            styles.glyphBody,
+            { backgroundColor: C.skeletonStrong, height: 7, marginTop: 4 },
+          ]}
+        />
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Live price + change readout (the only "real" content besides the chart).
+ * Mirrors `value` (or the scrubbed value) and the `baseline` (the window-open)
+ * into React state via UI-thread reactions — once per change, not per frame —
+ * flashes the price green/red on each tick, and computes change/percent against
+ * that live baseline. The secondary stats (Mkt Cap / Vol) stay grey skeletons.
+ * Seeded with plain numbers (never reads a SharedValue during render → no
+ * strict-mode warning).
+ */
+function BackpackPriceReadout({
+  value,
+  baseline,
+}: {
+  value: SharedValue<number>;
+  baseline: SharedValue<number>;
+}) {
+  const flash = useSharedValue(0);
+  const [raw, setRaw] = useState(START_PRICE);
+  const [base, setBase] = useState(START_PRICE);
+
+  useAnimatedReaction(
+    () => value.get(),
+    (cur, prev) => {
+      if (cur === prev || !Number.isFinite(cur)) return;
+      if (prev != null && Number.isFinite(prev)) {
+        const dir = cur > prev ? 1 : -1;
+        flash.set(
+          withSequence(
+            withTiming(dir, { duration: 100 }),
+            withTiming(0, { duration: 280, easing: Easing.out(Easing.cubic) }),
+          ),
+        );
+      }
+      runOnJS(setRaw)(cur);
+    },
+  );
+
+  // Baseline steps slowly (only as the window-open point scrolls), so this fires
+  // far less than once per tick.
+  useAnimatedReaction(
+    () => baseline.get(),
+    (b, prev) => {
+      if (b !== prev && Number.isFinite(b)) runOnJS(setBase)(b);
+    },
+  );
+
+  const priceStyle = useAnimatedStyle(() => ({
+    color: interpolateColor(flash.get(), [-1, 0, 1], [C.red, C.text, C.green]),
+  }));
+
+  const delta = raw - base;
+  const pct = base !== 0 ? (delta / base) * 100 : 0;
+  const up = delta >= 0;
+  const changeColor = up ? C.green : C.red;
+
+  return (
+    <View>
+      <View style={styles.priceRow}>
+        <Animated.Text style={[styles.price, priceStyle]}>
+          {PRICE_FMT.format(raw)}
+        </Animated.Text>
+        <Ionicons name="swap-vertical" size={18} color={C.muted} />
+      </View>
+      <View style={styles.statsRow}>
+        <Text style={[styles.change, { color: changeColor }]}>
+          {up ? "▲" : "▼"} {Math.abs(pct).toFixed(2)}%
+        </Text>
+        <Text style={styles.changeSuffix}> {CHANGE_LABEL}</Text>
+        {/* Secondary stats (Mkt Cap · 24h Vol) — grey skeletons. */}
+        <Sk w={78} h={13} style={{ marginLeft: 14 }} />
+        <Sk w={64} h={13} style={{ marginLeft: 10 }} />
+      </View>
+    </View>
+  );
+}
+
+export default function BackpackShowcase() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  // Live feed: 3 ticks/sec → a busy, fast-moving line. Line-only (no candles /
+  // tape / multi-series) keeps the per-tick work minimal.
+  const { data, value } = useSimulatedChartData({
+    volatilityMode: "normal",
+    tradesPerSecond: 3,
+    startValue: START_PRICE,
+    tokenSymbol: "BP",
+    multiSeries: false,
+    tradeStream: false,
+    candleAggregation: false,
+    historyRange: "1m",
+    historySpanSeconds: WINDOW_SECS + 20,
+    maxPoints: 4000,
+  });
+
+  // The readout follows the live value, except while scrubbing it shows the
+  // crosshair's value (and snaps back to live when the gesture ends).
+  const isScrubbing = useSharedValue(false);
+  const displayValue = useSharedValue(START_PRICE);
+  useAnimatedReaction(
+    () => value.get(),
+    (v) => {
+      if (!isScrubbing.get()) displayValue.set(v);
+    },
+  );
+
+  // Live window-open reference = the value of the first point inside the window
+  // (latest time − window). Drives the change % and the red/green trend so both
+  // reflect the visible window, not a fixed anchor that drifts the whole session.
+  const baseline = useSharedValue(START_PRICE);
+  useAnimatedReaction(
+    () => {
+      const arr = data.get();
+      const n = arr.length;
+      if (n === 0) return START_PRICE;
+      const openT = arr[n - 1].time - WINDOW_SECS;
+      // Binary search for the first point at/after the window's left edge (data
+      // is time-sorted; the buffer can hold more than the window).
+      let lo = 0;
+      let hi = n - 1;
+      let idx = 0;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (arr[mid].time >= openT) {
+          idx = mid;
+          hi = mid - 1;
+        } else {
+          lo = mid + 1;
+        }
+      }
+      return arr[idx].value;
+    },
+    (openVal) => {
+      if (Number.isFinite(openVal)) baseline.set(openVal);
+    },
+  );
+
+  // Red when the price is below the window-open, green when above — recolors the
+  // line, dot, and glow together. Flips only on a crossing (rare).
+  const [trendDown, setTrendDown] = useState(false);
+  useAnimatedReaction(
+    () => value.get() < baseline.get(),
+    (down, prev) => {
+      if (down !== prev) runOnJS(setTrendDown)(down);
+    },
+  );
+  const trendColor = trendDown ? C.red : C.green;
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <StatusBar style="dark" />
+
+      {/* ── Header: real back button, everything else grey */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Back to Examples"
+        >
+          <Ionicons name="chevron-back" size={26} color={C.text} />
+        </Pressable>
+        <Sk w={30} h={30} r={15} />
+        <View style={styles.headerTitle}>
+          <Sk w={42} h={13} strong />
+          <Sk w={72} h={10} style={{ marginTop: 5 }} />
+        </View>
+        <View style={styles.headerIcons}>
+          <Sk w={24} h={24} r={12} />
+          <Sk w={6} h={22} r={3} />
+        </View>
+      </View>
+
+      {/* ── Token name (grey) */}
+      <View style={styles.nameBlock}>
+        <Sk w={150} h={24} strong />
+      </View>
+
+      {/* ── Price + change (the live readout) */}
+      <View style={styles.priceBlock}>
+        <BackpackPriceReadout value={displayValue} baseline={baseline} />
+      </View>
+
+      {/* ── Hero chart: clean edgy green line + pulse dot + scrub dim-split */}
+      <View style={styles.chartWrap}>
+        <LiveChart
+          data={data}
+          value={value}
+          // Transparent container so the pure-white page shows through (the light
+          // theme's default surface is a faint zinc-50 wash). The scrub dim erases
+          // to this same white via `dstOut`.
+          style={styles.chartCanvas}
+          theme="light"
+          accentColor={trendColor}
+          // Bold + hard-edged: `curve: "linear"` draws straight segments (no
+          // spline smoothing) and `join: "miter"` keeps peaks as sharp points.
+          line={{ color: trendColor, width: 3.5, curve: "linear", join: "miter" }}
+          dot={{ radius: 4.5 }}
+          // Soft halo that grows out from the dot and fades — reads as the
+          // "live" pulse at the leading edge.
+          pulse={{ maxRadius: 16, strokeWidth: 7, opacity: 0.35 }}
+          gradient={false}
+          badge={false}
+          valueLine={false}
+          momentum={false}
+          yAxis={false}
+          xAxis={false}
+          // Vertical breathing room; the larger top inset is a header band the
+          // scrub time label floats in (see `tooltipMargin` below). A small right
+          // gutter keeps the live-dot glow off the hard edge.
+          insets={{ left: 0, right: 16, top: 40, bottom: 20 }}
+          timeWindow={WINDOW_SECS}
+          formatTime={formatStamp}
+          renderTooltip={BackpackTooltip}
+          selectionDot={{ size: 5, color: trendColor, ring: false }}
+          scrub={{
+            tooltipPlacement: "top",
+            crosshairLineColor: C.crosshair,
+            // Dashed vertical line, like Backpack's scrub crosshair.
+            crosshairDash: [3, 4],
+            // Negative margin lifts the time label up into the top inset so it
+            // sits ABOVE the crosshair line (which starts at the plot top),
+            // rather than the line running behind the text.
+            tooltipMargin: -26,
+            dimOpacity: 0.28,
+          }}
+          onScrub={(point: ScrubPoint | null) => {
+            "worklet";
+            if (point === null) {
+              isScrubbing.set(false);
+              displayValue.set(value.get());
+              return;
+            }
+            isScrubbing.set(true);
+            displayValue.set(point.value);
+          }}
+        />
+      </View>
+
+      {/* ── Timeframe selector (grey pills, first = active) + chart-type toggle */}
+      <View style={styles.timeframes}>
+        <View style={styles.tfPills}>
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <Sk key={i} h={30} r={9} strong={i === 0} style={styles.tfChip} />
+          ))}
+        </View>
+        <View style={styles.chartTypeBtn}>
+          <CandleGlyph />
+        </View>
+      </View>
+
+      {/* ── About (grey heading + description) */}
+      <View style={styles.section}>
+        <Sk w={92} h={20} strong />
+        <Sk w="92%" h={13} style={{ marginTop: 16 }} />
+        <Sk w="78%" h={13} style={{ marginTop: 9 }} />
+        <View style={styles.linkRow}>
+          <Sk w={36} h={36} r={18} />
+          <Sk w={36} h={36} r={18} />
+          <Sk w={132} h={36} r={18} />
+        </View>
+      </View>
+
+      {/* ── Stats (grey heading + one row) */}
+      <View style={styles.section}>
+        <Sk w={76} h={20} strong />
+        <View style={styles.statLine}>
+          <Sk w={96} h={13} />
+          <Sk w={44} h={13} />
+        </View>
+      </View>
+
+      <View style={{ flex: 1 }} />
+
+      {/* ── Buy CTA (grey placeholder button) */}
+      <View style={[styles.ctaArea, { paddingBottom: insets.bottom + 8 }]}>
+        <Sk w="100%" h={54} r={27} strong />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: C.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 14,
+    height: 48,
+  },
+  backButton: {
+    width: 26,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerTitle: {
+    flex: 1,
+  },
+  headerIcons: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+  },
+  nameBlock: {
+    paddingHorizontal: 20,
+    marginTop: 10,
+  },
+  priceBlock: {
+    paddingHorizontal: 20,
+    marginTop: 12,
+  },
+  priceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  price: {
+    fontSize: 36,
+    fontFamily: FONT_BOLD,
+    letterSpacing: -0.5,
+    // Tabular figures: equal-width digits so the ticking price doesn't jitter.
+    fontVariant: ["tabular-nums"],
+  },
+  statsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 10,
+  },
+  change: {
+    fontSize: 14,
+    fontFamily: FONT_SEMIBOLD,
+    fontVariant: ["tabular-nums"],
+  },
+  changeSuffix: {
+    color: C.muted,
+    fontSize: 14,
+    fontFamily: FONT_MEDIUM,
+  },
+  chartWrap: {
+    height: CHART_HEIGHT,
+    marginTop: 10,
+  },
+  chartCanvas: {
+    backgroundColor: "transparent",
+  },
+  timeframes: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    marginTop: 6,
+  },
+  tfPills: {
+    flex: 1,
+    flexDirection: "row",
+    gap: 10,
+  },
+  tfChip: {
+    flex: 1,
+  },
+  chartTypeBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: C.hairline,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  glyph: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 3,
+    width: 22,
+    height: 20,
+  },
+  glyphCandle: {
+    width: 6,
+    height: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  glyphWick: {
+    position: "absolute",
+    width: 1.5,
+    height: 16,
+    borderRadius: 1,
+  },
+  glyphBody: {
+    width: 6,
+    borderRadius: 1.5,
+  },
+  section: {
+    paddingHorizontal: 20,
+    marginTop: 18,
+  },
+  linkRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginTop: 14,
+  },
+  statLine: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: 12,
+    paddingBottom: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: C.hairline,
+  },
+  ctaArea: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+  tipText: {
+    // Fixed width (measured once) + centred — wide enough for "12:00:00.000 PM".
+    width: 168,
+    textAlign: "center",
+    color: C.muted,
+    fontSize: 14,
+    fontFamily: FONT_MEDIUM,
+    fontVariant: ["tabular-nums"],
+    padding: 0,
+  },
+});

--- a/demo-lib/examples.ts
+++ b/demo-lib/examples.ts
@@ -45,6 +45,14 @@ export const EXAMPLES: ExampleEntry[] = [
     status: "ready",
   },
   {
+    id: "backpack",
+    title: "Backpack",
+    tagline: "Token detail (light) — live-scrolling edgy line + scrub split",
+    accent: "#1FC85C",
+    href: "/showcase/backpack",
+    status: "ready",
+  },
+  {
     id: "coinbase",
     title: "Coinbase",
     tagline: "Asset detail page with candle + line modes",

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -222,6 +222,7 @@ interface ScrubConfig {
   tooltip?: boolean;
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
+  crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;
   tooltipBorderRadius?: number; // pill corner radius; default 5
   tooltipPlacement?: "side" | "top" | "bottom"; // default "side" (offset/flip); top/bottom center over the line

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -143,6 +143,22 @@ Default `0.3`.
 
 The same `dimOpacity` option works on `LiveChartSeries`.
 
+## Dashed crosshair (`crosshairDash`)
+
+The vertical crosshair line is solid by default. Set `crosshairDash` to draw it dashed — `true`
+applies a default `[4, 4]` dash, or pass explicit Skia dash intervals `[on, off, …]` in pixels for
+finer control. Omitting it (or `false`) keeps the solid line.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  scrub={{ crosshairLineColor: "#94a3b8", crosshairDash: [3, 4] }}
+/>
+```
+
+Pairs with `crosshairLineColor` for the stroke color, and works on `LiveChartSeries` too.
+
 ## Press-and-hold to scrub (`panGestureDelay`)
 
 By default scrubbing starts the moment the user drags. When the chart sits inside a horizontally

--- a/package-lock.json
+++ b/package-lock.json
@@ -17597,7 +17597,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "3.8.2",
+      "version": "3.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "3.8.2"
+  "version": "3.9.0"
 }

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -1,4 +1,4 @@
-import { Group, Line, Rect } from "@shopify/react-native-skia";
+import { DashPathEffect, Group, Line, Rect } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { type ChartPadding } from "../draw/line";
 import type { LiveChartPalette } from "../types";
@@ -23,6 +23,7 @@ export function CrosshairLine({
   dimOpacity = 0.3,
   liveDotExtent = 0,
   crosshairLineColor,
+  crosshairDash,
   crosshairDimColor,
 }: {
   scrubX: SharedValue<number>;
@@ -48,6 +49,8 @@ export function CrosshairLine({
    *  the gutter reserves beyond them bright. Default 0. */
   liveDotExtent?: number;
   crosshairLineColor?: string;
+  /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
+  crosshairDash?: number[];
   crosshairDimColor?: string;
 }) {
   // Explicit dependency arrays: with React Compiler enabled, Reanimated's
@@ -119,7 +122,9 @@ export function CrosshairLine({
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
           strokeWidth={1}
-        />
+        >
+          {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
+        </Line>
 
         {/* Selection dot at the scrub intersection (leading series). `null`
             hides it; a custom component renders the consumer's dot. */}

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -1,4 +1,5 @@
 import {
+  DashPathEffect,
   Group,
   Line,
   Rect,
@@ -33,6 +34,7 @@ export function CrosshairOverlay({
   dimOpacity = 0.3,
   liveDotExtent = 0,
   crosshairLineColor,
+  crosshairDash,
   crosshairDimColor,
   tooltipBackground,
   tooltipColor,
@@ -75,6 +77,8 @@ export function CrosshairOverlay({
    *  reserves beyond it. Default 0. */
   liveDotExtent?: number;
   crosshairLineColor?: string;
+  /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
+  crosshairDash?: number[];
   crosshairDimColor?: string;
   tooltipBackground?: string;
   tooltipColor?: string;
@@ -168,7 +172,9 @@ export function CrosshairOverlay({
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
           strokeWidth={1}
-        />
+        >
+          {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
+        </Line>
 
         {/* Selection dot at the scrub intersection. `null` hides it; a custom
             component renders the consumer's dot; otherwise the built-in dot. */}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1117,6 +1117,7 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
           dimOpacity={scrubCfg.dimOpacity}
           liveDotExtent={liveDotExtent}
           crosshairLineColor={scrubCfg.crosshairLineColor}
+          crosshairDash={scrubCfg.crosshairDash}
           crosshairDimColor={scrubCfg.crosshairDimColor}
           tooltipBackground={scrubCfg.tooltipBackground}
           tooltipColor={scrubCfg.tooltipColor}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -723,6 +723,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 dimOpacity={scrubCfg.dimOpacity}
                 liveDotExtent={liveDotExtent}
                 crosshairLineColor={scrubCfg.crosshairLineColor}
+                crosshairDash={scrubCfg.crosshairDash}
                 crosshairDimColor={scrubCfg.crosshairDimColor}
               />
             )}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -81,6 +81,8 @@ export interface ResolvedScrubConfig {
   dimOpacity: number;
   /** undefined → palette.crosshairLine */
   crosshairLineColor: string | undefined;
+  /** Dash intervals `[on, off, …]` for the crosshair line; undefined → solid. */
+  crosshairDash: number[] | undefined;
   /** undefined → palette.crosshairDim */
   crosshairDimColor: string | undefined;
   /** undefined → palette.tooltipBg */
@@ -363,6 +365,7 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltip: true,
   dimOpacity: 0.3,
   crosshairLineColor: undefined,
+  crosshairDash: undefined,
   crosshairDimColor: undefined,
   tooltipBackground: undefined,
   tooltipColor: undefined,
@@ -382,7 +385,14 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
 export function resolveScrub(
   prop: boolean | ScrubConfig | undefined,
 ): ResolvedScrubConfig | null {
-  return resolveToggle(prop, SCRUB_DEFAULTS, false);
+  const resolved = resolveToggle(prop, SCRUB_DEFAULTS, false);
+  if (resolved) {
+    // Normalize the dash shorthand: `true` → a default dash, an array passes
+    // through, anything falsy → solid (undefined).
+    const dash = typeof prop === "object" ? prop.crosshairDash : undefined;
+    resolved.crosshairDash = dash === true ? [4, 4] : dash || undefined;
+  }
+  return resolved;
 }
 
 const SCRUB_ACTION_DEFAULTS: ResolvedScrubActionConfig = {

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -383,6 +383,12 @@ export interface ScrubConfig {
   /** Vertical crosshair line stroke. Omit to use theme `crosshairLine`. */
   crosshairLineColor?: string;
   /**
+   * Dash the vertical crosshair line. `true` → a default `[4, 4]` dash; an array
+   * sets explicit Skia dash intervals `[on, off, …]` in px. Omit / `false` → a
+   * solid line.
+   */
+  crosshairDash?: number[] | boolean;
+  /**
    * Legacy: fill the region right of the crosshair with this solid (usually
    * semi-transparent) color — a mask painted *over* the chart, so it only looks
    * right when it matches the background. Prefer `dimOpacity`. When set, it

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -372,6 +372,27 @@ describe("CrosshairOverlay", () => {
     render(<Fixture />);
   });
 
+  it("renders a dashed crosshair line when crosshairDash is set", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(1);
+      const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          crosshairDash={[4, 4]}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
   it("renders tooltip pill when showTooltip=true", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
@@ -776,6 +797,29 @@ describe("CrosshairLine", () => {
           selectionY={selectionY}
           scrubActive={scrubActive}
           selectionColor="#abcdef"
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("renders a dashed crosshair line when crosshairDash is set", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
+      const selectionY = useSharedValue(140);
+      return (
+        <CrosshairLine
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          selectionDot={resolveSelectionDot(true)}
+          selectionY={selectionY}
+          scrubActive={scrubActive}
+          crosshairDash={[4, 4]}
         />
       );
     }

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -225,6 +225,16 @@ describe("resolveScrub", () => {
     });
   });
 
+  it("normalizes the crosshairDash shorthand", () => {
+    // `true` → a default dash, an array passes through, `false` → solid.
+    expect(resolveScrub(true)?.crosshairDash).toBeUndefined();
+    expect(resolveScrub({ crosshairDash: true })?.crosshairDash).toEqual([4, 4]);
+    expect(resolveScrub({ crosshairDash: [2, 6] })?.crosshairDash).toEqual([
+      2, 6,
+    ]);
+    expect(resolveScrub({ crosshairDash: false })?.crosshairDash).toBeUndefined();
+  });
+
   it("carries a custom panGestureDelay (press-and-hold to scrub)", () => {
     expect(resolveScrub({ panGestureDelay: 300 })).toEqual({
       tooltip: true,


### PR DESCRIPTION
## Summary

Adds an opt-in scrub option **`scrub.crosshairDash`** and a **Backpack** token-detail showcase that uses it. Cuts **v3.9.0** (minor — new optional API, no breaking changes).

## `scrub.crosshairDash` (new, backward-compatible)

Dashes the vertical scrub crosshair line on `LiveChart` and `LiveChartSeries`:

- `true` → default `[4, 4]` dash
- `number[]` → explicit Skia dash intervals `[on, off, …]` in px
- omit / `false` → solid line (unchanged default)

Wired `ScrubConfig` → `resolveScrub` → `CrosshairOverlay` (single-series) and `CrosshairLine` (multi-series) via a Skia `DashPathEffect`.

## Backpack showcase (`app/showcase/backpack.tsx`)

Light-theme token-detail recreation, following the Fomo/Robinhood skeleton convention (grey chrome; only the back button, chart, and live price/change are real):

- live-scrolling "1H" window, bold hard-edged green line, pulsing leading dot, green/red trend recolor
- scrub dim-split with a **dashed** crosshair + a top time label (down to the millisecond)
- registered in the Examples tab via `demo-lib/examples.ts`

## Docs

- `crosshairDash` added to the `ScrubConfig` type reference (`docs/api-reference/types.mdx`)
- new "Dashed crosshair" section in the scrubbing guide (`docs/guides/scrubbing.mdx`)

## Test plan

- `npm run verify` green — typecheck + lint + **936 tests** (3 new: `resolveScrub` dash normalization, plus a dashed-line render case for each crosshair overlay)
- `package-lock.json` reconciled with npm 10 (single version-line diff, `@emnapi` entries intact — avoids the `npm ci` CI trap)
- Verified on the iPhone 17 simulator: skeleton UI matches the reference screenshots, live scroll + pulse dot, bold line; dashed crosshair + ms tooltip confirmed via manual scrub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
