### PR TITLE
chore(renovate): disable the Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
     ":semanticCommits"
   ],
+  "dependencyDashboard": false,
   "schedule": ["before 6am on monday"],
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,


### PR DESCRIPTION
## What

Disables Renovate's **Dependency Dashboard** by dropping the `:dependencyDashboard` preset from `extends` and setting `"dependencyDashboard": false` explicitly.

That preset is what creates and re-maintains the [Dependency Dashboard issue (#96)](https://github.com/brandtnewlabs/react-native-livechart/issues/96) — closing the issue by hand doesn't stick because Renovate reopens it on every run while the preset is active.

## Why

The dashboard mostly lists updates we deliberately don't take via Renovate (SDK-governed deps are pinned by Expo and bumped with `expo install`, peer deps are the consumer's choice), so it's noise rather than a control panel.

## Scope

Renovate keeps doing everything else — it still opens scheduled update PRs for the non-SDK tooling (eslint, GitHub Actions, `@testing-library`, `react-doctor`, `husky`) and runs lock-file maintenance. Only the dashboard issue goes away.

Once this lands on `main`, Renovate won't recreate the dashboard. Merging also closes the issue directly.

Closes #96
