### PR TITLE
feat(labels): position topLabel/bottomLabel at extrema points (#131)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -127,6 +127,11 @@ const SECTIONS: DemoSection[] = [
         title: "Axes & grid",
         blurb: "Hide X/Y, minGap, insets; LiveChart vs LiveChartSeries.",
       },
+      {
+        href: "/demo/extrema-labels",
+        title: "Extrema labels",
+        blurb: 'topLabel / bottomLabel at the actual high / low point (position="extrema").',
+      },
     ],
   },
   {

--- a/app/demo/extrema-labels.tsx
+++ b/app/demo/extrema-labels.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import type { AxisLabelConfig, CandlePoint } from "react-native-livechart";
+import { LiveChart } from "react-native-livechart";
+import { useSharedValue } from "react-native-reanimated";
+
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Extrema labels" };
+
+type Position = "extrema" | "extrema-edge" | "right";
+
+// `"extrema"` floats topLabel/bottomLabel at the actual high / low data point;
+// `"extrema-edge"` keeps the value on the top/bottom rail (x-aligned with the
+// extremum) and joins it to a dot on the point with a connector line; `"right"`
+// is the classic edge-pinned readout for comparison.
+const POSITION_OPTIONS: { value: Position; label: string }[] = [
+  { value: "extrema", label: "At the point" },
+  { value: "extrema-edge", label: "At the edge" },
+  { value: "right", label: "Pinned right" },
+];
+
+type DisplayMode = "line" | "candle";
+
+const DISPLAY_OPTIONS: { value: DisplayMode; label: string }[] = [
+  { value: "line", label: "Line" },
+  { value: "candle", label: "Candle" },
+];
+
+// Built-in label styling knobs (fontSize / fontWeight / dotSize / dot) — applied
+// to topLabel + bottomLabel below.
+const FONT_SIZE_OPTIONS: { value: number; label: string }[] = [
+  { value: 11, label: "11" },
+  { value: 14, label: "14" },
+  { value: 18, label: "18" },
+];
+
+const DOT_SIZE_OPTIONS: { value: number; label: string }[] = [
+  { value: 7, label: "Small" },
+  { value: 11, label: "Medium" },
+  { value: 16, label: "Large" },
+];
+
+const HIGH_COLOR = "#34d399";
+const LOW_COLOR = "#f87171";
+
+// Worklet-safe: `formatValue` and the label `format` are called on the UI thread
+// (grid labels + the extrema label text), so they need the worklet directive —
+// same requirement as the States demo's formatters.
+function fmt(v: number): string {
+  "worklet";
+  return `$${v.toFixed(2)}`;
+}
+
+export default function ExtremaLabelsScreen() {
+  const [position, setPosition] = useState<Position>("extrema");
+  const [custom, setCustom] = useState(false);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("line");
+  // Built-in label styling.
+  const [fontSize, setFontSize] = useState(11);
+  const [bold, setBold] = useState(false);
+  const [showDot, setShowDot] = useState(true);
+  const [dotSize, setDotSize] = useState(7);
+  const [connector, setConnector] = useState(true);
+
+  const windowSecs = 300;
+  const candleWidthSecs = 15;
+  const isCandle = displayMode === "candle";
+
+  const { data, value, candles, liveCandle } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: isCandle,
+    tradeStream: false,
+    candleWidth: candleWidthSecs,
+    // Keep the line calm + low-frequency so it reads cleanly and the high / low
+    // points stand out — this demo is about the labels, not volatility. Candle
+    // mode bumps the volatility so the 15s buckets still get real bodies + wicks.
+    historySpanSeconds: windowSecs,
+    historyRange: "1m",
+    volatilityMode: isCandle ? "volatile" : "calm",
+    tradesPerSecond: 2,
+    maxPoints: 6000,
+  });
+
+  const emptyCandles = useSharedValue<CandlePoint[]>([]);
+  const nullLive = useSharedValue<CandlePoint | null>(null);
+
+  // Built-in styling shared by both labels: font size + weight style the value
+  // text (in either position mode); dot + dotSize style the extrema marker;
+  // connector is the dot → edge line in "At the edge" mode (ignored otherwise).
+  const styleProps = {
+    fontSize,
+    fontWeight: bold ? ("700" as const) : undefined,
+    dot: showDot,
+    dotSize,
+    connector,
+  };
+
+  // The high tracks the peak, the low tracks the trough. `render` floats any RN
+  // element at the point instead of the built-in dot + value (and ignores the
+  // style knobs — you own the chrome).
+  const topLabel: AxisLabelConfig = custom
+    ? {
+        position,
+        render: () => (
+          <View style={[styles.tag, { backgroundColor: HIGH_COLOR }]}>
+            <Text style={styles.tagText}>HIGH</Text>
+          </View>
+        ),
+      }
+    : { position, format: fmt, color: HIGH_COLOR, ...styleProps };
+
+  const bottomLabel: AxisLabelConfig = custom
+    ? {
+        position,
+        render: () => (
+          <View style={[styles.tag, { backgroundColor: LOW_COLOR }]}>
+            <Text style={styles.tagText}>LOW</Text>
+          </View>
+        ),
+      }
+    : { position, format: fmt, color: LOW_COLOR, ...styleProps };
+
+  return (
+    <DemoScreen
+      title="Extrema labels"
+      docs="guides/theming"
+      description='topLabel / bottomLabel extrema modes: "At the point" floats the readout on the high/low data point; "At the edge" keeps it on the top/bottom rail (x-aligned) with a connector to a dot on the point.'
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          mode={displayMode}
+          candles={isCandle ? candles : emptyCandles}
+          liveCandle={isCandle ? liveCandle : nullLive}
+          candleWidth={candleWidthSecs}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={windowSecs}
+          formatValue={fmt}
+          topLabel={topLabel}
+          bottomLabel={bottomLabel}
+        />
+      }
+    >
+      <ChipRow
+        label="Label position"
+        options={POSITION_OPTIONS}
+        value={position}
+        onChange={setPosition}
+      />
+      <ChipRow
+        label="Display"
+        options={DISPLAY_OPTIONS}
+        value={displayMode}
+        onChange={setDisplayMode}
+      />
+      <ChipRow
+        label="Font size"
+        options={FONT_SIZE_OPTIONS}
+        value={fontSize}
+        onChange={setFontSize}
+      />
+      <ChipRow
+        label="Dot size"
+        options={DOT_SIZE_OPTIONS}
+        value={dotSize}
+        onChange={setDotSize}
+      />
+      <ControlRow label="Built-in style">
+        {/* fontWeight, the dot toggle, and the "At the edge" connector line.
+            These style the built-in label; a custom `render` ignores them. */}
+        <ToggleChip label="Bold" value={bold} onChange={setBold} />
+        <ToggleChip label="Show dot" value={showDot} onChange={setShowDot} />
+        <ToggleChip
+          label="Connector"
+          value={connector}
+          onChange={setConnector}
+        />
+      </ControlRow>
+      <ControlRow label="Rendering">
+        {/* Built-in = dot + value text; Custom = a `render` element at the point. */}
+        <ToggleChip label="Custom render" value={custom} onChange={setCustom} />
+      </ControlRow>
+    </DemoScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  tag: {
+    borderRadius: 6,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+  },
+  tagText: {
+    color: "#0b1220",
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+});

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -218,6 +218,8 @@ interface PulseConfig {
   opacity?: number; strokeWidth?: number;
 }
 interface ValueLineConfig { strokeWidth?: number; intervals?: [number, number]; color?: string }
+// Shared styling for a straight line (the connector, valueLine, …). Omit `intervals` for solid.
+interface LineStyleConfig { color?: string; strokeWidth?: number; intervals?: [number, number] }
 interface ScrubConfig {
   tooltip?: boolean;
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
@@ -259,8 +261,20 @@ interface XAxisConfig { minGap?: number } // default 60
 interface AxisLabelConfig {
   format?: (v: number) => string; // built-in value formatter; defaults to formatValue
   color?: string;                 // text color; defaults to palette.gridLabel (muted)
-  position?: "left" | "right";    // alignment within the plot width; default "right"
-  render?: () => React.ReactElement | null; // custom element; overrides the built-in value
+  // "left"/"right" pin to that edge (default "right"). "extrema" floats the label
+  // on the actual high (topLabel) / low (bottomLabel) data point. "extrema-edge"
+  // keeps the label on the top/bottom edge (x-aligned) with a dot + connector.
+  position?: "left" | "right" | "extrema" | "extrema-edge";
+  fontSize?: number;              // built-in value text size (px); default 11
+  fontWeight?: FontWeight;        // built-in value text weight; default platform default
+  fontFamily?: string;            // built-in value text font family
+  dotColor?: string;              // extrema modes — dot color; defaults to color
+  dotSize?: number;               // extrema modes — dot diameter (px); default 7
+  dot?: boolean;                  // extrema modes — draw the marker dot; default true
+  // "extrema-edge" connector (dot → edge label). true = dashed default, false =
+  // none, or a LineStyleConfig. Default on (dashed) in "extrema-edge" mode.
+  connector?: boolean | LineStyleConfig;
+  render?: () => React.ReactElement | null; // custom element; overrides everything above
 }
 interface ChartInsets { top?: number; right?: number; bottom?: number; left?: number }
 interface LeftEdgeFadeConfig { width?: number; startColor?: string; endColor?: string }
@@ -305,8 +319,11 @@ With `true`, the chart floats its current top (`topLabel`) / bottom
 to the chart's `formatValue`) in `color` (falling back to the muted
 `palette.gridLabel`), aligned by `position`. The values track the live Y-axis
 range each frame on the UI thread. Set `render` to float a fully custom element
