### PR TITLE
feat(curve): multi-series SeriesConfig.curve + linear marker anchoring (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2026-06-17
+
+### Added
+
+- **`curve` for multi-series lines** (`LiveChartSeries`). `SeriesConfig` gains
+  `curve?: "monotone" | "linear"` (per series, default `"monotone"`), mirroring
+  `LineConfig.curve` on the single-series `LiveChart` — set `"linear"` to draw a
+  series as straight segments between samples instead of the monotone cubic. Each
+  series chooses independently.
+  ([#141](https://github.com/brandtnewlabs/react-native-livechart/issues/141))
+
+### Fixed
+
+- **Markers anchored to a `"linear"` line now sit on the line.** A value-less
+  marker (single-series, pinned to the line by `time`) or a `seriesId`-anchored
+  marker was always projected onto the monotone spline, so in `curve: "linear"`
+  mode the glyph floated off the straight segment — most visibly on sparse ranges
+  (e.g. 1Y). Such markers now follow the rendered interpolation: the straight
+  chord when the line/series is `"linear"`, the spline otherwise.
+  ([#141](https://github.com/brandtnewlabs/react-native-livechart/issues/141))
+
 ## [3.11.0] - 2026-06-16
 
 ### Added

--- a/app/demo/line.tsx
+++ b/app/demo/line.tsx
@@ -27,25 +27,42 @@ const LINE_OPTIONS: { value: LineMode; label: string }[] = [
   { value: "custom", label: "Custom" },
 ];
 
+type CurveMode = "monotone" | "linear";
+
+const CURVE_OPTIONS: { value: CurveMode; label: string }[] = [
+  { value: "monotone", label: "Monotone" },
+  { value: "linear", label: "Linear" },
+];
+
 function resolveLine(
   mode: LineMode,
   customColors: string[],
+  curve: CurveMode,
 ): LineConfig | undefined {
+  let base: LineConfig | undefined;
   switch (mode) {
     case "solid":
-      return { color: "#ff6b6b" };
+      base = { color: "#ff6b6b" };
+      break;
     case "gradient":
-      return { colors: ["#ff6b6b", "#6b6bff"] };
+      base = { colors: ["#ff6b6b", "#6b6bff"] };
+      break;
     case "tricolor":
-      return { colors: ["#ff6b6b", "#6bff6b", "#6b6bff"] };
+      base = { colors: ["#ff6b6b", "#6bff6b", "#6b6bff"] };
+      break;
     case "custom": {
       const valid = customColors.filter((c) => c.trim().length > 0);
-      if (valid.length < 2) return undefined;
-      return { colors: valid };
+      base = valid.length < 2 ? undefined : { colors: valid };
+      break;
     }
     default:
-      return undefined;
+      base = undefined;
   }
+  // "linear" draws straight segments (+ miter join / butt cap for true sharp
+  // vertices); "monotone" is the default smooth spline, so leave `base` as-is.
+  return curve === "linear"
+    ? { ...(base ?? {}), curve: "linear", join: "miter", cap: "butt" }
+    : base;
 }
 
 function resolveBadge(mode: BadgeMode): boolean | BadgeConfig {
@@ -94,6 +111,7 @@ export default function LineScreen() {
   const [badgeMode, setBadgeMode] = useState<BadgeMode>("on");
   const [pulseMode, setPulseMode] = useState<PulseMode>("on");
   const [lineMode, setLineMode] = useState<LineMode>("default");
+  const [curve, setCurve] = useState<CurveMode>("monotone");
   const [customColors, setCustomColors] = useState(["#ff6b6b", "#6bff6b"]);
   const [valueLine, setValueLine] = useState(true);
   const [showValue, setShowValue] = useState(false);
@@ -122,7 +140,7 @@ export default function LineScreen() {
           value={value}
           accentColor={ACCENT}
           theme={APP_THEME}
-          line={resolveLine(lineMode, customColors)}
+          line={resolveLine(lineMode, customColors, curve)}
           badge={resolveBadge(badgeMode)}
           pulse={resolvePulse(pulseMode)}
           dot={{ show: dots, ring }}
@@ -144,6 +162,12 @@ export default function LineScreen() {
         options={LINE_OPTIONS}
         value={lineMode}
         onChange={setLineMode}
+      />
+      <ChipRow
+        label="Curve"
+        options={CURVE_OPTIONS}
+        value={curve}
+        onChange={setCurve}
       />
       {lineMode === "custom" && (
         <ControlRow label="Gradient colors">

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -76,6 +76,13 @@ const AXIS_OPTIONS: { value: "both" | "noY" | "noX" | "none"; label: string }[] 
     { value: "none", label: "None" },
   ];
 
+// Per-series interpolation. "linear" draws straight segments between samples
+// instead of the default monotone cubic.
+const CURVE_OPTIONS: { value: "monotone" | "linear"; label: string }[] = [
+  { value: "monotone", label: "Monotone" },
+  { value: "linear", label: "Linear" },
+];
+
 export default function MultiSeriesScreen() {
   const seriesVisibilityRef = useRef<Record<string, boolean>>({});
   const emptySeries = useSharedValue<SeriesConfig[]>([]);
@@ -83,7 +90,7 @@ export default function MultiSeriesScreen() {
   const [empty, setEmpty] = useState(false);
   const [paused, setPaused] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [windowSecs, setWindowSecs] = useState(60);
+  const [windowSecs, setWindowSecs] = useState(30);
   const [smoothing, setSmoothing] = useState(0.12);
   const [exaggerate, setExaggerate] = useState(false);
   const [degen, setDegen] = useState(false);
@@ -112,12 +119,16 @@ export default function MultiSeriesScreen() {
   const [legendPosition, setLegendPosition] = useState<"top" | "bottom">("top");
   const [styled, setStyled] = useState(false);
   const [legendStyled, setLegendStyled] = useState(false);
+  const [curve, setCurve] = useState<"monotone" | "linear">("monotone");
 
   const sim = useSimulatedChartData({
     multiSeries: !empty,
     candleAggregation: false,
     tradeStream: false,
     paused,
+    // Sparse stream (≈1 point / 1.4s) so the per-series `curve` toggle is
+    // actually visible — on a dense feed linear vs. monotone is sub-pixel.
+    tradesPerSecond: 0.7,
     seriesVisibilityRef: empty ? undefined : seriesVisibilityRef,
   });
 
@@ -133,6 +144,7 @@ export default function MultiSeriesScreen() {
     sim.series.modify((arr) => {
       "worklet";
       for (let i = 0; i < arr.length; i++) {
+        arr[i].curve = curve;
         if (styled) {
           arr[i].style = i % 2 === 1 ? "dashed" : "solid";
           arr[i].glow = i === 0;
@@ -145,7 +157,7 @@ export default function MultiSeriesScreen() {
       }
       return arr;
     });
-  }, [styled, empty, sim.series]);
+  }, [styled, curve, empty, sim.series]);
 
   const dotConfig: MultiSeriesDotConfig = {
     radius: dotRadius,
@@ -283,6 +295,13 @@ export default function MultiSeriesScreen() {
           onChange={setLegendStyled}
         />
       </ControlRow>
+
+      <ChipRow
+        label="Curve (per-series interpolation)"
+        options={CURVE_OPTIONS}
+        value={curve}
+        onChange={setCurve}
+      />
 
       <ChipRow
         label="Time window"

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -38,6 +38,7 @@ interface SeriesConfig {
   visible?: boolean;        // default true
   style?: "solid" | "dashed";
   intervals?: [number, number];
+  curve?: "monotone" | "linear"; // interpolation; default "monotone"
   strokeWidth?: number;
   glow?: boolean;
   kind?: "outcome" | "derived";

--- a/docs/guides/multi-series.mdx
+++ b/docs/guides/multi-series.mdx
@@ -46,6 +46,7 @@ Each `SeriesConfig` supports:
 | `label`       | Legend chip text                                               |
 | `visible`     | Show/hide the series (default `true`)                          |
 | `style`       | `"solid"` or `"dashed"` (with `intervals`)                     |
+| `curve`       | `"monotone"` (default) smooth spline or `"linear"` straight segments |
 | `strokeWidth` | Per-series width override                                      |
 | `glow`        | Soft glow behind the line                                      |
 | `kind`        | `"outcome"` (default) or `"derived"` (subdued/dashed chip)     |

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "3.11.0"
+  "version": "3.12.0"
 }

--- a/packages/react-native-livechart/src/components/CustomMarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomMarkerOverlay.tsx
@@ -33,6 +33,7 @@ function CustomMarkerView({
   padding,
   seriesSV,
   lineDataSV,
+  lineLinear,
 }: {
   marker: Marker;
   element: React.ReactElement;
@@ -40,6 +41,7 @@ function CustomMarkerView({
   padding: ChartPadding;
   seriesSV?: SharedValue<SeriesConfig[]>;
   lineDataSV?: SharedValue<LiveChartPoint[]>;
+  lineLinear?: boolean;
 }) {
   const time = marker.time;
   const value = marker.value;
@@ -59,6 +61,7 @@ function CustomMarkerView({
       displayMax: engine.displayMax.get(),
       series: seriesSV?.get(),
       lineData: lineDataSV?.get(),
+      lineLinear,
     }),
   );
 
@@ -111,6 +114,7 @@ export function CustomMarkerOverlay({
   padding,
   series,
   lineData,
+  lineLinear,
 }: {
   markers: SharedValue<Marker[]>;
   renderMarker: (marker: Marker) => React.ReactElement | null | undefined;
@@ -120,6 +124,8 @@ export function CustomMarkerOverlay({
   series?: SharedValue<SeriesConfig[]>;
   /** Single-series line data; anchors markers that omit `value`. */
   lineData?: SharedValue<LiveChartPoint[]>;
+  /** Single-series line is drawn linear — anchor `lineData` markers on the chord. */
+  lineLinear?: boolean;
 }) {
   const [snapshot, setSnapshot] = useState<Marker[]>(() => markers.get().slice());
 
@@ -156,6 +162,7 @@ export function CustomMarkerOverlay({
           padding={padding}
           seriesSV={series}
           lineDataSV={lineData}
+          lineLinear={lineLinear}
         />
       ))}
     </View>

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -407,14 +407,18 @@ function useLiveChartController({
     ? thresholdStops(thresholdCfg, palette)
     : null;
 
+  // Straight polyline instead of the monotone cubic when line.curve === "linear".
+  // Shared by the path builders and the marker anchoring so glyphs sit on the
+  // rendered line rather than the phantom spline.
+  const lineIsLinear = lineProp?.curve === "linear";
+
   const { linePath, fillPath, thresholdFillPath } = useChartPaths(
     engine,
     effectivePadding,
     reveal.morphT,
     // Only build the band path when the fill is actually on.
     thresholdCfg?.fill ? thresholdGeom.lineY : undefined,
-    // Straight polyline instead of the monotone cubic when line.curve === "linear".
-    lineProp?.curve === "linear",
+    lineIsLinear,
   );
 
   // Area-dots fill shader color as a vec4 (channels 0..1), with the config
@@ -518,6 +522,7 @@ function useLiveChartController({
     undefined, // seriesSV — single-series has none
     engine.data, // anchor value-less markers to the line
     !isStatic, // static: no marker-projection loop
+    lineIsLinear, // match marker anchoring to the rendered curve
   );
 
   // Pressable reference-line badges (working orders / alerts). Built before
@@ -705,6 +710,7 @@ function useLiveChartController({
     linePath,
     fillPath,
     thresholdFillPath,
+    lineIsLinear,
     upBodiesPath,
     downBodiesPath,
     upWicksPath,
@@ -864,6 +870,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     formatValue,
     lineGroupOpacity,
     linePath,
+    lineIsLinear,
     strokeWidth,
     lineProp,
     candleGroupOpacity,
@@ -1060,6 +1067,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
             palette={palette}
             font={skiaFont}
             lineData={engine.data}
+            lineLinear={lineIsLinear}
             renderMarker={renderMarker}
           />
         </Group>
@@ -1338,6 +1346,7 @@ export function LiveChart(props: LiveChartProps) {
     extremaTimeOffset,
     topConnector,
     bottomConnector,
+    lineIsLinear,
   } = model;
 
   return (
@@ -1414,6 +1423,7 @@ export function LiveChart(props: LiveChartProps) {
             engine={engine}
             padding={effectivePadding}
             lineData={engine.data}
+            lineLinear={lineIsLinear}
           />
         )}
 

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -51,6 +51,7 @@ function ConnectorGlyph({
   padding,
   seriesSV,
   lineDataSV,
+  lineLinear,
   axisY,
 }: {
   marker: Marker;
@@ -59,6 +60,7 @@ function ConnectorGlyph({
   padding: ChartPadding;
   seriesSV?: SharedValue<SeriesConfig[]>;
   lineDataSV?: SharedValue<LiveChartPoint[]>;
+  lineLinear?: boolean;
   axisY: SharedValue<number>;
 }) {
   const { kind } = marker;
@@ -80,6 +82,7 @@ function ConnectorGlyph({
       displayMax: engine.displayMax.get(),
       series: seriesSV?.get(),
       lineData: lineDataSV?.get(),
+      lineLinear,
     }),
   );
 
@@ -148,6 +151,7 @@ export function MarkerOverlay({
   font,
   series,
   lineData,
+  lineLinear,
   renderMarker,
 }: {
   markers: SharedValue<Marker[]>;
@@ -159,6 +163,8 @@ export function MarkerOverlay({
   series?: SharedValue<SeriesConfig[]>;
   /** Single-series line data; anchors markers that omit `value`. */
   lineData?: SharedValue<LiveChartPoint[]>;
+  /** Single-series line is drawn linear — anchor `lineData` markers on the chord. */
+  lineLinear?: boolean;
   /**
    * When provided, markers it returns an element for are rendered as RN views by
    * `CustomMarkerOverlay` instead — so they're excluded from the atlas here to
@@ -263,6 +269,7 @@ export function MarkerOverlay({
         displayMax: engine.displayMax.get(),
         series: series?.get(),
         lineData: lineData?.get(),
+        lineLinear,
       });
       const transforms = [];
       const sprites = [];
@@ -284,7 +291,7 @@ export function MarkerOverlay({
       }
       return { transforms, sprites };
     },
-    [cells, customIds, invScale, markers, engine, padding, series, lineData],
+    [cells, customIds, invScale, markers, engine, padding, series, lineData, lineLinear],
   );
   const transforms = useDerivedValue(() => atlasData.get().transforms, [atlasData]);
   const sprites = useDerivedValue(() => atlasData.get().sprites, [atlasData]);
@@ -309,6 +316,7 @@ export function MarkerOverlay({
           padding={padding}
           seriesSV={series}
           lineDataSV={lineData}
+          lineLinear={lineLinear}
           axisY={axisY}
         />
       ))}

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -32,6 +32,9 @@ export function useMarkers(
   lineData?: SharedValue<LiveChartPoint[]>,
   /** Static charts run no loops: register without starting. Default `true`. */
   autostart = true,
+  /** Single-series line is drawn linear (`line.curve === "linear"`) — anchor
+   *  `lineData` markers on the straight chord rather than the spline. */
+  lineLinear = false,
 ): {
   projected: SharedValue<ProjectedMarker[]>;
   tapGesture: ReturnType<typeof Gesture.Tap>;
@@ -77,6 +80,7 @@ export function useMarkers(
         displayMax: engine.displayMax.get(),
         series: seriesSV?.get(),
         lineData: lineData?.get(),
+        lineLinear,
       });
       projected.set(buf);
     },

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -63,7 +63,8 @@ export function useMultiSeriesLinePaths(
       if (n >= 2) {
         const b = slots[i];
         b.moveTo(pts[0], pts[1]);
-        drawSpline(b, pts, pool.scratch);
+        // Straight polyline when this series opts into `curve: "linear"`.
+        drawSpline(b, pts, pool.scratch, s[i].curve === "linear");
         out.push(b.detach());
       } else {
         out.push(pool.empty);

--- a/packages/react-native-livechart/src/math/markers.ts
+++ b/packages/react-native-livechart/src/math/markers.ts
@@ -1,4 +1,5 @@
 import type { LiveChartPoint, Marker, SeriesConfig } from "../types";
+import { interpolateAtTime } from "./interpolate";
 import { splineValueAtTime } from "./spline";
 
 /** Screen-space position for one marker, index-aligned with the marker array. */
@@ -23,6 +24,11 @@ export interface ProjectMarkersOpts {
   series?: SeriesConfig[];
   /** Single-series line data; anchors markers that omit `value` (and `seriesId`). */
   lineData?: LiveChartPoint[];
+  /** When the single-series line is drawn with `line.curve === "linear"`, anchor
+   *  `lineData` markers on the straight chord (linear interpolation) instead of the
+   *  monotone spline so the glyph sits exactly on the rendered line. Multi-series
+   *  markers read their curve per-series from {@link SeriesConfig.curve}. */
+  lineLinear?: boolean;
 }
 
 /** How far off-chart (px) a marker may sit before it is culled. */
@@ -66,16 +72,23 @@ function projectInto(
   } else if (seriesId !== undefined && opts.series) {
     for (let j = 0; j < opts.series.length; j++) {
       if (opts.series[j].id === seriesId) {
-        // Evaluate the rendered spline (not the linear chord) so the glyph sits
-        // exactly on the curve between data points.
-        v = splineValueAtTime(opts.series[j].data, time);
+        // Anchor on the same interpolation the series is rendered with, so the
+        // glyph sits exactly on the line: the linear chord for `curve: "linear"`,
+        // the monotone spline otherwise.
+        v =
+          opts.series[j].curve === "linear"
+            ? interpolateAtTime(opts.series[j].data, time)
+            : splineValueAtTime(opts.series[j].data, time);
         break;
       }
     }
   } else if (opts.lineData) {
-    // Single-series anchor: omit `value` to pin the marker to the line at `time`
-    // (on the rendered spline curve, not the linear chord between points).
-    v = splineValueAtTime(opts.lineData, time);
+    // Single-series anchor: omit `value` to pin the marker to the line at `time`.
+    // Match the rendered curve — straight chord when `line.curve === "linear"`,
+    // the monotone spline otherwise.
+    v = opts.lineLinear
+      ? interpolateAtTime(opts.lineData, time)
+      : splineValueAtTime(opts.lineData, time);
   }
   if (v === null) {
     target.visible = false;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -935,6 +935,13 @@ export interface SeriesConfig {
   style?: "solid" | "dashed";
   /** Dash pattern as `[dashLength, gapLength]` when `style` is `"dashed"`. Default `[6, 4]`. */
   intervals?: [number, number];
+  /**
+   * Interpolation for this series' line, mirroring {@link LineConfig.curve}.
+   * - `"monotone"` (default): Fritsch-Carlson monotone cubic spline.
+   * - `"linear"`: straight segments between samples (sharp vertices). Markers
+   *   anchored to this series snap to the straight chord to match.
+   */
+  curve?: "monotone" | "linear";
   /** Per-series stroke width override (px). Falls back to the chart line width. */
   strokeWidth?: number;
   /** Render a soft glow behind this series' line. Default `false`. */

--- a/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
@@ -48,6 +48,30 @@ describe("useChartPaths", () => {
     expect(result.current.linePath.value).toBeDefined();
   });
 
+  it("builds straight-polyline paths when linear, incl. the threshold band", () => {
+    const { result } = renderHook(() => {
+      const thresholdY = useSharedValue(60);
+      return useChartPaths(
+        makeEngine({
+          data: {
+            value: [
+              { time: 980, value: 1 },
+              { time: 990, value: 1.5 },
+              { time: 1000, value: 2 },
+            ],
+          },
+        } as unknown as Partial<SingleEngineState>),
+        DEFAULT_PADDING,
+        undefined,
+        thresholdY,
+        true, // linear
+      );
+    });
+    expect(result.current.linePath.value).toBeDefined();
+    expect(result.current.fillPath.value).toBeDefined();
+    expect(result.current.thresholdFillPath.value).toBeDefined();
+  });
+
   it("blends toward squiggly when morphT < 1", () => {
     const { result } = renderHook(() => {
       const morphT = useSharedValue(0.5);

--- a/packages/react-native-livechart/tests/hooks/useMultiSeriesLinePaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useMultiSeriesLinePaths.test.tsx
@@ -39,4 +39,41 @@ describe("useMultiSeriesLinePaths", () => {
     });
     expect(result.current.value.length).toBeGreaterThan(0);
   });
+
+  it("builds a straight-polyline path for a series with curve: \"linear\"", () => {
+    const { result } = renderHook(() => {
+      const series = useSharedValue([
+        {
+          id: "a",
+          data: [
+            { time: 1_700_000_000, value: 10 },
+            { time: 1_700_000_015, value: 18 },
+            { time: 1_700_000_030, value: 12 },
+          ],
+          value: 12,
+          color: "#3b82f6",
+          curve: "linear" as const,
+        },
+      ]);
+      const displaySeriesValues = useSharedValue([12]);
+      const seriesOpacities = useSharedValue([1]);
+      const engine = withSharedValueAccessors({
+        data: { value: [] },
+        value: { value: 0 },
+        displayValue: { value: 0 },
+        series,
+        displaySeriesValues,
+        seriesOpacities,
+        timestamp: { value: 1_700_000_030 },
+        displayWindow: { value: 30 },
+        displayMin: { value: 0 },
+        displayMax: { value: 20 },
+        canvasWidth: { value: 400 },
+        canvasHeight: { value: 300 },
+      }) as unknown as MultiEngineState;
+      const padding = { top: 12, right: 44, bottom: 28, left: 12 };
+      return useMultiSeriesLinePaths(engine, padding);
+    });
+    expect(result.current.value.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/react-native-livechart/tests/math/markers.test.ts
+++ b/packages/react-native-livechart/tests/math/markers.test.ts
@@ -68,6 +68,44 @@ describe("projectMarkers", () => {
     expect(out[0].y).toBeCloseTo(194);
   });
 
+  // Triangle peak so the monotone spline bows off the straight chord: at the
+  // midpoint of the rising segment (t=985) the linear chord is v=30 (y≈194) but
+  // the monotone cubic is v=37.5 (y≈174.5). These let us tell which interpolant
+  // each anchoring path used.
+  const PEAK = [
+    { time: 980, value: 0 },
+    { time: 990, value: 60 },
+    { time: 1000, value: 0 },
+  ];
+
+  it("anchors lineData markers on the monotone spline by default", () => {
+    const markers: Marker[] = [{ id: "a", time: 985, kind: "trade" }];
+    const out: ProjectedMarker[] = [];
+    projectMarkers(markers, out, { ...BASE, lineData: PEAK });
+    expect(out[0].y).toBeCloseTo(174.5); // spline v=37.5
+  });
+
+  it("anchors lineData markers on the straight chord when lineLinear", () => {
+    const markers: Marker[] = [{ id: "a", time: 985, kind: "trade" }];
+    const out: ProjectedMarker[] = [];
+    projectMarkers(markers, out, { ...BASE, lineData: PEAK, lineLinear: true });
+    expect(out[0].y).toBeCloseTo(194); // linear v=30
+  });
+
+  it("anchors seriesId markers on the straight chord when the series is linear", () => {
+    const spline: SeriesConfig[] = [{ id: "s1", value: 0, data: PEAK }];
+    const linear: SeriesConfig[] = [
+      { id: "s1", value: 0, data: PEAK, curve: "linear" },
+    ];
+    const markers: Marker[] = [{ id: "a", time: 985, kind: "winner", seriesId: "s1" }];
+    const splineOut: ProjectedMarker[] = [];
+    const linearOut: ProjectedMarker[] = [];
+    projectMarkers(markers, splineOut, { ...BASE, series: spline });
+    projectMarkers(markers, linearOut, { ...BASE, series: linear });
+    expect(splineOut[0].y).toBeCloseTo(174.5); // monotone default
+    expect(linearOut[0].y).toBeCloseTo(194); // curve: "linear"
+  });
+
   it("marks invisible when neither value nor a matching series resolves", () => {
     const out: ProjectedMarker[] = [];
     projectMarkers(

--- a/sim/useSimulatedChartData.ts
+++ b/sim/useSimulatedChartData.ts
@@ -182,6 +182,7 @@ function computeSeed(params: {
   multiSeries: boolean;
   candleAggregation: boolean;
   tradeStreamEnabled: boolean;
+  tradesPerSecond: number;
   tokenSymbol?: string;
   rng: () => number;
 }): SeedResult {
@@ -195,6 +196,7 @@ function computeSeed(params: {
     multiSeries,
     candleAggregation,
     tradeStreamEnabled,
+    tradesPerSecond,
     tokenSymbol,
     rng,
   } = params;
@@ -213,12 +215,18 @@ function computeSeed(params: {
     ? seedTradeTapeFromMid(lastMid, INITIAL_TAPE_EVENTS, vol, rng, tokenSymbol)
     : [];
 
+  // Match the seed cadence to the live stream (≈1 point / `1/tradesPerSecond`s)
+  // over a fixed ~30s span, so the seeded history and the incoming trades share a
+  // point density — no dense-history-meets-sparse-live seam. At the default high
+  // TPS this resolves to the previous 150 points @ 0.2s.
+  const seedInterval = tradesPerSecond > 0 ? 1 / tradesPerSecond : 0.2;
   const initialSeries = multiSeries
     ? generateMultiSeries({
         ids: ["yes", "no", "maybe"],
         colors: ["#3b82f6", "#ef4444", "#f59e0b"],
         labels: ["Yes", "No", "Maybe"],
-        count: 150,
+        interval: seedInterval,
+        count: Math.max(2, Math.round(30 / seedInterval)),
         sumToHundred: true,
       })
     : [];
@@ -305,6 +313,7 @@ export function useSimulatedChartData(
       multiSeries,
       candleAggregation,
       tradeStreamEnabled,
+      tradesPerSecond,
       tokenSymbol,
       rng: random01Ref.current,
     });
@@ -335,6 +344,7 @@ export function useSimulatedChartData(
     multiSeries,
     candleAggregation,
     tradeStreamEnabled,
+    tradesPerSecond,
     tokenSymbol,
     resetNonce,
     data,


### PR DESCRIPTION
## Summary

Completes [#141](https://github.com/brandtnewlabs/react-native-livechart/issues/141). The single-series `LineConfig.curve` (`"monotone"` | `"linear"`) shipped in **3.8.0**; this PR extends the feature across the rest of the surface and fixes a related anchoring gap.

## What's in here

- **`SeriesConfig.curve`** (`"monotone"` | `"linear"`) — per-series interpolation for `LiveChartSeries`, wired through `useMultiSeriesLinePaths`. Each series chooses independently; default `"monotone"`.
- **Marker anchoring follows the rendered curve.** A marker anchored to the line by `time` (no explicit `value`) was always projected onto the monotone spline, so in `curve: "linear"` mode it floated off the straight segment — most visible on sparse ranges. It now uses the straight chord when the line/series is `"linear"`, the spline otherwise. Threaded through `markers.ts`, `useMarkers`, `MarkerOverlay`, `CustomMarkerOverlay`, `LiveChart`.
- **Demos:** a **Curve** toggle on both the **Line & area** and **Multi-series** demo screens.
- **Sim:** the seeded history cadence now derives from `tradesPerSecond`, so seeded history and the live stream share a point density (no dense-seed / sparse-live seam). At the default `normal` volatility (5 tps) this resolves to the prior `150 @ 0.2s`, so existing demos are unchanged.

## Tests / verification

- Added tests: linear marker anchoring (single-series `lineLinear` + multi-series `curve`), `useChartPaths` linear + threshold-band, multi-series linear path.
- `npm run verify` green (typecheck + lint + 988 tests); coverage above thresholds.
- QA'd on the iOS 26.4 simulator: markers sit on the line in both modes; multi-series linear renders sharp segments; seed/live density consistent.

## Docs

- `SeriesConfig.curve` documented in `docs/api-reference/types.mdx` and the multi-series guide.
- CHANGELOG + version bump to **3.12.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
