### PR TITLE
feat(area-dots): dot-lattice area fill + Kraken showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.11.0] - 2026-06-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`areaDots` — dot-lattice area fill** (`LiveChart`). A new `areaDots` prop
+  (`boolean | AreaDotsConfig`) fills the area **beneath the line** with a
+  screen-fixed dot lattice clipped to the under-line region (the line scrolls
+  over the dots; nothing is drawn above it). It composes with `gradient` or
+  replaces it (`gradient={false}`), and `AreaDotsConfig` tunes `spacing`, `size`,
+  `color` (defaults to a faint tint of the line color), and `opacity`. Inert in
+  candle mode, like the gradient fill. See the new `app/showcase/kraken.tsx`
+  example.
+
 ## [3.10.0] - 2026-06-16
 
 ### Added

--- a/app/showcase/kraken.tsx
+++ b/app/showcase/kraken.tsx
@@ -1,0 +1,576 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useState } from "react";
+import {
+  type DimensionValue,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type ViewStyle,
+} from "react-native";
+import {
+  LiveChart,
+  type ScrubPoint,
+  type TooltipRenderProps,
+} from "react-native-livechart";
+import Animated, {
+  Easing,
+  interpolateColor,
+  type SharedValue,
+  useAnimatedProps,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+/**
+ * Kraken — asset-detail recreation (light theme, BTC/USD).
+ *
+ * Same skeleton philosophy as the other showcases (Fomo / Robinhood / Backpack):
+ * everything but the chart and the live price readout is a grey placeholder, so
+ * focus stays on LiveChart. The "real" pieces are the back button, the BTC
+ * mark/ticker, the `LiveChart`, and `KrakenPriceReadout` (price + change).
+ *
+ * The chart is the showpiece for the library's `areaDots` feature: a thin orange
+ * line whose area below the line is filled with a DOT LATTICE (a procedural
+ * shader bounded to the under-line region) instead of a gradient. It also pairs
+ * right-gutter Y-axis labels and a dashed scrub crosshair + time pill.
+ *
+ * To add another app, copy this file to `app/showcase/<id>.tsx` and register it
+ * in `demo-lib/examples.ts`.
+ */
+
+// ── Kraken palette (scoped — light surface).
+const C = {
+  bg: "#FFFFFF",
+  orange: "#F7931A", // Bitcoin orange — the line + dot color
+  green: "#15B870",
+  red: "#FF4D4D",
+  text: "#0A0A0A",
+  muted: "rgba(0,0,0,0.45)",
+  skeleton: "rgba(0,0,0,0.06)",
+  skeletonStrong: "rgba(0,0,0,0.11)",
+  hairline: "rgba(0,0,0,0.08)",
+  crosshair: "rgba(0,0,0,0.30)",
+  // Faint orange tint for the dot lattice under the line — kept subtle so it
+  // reads as texture, not a second data layer.
+  areaDots: "rgba(247,147,26,0.18)",
+} as const;
+
+const FONT_BOLD = "PlusJakartaSans_700Bold";
+const FONT_SEMIBOLD = "PlusJakartaSans_600SemiBold";
+const FONT_MEDIUM = "PlusJakartaSans_500Medium";
+
+// Seed/start price (BTC ~ $55.9k). The sim walks proportionally (steps scale
+// with the price), so the line stays lively.
+const START_PRICE = 55866.9;
+
+// Chart geometry. A short ~3min "LIVE" window so the chart visibly scrolls (the
+// dot pushes in at the right and the line drifts left). `historyRange: "1m"`
+// seeds ~1 point/sec so the window fills edge-to-edge (a plain
+// `historySpanSeconds` would inherit the 60s default step and seed nearly empty
+// — see the candle-seed-density note).
+const WINDOW_SECS = 180;
+const CHART_HEIGHT = 230;
+
+/**
+ * Worklet-safe USD axis formatter (NO `Intl` — `grid.ts` calls `formatValue` on
+ * the UI thread, so it must be a worklet; `Intl` is not worklet-safe). Groups
+ * thousands with "," and drops the cents → "$58,000".
+ */
+function formatUsd(v: number): string {
+  "worklet";
+  const sign = v < 0 ? "-" : "";
+  const digits = String(Math.round(Math.abs(v)));
+  let grouped = "";
+  for (let i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 === 0) grouped += ",";
+    grouped += digits[i];
+  }
+  return `${sign}$${grouped}`;
+}
+
+/** "13:15" — 24-hour clock to the minute, for the scrub time label. */
+function formatClock(t: number): string {
+  "worklet";
+  const d = new Date(t * 1000);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+// Price + change readout formatting (React thread — `Intl` is fine here).
+const USD_FMT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+/**
+ * Scrub tooltip — a small grey pill with the time, floated centred at the top of
+ * the plot. Bound to the `timeStr` SharedValue so it updates on the UI thread
+ * while scrubbing (no JS re-render per pointer move).
+ */
+function KrakenTooltip({ timeStr }: TooltipRenderProps) {
+  const animatedProps = useAnimatedProps(() => {
+    const t = timeStr.get();
+    return { text: t, defaultValue: t };
+  });
+  return (
+    <View style={styles.tip}>
+      <AnimatedTextInput
+        editable={false}
+        underlineColorAndroid="transparent"
+        style={styles.tipText}
+        animatedProps={animatedProps}
+      />
+    </View>
+  );
+}
+
+/** Grey placeholder block (bar or, with `r = h/2`, a circle). */
+function Sk({
+  w,
+  h,
+  r = 6,
+  strong,
+  style,
+}: {
+  w?: DimensionValue;
+  h: number;
+  r?: number;
+  strong?: boolean;
+  style?: ViewStyle;
+}) {
+  return (
+    <View
+      style={[
+        {
+          width: w,
+          height: h,
+          borderRadius: r,
+          backgroundColor: strong ? C.skeletonStrong : C.skeleton,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+/** BTC mark — an orange coin with the Bitcoin glyph. The only real logo on the
+ *  otherwise-skeleton page (alongside the ticker + name). */
+function BtcLogo({ size = 34 }: { size?: number }) {
+  return (
+    <View
+      style={[
+        styles.logo,
+        { width: size, height: size, borderRadius: size / 2 },
+      ]}
+    >
+      <Ionicons name="logo-bitcoin" size={size * 0.6} color="#FFFFFF" />
+    </View>
+  );
+}
+
+/**
+ * Live price + change readout (the only "real" content besides the chart).
+ * Mirrors `value` (or the scrubbed value) and the `baseline` (window-open) into
+ * React state via UI-thread reactions — once per change, not per frame — flashes
+ * the price green/red on each tick, and computes change/percent against that live
+ * baseline. Seeded with plain numbers (never reads a SharedValue during render →
+ * no strict-mode warning).
+ */
+function KrakenPriceReadout({
+  value,
+  baseline,
+}: {
+  value: SharedValue<number>;
+  baseline: SharedValue<number>;
+}) {
+  const flash = useSharedValue(0);
+  const [raw, setRaw] = useState(START_PRICE);
+  const [base, setBase] = useState(START_PRICE);
+
+  useAnimatedReaction(
+    () => value.get(),
+    (cur, prev) => {
+      if (cur === prev || !Number.isFinite(cur)) return;
+      if (prev != null && Number.isFinite(prev)) {
+        const dir = cur > prev ? 1 : -1;
+        flash.set(
+          withSequence(
+            withTiming(dir, { duration: 100 }),
+            withTiming(0, { duration: 280, easing: Easing.out(Easing.cubic) }),
+          ),
+        );
+      }
+      runOnJS(setRaw)(cur);
+    },
+  );
+
+  // Baseline steps slowly (only as the window-open point scrolls), so this fires
+  // far less than once per tick.
+  useAnimatedReaction(
+    () => baseline.get(),
+    (b, prev) => {
+      if (b !== prev && Number.isFinite(b)) runOnJS(setBase)(b);
+    },
+  );
+
+  const priceStyle = useAnimatedStyle(() => ({
+    color: interpolateColor(flash.get(), [-1, 0, 1], [C.red, C.text, C.green]),
+  }));
+
+  const delta = raw - base;
+  const pct = base !== 0 ? (delta / base) * 100 : 0;
+  const up = delta >= 0;
+  const changeColor = up ? C.green : C.red;
+
+  return (
+    <View>
+      <Animated.Text style={[styles.price, priceStyle]}>
+        {USD_FMT.format(raw)}
+      </Animated.Text>
+      <Text style={[styles.change, { color: changeColor }]}>
+        {up ? "+" : "−"}
+        {USD_FMT.format(Math.abs(delta))} · {up ? "↗" : "↘"}{" "}
+        {Math.abs(pct).toFixed(2)}%
+      </Text>
+    </View>
+  );
+}
+
+/** One stats skeleton row: grey label (left) + grey value (right). */
+function StatRow() {
+  return (
+    <View style={styles.statRow}>
+      <Sk w={96} h={13} />
+      <Sk w={64} h={13} />
+    </View>
+  );
+}
+
+export default function KrakenShowcase() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  // Live feed: 3 ticks/sec → a busy, fast-moving line. Line-only (no candles /
+  // tape / multi-series) keeps the per-tick work minimal.
+  const { data, value } = useSimulatedChartData({
+    volatilityMode: "normal",
+    tradesPerSecond: 3,
+    startValue: START_PRICE,
+    tokenSymbol: "BTC",
+    multiSeries: false,
+    tradeStream: false,
+    candleAggregation: false,
+    historyRange: "1m",
+    historySpanSeconds: WINDOW_SECS + 20,
+    maxPoints: 4000,
+  });
+
+  // The readout follows the live value, except while scrubbing it shows the
+  // crosshair's value (and snaps back to live when the gesture ends).
+  const isScrubbing = useSharedValue(false);
+  const displayValue = useSharedValue(START_PRICE);
+  useAnimatedReaction(
+    () => value.get(),
+    (v) => {
+      if (!isScrubbing.get()) displayValue.set(v);
+    },
+  );
+
+  // Live window-open reference = the value of the first point inside the window
+  // (latest time − window). Drives the change % so it reflects the visible
+  // window, not a fixed anchor that drifts the whole session.
+  const baseline = useSharedValue(START_PRICE);
+  useAnimatedReaction(
+    () => {
+      const arr = data.get();
+      const n = arr.length;
+      if (n === 0) return START_PRICE;
+      const openT = arr[n - 1].time - WINDOW_SECS;
+      // Binary search for the first point at/after the window's left edge (data
+      // is time-sorted; the buffer can hold more than the window).
+      let lo = 0;
+      let hi = n - 1;
+      let idx = 0;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (arr[mid].time >= openT) {
+          idx = mid;
+          hi = mid - 1;
+        } else {
+          lo = mid + 1;
+        }
+      }
+      return arr[idx].value;
+    },
+    (openVal) => {
+      if (Number.isFinite(openVal)) baseline.set(openVal);
+    },
+  );
+
+  return (
+    <View
+      style={[
+        styles.root,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+    >
+      <StatusBar style="dark" />
+
+      {/* ── Header: real back button + BTC ticker, everything else grey */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Back to Examples"
+        >
+          <Ionicons name="chevron-back" size={26} color={C.text} />
+        </Pressable>
+        <Text style={styles.hdrTitle}>BTC</Text>
+        <View style={styles.headerIcons}>
+          <Sk w={26} h={26} r={13} />
+          <Sk w={26} h={26} r={13} />
+          <Sk w={26} h={26} r={13} />
+        </View>
+      </View>
+
+      {/* ── Asset mark + name */}
+      <View style={styles.nameBlock}>
+        <BtcLogo size={34} />
+        <Text style={styles.tokenName}>Bitcoin</Text>
+      </View>
+
+      {/* ── Price + change (the live readout) */}
+      <View style={styles.priceBlock}>
+        <KrakenPriceReadout value={displayValue} baseline={baseline} />
+      </View>
+
+      {/* ── Hero chart: thin orange line + dot-lattice area fill + scrub crosshair */}
+      <View style={styles.chartWrap}>
+        <LiveChart
+          data={data}
+          value={value}
+          // Transparent container so the white page shows through.
+          style={styles.chartCanvas}
+          theme="light"
+          accentColor={C.orange}
+          line={{ color: C.orange, width: 2 }}
+          // ✦ The feature: a fine, faint dot lattice filling the area UNDER the
+          //   line — tight pitch + low alpha so it reads as texture. Pitch/alpha
+          //   measured off the reference (~2% of width, ~9–10 rows per gridline).
+          areaDots={{ spacing: 8, size: 1.5, color: C.areaDots }}
+          gradient={false}
+          dot={{ radius: 4 }}
+          pulse={{ maxRadius: 14, strokeWidth: 6, opacity: 0.3 }}
+          badge={false}
+          valueLine={false}
+          momentum={false}
+          // Right-gutter price labels only — no horizontal grid lines (a clean
+          // chart). `gridStyle.opacity: 0` hides the lines; labels are unaffected.
+          yAxis
+          gridStyle={{ opacity: 0 }}
+          xAxis={false}
+          formatValue={formatUsd}
+          // Right gutter ≈ 21% of width to match the reference (plot ends ~78%
+          // across, labels occupy the right ~22% with a ~16pt right margin); top
+          // band for the scrub time pill; small bottom inset floats the line.
+          insets={{ left: 0, right: 84, top: 36, bottom: 18 }}
+          timeWindow={WINDOW_SECS}
+          formatTime={formatClock}
+          renderTooltip={KrakenTooltip}
+          selectionDot={{ size: 5, color: C.orange, ring: false }}
+          scrub={{
+            tooltipPlacement: "top",
+            crosshairLineColor: C.crosshair,
+            // Dashed vertical crosshair.
+            crosshairDash: [3, 4],
+            tooltipMargin: 10,
+            dimOpacity: 0.22,
+          }}
+          onScrub={(point: ScrubPoint | null) => {
+            "worklet";
+            if (point === null) {
+              isScrubbing.set(false);
+              displayValue.set(value.get());
+              return;
+            }
+            isScrubbing.set(true);
+            displayValue.set(point.value);
+          }}
+        />
+      </View>
+
+      {/* ── Timeframe selector (grey pills, first = active) */}
+      <View style={styles.timeframes}>
+        {[0, 1, 2, 3, 4, 5, 6].map((i) => (
+          <Sk key={i} h={28} r={9} strong={i === 0} style={styles.tfChip} />
+        ))}
+      </View>
+
+      {/* ── Action buttons (grey placeholders) */}
+      <View style={styles.actionRow}>
+        <Sk w="48%" h={48} r={14} />
+        <Sk w="48%" h={48} r={14} />
+      </View>
+
+      {/* ── Stats (grey heading + rows) */}
+      <View style={styles.section}>
+        <Sk w={150} h={20} strong />
+        <StatRow />
+        <StatRow />
+      </View>
+
+      <View style={{ flex: 1 }} />
+
+      {/* ── Footer CTAs (grey skeleton placeholders) */}
+      <View style={styles.ctaArea}>
+        <Sk w="48%" h={52} r={16} />
+        <Sk w="48%" h={52} r={16} strong />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: C.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 14,
+    height: 48,
+  },
+  backButton: {
+    width: 26,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  hdrTitle: {
+    flex: 1,
+    textAlign: "center",
+    fontSize: 17,
+    fontFamily: FONT_BOLD,
+    color: C.text,
+    // Offset the back button so the title is visually centred.
+    marginLeft: -26,
+  },
+  headerIcons: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  logo: {
+    backgroundColor: C.orange,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  nameBlock: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 20,
+    marginTop: 12,
+  },
+  tokenName: {
+    fontSize: 17,
+    fontFamily: FONT_SEMIBOLD,
+    color: C.text,
+  },
+  priceBlock: {
+    paddingHorizontal: 20,
+    marginTop: 10,
+  },
+  price: {
+    fontSize: 34,
+    fontFamily: FONT_BOLD,
+    letterSpacing: -0.5,
+    // Tabular figures: equal-width digits so the ticking price doesn't jitter.
+    fontVariant: ["tabular-nums"],
+  },
+  change: {
+    fontSize: 14,
+    fontFamily: FONT_SEMIBOLD,
+    fontVariant: ["tabular-nums"],
+    marginTop: 8,
+  },
+  chartWrap: {
+    height: CHART_HEIGHT,
+    marginTop: 10,
+  },
+  chartCanvas: {
+    backgroundColor: "transparent",
+  },
+  timeframes: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 16,
+    marginTop: 8,
+  },
+  tfChip: {
+    flex: 1,
+  },
+  actionRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    marginTop: 18,
+  },
+  section: {
+    paddingHorizontal: 20,
+    marginTop: 22,
+  },
+  statRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: 16,
+    paddingBottom: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: C.hairline,
+  },
+  ctaArea: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 8,
+  },
+  tip: {
+    backgroundColor: "rgba(0,0,0,0.06)",
+    borderRadius: 7,
+    paddingHorizontal: 9,
+    paddingVertical: 3,
+  },
+  tipText: {
+    // Fixed width (measured once) + centred — wide enough for "13:15".
+    width: 44,
+    textAlign: "center",
+    color: C.text,
+    fontSize: 13,
+    fontFamily: FONT_MEDIUM,
+    fontVariant: ["tabular-nums"],
+    padding: 0,
+  },
+});

--- a/demo-lib/examples.ts
+++ b/demo-lib/examples.ts
@@ -53,6 +53,14 @@ export const EXAMPLES: ExampleEntry[] = [
     status: "ready",
   },
   {
+    id: "kraken",
+    title: "Kraken",
+    tagline: "BTC/USD detail (light) — thin line + dot-lattice area fill",
+    accent: "#7132F5",
+    href: "/showcase/kraken",
+    status: "ready",
+  },
+  {
     id: "coinbase",
     title: "Coinbase",
     tagline: "Asset detail page with candle + line modes",

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -55,6 +55,14 @@ provided; everything else has a default.
   accent color.
 </ParamField>
 
+<ParamField body="areaDots" type="boolean | AreaDotsConfig" default="false">
+  Dot-lattice fill of the area beneath the line — a screen-fixed grid of dots
+  clipped to the region between the line and the baseline. Composes with
+  `gradient` (both paint) or replaces it (`gradient={false}`). Pass an
+  `AreaDotsConfig` to tune `spacing`, `size`, `color`, and `opacity`; the color
+  defaults to a faint tint of the line/accent color. Inert in candle mode.
+</ParamField>
+
 <ParamField body="badge" type="boolean | BadgeConfig" default="true">
   Value badge pill at the tip.
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -192,6 +192,12 @@ interface GradientConfig {
   positions?: number[];   // optional stop positions (0..1, ascending), same
                           //   length as colors; ignored if the lengths differ
 }
+interface AreaDotsConfig {  // dot-lattice fill of the area beneath the line
+  spacing?: number; // lattice pitch (px) between dots, both axes; default 12
+  size?: number;    // dot diameter (px); default 1.6
+  color?: string;   // dot color; omit to derive a faint tint from the line color
+  opacity?: number; // overall field opacity (0..1); default 1
+}
 interface ThresholdConfig {
   value: SharedValue<number>; // the split value (Y-axis units), always live
   aboveColor?: string;        // stroke at/above value; default palette up-green

--- a/docs/guides/line-and-area.mdx
+++ b/docs/guides/line-and-area.mdx
@@ -40,6 +40,32 @@ Override the stroke with the `line` prop, and the area fill with `gradient`:
 
 Pass `gradient={false}` to remove the area fill entirely.
 
+### Dotted area fill
+
+For a textured fill, `areaDots` paints a screen-fixed dot lattice clipped to the
+area **beneath the line** (the line scrolls over the dots; nothing is drawn above
+it). It composes with `gradient`, or use it alone with `gradient={false}`:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  line={{ width: 2, color: "#F7931A" }}
+  areaDots={{ spacing: 12, size: 1.6 }} // color defaults to a faint line tint
+  gradient={false}
+/>
+```
+
+Tune `spacing` (lattice pitch), `size` (dot diameter), `color`, and `opacity`.
+Like `gradient`, it's a line-mode feature (inert in candle mode).
+
+<Note>
+  **Live example:**
+  [`app/showcase/kraken.tsx`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/showcase/kraken.tsx)
+  pairs the dotted area fill with a thin line, Y-axis labels, and a dashed scrub
+  crosshair.
+</Note>
+
 ### Curve & edges
 
 By default the line is a smooth monotone cubic with rounded joins and caps. For an

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -145,6 +145,8 @@ jest.mock("@shopify/react-native-skia", () => {
     Text: View,
     Path: ({ children, ...props }) =>
       React.createElement(View, props, children),
+    Points: View,
+    Shader: View,
     DashPathEffect: View,
     Blur: View,
     Image: View,
@@ -177,6 +179,9 @@ jest.mock("@shopify/react-native-skia", () => {
       XYWHRect: jest.fn((x, y, width, height) => ({ x, y, width, height })),
       Color: jest.fn((c) => c),
       Paint: jest.fn(() => createMockPaint()),
+      RuntimeEffect: {
+        Make: jest.fn(() => ({ source: jest.fn() })),
+      },
     },
   };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17597,7 +17597,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "3.10.0"
+  "version": "3.11.0"
 }

--- a/packages/react-native-livechart/src/components/AreaDotsOverlay.tsx
+++ b/packages/react-native-livechart/src/components/AreaDotsOverlay.tsx
@@ -1,0 +1,62 @@
+import { Path, Shader, Skia, type SkPath } from "@shopify/react-native-skia";
+import type { SharedValue } from "react-native-reanimated";
+
+/**
+ * Screen-fixed dot lattice as a procedural fragment shader. `xy` is the canvas
+ * coordinate, so the lattice is fixed in screen space (the line scrolls over it).
+ * Each `spacing`×`spacing` cell holds one dot of radius `radius`, centered, with
+ * ~1px antialiasing. Returns premultiplied alpha (Skia's shader convention).
+ */
+const DOT_SKSL = `
+uniform float spacing;
+uniform float radius;
+uniform vec4 color; // straight-alpha rgba, 0..1
+
+half4 main(vec2 xy) {
+  vec2 c = mod(xy, spacing) - 0.5 * spacing;
+  float d = length(c);
+  float cov = clamp(radius + 0.5 - d, 0.0, 1.0);
+  float a = color.a * cov;
+  return half4(half3(color.rgb) * a, a);
+}`;
+
+// Compiled once. Null only if the SkSL fails to compile (then the overlay no-ops).
+const DOT_EFFECT = Skia.RuntimeEffect.Make(DOT_SKSL);
+
+interface AreaDotsOverlayProps {
+  /** Live area-under-line path (`fillPath`). Filling it with the dot shader keeps
+   *  the dots inside the under-line region — no per-frame clip layer. */
+  fillPath: SharedValue<SkPath>;
+  /** Dot color as `[r, g, b, a]`, channels 0..1 (alpha already folded with the
+   *  config `opacity`). */
+  color: number[];
+  /** Lattice pitch (px) between dots. */
+  spacing: number;
+  /** Dot diameter (px). */
+  size: number;
+}
+
+/**
+ * Dot-lattice area fill: the live `fillPath` painted with a procedural dot
+ * shader. One GPU fill draw — the dots are generated in the fragment shader from
+ * the screen-space coordinate, so there is no Points geometry and no per-frame
+ * clip/`saveLayer` (which is what made the earlier clipped-`Points` approach
+ * drop frames). See `AreaDotsConfig`.
+ */
+export function AreaDotsOverlay({
+  fillPath,
+  color,
+  spacing,
+  size,
+}: AreaDotsOverlayProps) {
+  /* istanbul ignore next -- defensive: DOT_SKSL is static and compiles */
+  if (!DOT_EFFECT) return null;
+  return (
+    <Path path={fillPath} style="fill">
+      <Shader
+        source={DOT_EFFECT}
+        uniforms={{ spacing, radius: size / 2, color }}
+      />
+    </Path>
+  );
+}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -19,6 +19,7 @@ import {
 
 import { DEFAULT_ACCENT_COLOR } from "../constants";
 import {
+  resolveAreaDots,
   resolveAxisLabel,
   resolveBadge,
   resolveDegen,
@@ -73,6 +74,7 @@ import {
   applyPaletteOverride,
   leftEdgeFadeColorsFromBgRgb,
   parseColorRgb,
+  parseColorRgba,
   resolveTheme,
 } from "../theme";
 import type {
@@ -85,6 +87,7 @@ import {
   ThresholdBadgeOverlay,
   ThresholdLineOverlay,
 } from "./ThresholdLineOverlay";
+import { AreaDotsOverlay } from "./AreaDotsOverlay";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
 import {
   ExtremaConnectorOverlay,
@@ -150,6 +153,7 @@ function useLiveChartController({
   theme = "dark",
   accentColor = DEFAULT_ACCENT_COLOR,
   gradient = true,
+  areaDots,
   line: lineProp,
   font: fontProp,
   insets,
@@ -236,6 +240,9 @@ function useLiveChartController({
   // Static charts run no gestures, so scrub-action (tap/drag to lock a price) is off.
   const scrubActionCfg = isStatic ? null : resolveScrubAction(scrubAction);
   const gradientCfg = isCandle ? null : resolveGradient(gradient);
+  // Dot-lattice area fill (clipped to the under-line region). Inert in candle
+  // mode, same as the gradient fill.
+  const areaDotsCfg = isCandle ? null : resolveAreaDots(areaDots);
   // Threshold split is a line-mode feature (candle bodies carry their own up/down
   // colors), so it's inert in candle mode — same as the area gradient.
   const thresholdCfg = isCandle ? null : resolveThreshold(threshold);
@@ -409,6 +416,22 @@ function useLiveChartController({
     // Straight polyline instead of the monotone cubic when line.curve === "linear".
     lineProp?.curve === "linear",
   );
+
+  // Area-dots fill shader color as a vec4 (channels 0..1), with the config
+  // `opacity` folded into the alpha. Defaults to a faint tint of the line/accent
+  // color (theme-aware) so out-of-the-box dots read as a subtle field.
+  const areaDotRgb = parseColorRgb(lineProp?.color ?? palette.line);
+  const [adR, adG, adB, adA] = parseColorRgba(
+    areaDotsCfg?.color ??
+      `rgba(${areaDotRgb[0]}, ${areaDotRgb[1]}, ${areaDotRgb[2]}, 0.22)`,
+  );
+  const areaDotColorVec = [
+    adR / 255,
+    adG / 255,
+    adB / 255,
+    adA * (areaDotsCfg?.opacity ?? 1),
+  ];
+
   const { upBodiesPath, downBodiesPath, upWicksPath, downWicksPath } =
     useCandlePaths(
       engine,
@@ -639,6 +662,8 @@ function useLiveChartController({
     scrubCfg,
     scrubActionCfg,
     gradientCfg,
+    areaDotsCfg,
+    areaDotColorVec,
     valueLineCfg,
     pulseCfg,
     dotCfg,
@@ -736,6 +761,8 @@ function ChartFillLayer({ model }: { model: LiveChartModel }) {
     gridStyleCfg,
     metricsCfg,
     gradientCfg,
+    areaDotsCfg,
+    areaDotColorVec,
     fillPath,
     gradientEnd,
     gradientColors,
@@ -761,6 +788,20 @@ function ChartFillLayer({ model }: { model: LiveChartModel }) {
             badgeTail={badgeCfg?.tail ?? true}
             badgeMetrics={metricsCfg.badge}
             gridStyle={gridStyleCfg}
+          />
+        </Group>
+      )}
+
+      {/* Dot-lattice area fill (the under-line `fillPath` painted with a dot
+          shader). Drawn before the gradient so a gradient (if also enabled)
+          composites on top. */}
+      {areaDotsCfg && (
+        <Group opacity={reveal.fillOpacity}>
+          <AreaDotsOverlay
+            fillPath={fillPath}
+            color={areaDotColorVec}
+            spacing={areaDotsCfg.spacing}
+            size={areaDotsCfg.size}
           />
         </Group>
       )}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -1,4 +1,5 @@
 import type {
+  AreaDotsConfig,
   AxisLabelConfig,
   BadgeConfig,
   BadgeVariant,
@@ -156,6 +157,14 @@ export interface ResolvedGradientConfig {
   colors: string[] | undefined;
   /** Stop positions (0..1) matching `colors` length. */
   positions: number[] | undefined;
+}
+
+export interface ResolvedAreaDotsConfig {
+  spacing: number;
+  size: number;
+  /** undefined → derive a faint tint from the line/accent color at render time. */
+  color: string | undefined;
+  opacity: number;
 }
 
 export interface ResolvedPulseConfig {
@@ -502,6 +511,24 @@ export function resolveGradient(
   prop: boolean | GradientConfig | undefined,
 ): ResolvedGradientConfig | null {
   return resolveToggle(prop, GRADIENT_DEFAULTS, false);
+}
+
+const AREA_DOTS_DEFAULTS: ResolvedAreaDotsConfig = {
+  spacing: 12,
+  size: 1.6,
+  color: undefined,
+  opacity: 1,
+};
+
+/**
+ * Resolves `areaDots` prop to a fully-typed config or null (disabled).
+ * `true` → defaults (palette-derived color), object → merged with defaults,
+ * falsy/omitted → null. Default OFF (unlike `gradient`).
+ */
+export function resolveAreaDots(
+  prop: boolean | AreaDotsConfig | undefined,
+): ResolvedAreaDotsConfig | null {
+  return resolveToggle(prop, AREA_DOTS_DEFAULTS, false);
 }
 
 /** Fallback when no theme background is passed (e.g. unit tests). */

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -28,6 +28,7 @@ export { useTradeStream } from "./hooks/useTradeStream";
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type {
+  AreaDotsConfig,
   AxisLabelConfig,
   BadgeConfig,
   BadgeMetrics,

--- a/packages/react-native-livechart/src/theme.ts
+++ b/packages/react-native-livechart/src/theme.ts
@@ -99,6 +99,20 @@ function rgba(r: number, g: number, b: number, a: number): string {
 }
 
 /**
+ * Parse a color into `[r, g, b, a]` — RGB channels 0–255, alpha 0–1. Extends
+ * {@link parseColorRgb} with the alpha channel of an `rgba(...)` string;
+ * `rgb(...)` and `#hex` (which carry no alpha) default to `a = 1`. Used to feed
+ * the area-dots shader a vec4 color uniform.
+ */
+export function parseColorRgba(
+  color: string,
+): [number, number, number, number] {
+  const [r, g, b] = parseColorRgb(color);
+  const rgba = color.match(/rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*([\d.]+)\s*\)/);
+  return [r, g, b, rgba ? +rgba[1] : 1];
+}
+
+/**
  * Default left-edge fade gradient stops for `dstOut` blending: same RGB as the chart
  * background (`palette.bgRgb`), opacity 1 → 0. Matches the container `backgroundColor`.
  */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -340,6 +340,22 @@ export interface GradientConfig {
   positions?: number[];
 }
 
+/**
+ * Dot-lattice fill of the area beneath the line — a screen-fixed grid of dots
+ * clipped to the region between the line and the baseline. Composes with
+ * `gradient` (both paint), or use it alone with `gradient={false}`.
+ */
+export interface AreaDotsConfig {
+  /** Lattice pitch (px) between dots, both axes. Default `12`. */
+  spacing?: number;
+  /** Dot diameter (px). Default `1.6`. */
+  size?: number;
+  /** Dot color. Omit to derive a faint tint from the line/accent color. */
+  color?: string;
+  /** Overall opacity (0..1) applied to the whole field. Default `1`. */
+  opacity?: number;
+}
+
 /** Value badge pill configuration. */
 export interface BadgeConfig {
   /** Visual style of the badge pill. Default `"default"`. */
@@ -1232,6 +1248,12 @@ export interface LiveChartCoreProps {
 export interface LiveChartProps extends LiveChartCoreProps {
   /** Area gradient fill under the line. `true` = defaults, or pass `GradientConfig`. Default `true`. */
   gradient?: boolean | GradientConfig;
+  /**
+   * Dot-lattice fill of the area beneath the line (clipped to the under-line
+   * region). `true` = defaults, or pass `AreaDotsConfig`. Composes with
+   * `gradient`. Default `false` (off). Inert in candle mode.
+   */
+  areaDots?: boolean | AreaDotsConfig;
   /** Value badge pill at the chart tip. `true` = defaults, or pass `BadgeConfig`. Default `true`. */
   badge?: boolean | BadgeConfig;
   /**

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -93,6 +93,28 @@ describe("LiveChart", () => {
     render(<Harness gradient={false} yAxis={false} badge={false} />);
   });
 
+  it("renders areaDots (dot-lattice area fill) with default palette tint", () => {
+    // Layout must fire so the lattice is non-empty and AreaDotsOverlay mounts.
+    const screen = render(<Harness areaDots />);
+    layoutFirst(screen);
+  });
+
+  it("renders an areaDots config alongside gradient off (dots-only fill)", () => {
+    const screen = render(
+      <Harness
+        gradient={false}
+        areaDots={{
+          spacing: 16,
+          size: 2,
+          color: "rgba(247,147,26,0.3)",
+          opacity: 0.9,
+        }}
+        line={{ color: "#F7931A", width: 2 }}
+      />,
+    );
+    layoutFirst(screen);
+  });
+
   it("uses custom insets and referenceLines", () => {
     render(
       <Harness

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAreaDots,
   resolveAxisLabel,
   resolveBadge,
   resolveDegen,
@@ -555,6 +556,42 @@ describe("resolveGradient", () => {
       bottomOpacity: undefined,
       colors: undefined,
       positions: undefined,
+    });
+  });
+});
+
+// ─── resolveAreaDots ──────────────────────────────────────────────────────────
+
+describe("resolveAreaDots", () => {
+  const DEFAULTS = { spacing: 12, size: 1.6, color: undefined, opacity: 1 };
+
+  it("returns null for undefined (default off)", () => {
+    expect(resolveAreaDots(undefined)).toBeNull();
+  });
+
+  it("returns null for false", () => {
+    expect(resolveAreaDots(false)).toBeNull();
+  });
+
+  it("returns defaults for true (color undefined = palette-derived tint)", () => {
+    expect(resolveAreaDots(true)).toEqual(DEFAULTS);
+  });
+
+  it("merges a partial override over the defaults", () => {
+    expect(resolveAreaDots({ spacing: 16 })).toEqual({
+      ...DEFAULTS,
+      spacing: 16,
+    });
+  });
+
+  it("preserves an explicit color and opacity", () => {
+    expect(
+      resolveAreaDots({ color: "rgba(247,147,26,0.3)", size: 2, opacity: 0.8 }),
+    ).toEqual({
+      spacing: 12,
+      size: 2,
+      color: "rgba(247,147,26,0.3)",
+      opacity: 0.8,
     });
   });
 });

--- a/packages/react-native-livechart/tests/theme.test.ts
+++ b/packages/react-native-livechart/tests/theme.test.ts
@@ -3,6 +3,7 @@ import {
   applyPaletteOverride,
   leftEdgeFadeColorsFromBgRgb,
   parseColorRgb,
+  parseColorRgba,
   resolveSeriesPalettes,
   resolveTheme,
 } from "../src/theme";
@@ -44,6 +45,20 @@ describe("parseColorRgb", () => {
 
   it("falls back for unknown strings", () => {
     expect(parseColorRgb("not-a-color")).toEqual([128, 128, 128]);
+  });
+});
+
+describe("parseColorRgba", () => {
+  it("extracts the alpha from rgba()", () => {
+    expect(parseColorRgba("rgba(10, 20, 30, 0.5)")).toEqual([10, 20, 30, 0.5]);
+  });
+
+  it("defaults alpha to 1 for rgb()", () => {
+    expect(parseColorRgba("rgb(1, 2, 3)")).toEqual([1, 2, 3, 1]);
+  });
+
+  it("defaults alpha to 1 for hex", () => {
+    expect(parseColorRgba("#3b82f6")).toEqual([59, 130, 246, 1]);
   });
 });
 


### PR DESCRIPTION
## areaDots — dot-lattice area fill + Kraken showcase

### Library
- New public prop `areaDots?: boolean | AreaDotsConfig` (`{ spacing, size, color, opacity }`) on `LiveChart`, resolved like `gradient`/`pulse`. Composes with `gradient` or replaces it (`gradient={false}`); inert in candle mode.
- Implemented as a procedural dot **shader** filling the live under-line `fillPath` — one GPU fill draw, no per-frame clip/`saveLayer` (an earlier clipped-`Points` approach dropped the UI thread to 30fps).
- Adds `parseColorRgba` to `theme.ts`; exports `AreaDotsConfig`.

### Showcase
- New **Kraken** example (`app/showcase/kraken.tsx`) + registration: light-theme skeleton, thin Bitcoin-orange line, dot-lattice area fill, right-gutter price labels (grid lines off via `gridStyle.opacity`), dashed scrub crosshair + time pill, and a live price/change readout. Dot pitch and gutter width were measured against the reference.

### Release
- Bundles the **v3.11.0** release (minor): version bump + dated `CHANGELOG.md` entry. Lockfile regenerated with npm 10 (CI-consistent — no `@emnapi` drift). Publish happens after merge.

### Docs / tests
- Docs: `livechart.mdx` ParamField, `types.mdx` interface, `line-and-area.mdx` section, `CHANGELOG.md`.
- Unit tests for `resolveAreaDots`, `parseColorRgba`, and `areaDots` render cases. `npm run verify` is green and coverage thresholds held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