-at the edge instead of the built-in value. See
-[Axis labels](/guides/theming#axis-edge-labels).
+at the edge instead of the built-in value. `position: "extrema"` instead floats
+the label (a dot + value, or your `render` element) at the actual data point
+where the high / low occurs, tracking it as the chart scrolls. See
+[Axis labels](/guides/theming#axis-edge-labels) and
+[Marking the extrema points](/guides/theming#marking-the-extrema-points).
 
 ## SelectionDotProps
 

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -126,13 +126,14 @@ its current top (`topLabel`) and bottom (`bottomLabel`) Y-axis bound, formatted 
 ```
 
 Both default off. Pass an [`AxisLabelConfig`](/api-reference/types#axislabelconfig) to tune the
-built-in label — `format`, `color`, and `position` (`"left"` | `"right"`, default `"right"`):
+built-in label — `format`, `color`, `position` (`"left"` | `"right"`, default `"right"`), and the
+text `fontSize` / `fontWeight` / `fontFamily`:
 
 ```tsx
 <LiveChart
   data={data}
   value={value}
-  topLabel={{ color: "#22d3ee", position: "left" }}
+  topLabel={{ color: "#22d3ee", position: "left", fontSize: 14, fontWeight: "600" }}
   bottomLabel={{ format: (v) => `$${v.toFixed(2)}` }}
 />
 ```
@@ -148,9 +149,79 @@ built-in value):
 />
 ```
 
+### Marking the extrema points
+
+`position: "extrema"` floats the label at the **actual data point** where the value occurs instead
+of pinning it to an edge — `topLabel` tracks the highest point, `bottomLabel` the lowest. The chart
+projects the extremum's `(time, value)` to a canvas pixel each frame and positions a small dot +
+the value there on the UI thread, so it tracks the point as the chart scrolls and the Y-axis
+rescales. It's the easiest way to show **when** the high / low happened, not just what it was.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  topLabel={{ position: "extrema", color: "#34d399" }}
+  bottomLabel={{ position: "extrema", color: "#f87171" }}
+/>
+```
+
+The label hides itself when the window holds no data, or when the extremum scrolls off the plot
+(the engine re-picks the visible high / low every frame). It works in **candle mode** too — the
+extrema track the highest high / lowest low.
+
+**`"extrema-edge"`** is a variant that keeps the readout on a clean rail: the value label pins to the
+top / bottom **edge** (still horizontally aligned with the extremum), and a dot marks the actual
+point, joined by a **connector** line. Good when a point-anchored label would crowd the live dot or
+sit awkwardly mid-candle.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  topLabel={{ position: "extrema-edge", color: "#34d399" }}
+  // The connector is a LineStyleConfig (color, strokeWidth, intervals) — the same
+  // shape as `valueLine`. Defaults to a dashed line in the label color.
+  bottomLabel={{ position: "extrema-edge", connector: { color: "#475569", intervals: [4, 4] } }}
+/>
+```
+
+The connector defaults on (dashed) in `"extrema-edge"` mode; pass `connector: false` to drop it
+(value at the edge + dot on the point, no line), or a [`LineStyleConfig`](/api-reference/types#linestyleconfig)
+to style it. `dot: false` removes the dot.
+
+Style the built-in label without dropping to a custom render — `fontSize`, `fontWeight`,
+`fontFamily` size the value text, and `dotColor`, `dotSize`, and `dot: false` control the marker:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  topLabel={{
+    position: "extrema",
+    color: "#34d399",
+    fontSize: 14,
+    fontWeight: "700",
+    dotSize: 10,        // or dotColor: "#fff", or dot: false for a dotless label
+  }}
+/>
+```
+
+(`fontSize` / `fontWeight` / `fontFamily` style the edge `"left"` / `"right"` labels too; the
+`dot*` knobs are `"extrema"`-only.) For anything beyond that, a custom `render` is centered over the
+point instead of the built-in dot + value — you own the chrome:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  topLabel={{ position: "extrema", render: () => <PeakTag /> }}
+/>
+```
+
 The same props work on [`LiveChartSeries`](/api-reference/livechart-series#axis-labels), where the
-bounds track the combined range of the visible series. The labels are display-only
-(`pointerEvents="none"`), so they never block scrubbing.
+bounds track the combined range of the visible series (and `"extrema"` marks the global high / low
+across them). The labels are display-only (`pointerEvents="none"`), so they never block scrubbing.
 
 ## Fonts
 

--- a/packages/react-native-livechart/src/components/AxisLabelOverlay.tsx
+++ b/packages/react-native-livechart/src/components/AxisLabelOverlay.tsx
@@ -1,16 +1,60 @@
-import { TextInput, StyleSheet, View } from "react-native";
+import { useState } from "react";
+import {
+  TextInput,
+  StyleSheet,
+  Text,
+  View,
+  type LayoutChangeEvent,
+} from "react-native";
 import Animated, {
   useAnimatedProps,
+  useAnimatedReaction,
+  useAnimatedStyle,
   useDerivedValue,
+  useSharedValue,
 } from "react-native-reanimated";
 import type { SharedValue } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
 
 import type { ResolvedAxisLabelConfig } from "../core/resolveConfig";
-import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type {
+  ChartEngineExtrema,
+  ChartEngineLayout,
+} from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
+import type { FontWeight } from "../types";
+
+/** Resolved text-styling knobs shared by the edge and extrema built-in labels. */
+interface LabelFontStyle {
+  fontSize?: number;
+  fontWeight?: FontWeight;
+  fontFamily?: string;
+}
+
+/** Pluck the font knobs off a resolved axis-label config. */
+function labelFont(cfg: ResolvedAxisLabelConfig): LabelFontStyle {
+  return {
+    fontSize: cfg.fontSize,
+    fontWeight: cfg.fontWeight,
+    fontFamily: cfg.fontFamily,
+  };
+}
 
 /** Editable={false} TextInput so its `text` prop can be animated on the UI thread. */
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+/** Marker dot drawn at the exact extrema point (built-in `"extrema"` label). */
+const EXTREMA_DOT_SIZE = 7;
+/** Gap (px) between the extrema dot and its value text. */
+const EXTREMA_GAP = 3;
+/** How far off-plot (px) the extrema point may sit before the label is hidden. */
+const EXTREMA_CULL = 24;
+/** `"extrema-edge"` top label's inset from the very top of the chart (px). The
+ *  connector ({@link ExtremaConnectorOverlay}) reads this to stop at the label. */
+export const EXTREMA_EDGE_INSET = 2;
+/** Default value-text size (px). Mirrors `styles.extremaText`; the connector
+ *  reads it to estimate where the edge label ends. */
+export const EXTREMA_LABEL_FONT_SIZE = 11;
 
 /**
  * The batteries-included axis edge label — an animated RN text driven by a
@@ -26,11 +70,13 @@ function BuiltInAxisValueLabel({
   format,
   color,
   position,
+  font,
 }: {
   value: SharedValue<number>;
   format: (v: number) => string;
   color: string;
-  position: "left" | "right";
+  position: "left" | "right" | "extrema" | "extrema-edge";
+  font: LabelFontStyle;
 }) {
   const text = useDerivedValue(() => format(value.get()));
   const animatedProps = useAnimatedProps(() => {
@@ -45,9 +91,236 @@ function BuiltInAxisValueLabel({
         color,
         textAlign: position === "left" ? "left" : "right",
         padding: 0,
+        // undefined keys are ignored by RN, so each falls back to its default.
+        fontSize: font.fontSize,
+        fontWeight: font.fontWeight,
+        fontFamily: font.fontFamily,
       }}
       animatedProps={animatedProps}
     />
+  );
+}
+
+/**
+ * An axis label floated at the *actual data point* where the extreme value
+ * occurs — `topLabel` over the highest point, `bottomLabel` under the lowest —
+ * rather than pinned to a fixed plot edge. The chart projects the extremum's
+ * (time, value) to a canvas pixel each frame and positions the label there on
+ * the UI thread, so the dot + value track the point as the chart scrolls and
+ * the Y-axis rescales (the same projection the markers / scrub dot use).
+ *
+ * The value text rides a JS-thread `useState` rather than UI-thread animated
+ * text: it changes only when a *new* extremum appears (not every frame), and a
+ * plain `<Text>` re-measures on change so the box stays correctly centered over
+ * the point (an animated `TextInput`'s width is fixed at its last layout, which
+ * would clip / drift as the digit count changes). Hidden (`opacity: 0`) when the
+ * window holds no data (value is `NaN`) or the point scrolls off-plot.
+ */
+function ExtremaAxisLabel({
+  side,
+  timeSV,
+  valueSV,
+  timeOffset,
+  edgeAnchor,
+  engine,
+  padding,
+  format,
+  color,
+  font,
+  dotColor,
+  dotSize,
+  dot,
+  render,
+}: {
+  /** `"top"` floats above the max point; `"bottom"` below the min point. */
+  side: "top" | "bottom";
+  timeSV: SharedValue<number>;
+  valueSV: SharedValue<number>;
+  /**
+   * `"extrema-edge"` mode: pin the value label to the plot's top / bottom edge
+   * (x-aligned with the extremum) instead of floating it over the point. The dot
+   * still sits on the point; a connector line (drawn in Skia) joins them.
+   */
+  edgeAnchor: boolean;
+  /**
+   * Seconds added to the extremum time before projecting to x. `0` for line /
+   * multi-series (the point sits at its exact time); half a candle width in
+   * candle mode so the dot lands on the candle's drawn center, not its left edge.
+   */
+  timeOffset: number;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  format: (v: number) => string;
+  color: string;
+  font: LabelFontStyle;
+  /** Dot color; falls back to `color`. */
+  dotColor?: string;
+  /** Dot diameter (px); falls back to the built-in default. */
+  dotSize?: number;
+  /** Whether to draw the marker dot. */
+  dot: boolean;
+  render?: () => React.ReactElement | null;
+}) {
+  const isCustom = render != null;
+  // Resolved dot geometry. `hasDot` also gates the label's vertical offset (it
+  // sits past the dot when shown, otherwise just past the point).
+  const dotSizePx = dotSize ?? EXTREMA_DOT_SIZE;
+  const hasDot = !isCustom && dot;
+  // Measured size of the content (text or custom element) — used only to center
+  // and clamp the LABEL horizontally. The dot is pinned to the point regardless.
+  const size = useSharedValue({ width: 0, height: 0 });
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    size.value = { width, height };
+  };
+
+  // The value text changes only when the extremum does, so push it to JS state
+  // (a re-measured <Text>) instead of UI-thread animated text. Skipped when a
+  // custom element owns the content.
+  const [valueText, setValueText] = useState("");
+  useAnimatedReaction(
+    () => {
+      const v = valueSV.get();
+      return isCustom || !Number.isFinite(v) ? "" : format(v);
+    },
+    (curr, prev) => {
+      if (curr !== prev) scheduleOnRN(setValueText, curr);
+    },
+  );
+
+  // Project the extremum's (time, value) to a canvas pixel once; the dot and the
+  // label both read it. `visible` is false when the window is empty or the point
+  // scrolls off-plot.
+  const proj = useDerivedValue(() => {
+    const value = valueSV.get();
+    const time = timeSV.get();
+    const cw = engine.canvasWidth.get();
+    const ch = engine.canvasHeight.get();
+    const displayMin = engine.displayMin.get();
+    const displayMax = engine.displayMax.get();
+    const win = engine.displayWindow.get();
+    const ts = engine.timestamp.get();
+
+    const chartLeft = padding.left;
+    const chartRight = cw - padding.right;
+    const chartW = chartRight - chartLeft;
+    const chartTop = padding.top;
+    const chartBottom = ch - padding.bottom;
+    const chartH = chartBottom - chartTop;
+    const valRange = displayMax - displayMin;
+
+    if (
+      !Number.isFinite(value) ||
+      cw === 0 ||
+      ch === 0 ||
+      chartW <= 0 ||
+      chartH <= 0 ||
+      win <= 0 ||
+      valRange <= 0
+    ) {
+      return { px: 0, py: 0, visible: false };
+    }
+
+    const winStart = ts - win;
+    const px = chartLeft + ((time + timeOffset - winStart) / win) * chartW;
+    const py = chartTop + ((displayMax - value) / valRange) * chartH;
+    // Scrolled out of view — hide rather than clamp it to the edge.
+    const visible = px >= chartLeft - EXTREMA_CULL && px <= chartRight + EXTREMA_CULL;
+    return { px, py, visible };
+  });
+
+  // The dot sits EXACTLY on the data point (its center at px, py) — never
+  // clamped, so it always marks where the high / low occurred.
+  const dotStyle = useAnimatedStyle(() => {
+    const p = proj.get();
+    if (!p.visible) return { opacity: 0 };
+    return {
+      opacity: 1,
+      transform: [
+        { translateX: p.px - dotSizePx / 2 },
+        { translateY: p.py - dotSizePx / 2 },
+      ],
+    };
+  });
+
+  // The label is centered on the point but clamped into the plot width so it
+  // stays readable near an edge — independent of the dot, which stays on-point.
+  const labelStyle = useAnimatedStyle(() => {
+    const p = proj.get();
+    const s = size.get();
+    if (!p.visible) {
+      return { opacity: 0, transform: [{ translateX: 0 }, { translateY: 0 }] };
+    }
+    const cw = engine.canvasWidth.get();
+    const chartLeft = padding.left;
+    const chartRight = cw - padding.right;
+    const rightBound = chartRight - s.width;
+    const x = Math.min(
+      Math.max(p.px - s.width / 2, chartLeft),
+      Math.max(chartLeft, rightBound),
+    );
+    let y: number;
+    if (edgeAnchor) {
+      // Pin to the OUTERMOST edge (x stays aligned with the extremum): the top
+      // label rides the very top of the chart; the bottom label sits flush with
+      // the plot's bottom (clear of the x-axis below). The connector stops at the
+      // label, so the line never runs through the text.
+      const ch = engine.canvasHeight.get();
+      y =
+        side === "top"
+          ? EXTREMA_EDGE_INSET
+          : ch - padding.bottom - s.height;
+    } else {
+      // Sit just past the dot (max → above it, min → below it). With no dot (or a
+      // custom element), sit just past the point itself.
+      const gap = hasDot ? dotSizePx / 2 + EXTREMA_GAP : EXTREMA_GAP;
+      y = side === "top" ? p.py - gap - s.height : p.py + gap;
+    }
+    return { opacity: 1, transform: [{ translateX: x }, { translateY: y }] };
+  });
+
+  return (
+    <>
+      {hasDot && (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.extremaDot,
+            {
+              width: dotSizePx,
+              height: dotSizePx,
+              borderRadius: dotSizePx / 2,
+              backgroundColor: dotColor ?? color,
+            },
+            dotStyle,
+          ]}
+        />
+      )}
+      <Animated.View
+        pointerEvents="none"
+        onLayout={onLayout}
+        style={[styles.extremaAnchor, labelStyle]}
+      >
+        {isCustom ? (
+          render()
+        ) : (
+          <Text
+            style={[
+              styles.extremaText,
+              {
+                color,
+                // undefined keys fall back to the base style / RN defaults.
+                fontSize: font.fontSize,
+                fontWeight: font.fontWeight,
+                fontFamily: font.fontFamily,
+              },
+            ]}
+          >
+            {valueText}
+          </Text>
+        )}
+      </Animated.View>
+    </>
   );
 }
 
@@ -62,6 +335,10 @@ function BuiltInAxisValueLabel({
  * bounds — formatted with the config's `format` (falling back to the chart's
  * `formatValue`) in the config `color` (falling back to `defaultColor`).
  *
+ * When a side's `position` is `"extrema"` (and the engine exposes the live
+ * extrema), it instead floats at the actual data point where the high / low
+ * occurs via {@link ExtremaAxisLabel}.
+ *
  * Because the chart's `<View>` is the canvas size, the plot's top edge sits
  * `padding.top` px from the top and its bottom edge `padding.bottom` px from
  * the bottom — so positioning needs only the resolved padding (no live height,
@@ -75,59 +352,135 @@ export function AxisLabelOverlay({
   formatValue,
   defaultColor,
   padding,
+  extremaTimeOffset = 0,
 }: {
   topLabel: ResolvedAxisLabelConfig | null;
   bottomLabel: ResolvedAxisLabelConfig | null;
-  engine: ChartEngineLayout;
+  engine: ChartEngineLayout & Partial<ChartEngineExtrema>;
   formatValue: (v: number) => string;
   defaultColor: string;
   padding: ChartPadding;
+  /**
+   * Seconds added to each extremum time before projecting (for `"extrema"`
+   * labels). Half a candle width in candle mode so the dot aligns with the
+   * candle's drawn center; `0` (default) for line / multi-series.
+   */
+  extremaTimeOffset?: number;
 }) {
   if (!topLabel && !bottomLabel) return null;
+
+  // Both extrema modes need the engine's live extrema SharedValues; without them
+  // (e.g. an engine that doesn't track them) fall back to the edge label.
+  const topMode = topLabel?.position;
+  const bottomMode = bottomLabel?.position;
+  const topExtrema =
+    (topMode === "extrema" || topMode === "extrema-edge") &&
+    engine.extremaMaxTime != null &&
+    engine.extremaMaxValue != null;
+  const bottomExtrema =
+    (bottomMode === "extrema" || bottomMode === "extrema-edge") &&
+    engine.extremaMinTime != null &&
+    engine.extremaMinValue != null;
+
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="none">
-      {topLabel && (
-        <View
-          style={{
-            position: "absolute",
-            top: padding.top,
-            left: padding.left,
-            right: padding.right,
-          }}
-        >
-          {topLabel.render ? (
-            topLabel.render()
-          ) : (
-            <BuiltInAxisValueLabel
-              value={engine.displayMax}
-              format={topLabel.format ?? formatValue}
-              color={topLabel.color ?? defaultColor}
-              position={topLabel.position}
-            />
-          )}
-        </View>
-      )}
-      {bottomLabel && (
-        <View
-          style={{
-            position: "absolute",
-            bottom: padding.bottom,
-            left: padding.left,
-            right: padding.right,
-          }}
-        >
-          {bottomLabel.render ? (
-            bottomLabel.render()
-          ) : (
-            <BuiltInAxisValueLabel
-              value={engine.displayMin}
-              format={bottomLabel.format ?? formatValue}
-              color={bottomLabel.color ?? defaultColor}
-              position={bottomLabel.position}
-            />
-          )}
-        </View>
-      )}
+      {topLabel &&
+        (topExtrema ? (
+          <ExtremaAxisLabel
+            side="top"
+            timeSV={engine.extremaMaxTime!}
+            valueSV={engine.extremaMaxValue!}
+            timeOffset={extremaTimeOffset}
+            edgeAnchor={topMode === "extrema-edge"}
+            engine={engine}
+            padding={padding}
+            format={topLabel.format ?? formatValue}
+            color={topLabel.color ?? defaultColor}
+            font={labelFont(topLabel)}
+            dotColor={topLabel.dotColor}
+            dotSize={topLabel.dotSize}
+            dot={topLabel.dot}
+            render={topLabel.render ?? undefined}
+          />
+        ) : (
+          <View
+            style={{
+              position: "absolute",
+              top: padding.top,
+              left: padding.left,
+              right: padding.right,
+            }}
+          >
+            {topLabel.render ? (
+              topLabel.render()
+            ) : (
+              <BuiltInAxisValueLabel
+                value={engine.displayMax}
+                format={topLabel.format ?? formatValue}
+                color={topLabel.color ?? defaultColor}
+                position={topLabel.position}
+                font={labelFont(topLabel)}
+              />
+            )}
+          </View>
+        ))}
+      {bottomLabel &&
+        (bottomExtrema ? (
+          <ExtremaAxisLabel
+            side="bottom"
+            timeSV={engine.extremaMinTime!}
+            valueSV={engine.extremaMinValue!}
+            timeOffset={extremaTimeOffset}
+            edgeAnchor={bottomMode === "extrema-edge"}
+            engine={engine}
+            padding={padding}
+            format={bottomLabel.format ?? formatValue}
+            color={bottomLabel.color ?? defaultColor}
+            font={labelFont(bottomLabel)}
+            dotColor={bottomLabel.dotColor}
+            dotSize={bottomLabel.dotSize}
+            dot={bottomLabel.dot}
+            render={bottomLabel.render ?? undefined}
+          />
+        ) : (
+          <View
+            style={{
+              position: "absolute",
+              bottom: padding.bottom,
+              left: padding.left,
+              right: padding.right,
+            }}
+          >
+            {bottomLabel.render ? (
+              bottomLabel.render()
+            ) : (
+              <BuiltInAxisValueLabel
+                value={engine.displayMin}
+                format={bottomLabel.format ?? formatValue}
+                color={bottomLabel.color ?? defaultColor}
+                position={bottomLabel.position}
+                font={labelFont(bottomLabel)}
+              />
+            )}
+          </View>
+        ))}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  // top/left 0 + a measured transform places each piece over the point.
+  extremaAnchor: { position: "absolute", top: 0, left: 0, alignItems: "center" },
+  // The dot, pinned exactly on the data point (transform lands its center there).
+  // Size + radius are applied inline (configurable via `dotSize`).
+  extremaDot: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+  },
+  extremaText: {
+    fontSize: EXTREMA_LABEL_FONT_SIZE,
+    padding: 0,
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/packages/react-native-livechart/src/components/ExtremaConnectorOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ExtremaConnectorOverlay.tsx
@@ -1,0 +1,193 @@
+import { DashPathEffect, Path } from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type {
+  ResolvedAxisLabelConfig,
+  ResolvedLineStyleConfig,
+} from "../core/resolveConfig";
+import type {
+  ChartEngineExtrema,
+  ChartEngineLayout,
+} from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { usePathBuilder } from "../hooks/usePathBuilder";
+import { EXTREMA_EDGE_INSET, EXTREMA_LABEL_FONT_SIZE } from "./AxisLabelOverlay";
+
+/** How far off-plot (px) the extremum may sit before the connector is dropped. */
+const CONNECTOR_CULL = 24;
+/** Gap (px) between the connector's end and the value label. */
+const LABEL_GAP = 3;
+/** Single-line text height as a fraction of font size — a safe over-estimate, so
+ *  the connector stops just shy of the label rather than running under it. */
+const LABEL_HEIGHT_FACTOR = 1.5;
+
+/** Connector style + the label font size (to estimate where the label edge is). */
+export interface ResolvedConnector {
+  line: ResolvedLineStyleConfig;
+  fontSize: number;
+}
+
+/**
+ * The connector config for one axis-label side — non-null only when it's an
+ * `"extrema-edge"` label with its connector enabled. The line `color` defaults
+ * to the label color (then `defaultColor`), so the connector matches its readout.
+ */
+export function labelConnector(
+  cfg: ResolvedAxisLabelConfig | null,
+  defaultColor: string,
+): ResolvedConnector | null {
+  if (!cfg || cfg.position !== "extrema-edge" || !cfg.connector) return null;
+  return {
+    line: {
+      ...cfg.connector,
+      color: cfg.connector.color ?? cfg.color ?? defaultColor,
+    },
+    fontSize: cfg.fontSize ?? EXTREMA_LABEL_FONT_SIZE,
+  };
+}
+
+/** A single vertical connector from the edge value label down/up to its dot. */
+function ConnectorLine({
+  side,
+  timeSV,
+  valueSV,
+  timeOffset,
+  engine,
+  padding,
+  config,
+}: {
+  side: "top" | "bottom";
+  timeSV: SharedValue<number>;
+  valueSV: SharedValue<number>;
+  timeOffset: number;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  config: ResolvedConnector;
+}) {
+  const builder = usePathBuilder();
+  const { line, fontSize } = config;
+
+  const path = useDerivedValue(() => {
+    const b = builder.value;
+    const value = valueSV.get();
+    const time = timeSV.get();
+    const cw = engine.canvasWidth.get();
+    const ch = engine.canvasHeight.get();
+    const displayMin = engine.displayMin.get();
+    const displayMax = engine.displayMax.get();
+    const win = engine.displayWindow.get();
+    const ts = engine.timestamp.get();
+
+    const chartLeft = padding.left;
+    const chartRight = cw - padding.right;
+    const chartW = chartRight - chartLeft;
+    const chartTop = padding.top;
+    const chartBottom = ch - padding.bottom;
+    const chartH = chartBottom - chartTop;
+    const valRange = displayMax - displayMin;
+
+    if (
+      !Number.isFinite(value) ||
+      cw === 0 ||
+      ch === 0 ||
+      chartW <= 0 ||
+      chartH <= 0 ||
+      win <= 0 ||
+      valRange <= 0
+    ) {
+      return b.detach();
+    }
+
+    const winStart = ts - win;
+    const px = chartLeft + ((time + timeOffset - winStart) / win) * chartW;
+    // Off-plot (scrolled out) — emit nothing this frame.
+    if (px < chartLeft - CONNECTOR_CULL || px > chartRight + CONNECTOR_CULL) {
+      return b.detach();
+    }
+    const py = chartTop + ((displayMax - value) / valRange) * chartH;
+
+    // Stop the line just shy of the value label (which sits on the rail), not at
+    // the plot edge — so it never runs through the text. The label's inner edge
+    // is estimated from its font height (the label measures itself in RN; an
+    // over-estimate keeps a clean gap). Skip when the dot is inside the band.
+    const band = fontSize * LABEL_HEIGHT_FACTOR;
+    if (side === "top") {
+      const edgeY = EXTREMA_EDGE_INSET + band + LABEL_GAP;
+      if (py <= edgeY) return b.detach();
+      b.moveTo(px, edgeY);
+      b.lineTo(px, py);
+    } else {
+      const edgeY = chartBottom - band - LABEL_GAP;
+      if (py >= edgeY) return b.detach();
+      b.moveTo(px, py);
+      b.lineTo(px, edgeY);
+    }
+    return b.detach();
+  });
+
+  return (
+    <Path
+      path={path}
+      style="stroke"
+      strokeWidth={line.strokeWidth}
+      color={line.color}
+    >
+      {line.intervals ? <DashPathEffect intervals={line.intervals} /> : null}
+    </Path>
+  );
+}
+
+/**
+ * Skia connector lines for `"extrema-edge"` axis labels — a vertical line at the
+ * extremum's x joining its edge value label to the marker dot on the data point.
+ * Drawn in the canvas (so it dashes "like all lines"); the dot + label are RN
+ * overlays positioned with the same projection, so the three pieces line up. The
+ * line stops at the label edge, not the plot edge, so it never crosses the text.
+ *
+ * `top` / `bottom` are non-null only for a side in `"extrema-edge"` mode with its
+ * connector enabled.
+ */
+export function ExtremaConnectorOverlay({
+  engine,
+  padding,
+  extremaTimeOffset = 0,
+  top,
+  bottom,
+}: {
+  engine: ChartEngineLayout & Partial<ChartEngineExtrema>;
+  padding: ChartPadding;
+  extremaTimeOffset?: number;
+  top: ResolvedConnector | null;
+  bottom: ResolvedConnector | null;
+}) {
+  const hasTop = top != null && engine.extremaMaxTime != null;
+  const hasBottom = bottom != null && engine.extremaMinTime != null;
+  if (!hasTop && !hasBottom) return null;
+
+  return (
+    <>
+      {hasTop && (
+        <ConnectorLine
+          side="top"
+          timeSV={engine.extremaMaxTime!}
+          valueSV={engine.extremaMaxValue!}
+          timeOffset={extremaTimeOffset}
+          engine={engine}
+          padding={padding}
+          config={top!}
+        />
+      )}
+      {hasBottom && (
+        <ConnectorLine
+          side="bottom"
+          timeSV={engine.extremaMinTime!}
+          valueSV={engine.extremaMinValue!}
+          timeOffset={extremaTimeOffset}
+          engine={engine}
+          padding={padding}
+          config={bottom!}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -86,6 +86,10 @@ import {
   ThresholdLineOverlay,
 } from "./ThresholdLineOverlay";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
+import {
+  ExtremaConnectorOverlay,
+  labelConnector,
+} from "./ExtremaConnectorOverlay";
 import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
 import { CustomTooltipOverlay } from "./CustomTooltipOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
@@ -625,6 +629,9 @@ function useLiveChartController({
     lineProp,
     formatValue,
     isCandle,
+    // Half a candle width (seconds) so an "extrema" axis label's dot lands on the
+    // candle's drawn center, not its bucket-start (left) edge. 0 in line mode.
+    extremaTimeOffset: isCandle ? candleWidth / 2 : 0,
     // configs
     yAxisCfg,
     xAxisCfg,
@@ -700,6 +707,9 @@ function useLiveChartController({
     // RN axis edge labels (floated over the canvas as a sibling layer)
     topLabelCfg,
     bottomLabelCfg,
+    // Skia connector lines for "extrema-edge" labels (dot → edge readout).
+    topConnector: labelConnector(topLabelCfg, palette.gridLabel),
+    bottomConnector: labelConnector(bottomLabelCfg, palette.gridLabel),
   };
 }
 
@@ -1282,6 +1292,9 @@ export function LiveChart(props: LiveChartProps) {
     scrubCfg,
     crosshair,
     isCandle,
+    extremaTimeOffset,
+    topConnector,
+    bottomConnector,
   } = model;
 
   return (
@@ -1312,6 +1325,16 @@ export function LiveChart(props: LiveChartProps) {
           {/* Line stack above the fade so the line stays crisp at the left edge. */}
           <ChartStack model={model} />
 
+          {/* "extrema-edge" connector lines (dot → edge readout), above the chart
+              content so the dashed guide reads over the line / candles. */}
+          <ExtremaConnectorOverlay
+            engine={engine}
+            padding={effectivePadding}
+            extremaTimeOffset={extremaTimeOffset}
+            top={topConnector}
+            bottom={bottomConnector}
+          />
+
           {/* Reference-line badges + labels above the fade so they stay crisp. */}
           <ChartRefBadgeLayer model={model} />
 
@@ -1336,6 +1359,7 @@ export function LiveChart(props: LiveChartProps) {
           formatValue={formatValue}
           defaultColor={palette.gridLabel}
           padding={effectivePadding}
+          extremaTimeOffset={extremaTimeOffset}
         />
 
         {/* Custom-rendered markers — RN views floated over the canvas (non-Skia),

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -63,6 +63,10 @@ import {
 } from "../theme";
 import type { LiveChartSeriesProps, Marker, SeriesConfig } from "../types";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
+import {
+  ExtremaConnectorOverlay,
+  labelConnector,
+} from "./ExtremaConnectorOverlay";
 import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
 import { CrosshairLine } from "./CrosshairLine";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
@@ -395,6 +399,9 @@ function useLiveChartSeriesController({
     // RN axis edge labels (floated over the canvas as a sibling layer)
     topLabelCfg,
     bottomLabelCfg,
+    // Skia connector lines for "extrema-edge" labels (dot → edge readout).
+    topConnector: labelConnector(topLabelCfg, palette.gridLabel),
+    bottomConnector: labelConnector(bottomLabelCfg, palette.gridLabel),
   };
 }
 
@@ -654,6 +661,8 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     formatValue,
     topLabelCfg,
     bottomLabelCfg,
+    topConnector,
+    bottomConnector,
     markersActive,
     markersSV,
     renderMarker,
@@ -695,6 +704,15 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
         <View style={{ flex: 1 }} onLayout={onLayout}>
           <Canvas style={{ flex: 1, minHeight: layoutHeight || 1 }}>
             <SeriesChartStack model={model} />
+
+            {/* "extrema-edge" connector lines (dot → edge readout). Outside the
+                stack's degen-shake group so they track the (unshaken) RN dot. */}
+            <ExtremaConnectorOverlay
+              engine={engine}
+              padding={effectivePadding}
+              top={topConnector}
+              bottom={bottomConnector}
+            />
 
             {leftEdgeFadeCfg && (
               <LeftEdgeFade

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -9,6 +9,17 @@ export interface EngineTickMutable {
   displayMax: number;
   displayWindow: number;
   timestamp: number;
+  /**
+   * Value + time of the lowest / highest data point in the visible window —
+   * the actual extrema, NOT the smoothed display bounds (which carry margin and
+   * fold in the live value / reference lines). `NaN` when the window holds no
+   * data. Used to float `topLabel` / `bottomLabel` at their occurrence point
+   * (see {@link AxisLabelConfig.position} `"extrema"`).
+   */
+  extremaMinValue: number;
+  extremaMaxValue: number;
+  extremaMinTime: number;
+  extremaMaxTime: number;
 }
 
 export interface EngineTickInput {
@@ -93,6 +104,12 @@ export function tickLiveChartEngineFrame(
 
   let tMin = Infinity;
   let tMax = -Infinity;
+  // Time of the running min / max — captured alongside the value so an extrema
+  // label can be pinned at the point's x. Holds the data extrema only (folded
+  // below with the live value / references for the Y range, but snapshotted
+  // before that into `extrema*` so the label tracks the real high/low).
+  let minTime = 0;
+  let maxTime = 0;
 
   if (input.mode === "candle") {
     const candles = input.candles;
@@ -107,17 +124,29 @@ export function tickLiveChartEngineFrame(
       for (let i = lo; i < candles.length; i++) {
         if (candles[i].time > state.timestamp) break;
         /* istanbul ignore next -- trivial min/max */
-        if (candles[i].low < tMin) tMin = candles[i].low;
+        if (candles[i].low < tMin) {
+          tMin = candles[i].low;
+          minTime = candles[i].time;
+        }
         /* istanbul ignore next -- trivial min/max */
-        if (candles[i].high > tMax) tMax = candles[i].high;
+        if (candles[i].high > tMax) {
+          tMax = candles[i].high;
+          maxTime = candles[i].time;
+        }
       }
     }
     const lc = input.liveCandle;
     if (lc) {
       /* istanbul ignore next -- trivial min/max */
-      if (lc.low < tMin) tMin = lc.low;
+      if (lc.low < tMin) {
+        tMin = lc.low;
+        minTime = lc.time;
+      }
       /* istanbul ignore next -- trivial min/max */
-      if (lc.high > tMax) tMax = lc.high;
+      if (lc.high > tMax) {
+        tMax = lc.high;
+        maxTime = lc.time;
+      }
     }
   } else {
     const points = input.points;
@@ -130,10 +159,26 @@ export function tickLiveChartEngineFrame(
     }
     for (let i = lo; i < points.length; i++) {
       const v = points[i].value;
-      if (v < tMin) tMin = v;
-      if (v > tMax) tMax = v;
+      if (v < tMin) {
+        tMin = v;
+        minTime = points[i].time;
+      }
+      if (v > tMax) {
+        tMax = v;
+        maxTime = points[i].time;
+      }
     }
   }
+
+  // Snapshot the raw data extrema (value + time) before the live value /
+  // reference values fold into tMin/tMax for the Y range. NaN when the window
+  // is empty so the extrema label hides rather than pinning to a fake point.
+  const hasMin = tMin !== Infinity;
+  const hasMax = tMax !== -Infinity;
+  state.extremaMinValue = hasMin ? tMin : NaN;
+  state.extremaMaxValue = hasMax ? tMax : NaN;
+  state.extremaMinTime = hasMin ? minTime : NaN;
+  state.extremaMaxTime = hasMax ? maxTime : NaN;
 
   const cv = state.displayValue;
   if (cv < tMin) tMin = cv;

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -9,6 +9,16 @@ export interface MultiEngineTickMutable {
   timestamp: number;
   displayValues: number[];
   opacities: number[];
+  /**
+   * Value + time of the lowest / highest point across the visible series — the
+   * actual extrema, NOT the smoothed display bounds. `NaN` when no visible
+   * series has data in the window. Used to float `topLabel` / `bottomLabel` at
+   * their occurrence point (see {@link AxisLabelConfig.position} `"extrema"`).
+   */
+  extremaMinValue: number;
+  extremaMaxValue: number;
+  extremaMinTime: number;
+  extremaMaxTime: number;
 }
 
 export interface MultiEngineTickInput {
@@ -95,6 +105,13 @@ export function tickLiveChartSeriesEngineFrame(
 
   let tMin = Infinity;
   let tMax = -Infinity;
+  // Time of the running global min / max data point — captured so an extrema
+  // label can be pinned at its x (data extrema only; the live tips folded below
+  // into the Y range are snapshotted out before that).
+  let minTime = 0;
+  let maxTime = 0;
+  let dataMin = Infinity;
+  let dataMax = -Infinity;
 
   for (let i = 0; i < n; i++) {
     if (series[i].visible === false) continue;
@@ -112,11 +129,28 @@ export function tickLiveChartSeriesEngineFrame(
       if (v < tMin) tMin = v;
       /* istanbul ignore next -- trivial min/max */
       if (v > tMax) tMax = v;
+      if (v < dataMin) {
+        dataMin = v;
+        minTime = points[j].time;
+      }
+      if (v > dataMax) {
+        dataMax = v;
+        maxTime = points[j].time;
+      }
     }
     const cv = state.displayValues[i];
     if (cv < tMin) tMin = cv;
     if (cv > tMax) tMax = cv;
   }
+
+  // Snapshot the raw data extrema before the references fold in. NaN when no
+  // visible series has data in the window so the extrema label hides.
+  const hasMin = dataMin !== Infinity;
+  const hasMax = dataMax !== -Infinity;
+  state.extremaMinValue = hasMin ? dataMin : NaN;
+  state.extremaMaxValue = hasMax ? dataMax : NaN;
+  state.extremaMinTime = hasMin ? minTime : NaN;
+  state.extremaMaxTime = hasMax ? maxTime : NaN;
 
   const ref = input.referenceValue;
   if (ref !== undefined) {

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -10,6 +10,7 @@ import type {
   LeftEdgeFadeConfig,
   LegendConfig,
   LegendStyle,
+  LineStyleConfig,
   LiveChartMetrics,
   LiveChartMetricsOverride,
   DotConfig,
@@ -61,12 +62,35 @@ export interface ResolvedYAxisConfig {
   minGap: number;
 }
 
+/** Resolved straight-line styling (connector, etc.). `color: undefined` → caller default. */
+export interface ResolvedLineStyleConfig {
+  color: string | undefined;
+  strokeWidth: number;
+  /** undefined → solid (no dash). */
+  intervals: [number, number] | undefined;
+}
+
 export interface ResolvedAxisLabelConfig {
   /** undefined → use the chart's `formatValue` at render time. */
   format?: (v: number) => string;
   /** undefined → use the muted default label color at render time. */
   color?: string;
-  position: "left" | "right";
+  /** `"left"`/`"right"` pin to that edge; `"extrema"`(-`edge`) tracks the data point. */
+  position: "left" | "right" | "extrema" | "extrema-edge";
+  /** undefined → the built-in default text size (11). */
+  fontSize?: number;
+  /** undefined → the platform `<Text>` default weight. */
+  fontWeight?: FontWeight;
+  /** undefined → the platform `<Text>` default family. */
+  fontFamily?: string;
+  /** Extrema dot color; undefined → use `color`. */
+  dotColor?: string;
+  /** Extrema dot diameter (px); undefined → the built-in default (7). */
+  dotSize?: number;
+  /** Extrema — whether to draw the marker dot. */
+  dot: boolean;
+  /** `"extrema-edge"` connector line (dot → edge label); null → none. */
+  connector: ResolvedLineStyleConfig | null;
   /** When set, the built-in value label is replaced by this custom element. */
   render?: () => ReactElement | null;
 }
@@ -333,18 +357,65 @@ const AXIS_LABEL_DEFAULTS: ResolvedAxisLabelConfig = {
   format: undefined,
   color: undefined,
   position: "right",
+  fontSize: undefined,
+  fontWeight: undefined,
+  fontFamily: undefined,
+  dotColor: undefined,
+  dotSize: undefined,
+  dot: true,
+  // Always overwritten by resolveAxisLabel (per-position default-on); placeholder.
+  connector: null,
   render: undefined,
 };
+
+/** Dashed by default — a subtle guide tying the extrema dot to its edge label. */
+const CONNECTOR_DEFAULTS: ResolvedLineStyleConfig = {
+  color: undefined,
+  strokeWidth: 1,
+  intervals: [2, 3],
+};
+
+/**
+ * Resolves the extrema-label `connector` sub-prop to a line style or null.
+ * `defaultOn` (true in `"extrema-edge"` mode) means an unset connector draws the
+ * dashed default; `false` → null; an object → merged; a `LineStyleConfig` is
+ * normalized (its `intervals` may be omitted for a solid line).
+ */
+export function resolveConnector(
+  prop: boolean | LineStyleConfig | undefined,
+  defaultOn: boolean,
+): ResolvedLineStyleConfig | null {
+  if (prop === false) return null;
+  if (prop == null) return defaultOn ? CONNECTOR_DEFAULTS : null;
+  if (prop === true) return CONNECTOR_DEFAULTS;
+  return {
+    color: prop.color,
+    strokeWidth: prop.strokeWidth ?? CONNECTOR_DEFAULTS.strokeWidth,
+    // An explicit object opts into its own dash (or solid when omitted).
+    intervals: prop.intervals,
+  };
+}
 
 /**
  * Resolves a `topLabel` / `bottomLabel` prop to a fully-typed config or null
  * (no label). Opt-in, so `undefined`/`false` → null; `true` → the built-in
  * value label with defaults; object → configured built-in (or a custom `render`).
+ * The `connector` defaults on (dashed) in `"extrema-edge"` mode, else off.
  */
 export function resolveAxisLabel(
   prop: boolean | AxisLabelConfig | undefined,
 ): ResolvedAxisLabelConfig | null {
-  return resolveToggle(prop, AXIS_LABEL_DEFAULTS, false);
+  const resolved = resolveToggle(prop, AXIS_LABEL_DEFAULTS, false);
+  if (!resolved) return null;
+  const connectorProp =
+    typeof prop === "object" ? prop.connector : undefined;
+  return {
+    ...resolved,
+    connector: resolveConnector(
+      connectorProp,
+      resolved.position === "extrema-edge",
+    ),
+  };
 }
 
 const X_AXIS_DEFAULTS: ResolvedXAxisConfig = {

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -63,13 +63,26 @@ export interface ChartEngineLayout {
   timestamp: SharedValue<number>;
 }
 
-export interface SingleEngineState extends ChartEngineLayout {
+/**
+ * Live extrema (value + time of the lowest / highest data point in the visible
+ * window) — the raw data high/low, not the smoothed display bounds. Each field
+ * is `NaN` when the window holds no data. Provided by both engines so an
+ * `"extrema"`-positioned `topLabel` / `bottomLabel` can be pinned at the point.
+ */
+export interface ChartEngineExtrema {
+  extremaMinValue: SharedValue<number>;
+  extremaMaxValue: SharedValue<number>;
+  extremaMinTime: SharedValue<number>;
+  extremaMaxTime: SharedValue<number>;
+}
+
+export interface SingleEngineState extends ChartEngineLayout, ChartEngineExtrema {
   data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   displayValue: SharedValue<number>;
 }
 
-export interface MultiEngineState extends ChartEngineLayout {
+export interface MultiEngineState extends ChartEngineLayout, ChartEngineExtrema {
   data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
   displayValue: SharedValue<number>;
@@ -109,6 +122,10 @@ export interface EngineFrameRefs {
   modeSV: SharedValue<"line" | "candle">;
   candles?: SharedValue<CandlePoint[]>;
   liveCandle?: SharedValue<CandlePoint | null>;
+  extremaMinValue: SharedValue<number>;
+  extremaMaxValue: SharedValue<number>;
+  extremaMinTime: SharedValue<number>;
+  extremaMaxTime: SharedValue<number>;
 }
 
 /**
@@ -127,6 +144,10 @@ export function applyLiveChartEngineFrame(
     displayMax: sv.displayMax.value,
     displayWindow: sv.displayWindow.value,
     timestamp: sv.timestamp.value,
+    extremaMinValue: sv.extremaMinValue.value,
+    extremaMaxValue: sv.extremaMaxValue.value,
+    extremaMinTime: sv.extremaMinTime.value,
+    extremaMaxTime: sv.extremaMaxTime.value,
   };
   tickLiveChartEngineFrame(state, {
     dt,
@@ -155,6 +176,10 @@ export function applyLiveChartEngineFrame(
   sv.displayMax.value = state.displayMax;
   sv.displayWindow.value = state.displayWindow;
   sv.timestamp.value = state.timestamp;
+  sv.extremaMinValue.value = state.extremaMinValue;
+  sv.extremaMaxValue.value = state.extremaMaxValue;
+  sv.extremaMinTime.value = state.extremaMinTime;
+  sv.extremaMaxTime.value = state.extremaMaxTime;
 }
 
 export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
@@ -186,6 +211,13 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   // Seed once; overwritten by the frame callback on the first tick.
   const [initialTimestamp] = useState(() => Date.now() / 1000);
   const timestamp = useSharedValue(initialTimestamp);
+
+  // Live data extrema (value + time of the visible high / low). NaN until the
+  // first tick finds data — the extrema label stays hidden until then.
+  const extremaMinValue = useSharedValue(NaN);
+  const extremaMaxValue = useSharedValue(NaN);
+  const extremaMinTime = useSharedValue(NaN);
+  const extremaMaxTime = useSharedValue(NaN);
 
   // High-frequency data reads directly from the caller's shared values —
   // no useDerivedValue bridging, no closure serialization per tick.
@@ -221,6 +253,10 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
     modeSV,
     candles,
     liveCandle,
+    extremaMinValue,
+    extremaMaxValue,
+    extremaMinTime,
+    extremaMaxTime,
   };
 
   // `autostart=false` registers the frame callback without running it — the live
@@ -271,5 +307,9 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
     canvasWidth,
     canvasHeight,
     timestamp,
+    extremaMinValue,
+    extremaMaxValue,
+    extremaMinTime,
+    extremaMaxTime,
   };
 }

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -47,6 +47,10 @@ export interface MultiEngineFrameRefs {
   nowOverrideSV?: SharedValue<number | undefined>;
   windowBufferSV?: SharedValue<number>;
   pausedSV: SharedValue<boolean>;
+  extremaMinValue: SharedValue<number>;
+  extremaMaxValue: SharedValue<number>;
+  extremaMinTime: SharedValue<number>;
+  extremaMaxTime: SharedValue<number>;
 }
 
 /**
@@ -103,6 +107,10 @@ export function applyLiveChartSeriesEngineFrame(
     timestamp: sv.timestamp.value,
     displayValues,
     opacities,
+    extremaMinValue: sv.extremaMinValue.value,
+    extremaMaxValue: sv.extremaMaxValue.value,
+    extremaMinTime: sv.extremaMinTime.value,
+    extremaMaxTime: sv.extremaMaxTime.value,
   };
   tickLiveChartSeriesEngineFrame(state, {
     dt,
@@ -128,6 +136,10 @@ export function applyLiveChartSeriesEngineFrame(
   sv.timestamp.value = state.timestamp;
   sv.displaySeriesValues.value = state.displayValues;
   sv.seriesOpacities.value = state.opacities;
+  sv.extremaMinValue.value = state.extremaMinValue;
+  sv.extremaMaxValue.value = state.extremaMaxValue;
+  sv.extremaMinTime.value = state.extremaMinTime;
+  sv.extremaMaxTime.value = state.extremaMaxTime;
 }
 
 /**
@@ -160,6 +172,12 @@ export function useLiveChartSeriesEngine(
 
   const displaySeriesValues = useSharedValue<number[]>([]);
   const seriesOpacities = useSharedValue<number[]>([]);
+
+  // Live data extrema (value + time of the visible high / low across series).
+  const extremaMinValue = useSharedValue(NaN);
+  const extremaMaxValue = useSharedValue(NaN);
+  const extremaMinTime = useSharedValue(NaN);
+  const extremaMaxTime = useSharedValue(NaN);
 
   const data = useSharedValue<LiveChartPoint[]>([]);
   const value = useSharedValue(0);
@@ -199,6 +217,10 @@ export function useLiveChartSeriesEngine(
         nowOverrideSV,
         windowBufferSV,
         pausedSV,
+        extremaMinValue,
+        extremaMaxValue,
+        extremaMinTime,
+        extremaMaxTime,
       },
       scratch,
     );
@@ -218,5 +240,9 @@ export function useLiveChartSeriesEngine(
     series,
     displaySeriesValues,
     seriesOpacities,
+    extremaMinValue,
+    extremaMaxValue,
+    extremaMinTime,
+    extremaMaxTime,
   };
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -228,6 +228,20 @@ export interface ValueLineConfig {
   color?: string;
 }
 
+/**
+ * Shared styling for a simple straight line — color, thickness, and an optional
+ * dash. The common shape behind the chart's secondary lines (the `valueLine`,
+ * the extrema-label `connector`, etc.), so they configure the same way.
+ */
+export interface LineStyleConfig {
+  /** Line color. Defaults per usage (e.g. the connector uses the label color). */
+  color?: string;
+  /** Line thickness in pixels. Default `1`. */
+  strokeWidth?: number;
+  /** Dash pattern as `[dashLength, gapLength]` in pixels. Omit for a solid line. */
+  intervals?: [number, number];
+}
+
 /** Main chart line styling. */
 export interface LineConfig {
   /** Stroke width of the main line in pixels. Default `2`. */
@@ -356,9 +370,52 @@ export interface AxisLabelConfig {
   format?: (v: number) => string;
   /** Text color. Defaults to a muted label color (`palette.gridLabel`). */
   color?: string;
-  /** Horizontal alignment within the plot width. Default `"right"`. */
-  position?: "left" | "right";
-  /** Full custom element, floated at the edge. Overrides the built-in value label. */
+  /**
+   * Where the label sits.
+   * - `"left"` / `"right"` (default `"right"`) — pin to that edge of the plot,
+   *   horizontally aligned.
+   * - `"extrema"` — float at the **actual data point** where the value occurs
+   *   (`topLabel` tracks the highest point, `bottomLabel` the lowest), anchored
+   *   over the point with a marker dot, so you can see *when* the high / low
+   *   happened. The dot and label track the point on the UI thread.
+   * - `"extrema-edge"` — like `"extrema"`, but the value label is pinned to the
+   *   **top / bottom edge**, horizontally aligned with the extremum (not floated
+   *   over the point). The marker dot still sits on the data point, joined to the
+   *   edge label by a {@link AxisLabelConfig.connector} line. Keeps the readout on
+   *   a clean rail while still showing where the extremum is.
+   */
+  position?: "left" | "right" | "extrema" | "extrema-edge";
+  /** Built-in value text size in px. Default `11`. */
+  fontSize?: number;
+  /** Built-in value text weight. Default the platform `<Text>` default. */
+  fontWeight?: FontWeight;
+  /** Built-in value text font family (e.g. a loaded monospace face). */
+  fontFamily?: string;
+  /**
+   * Extrema modes only — color of the marker dot at the data point. Defaults to
+   * `color`. Lets the dot and the value text differ.
+   */
+  dotColor?: string;
+  /** Extrema modes only — marker dot diameter in px. Default `7`. */
+  dotSize?: number;
+  /**
+   * Extrema modes only — draw the marker dot at the data point. Default `true`.
+   * Set `false` for a value label with no dot.
+   */
+  dot?: boolean;
+  /**
+   * `"extrema-edge"` only — the line joining the marker dot (on the data point)
+   * to the edge value label. `true` = a dashed default, `false` = none, or pass a
+   * {@link LineStyleConfig} to style it (`color` defaults to the label `color`).
+   * Default on (dashed) in `"extrema-edge"` mode.
+   */
+  connector?: boolean | LineStyleConfig;
+  /**
+   * Full custom element, floated at the edge (or, in an extrema mode, centered
+   * over the extremum point). Overrides the built-in value label (and the
+   * `fontSize` / `fontWeight` / `fontFamily` / `dot*` knobs above — you own the
+   * styling).
+   */
   render?: () => ReactElement | null;
 }
 

--- a/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
@@ -1,15 +1,19 @@
-import { render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 import React from "react";
 import { Text, TextInput } from "react-native";
 
 import { AxisLabelOverlay } from "../../src/components/AxisLabelOverlay";
 import type { ResolvedAxisLabelConfig } from "../../src/core/resolveConfig";
-import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import type {
+  ChartEngineExtrema,
+  ChartEngineLayout,
+} from "../../src/core/useLiveChartEngine";
 import { DEFAULT_PADDING } from "../../src/draw/line";
+
+const sv = <T,>(value: T) => ({ value, get: () => value }) as never;
 
 /** A minimal engine stub: only displayMax/displayMin are read by the overlay. */
 function makeEngine(max = 120, min = 80): ChartEngineLayout {
-  const sv = <T,>(value: T) => ({ value, get: () => value }) as never;
   return {
     displayMax: sv(max),
     displayMin: sv(min),
@@ -17,13 +21,42 @@ function makeEngine(max = 120, min = 80): ChartEngineLayout {
     timeWindow: sv(30),
     canvasWidth: sv(300),
     canvasHeight: sv(200),
-    timestamp: sv(0),
+    timestamp: sv(1000),
+  };
+}
+
+/** Engine stub that also exposes the live extrema (for `"extrema"` labels). */
+function makeExtremaEngine(
+  over: Partial<{
+    maxValue: number;
+    maxTime: number;
+    minValue: number;
+    minTime: number;
+  }> = {},
+): ChartEngineLayout & ChartEngineExtrema {
+  const {
+    maxValue = 115,
+    maxTime = 985,
+    minValue = 85,
+    minTime = 990,
+  } = over;
+  return {
+    ...makeEngine(),
+    extremaMaxValue: sv(maxValue),
+    extremaMaxTime: sv(maxTime),
+    extremaMinValue: sv(minValue),
+    extremaMinTime: sv(minTime),
   };
 }
 
 const builtIn = (
   over: Partial<ResolvedAxisLabelConfig> = {},
-): ResolvedAxisLabelConfig => ({ position: "right", ...over });
+): ResolvedAxisLabelConfig => ({
+  position: "right",
+  dot: true,
+  connector: null,
+  ...over,
+});
 
 const fmt = (v: number) => v.toFixed(2);
 
@@ -100,5 +133,190 @@ describe("AxisLabelOverlay", () => {
     );
     expect(screen.getByText("LOW")).toBeTruthy();
     expect(screen.queryByText("HIGH")).toBeNull();
+  });
+
+  describe('position: "extrema"', () => {
+    it("floats the built-in top + bottom labels at the extrema points", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema" })}
+          bottomLabel={builtIn({ position: "extrema" })}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      // No animated TextInput in extrema mode — the value rides a plain <Text>.
+      expect(screen.UNSAFE_queryAllByType(TextInput)).toHaveLength(0);
+      // Mounts both anchors; the value text is empty until the reaction fires.
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it("drives onLayout to measure + center the extrema box", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({
+            position: "extrema",
+            render: () => <Text testID="peak">PEAK</Text>,
+          })}
+          bottomLabel={null}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      // The element's parent is the measured Animated.View anchor (onLayout).
+      fireEvent(screen.getByTestId("peak").parent!, "layout", {
+        nativeEvent: { layout: { x: 0, y: 0, width: 50, height: 24 } },
+      });
+      expect(screen.getByTestId("peak")).toBeTruthy();
+    });
+
+    it("renders a custom element at the extrema point", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({
+            position: "extrema",
+            render: () => <Text>PEAK</Text>,
+          })}
+          bottomLabel={builtIn({
+            position: "extrema",
+            render: () => <Text>VALLEY</Text>,
+          })}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.getByText("PEAK")).toBeTruthy();
+      expect(screen.getByText("VALLEY")).toBeTruthy();
+    });
+
+    it("stays mounted (hidden) when the extremum value is NaN", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema" })}
+          bottomLabel={builtIn({ position: "extrema" })}
+          engine={makeExtremaEngine({ maxValue: NaN, minValue: NaN })}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it("hides when the extremum point has scrolled off-plot", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema" })}
+          bottomLabel={null}
+          // maxTime far before the window start → projected x is off the plot.
+          engine={makeExtremaEngine({ maxTime: -10_000 })}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it("falls back to the edge label when the engine lacks extrema", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema" })}
+          bottomLabel={null}
+          engine={makeEngine()} // no extrema SharedValues
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      // Edge fallback renders the animated value TextInput.
+      expect(screen.UNSAFE_getAllByType(TextInput)).toHaveLength(1);
+    });
+
+    it("honors custom dotSize / dotColor and font knobs", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({
+            position: "extrema",
+            dotSize: 12,
+            dotColor: "#f0f",
+            fontSize: 16,
+            fontWeight: "700",
+            fontFamily: "JetBrainsMono",
+          })}
+          bottomLabel={null}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it('pins the value label to the edge in "extrema-edge" mode', () => {
+      // The dot stays on the point; only the value text moves to the edge.
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema-edge" })}
+          bottomLabel={builtIn({ position: "extrema-edge" })}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it("applies extremaTimeOffset (candle-center alignment)", () => {
+      // Half a candle width shifts the dot from the bucket-start to the center.
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema" })}
+          bottomLabel={builtIn({ position: "extrema" })}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+          extremaTimeOffset={7.5}
+        />,
+      );
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it("omits the marker dot when dot is false (value text only)", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ position: "extrema", dot: false })}
+          bottomLabel={null}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.toJSON()).toBeTruthy();
+    });
+
+    it("applies font knobs to the edge (non-extrema) label too", () => {
+      const screen = render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ fontSize: 18, fontWeight: "600" })}
+          bottomLabel={null}
+          engine={makeEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.UNSAFE_getAllByType(TextInput)).toHaveLength(1);
+    });
   });
 });

--- a/packages/react-native-livechart/tests/components/ExtremaConnectorOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ExtremaConnectorOverlay.test.tsx
@@ -1,0 +1,166 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+import {
+  ExtremaConnectorOverlay,
+  labelConnector,
+  type ResolvedConnector,
+} from "../../src/components/ExtremaConnectorOverlay";
+import type { ResolvedAxisLabelConfig } from "../../src/core/resolveConfig";
+import type {
+  ChartEngineExtrema,
+  ChartEngineLayout,
+} from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+
+const sv = <T,>(value: T) => ({ value, get: () => value }) as never;
+
+function makeEngine(
+  over: Partial<{
+    maxValue: number;
+    maxTime: number;
+    minValue: number;
+    minTime: number;
+  }> = {},
+): ChartEngineLayout & ChartEngineExtrema {
+  const { maxValue = 115, maxTime = 985, minValue = 85, minTime = 990 } = over;
+  return {
+    displayMax: sv(120),
+    displayMin: sv(80),
+    displayWindow: sv(30),
+    timeWindow: sv(30),
+    canvasWidth: sv(300),
+    canvasHeight: sv(200),
+    timestamp: sv(1000),
+    extremaMaxValue: sv(maxValue),
+    extremaMaxTime: sv(maxTime),
+    extremaMinValue: sv(minValue),
+    extremaMinTime: sv(minTime),
+  };
+}
+
+const dashed: ResolvedConnector = {
+  line: { color: "#34d399", strokeWidth: 1, intervals: [2, 3] },
+  fontSize: 11,
+};
+const solid: ResolvedConnector = {
+  line: { color: "#f87171", strokeWidth: 2, intervals: undefined },
+  fontSize: 14,
+};
+
+describe("ExtremaConnectorOverlay", () => {
+  it("renders dashed + solid connectors for top and bottom", () => {
+    const screen = render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine()}
+        padding={DEFAULT_PADDING}
+        top={dashed}
+        bottom={solid}
+      />,
+    );
+    expect(screen.toJSON()).toBeTruthy();
+  });
+
+  it("returns null when neither side has a connector", () => {
+    const screen = render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine()}
+        padding={DEFAULT_PADDING}
+        top={null}
+        bottom={null}
+      />,
+    );
+    expect(screen.toJSON()).toBeNull();
+  });
+
+  it("builds an empty path when the extremum is NaN or off-plot", () => {
+    // NaN value (no data) and an off-plot time both early-out in the worklet.
+    const nan = render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine({ maxValue: NaN })}
+        padding={DEFAULT_PADDING}
+        top={dashed}
+        bottom={null}
+      />,
+    );
+    expect(nan.toJSON()).toBeTruthy();
+
+    const offPlot = render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine({ maxTime: -10_000 })}
+        padding={DEFAULT_PADDING}
+        top={dashed}
+        bottom={null}
+      />,
+    );
+    expect(offPlot.toJSON()).toBeTruthy();
+  });
+
+  it("applies the candle-center time offset without throwing", () => {
+    const screen = render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine()}
+        padding={DEFAULT_PADDING}
+        extremaTimeOffset={7.5}
+        top={dashed}
+        bottom={solid}
+      />,
+    );
+    expect(screen.toJSON()).toBeTruthy();
+  });
+
+  it("skips the line when the dot is inside the label band", () => {
+    // High hugs the top rail (within the label band) → no top line drawn; low
+    // sits mid-plot → the bottom line draws. Exercises both worklet branches.
+    const screen = render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine({ maxValue: 119.5, minValue: 100 })}
+        padding={DEFAULT_PADDING}
+        top={dashed}
+        bottom={solid}
+      />,
+    );
+    expect(screen.toJSON()).toBeTruthy();
+  });
+});
+
+describe("labelConnector", () => {
+  const base: ResolvedAxisLabelConfig = {
+    position: "extrema-edge",
+    dot: true,
+    connector: { color: undefined, strokeWidth: 1, intervals: [2, 3] },
+  };
+
+  it("returns null for a null config", () => {
+    expect(labelConnector(null, "#888")).toBeNull();
+  });
+
+  it("returns null when not in extrema-edge mode", () => {
+    expect(labelConnector({ ...base, position: "extrema" }, "#888")).toBeNull();
+  });
+
+  it("returns null when the connector is disabled", () => {
+    expect(labelConnector({ ...base, connector: null }, "#888")).toBeNull();
+  });
+
+  it("defaults the connector color to the label color, then defaultColor", () => {
+    // No connector color, no label color → defaultColor.
+    expect(labelConnector(base, "#888")?.line.color).toBe("#888");
+    // Label color wins over defaultColor.
+    expect(labelConnector({ ...base, color: "#0f0" }, "#888")?.line.color).toBe(
+      "#0f0",
+    );
+    // Explicit connector color wins over everything.
+    expect(
+      labelConnector(
+        { ...base, color: "#0f0", connector: { ...base.connector!, color: "#abc" } },
+        "#888",
+      )?.line.color,
+    ).toBe("#abc");
+  });
+
+  it("carries the label font size (for the label-edge estimate)", () => {
+    expect(labelConnector(base, "#888")?.fontSize).toBe(11); // default
+    expect(labelConnector({ ...base, fontSize: 18 }, "#888")?.fontSize).toBe(18);
+  });
+});

--- a/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
@@ -52,6 +52,10 @@ function EngineHarness({
   const canvasWidthSV = useSharedValue(canvasWidth);
   const canvasHeightSV = useSharedValue(canvasHeight);
   const timestampSV = useSharedValue(1_700_000_000);
+  const extremaMinValueSV = useSharedValue(NaN);
+  const extremaMaxValueSV = useSharedValue(NaN);
+  const extremaMinTimeSV = useSharedValue(NaN);
+  const extremaMaxTimeSV = useSharedValue(NaN);
 
   const engine: MultiEngineState = {
     data,
@@ -67,6 +71,10 @@ function EngineHarness({
     canvasWidth: canvasWidthSV,
     canvasHeight: canvasHeightSV,
     timestamp: timestampSV,
+    extremaMinValue: extremaMinValueSV,
+    extremaMaxValue: extremaMaxValueSV,
+    extremaMinTime: extremaMinTimeSV,
+    extremaMaxTime: extremaMaxTimeSV,
   };
 
   const lineColors = colors ?? series.map((s) => s.color ?? "#888888");

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -7,6 +7,10 @@ function baseState() {
     displayMax: 1,
     displayWindow: 30,
     timestamp: 1000,
+    extremaMinValue: NaN,
+    extremaMaxValue: NaN,
+    extremaMinTime: NaN,
+    extremaMaxTime: NaN,
   };
 }
 
@@ -197,11 +201,10 @@ describe("tickLiveChartEngineFrame", () => {
 
   it("snaps displayMin down when tMin is below", () => {
     const s = {
+      ...baseState(),
       displayValue: 50,
       displayMin: 40,
       displayMax: 60,
-      displayWindow: 30,
-      timestamp: 1000,
     };
     tickLiveChartEngineFrame(s, {
       dt: 16.67,
@@ -223,11 +226,10 @@ describe("tickLiveChartEngineFrame", () => {
 
   it("snaps displayMax up when tMax is above", () => {
     const s = {
+      ...baseState(),
       displayValue: 50,
       displayMin: 40,
       displayMax: 55,
-      displayWindow: 30,
-      timestamp: 1000,
     };
     tickLiveChartEngineFrame(s, {
       dt: 16.67,
@@ -365,11 +367,10 @@ describe("tickLiveChartEngineFrame", () => {
 
   it("handles reference line below computed range", () => {
     const s = {
+      ...baseState(),
       displayValue: 10,
       displayMin: 0,
       displayMax: 20,
-      displayWindow: 30,
-      timestamp: 1000,
     };
     tickLiveChartEngineFrame(s, {
       dt: 16.67,
@@ -499,6 +500,100 @@ describe("tickLiveChartEngineFrame", () => {
     });
     expect(s.displayWindow).toBeGreaterThan(30);
     expect(s.displayWindow).toBeLessThan(60);
+  });
+
+  // ── Extrema tracking (for "extrema"-positioned axis labels) ──────────────
+  describe("extrema tracking", () => {
+    it("records the value + time of the lowest and highest point (line mode)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.2,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 30,
+        points: [
+          { time: 980, value: 30 },
+          { time: 985, value: 10 }, // the low
+          { time: 990, value: 55 }, // the high
+          { time: 995, value: 40 },
+        ],
+        nowSeconds: 1000,
+      });
+      expect(s.extremaMinValue).toBe(10);
+      expect(s.extremaMinTime).toBe(985);
+      expect(s.extremaMaxValue).toBe(55);
+      expect(s.extremaMaxTime).toBe(990);
+    });
+
+    it("ignores the live value / reference when picking extrema", () => {
+      const s = { ...baseState(), displayValue: 999 };
+      tickLiveChartEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.2,
+        exaggerate: false,
+        referenceValue: -999,
+        targetValue: 50,
+        points: [{ time: 990, value: 42 }],
+        nowSeconds: 1000,
+      });
+      // The display value (999) and reference (-999) widen the Y range but are
+      // NOT data points, so the extrema stay on the single real point.
+      expect(s.extremaMinValue).toBe(42);
+      expect(s.extremaMaxValue).toBe(42);
+      expect(s.extremaMinTime).toBe(990);
+      expect(s.extremaMaxTime).toBe(990);
+    });
+
+    it("reports NaN extrema when the window holds no points (line mode)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.2,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 1,
+        points: [],
+        nowSeconds: 1000,
+      });
+      expect(s.extremaMinValue).toBeNaN();
+      expect(s.extremaMaxValue).toBeNaN();
+      expect(s.extremaMinTime).toBeNaN();
+      expect(s.extremaMaxTime).toBeNaN();
+    });
+
+    it("tracks extrema from candle low/high + the live candle (candle mode)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 1,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 105,
+        points: [],
+        nowSeconds: 1000,
+        mode: "candle",
+        candles: [{ time: 980, open: 100, high: 120, low: 80, close: 110 }],
+        liveCandle: { time: 995, open: 110, high: 130, low: 70, close: 125 },
+      });
+      // Lowest low (70) is on the live candle; highest high (130) too.
+      expect(s.extremaMinValue).toBe(70);
+      expect(s.extremaMinTime).toBe(995);
+      expect(s.extremaMaxValue).toBe(130);
+      expect(s.extremaMaxTime).toBe(995);
+    });
   });
 
   // ── Candle mode ────────────────────────────────────────────────────────
@@ -640,6 +735,10 @@ describe("tickLiveChartEngineFrame adaptiveSpeedBoost", () => {
       displayMax: 10,
       displayWindow: 30,
       timestamp: 1000,
+      extremaMinValue: NaN,
+      extremaMaxValue: NaN,
+      extremaMinTime: NaN,
+      extremaMaxTime: NaN,
     };
     tickLiveChartEngineFrame(s, {
       dt: 16.67,

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -8,6 +8,10 @@ describe("tickLiveChartSeriesEngineFrame", () => {
     timestamp: number;
     displayValues: number[];
     opacities: number[];
+    extremaMinValue: number;
+    extremaMaxValue: number;
+    extremaMinTime: number;
+    extremaMaxTime: number;
   } {
     return {
       displayMin: 0,
@@ -16,6 +20,10 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       timestamp: 1000,
       displayValues: [],
       opacities: [],
+      extremaMinValue: NaN,
+      extremaMaxValue: NaN,
+      extremaMinTime: NaN,
+      extremaMaxTime: NaN,
     };
   }
 
@@ -522,5 +530,72 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       nowSeconds: 1000,
     });
     expect(s.displayMax).toBeGreaterThanOrEqual(500);
+  });
+
+  describe("extrema tracking", () => {
+    it("records the global low/high point + time across visible series", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.5,
+        exaggerate: false,
+        referenceValue: undefined,
+        series: [
+          {
+            id: "a",
+            data: [
+              { time: 980, value: 10 }, // global low
+              { time: 1000, value: 30 },
+            ],
+            value: 30,
+            color: "#00f",
+          },
+          {
+            id: "b",
+            data: [
+              { time: 985, value: 90 }, // global high
+              { time: 1000, value: 70 },
+            ],
+            value: 70,
+            color: "#f00",
+          },
+        ],
+        nowSeconds: 1000,
+      });
+      expect(s.extremaMinValue).toBe(10);
+      expect(s.extremaMinTime).toBe(980);
+      expect(s.extremaMaxValue).toBe(90);
+      expect(s.extremaMaxTime).toBe(985);
+    });
+
+    it("skips hidden series and reports NaN when no visible series has data", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.5,
+        exaggerate: false,
+        referenceValue: undefined,
+        series: [
+          {
+            id: "a",
+            data: [{ time: 980, value: 5 }],
+            value: 5,
+            color: "#00f",
+            visible: false,
+          },
+        ],
+        nowSeconds: 1000,
+      });
+      expect(s.extremaMinValue).toBeNaN();
+      expect(s.extremaMaxValue).toBeNaN();
+      expect(s.extremaMinTime).toBeNaN();
+      expect(s.extremaMaxTime).toBeNaN();
+    });
   });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -145,11 +145,13 @@ describe("resolveAxisLabel", () => {
     expect(resolveAxisLabel(false)).toBeNull();
   });
 
-  it("returns the built-in defaults for true", () => {
+  it("returns the built-in defaults for true (dot on, no connector)", () => {
     expect(resolveAxisLabel(true)).toEqual({
       format: undefined,
       color: undefined,
       position: "right",
+      dot: true,
+      connector: null,
       render: undefined,
     });
   });
@@ -159,6 +161,8 @@ describe("resolveAxisLabel", () => {
       format: undefined,
       color: "#abc",
       position: "left",
+      dot: true,
+      connector: null,
       render: undefined,
     });
   });
@@ -170,8 +174,82 @@ describe("resolveAxisLabel", () => {
       format,
       color: undefined,
       position: "right",
+      dot: true,
+      connector: null,
       render,
     });
+  });
+
+  it('carries through the "extrema" position mode (no connector)', () => {
+    expect(resolveAxisLabel({ position: "extrema" })).toEqual({
+      format: undefined,
+      color: undefined,
+      position: "extrema",
+      dot: true,
+      connector: null,
+      render: undefined,
+    });
+  });
+
+  it("carries through the font + dot styling knobs", () => {
+    expect(
+      resolveAxisLabel({
+        position: "extrema",
+        fontSize: 16,
+        fontWeight: "700",
+        fontFamily: "JetBrainsMono",
+        dotColor: "#f0f",
+        dotSize: 12,
+        dot: false,
+      }),
+    ).toEqual({
+      format: undefined,
+      color: undefined,
+      position: "extrema",
+      fontSize: 16,
+      fontWeight: "700",
+      fontFamily: "JetBrainsMono",
+      dotColor: "#f0f",
+      dotSize: 12,
+      dot: false,
+      connector: null,
+      render: undefined,
+    });
+  });
+
+  it('defaults the connector to dashed in "extrema-edge" mode', () => {
+    const resolved = resolveAxisLabel({ position: "extrema-edge" });
+    expect(resolved?.position).toBe("extrema-edge");
+    expect(resolved?.connector).toEqual({
+      color: undefined,
+      strokeWidth: 1,
+      intervals: [2, 3],
+    });
+  });
+
+  it('"extrema-edge" with connector: false disables the connector', () => {
+    expect(
+      resolveAxisLabel({ position: "extrema-edge", connector: false })
+        ?.connector,
+    ).toBeNull();
+  });
+
+  it("resolves a custom connector line style", () => {
+    expect(
+      resolveAxisLabel({
+        position: "extrema-edge",
+        connector: { color: "#abc", strokeWidth: 2, intervals: [5, 5] },
+      })?.connector,
+    ).toEqual({ color: "#abc", strokeWidth: 2, intervals: [5, 5] });
+  });
+
+  it("a solid connector omits intervals", () => {
+    expect(
+      resolveAxisLabel({
+        position: "extrema-edge",
+        connector: { color: "#abc" },
+      })?.connector,
+    ).toEqual({ color: "#abc", strokeWidth: 1, intervals: undefined });
   });
 });
 

--- a/packages/react-native-livechart/tests/useLiveChartEngine.test.tsx
+++ b/packages/react-native-livechart/tests/useLiveChartEngine.test.tsx
@@ -22,14 +22,26 @@ describe("applyLiveChartEngineFrame", () => {
       smoothing: { value: 0.5 },
       exaggerateSV: { value: false },
       referenceValue: { value: undefined as number | undefined },
+      // Pin "now" to the point's time so it falls inside the live window
+      // (otherwise the real-clock default scrolls it out and extrema go NaN).
+      nowOverrideSV: { value: 1700000000 },
+      windowBufferSV: { value: 0 },
       pausedSV: { value: false },
       modeSV: { value: "line" as const },
+      extremaMinValue: { value: NaN },
+      extremaMaxValue: { value: NaN },
+      extremaMinTime: { value: NaN },
+      extremaMaxTime: { value: NaN },
     };
     applyLiveChartEngineFrame(
       { timeSincePreviousFrame: 16.67 },
       sv as unknown as EngineFrameRefs,
     );
     expect(sv.displayValue.value).not.toBe(0);
+    // The data point's value + time become the live extrema.
+    expect(sv.extremaMinValue.value).toBe(10);
+    expect(sv.extremaMaxValue.value).toBe(10);
+    expect(sv.extremaMinTime.value).toBe(1700000000);
   });
 });
 
@@ -114,6 +126,10 @@ describe("useLiveChartEngine", () => {
       windowBufferSV: { value: 0 },
       pausedSV: { value: false },
       modeSV: { value: "line" as const },
+      extremaMinValue: { value: NaN },
+      extremaMaxValue: { value: NaN },
+      extremaMinTime: { value: NaN },
+      extremaMaxTime: { value: NaN },
     };
     applyLiveChartEngineFrame(
       { timeSincePreviousFrame: 16.67 },
@@ -124,5 +140,9 @@ describe("useLiveChartEngine", () => {
     expect(sv.displayValue.value).toBe(30);
     expect(sv.displayMin.value).toBeLessThanOrEqual(10);
     expect(sv.displayMax.value).toBeGreaterThanOrEqual(30);
+    // Extrema snapshot the raw data low/high (10 @ first point, 30 @ last).
+    expect(sv.extremaMinValue.value).toBe(10);
+    expect(sv.extremaMaxValue.value).toBe(30);
+    expect(sv.extremaMaxTime.value).toBe(1700000030);
   });
 });

--- a/packages/react-native-livechart/tests/useLiveChartSeriesEngine.test.tsx
+++ b/packages/react-native-livechart/tests/useLiveChartSeriesEngine.test.tsx
@@ -32,13 +32,24 @@ describe("applyLiveChartSeriesEngineFrame", () => {
       smoothing: { value: 0.5 },
       exaggerateSV: { value: false },
       referenceValue: { value: undefined as number | undefined },
+      // Pin "now" to the point's time so it falls inside the live window.
+      nowOverrideSV: { value: 1000 },
+      windowBufferSV: { value: 0 },
       pausedSV: { value: false },
+      extremaMinValue: { value: NaN },
+      extremaMaxValue: { value: NaN },
+      extremaMinTime: { value: NaN },
+      extremaMaxTime: { value: NaN },
     };
     applyLiveChartSeriesEngineFrame(
       { timeSincePreviousFrame: 16.67 },
       sv as unknown as MultiEngineFrameRefs,
     );
     expect(sv.displaySeriesValues.value.length).toBe(1);
+    // The single series' lone point becomes the live extrema.
+    expect(sv.extremaMinValue.value).toBe(10);
+    expect(sv.extremaMaxValue.value).toBe(10);
+    expect(sv.extremaMinTime.value).toBe(1000);
   });
 });
 


### PR DESCRIPTION
Implements #131 — extrema (min/max) axis labels, with two placement modes.

## What

Adds extrema-tracking modes to `AxisLabelConfig.position` so `topLabel` / `bottomLabel` follow the high / low **data point** instead of pinning to a fixed plot edge:

- **`"extrema"`** — floats the readout (a dot + value) on the actual peak / trough, tracked on the UI thread, so you can see *when* it happened.
- **`"extrema-edge"`** — keeps the value on the top / bottom **rail** (x-aligned with the extremum) and joins it to a dot on the point with a **connector** line. Good when a point-anchored label would crowd the live dot or sit mid-candle.

Both engines snapshot the **raw data extrema** (value + time) each frame — single- and multi-series, line + candle — exposed as new `SharedValue`s. The label overlay projects the point to a canvas pixel (the dot is pinned to the exact point; candle modes offset by half a candle width so it lands on the candle's drawn center, not its left edge). The value text is clamped on-screen in `"extrema"`, or edge-pinned in `"extrema-edge"`. Hidden when the window holds no data or the extremum scrolls off-plot. `"left"` / `"right"` are unchanged.

## Styling

The built-in label is fully styleable without a custom `render` — `AxisLabelConfig` gains:

- **`fontSize` / `fontWeight` / `fontFamily`** — the value text (apply to the edge labels too).
- **`dotColor` / `dotSize` / `dot`** — the extrema marker (`dot: false` for a dotless label).
- **`connector`** (`"extrema-edge"`) — `true` (dashed default), `false`, or a **`LineStyleConfig`** (`color` / `strokeWidth` / `intervals`). A new shared line-style type, so the connector configures like the other secondary lines. Rendered in Skia (`ExtremaConnectorOverlay`) so it dashes like the rest.

`render` still overrides everything.

## Demo

`app/demo/extrema-labels.tsx` (Appearance → **Extrema labels**): point / edge / pinned, line / candle, custom render, and on-screen **font-size / dot-size / bold / show-dot / connector** controls. The line uses calm data so the high/low read clearly; candle mode stays lively for real bodies.

## Docs

Theming guide → "Marking the extrema points" (point + edge + connector); types reference (`AxisLabelConfig`, `LineStyleConfig`).

## Tests / QA

New engine-tick cases (line / candle / empty → NaN), overlay cases (point / edge anchor / custom / NaN-hidden / off-plot / fallback / dot + font knobs / candle offset), an `ExtremaConnectorOverlay` suite (100% cover), and resolver cases (connector default-on in edge mode, custom/solid styles). Full suite green; typecheck + lint clean. Verified on the iOS simulator across line / candle and point / edge — the dot sits exactly on the peak/trough (centered on the candle), and the connector + size/style controls behave.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
