### PR TITLE
feat(overlay): renderOverlay price↔pixel bridge (#140)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -108,6 +108,11 @@ const SECTIONS: DemoSection[] = [
         blurb: "referenceLines: lines, value/time bands, off-axis badge.",
       },
       {
+        href: "/demo/overlay-bridge",
+        title: "Overlay bridge",
+        blurb: "renderOverlay: hand-rolled RN order overlay via the priceToY / yToPrice / timeToX bridge.",
+      },
+      {
         href: "/demo/threshold",
         title: "Threshold split",
         blurb: "threshold: green above / red below a live break-even — split stroke, P/L fill band, marker line.",

--- a/app/demo/overlay-bridge.tsx
+++ b/app/demo/overlay-bridge.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { StyleSheet, Text, type LayoutChangeEvent } from "react-native";
+import {
+  LiveChart,
+  usePriceY,
+  type ChartOverlayContext,
+} from "react-native-livechart";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+} from "react-native-reanimated";
+
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME, colors } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Overlay bridge" };
+
+const WINDOW_SECS = 60;
+
+type Level = { price: number; label: string; color: string };
+
+// Fixed price levels (the sim starts at 100). They hold their PRICE while the
+// line wiggles and the axis breathes — exactly what the bridge demonstrates;
+// a level that drifts off-range pins to the nearest plot edge.
+const LEVELS: Level[] = [
+  { price: 102, label: "Take profit", color: "#16a34a" },
+  { price: 99.5, label: "Avg entry", color: ACCENT },
+  { price: 97, label: "Liquidation", color: "#dc2626" },
+];
+
+/**
+ * `renderOverlay` demo — the price↔pixel bridge. The chart hands us worklet
+ * `priceToY` + a live `plot` rect; we hand-roll an order overlay (a full-width
+ * level line + a right-edge price tag) entirely in React Native, and it stays
+ * glued to its price as the Y-axis auto-rescales and while scrubbing — without
+ * re-deriving the scale or re-rendering. This is the building block for
+ * avg-entry / liquidation / working-order overlays.
+ */
+export default function OverlayBridgeScreen() {
+  const [showLines, setShowLines] = useState(true);
+
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    tradeStream: false,
+    historySpanSeconds: WINDOW_SECS,
+    historyRange: "1m",
+    volatilityMode: "volatile",
+  });
+
+  return (
+    <DemoScreen
+      title="Overlay bridge"
+      description="renderOverlay hands you worklet priceToY / yToPrice / timeToX + a live plot rect. Here a hand-rolled RN order overlay (level line + price tag) tracks each price as the axis rescales — drag the chart to scrub and watch the tags stay put."
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={WINDOW_SECS}
+          // Right gutter widened a touch so the price tags clear the y-axis labels.
+          insets={{ right: 96 }}
+          renderOverlay={(ctx) => (
+            <>
+              {LEVELS.map((lvl) => (
+                <OrderLevel
+                  key={lvl.label}
+                  ctx={ctx}
+                  level={lvl}
+                  showLine={showLines}
+                />
+              ))}
+            </>
+          )}
+        />
+      }
+    >
+      <ControlRow label="Overlay">
+        <ToggleChip
+          label="Level lines"
+          value={showLines}
+          onChange={setShowLines}
+        />
+      </ControlRow>
+    </DemoScreen>
+  );
+}
+
+/**
+ * One order level rendered entirely in RN from the bridge: a full-width line
+ * (when enabled) and a right-edge price tag. `usePriceY` gives the price's live Y
+ * as a SharedValue (the recommended path — reactivity is handled for us); `scale`
+ * supplies the plot rect for the line's x-extent + clamping.
+ */
+function OrderLevel({
+  ctx,
+  level,
+  showLine,
+}: {
+  ctx: ChartOverlayContext;
+  level: Level;
+  showLine: boolean;
+}) {
+  const { scale } = ctx;
+  const { price, label, color } = level;
+
+  // Reactive Y for this price — tracks the rescaling axis on the UI thread.
+  const y = usePriceY(ctx, price);
+
+  // Measured tag size, so it can be pinned by its right edge at the axis.
+  const tagSize = useSharedValue({ width: 0, height: 0 });
+  const onTagLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    tagSize.set({ width, height });
+  };
+
+  const lineStyle = useAnimatedStyle(() => {
+    const py = y.get();
+    const s = scale.get();
+    const clampedY = Math.max(s.plot.top, Math.min(s.plot.bottom, py));
+    return {
+      opacity: py < 0 || !showLine ? 0 : 1,
+      width: Math.max(0, s.plot.right - s.plot.left),
+      transform: [{ translateX: s.plot.left }, { translateY: clampedY }],
+    };
+  });
+
+  const tagStyle = useAnimatedStyle(() => {
+    const py = y.get();
+    const s = scale.get();
+    const clampedY = Math.max(s.plot.top, Math.min(s.plot.bottom, py));
+    const ts = tagSize.get();
+    return {
+      opacity: py < 0 ? 0 : 1,
+      transform: [
+        { translateX: s.plot.right - ts.width },
+        { translateY: clampedY - ts.height / 2 },
+      ],
+    };
+  });
+
+  return (
+    <>
+      <Animated.View
+        pointerEvents="none"
+        style={[styles.line, { backgroundColor: color }, lineStyle]}
+      />
+      <Animated.View
+        pointerEvents="none"
+        onLayout={onTagLayout}
+        style={[styles.tag, { borderColor: color }, tagStyle]}
+      >
+        <Text style={[styles.tagText, { color }]}>
+          {label} {price.toFixed(2)}
+        </Text>
+      </Animated.View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  line: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    height: StyleSheet.hairlineWidth,
+    opacity: 0.7,
+  },
+  tag: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 5,
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: colors.background,
+  },
+  tagText: { fontSize: 11, fontWeight: "600", fontVariant: ["tabular-nums"] },
+});

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -147,6 +147,23 @@ provided; everything else has a default.
   See [Custom tooltip](/guides/scrubbing#custom-tooltip-rendertooltip).
 </ParamField>
 
+<ParamField body="renderOverlay" type="(ctx: ChartOverlayContext) => ReactElement | null">
+  Render a custom overlay floated over the canvas, handed the price↔pixel /
+  time↔pixel bridge so it can track the **auto-rescaling** axis on the UI thread —
+  the same idea as `renderMarker`. The
+  [`ChartOverlayContext`](/api-reference/types#chartoverlaycontext) gives you a
+  per-frame `scale` `SharedValue` plus pure `priceToY` / `yToPrice` / `timeToX` /
+  `xToTime` mapping worklets. Easiest: render a component per level and call
+  [`usePriceY(ctx, price)`](/api-reference/types#chartoverlaycontext) /
+  `useTimeX(ctx, time)` — each returns a `SharedValue<number>` that tracks the axis,
+  which you read in `useAnimatedStyle`. (Or take the manual path: read `scale.get()`
+  in the worklet, then feed the snapshot to the mappings.) Return any RN view tree
+  (order / avg-entry / liquidation price tags, custom level lines); return
+  `null`/`undefined` for no overlay. The tree mounts full-bleed with
+  `pointerEvents="box-none"` so empty areas still scrub. **Single-series only.** See
+  [Overlay bridge](/guides/markers-and-references#overlay-bridge-renderoverlay).
+</ParamField>
+
 <ParamField body="referenceLines" type="ReferenceLine[]">
   Reference lines / bands (horizontal line, value band, or time band).
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -370,6 +370,64 @@ interface TooltipRenderProps {
 }
 ```
 
+## ChartOverlayContext
+
+The price↔pixel / time↔pixel bridge passed to a custom
+[`renderOverlay`](/api-reference/livechart#renderoverlay). It hands you a single
+per-frame `scale` `SharedValue` plus pure mapping worklets.
+
+```ts
+interface ChartOverlayContext {
+  scale: SharedValue<ChartScale>;                               // live scale, recomputed each frame
+  priceToY: (price: number, scale: ChartScale) => number;       // price → canvas Y px (-1 before layout)
+  yToPrice: (y: number, scale: ChartScale) => number | null;    // canvas Y px → price (clamped; null before layout)
+  timeToX: (time: number, scale: ChartScale) => number;         // unix seconds → canvas X px
+  xToTime: (x: number, scale: ChartScale) => number;            // canvas X px → unix seconds
+}
+
+interface ChartScale {
+  min: number;        // live Y-axis lower bound (price at the plot bottom)
+  max: number;        // live Y-axis upper bound (price at the plot top)
+  window: number;     // visible time window in seconds
+  now: number;        // right-edge timestamp (unix seconds)
+  plot: ChartPlotRect;
+}
+
+interface ChartPlotRect {
+  left: number;    // padding.left
+  top: number;     // padding.top
+  right: number;   // canvasWidth - padding.right
+  bottom: number;  // canvasHeight - padding.bottom
+  width: number;   // full canvas width
+  height: number;  // full canvas height
+}
+```
+
+**Easiest path — the `usePriceY` / `useTimeX` hooks.** They project a price / time to
+a `SharedValue<number>` that tracks the live axis for you. Render one component per
+level and read the value in your `useAnimatedStyle`:
+
+```tsx
+function PriceLevel({ ctx, price }) {
+  const y = usePriceY(ctx, price); // reactive — tracks the rescaling axis
+  const style = useAnimatedStyle(() => ({ transform: [{ translateY: y.get() }] }));
+  return <Animated.View style={style} />;
+}
+```
+
+**Manual path.** Read `scale.get()` inside your worklet — that read subscribes it to
+the live scale — then feed the snapshot to the pure mappings. (Reanimated only
+observes SharedValues read directly in a worklet's closure, so the mappings take the
+snapshot as an argument rather than reading it themselves.)
+
+```tsx
+const style = useAnimatedStyle(() => {
+  const s = scale.get();          // subscribe to the live scale
+  const y = priceToY(142.5, s);   // project a price level to its pixel
+  return { transform: [{ translateY: y }] };
+});
+```
+
 ## DegenOptions
 
 The most-used fields (see the source for the full tuning surface):

--- a/docs/guides/markers-and-references.mdx
+++ b/docs/guides/markers-and-references.mdx
@@ -166,6 +166,72 @@ referenceLines={[
 `text: false` (icon-only), and `background` / `borderColor` / `radius`. It supersedes the legacy
 `offAxisBadge` (still supported), which only appears once the value is off-screen and takes no icon.
 
+## Overlay bridge (`renderOverlay`)
+
+When the built-in lines and badges aren't enough — a draggable order book, an
+avg-entry / liquidation overlay with your own chrome — `renderOverlay` hands you
+the chart's **price↔pixel / time↔pixel scale** so you can hand-roll an overlay in
+plain React Native that stays glued to the auto-rescaling axis.
+
+The callback receives a [`ChartOverlayContext`](/api-reference/types#chartoverlaycontext).
+The returned tree mounts full-bleed over the canvas with `pointerEvents="box-none"`,
+so empty areas still scrub.
+
+### The easy path — `usePriceY` / `useTimeX`
+
+Render one component per level and call `usePriceY(ctx, price)` — it returns a
+`SharedValue<number>` that tracks the rescaling axis for you. Read it in your
+`useAnimatedStyle` like any SharedValue; no need to think about subscriptions.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  renderOverlay={(ctx) => <PriceTag ctx={ctx} price={142.5} label="Avg entry" />}
+/>
+
+function PriceTag({ ctx, price, label }) {
+  const y = usePriceY(ctx, price); // reactive — tracks the live axis
+  const style = useAnimatedStyle(() => ({
+    opacity: y.get() < 0 ? 0 : 1,
+    transform: [{ translateY: y.get() }],
+  }));
+  return <Animated.View pointerEvents="none" style={[styles.tag, style]}>{/* … */}</Animated.View>;
+}
+```
+
+`useTimeX(ctx, time)` is the time→x sibling. Both are hooks, so call them once per
+element (one component per level / annotation).
+
+### The manual path — `scale` + the pure mappings
+
+For one-off math (e.g. a gesture handler) or to keep everything in one worklet, read
+`scale.get()` yourself and feed the snapshot to the pure `priceToY` / `yToPrice` /
+`timeToX` / `xToTime` mappings:
+
+```tsx
+function PriceTag({ ctx, price }) {
+  const { priceToY, scale } = ctx;
+  const style = useAnimatedStyle(() => {
+    const s = scale.get();        // subscribe to the live scale (reactivity)
+    const y = priceToY(price, s); // pure projection against the snapshot
+    return { transform: [{ translateX: s.plot.left }, { translateY: y }] };
+  });
+  return <Animated.View pointerEvents="none" style={[styles.tag, style]} />;
+}
+```
+
+<Warning>
+  On the manual path, reactivity comes from reading `scale.get()` **inside** the
+  worklet — the mappings are pure and don't read it for you. A style that only calls
+  `priceToY(price, …)` without touching `scale.get()` won't re-run and the overlay
+  will freeze. (The `usePriceY` / `useTimeX` hooks handle this for you.)
+</Warning>
+
+These are the same projections the engine uses internally for the live dot, the
+scrub crosshair, and the [order-ticket drag](/guides/scrubbing#order-ticket-scrubaction)
+— so a custom overlay lines up pixel-for-pixel with the chart. Single-series only.
+
 ## Threshold split
 
 Where a reference line is a *static* annotation, `threshold` colors the line itself

--- a/packages/react-native-livechart/src/components/ChartOverlayLayer.tsx
+++ b/packages/react-native-livechart/src/components/ChartOverlayLayer.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from "react";
+import { StyleSheet, View } from "react-native";
+
+import type { ChartOverlayContext } from "../types";
+
+/**
+ * React Native overlay (NOT Skia) that floats a consumer's `renderOverlay` element
+ * tree over the Skia canvas — the same escape-hatch model as
+ * {@link CustomMarkerOverlay} / {@link CustomTooltipOverlay}. The consumer is
+ * handed the {@link ChartOverlayContext} (worklet price↔pixel / time↔pixel
+ * mappings + the live plot rect) and positions its own pieces on the UI thread.
+ *
+ * The element is wrapped full-bleed with `pointerEvents="box-none"` so empty areas
+ * fall through to the chart's scrub gesture while an interactive leaf inside the
+ * overlay can still receive touches. `render` is called on the JS thread per React
+ * render; the returned tree then tracks the axis via the context's SharedValues.
+ */
+export function ChartOverlayLayer({
+  render,
+  context,
+}: {
+  render: (ctx: ChartOverlayContext) => ReactElement | null | undefined;
+  context: ChartOverlayContext;
+}) {
+  const element = render(context);
+  if (element == null) return null;
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      {element}
+    </View>
+  );
+}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -47,6 +47,7 @@ import { useBadge } from "../hooks/useBadge";
 import { useCandlePaths } from "../hooks/useCandlePaths";
 import { useCanvasLayout } from "../hooks/useCanvasLayout";
 import { useChartColors } from "../hooks/useChartColors";
+import { useChartOverlayContext } from "../hooks/useChartOverlayContext";
 import { useChartPaths } from "../hooks/useChartPaths";
 import { useChartReveal } from "../hooks/useChartReveal";
 import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
@@ -96,6 +97,7 @@ import {
 import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
 import { CustomTooltipOverlay } from "./CustomTooltipOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
+import { ChartOverlayLayer } from "./ChartOverlayLayer";
 import { CrosshairOverlay } from "./CrosshairOverlay";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
 import { DotOverlay } from "./DotOverlay";
@@ -211,6 +213,7 @@ function useLiveChartController({
   markerHitRadius = 16,
   renderMarker,
   renderTooltip,
+  renderOverlay,
   leftEdgeFade = true,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
@@ -449,6 +452,10 @@ function useLiveChartController({
       !isStatic, // static: no candle-width lerp loop
     );
   const { dotX, dotY } = useLiveDot(engine, effectivePadding);
+
+  // Price↔pixel / time↔pixel bridge for a custom `renderOverlay`. Built
+  // unconditionally (hooks rule); only mounted when `renderOverlay` is provided.
+  const overlayContext = useChartOverlayContext(engine, effectivePadding);
 
   const momentumSV = useMomentum(engine, momentum);
 
@@ -732,6 +739,8 @@ function useLiveChartController({
     markersSV,
     renderMarker,
     renderTooltip,
+    renderOverlay,
+    overlayContext,
     // selection dot: resolved config + fallback color (the chart line/accent color)
     selectionDot: selectionDotCfg,
     selectionColor: lineProp?.color ?? palette.line,
@@ -1340,6 +1349,8 @@ export function LiveChart(props: LiveChartProps) {
     markersSV,
     renderMarker,
     renderTooltip,
+    renderOverlay,
+    overlayContext,
     scrubCfg,
     crosshair,
     isCandle,
@@ -1446,6 +1457,13 @@ export function LiveChart(props: LiveChartProps) {
             margin={scrubCfg.tooltipMargin}
             lineTop={crosshair.tooltipLineTop}
           />
+        )}
+
+        {/* Custom consumer overlay — an RN view tree floated over the canvas with
+            the price↔pixel / time↔pixel bridge, for order / avg-entry / liquidation
+            tags etc. Topmost RN sibling; `box-none` so empty areas still scrub. */}
+        {renderOverlay && (
+          <ChartOverlayLayer render={renderOverlay} context={overlayContext} />
         )}
       </View>
     </GestureDetector>

--- a/packages/react-native-livechart/src/hooks/overlayScale.ts
+++ b/packages/react-native-livechart/src/hooks/overlayScale.ts
@@ -1,0 +1,59 @@
+import type { ChartScale } from "../types";
+
+/**
+ * Pure worklet projections for the `renderOverlay` bridge ({@link ChartOverlayContext}).
+ *
+ * Each takes a {@link ChartScale} **snapshot** rather than reading any SharedValue
+ * itself — so the consumer's `useAnimatedStyle` / `useDerivedValue` becomes
+ * reactive simply by reading `scale.get()` (which subscribes it to the per-frame
+ * scale), and these stay trivially unit-testable as plain functions of data.
+ */
+
+/** Maps a price (Y-axis value) to its canvas Y pixel. -1 when not laid out. */
+export function priceToY(price: number, scale: ChartScale): number {
+  "worklet";
+  const { top, bottom } = scale.plot;
+  const chartH = bottom - top;
+  if (chartH <= 0) return -1;
+  const range = scale.max - scale.min;
+  if (range === 0) return top + chartH / 2;
+  return top + ((scale.max - price) / range) * chartH;
+}
+
+/**
+ * Inverse of {@link priceToY}: maps a canvas Y pixel back to a price. Clamps to
+ * the visible range (a level can't sit beyond the axis bounds); null when not
+ * laid out.
+ */
+export function yToPrice(y: number, scale: ChartScale): number | null {
+  "worklet";
+  const { top, bottom } = scale.plot;
+  const chartH = bottom - top;
+  if (chartH <= 0) return null;
+  const range = scale.max - scale.min;
+  if (range === 0) return scale.min;
+  const clampedY = Math.min(bottom, Math.max(top, y));
+  const frac = (clampedY - top) / chartH; // 0 at top, 1 at bottom
+  return scale.max - frac * range;
+}
+
+/** Maps a unix-seconds timestamp to its canvas X pixel. -1 when not laid out. */
+export function timeToX(time: number, scale: ChartScale): number {
+  "worklet";
+  const { left, right } = scale.plot;
+  const chartW = right - left;
+  if (chartW <= 0) return -1;
+  if (scale.window <= 0) return left;
+  const winStart = scale.now - scale.window;
+  return left + ((time - winStart) / scale.window) * chartW;
+}
+
+/** Inverse of {@link timeToX}: maps a canvas X pixel back to a unix-seconds timestamp. */
+export function xToTime(x: number, scale: ChartScale): number {
+  "worklet";
+  const { left, right } = scale.plot;
+  const chartW = right - left;
+  if (chartW <= 0) return -1;
+  const winStart = scale.now - scale.window;
+  return winStart + ((x - left) / chartW) * scale.window;
+}

--- a/packages/react-native-livechart/src/hooks/useChartOverlayContext.ts
+++ b/packages/react-native-livechart/src/hooks/useChartOverlayContext.ts
@@ -1,0 +1,93 @@
+import { useMemo } from "react";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import type { ChartOverlayContext, ChartScale } from "../types";
+import { priceToY, timeToX, xToTime, yToPrice } from "./overlayScale";
+
+/**
+ * Builds the {@link ChartOverlayContext} handed to a custom
+ * {@link LiveChartProps.renderOverlay}: a single per-frame {@link ChartScale}
+ * SharedValue plus the pure price↔pixel / time↔pixel mapping worklets.
+ *
+ * The `scale` derived value reads the engine SharedValues (range, window, "now")
+ * and the padding each frame, so a consumer's `useAnimatedStyle` becomes reactive
+ * just by reading `scale.get()` — that read subscribes it to per-frame updates
+ * (Reanimated only observes SharedValues found directly in a worklet's closure,
+ * not those hidden behind a function call). The mappings stay pure, taking the
+ * snapshot as an argument.
+ */
+export function useChartOverlayContext(
+  engine: ChartEngineLayout,
+  padding: ChartPadding,
+): ChartOverlayContext {
+  const { top: padTop, bottom: padBottom, left: padLeft, right: padRight } = padding;
+
+  const scale = useDerivedValue<ChartScale>(() => {
+    const width = engine.canvasWidth.get();
+    const height = engine.canvasHeight.get();
+    return {
+      min: engine.displayMin.get(),
+      max: engine.displayMax.get(),
+      window: engine.displayWindow.get(),
+      now: engine.timestamp.get(),
+      plot: {
+        left: padLeft,
+        top: padTop,
+        right: width - padRight,
+        bottom: height - padBottom,
+        width,
+        height,
+      },
+    };
+  }, [engine, padLeft, padTop, padRight, padBottom]);
+
+  return useMemo<ChartOverlayContext>(
+    () => ({ scale, priceToY, yToPrice, timeToX, xToTime }),
+    [scale],
+  );
+}
+
+/**
+ * Reactive Y for a price: projects `price` to its canvas Y pixel and returns it as
+ * a `SharedValue<number>` that tracks the live axis on the UI thread. The
+ * **recommended** way to place something at a price in a {@link LiveChartProps.renderOverlay}
+ * — read the returned value in your `useAnimatedStyle` like any SharedValue; the
+ * subscription to the chart's scale is handled here, so it can't be forgotten.
+ *
+ * ```tsx
+ * function PriceLevel({ ctx, price }) {
+ *   const y = usePriceY(ctx, price);
+ *   const style = useAnimatedStyle(() => ({ transform: [{ translateY: y.get() }] }));
+ *   return <Animated.View style={style} />;
+ * }
+ * ```
+ *
+ * It's a hook, so call it once per level (render one component per price). For
+ * one-off math off the render path (e.g. a gesture handler), use the pure
+ * {@link ChartOverlayContext.priceToY} with `ctx.scale.get()` instead.
+ */
+export function usePriceY(
+  ctx: ChartOverlayContext,
+  price: number,
+): SharedValue<number> {
+  const { scale, priceToY: toY } = ctx;
+  // Destructure `scale` so it sits directly in the worklet's closure (Reanimated
+  // observes top-level closure SharedValues, not ones reached via `ctx.scale`).
+  return useDerivedValue(() => toY(price, scale.get()), [scale, toY, price]);
+}
+
+/**
+ * Reactive X for a timestamp — the time↔pixel sibling of {@link usePriceY}.
+ * Projects `time` (unix seconds) to its canvas X pixel as a `SharedValue<number>`
+ * that tracks the scrolling window on the UI thread. Read it in your
+ * `useAnimatedStyle`; call once per element.
+ */
+export function useTimeX(
+  ctx: ChartOverlayContext,
+  time: number,
+): SharedValue<number> {
+  const { scale, timeToX: toX } = ctx;
+  return useDerivedValue(() => toX(time, scale.get()), [scale, toX, time]);
+}

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -25,6 +25,10 @@ export { MONO_FONT_FAMILY } from "./lib/monoFontFamily";
 export { useDegen } from "./hooks/useDegen";
 export { useTradeStream } from "./hooks/useTradeStream";
 
+// ── renderOverlay bridge hooks (reactive price→Y / time→X for custom overlays) ──
+
+export { usePriceY, useTimeX } from "./hooks/useChartOverlayContext";
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type {
@@ -36,6 +40,9 @@ export type {
   CandleMetrics,
   CandlePoint,
   ChartInsets,
+  ChartOverlayContext,
+  ChartPlotRect,
+  ChartScale,
   ChartSegment,
   DegenOptions,
   DegenShakePayload,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -626,6 +626,92 @@ export interface TooltipRenderProps {
   candle: SharedValue<CandlePoint | null>;
 }
 
+/** Inner plot rectangle in canvas pixels (a snapshot field of {@link ChartScale}). */
+export interface ChartPlotRect {
+  /** Inner plot left edge (`padding.left`). */
+  left: number;
+  /** Inner plot top edge (`padding.top`). */
+  top: number;
+  /** Inner plot right edge (`canvasWidth - padding.right`). */
+  right: number;
+  /** Inner plot bottom edge (`canvasHeight - padding.bottom`). */
+  bottom: number;
+  /** Full canvas width. */
+  width: number;
+  /** Full canvas height. */
+  height: number;
+}
+
+/**
+ * A snapshot of the chart's live scale — the value range, time window, and plot
+ * rect at one frame. Carried by {@link ChartOverlayContext.scale} (a `SharedValue`
+ * recomputed each frame) and consumed by the pure mapping functions. Reading
+ * `scale.get()` inside your worklet is what subscribes the overlay to per-frame
+ * updates, so it tracks the chart as it scrolls and rescales.
+ */
+export interface ChartScale {
+  /** Live Y-axis lower bound (price at the plot bottom). */
+  min: number;
+  /** Live Y-axis upper bound (price at the plot top). */
+  max: number;
+  /** Visible time window in seconds. */
+  window: number;
+  /** Right-edge timestamp (unix seconds) — "now". */
+  now: number;
+  /** Inner plot rectangle in canvas px. */
+  plot: ChartPlotRect;
+}
+
+/**
+ * The price↔pixel / time↔pixel bridge handed to a custom
+ * {@link LiveChartProps.renderOverlay}.
+ *
+ * **Easiest path — the `usePriceY` / `useTimeX` hooks.** They project a price / time
+ * to a `SharedValue<number>` that tracks the live axis for you; just read it in
+ * your `useAnimatedStyle` like any SharedValue:
+ *
+ * ```tsx
+ * function PriceLevel({ ctx, price }) {
+ *   const y = usePriceY(ctx, price); // reactive — tracks the rescaling axis
+ *   const style = useAnimatedStyle(() => ({ transform: [{ translateY: y.get() }] }));
+ *   return <Animated.View style={style} />;
+ * }
+ * ```
+ *
+ * **Manual path — {@link scale} + the pure mappings.** For one-off math (e.g. a
+ * gesture handler) or when you want everything in one worklet, read `scale.get()`
+ * inside your worklet — that read subscribes it to the per-frame scale — then pass
+ * the snapshot to the pure mappings (`priceToY` / `yToPrice` / `timeToX` /
+ * `xToTime`). The mappings do **not** read `scale` themselves, so they only reflect
+ * the chart live when you feed them `scale.get()`:
+ *
+ * ```tsx
+ * const style = useAnimatedStyle(() => {
+ *   const s = scale.get();          // subscribe to the live scale
+ *   const y = priceToY(142.5, s);   // project a price to its pixel
+ *   return { transform: [{ translateY: y }] };
+ * });
+ * ```
+ */
+export interface ChartOverlayContext {
+  /**
+   * The live {@link ChartScale} snapshot, recomputed each frame. Read `.get()`
+   * inside your worklet to subscribe it to chart updates.
+   */
+  scale: SharedValue<ChartScale>;
+  /** Maps a price (Y-axis value) → canvas Y px for a {@link ChartScale}. Worklet. -1 when not laid out. */
+  priceToY: (price: number, scale: ChartScale) => number;
+  /**
+   * Inverse of {@link priceToY}: canvas Y px → price. Worklet. Clamps to the
+   * visible range; `null` when not laid out.
+   */
+  yToPrice: (y: number, scale: ChartScale) => number | null;
+  /** Maps a unix-seconds timestamp → canvas X px for a {@link ChartScale}. Worklet. -1 when not laid out. */
+  timeToX: (time: number, scale: ChartScale) => number;
+  /** Inverse of {@link timeToX}: canvas X px → unix-seconds timestamp. Worklet. */
+  xToTime: (x: number, scale: ChartScale) => number;
+}
+
 /** Outer ring drawn around the built-in selection dot (the subtle halo). */
 export interface SelectionDotRingConfig {
   /** Ring color. Defaults to the dot color. */
@@ -1324,6 +1410,19 @@ export interface LiveChartProps extends LiveChartCoreProps {
    *  in a list. Pulse/scrub/degen and the entry animation are disabled. Frame the data
    *  with `timeWindow` + `nowOverride` (see the historical-data-fill pattern). */
   static?: boolean;
+  /**
+   * Render a custom overlay floated over the chart canvas, handed a price↔pixel /
+   * time↔pixel {@link ChartOverlayContext} so it can track the auto-rescaling axis
+   * on the UI thread. Return any React Native view tree (e.g. order / avg-entry /
+   * liquidation price tags) and position its pieces with the context's worklet
+   * mappings inside `useAnimatedStyle`; return `null`/`undefined` for no overlay.
+   *
+   * The returned tree is mounted as an RN sibling of the `<Canvas>` (like
+   * `renderMarker` / `renderTooltip`), full-bleed with `pointerEvents="box-none"`
+   * so empty areas still scrub while an interactive leaf can receive touches.
+   * Single-series only.
+   */
+  renderOverlay?: (ctx: ChartOverlayContext) => ReactElement | null | undefined;
   /** Called when the user scrubs the crosshair. `null` when scrub ends. */
   onScrub?: (point: ScrubPoint | null) => void;
   /**

--- a/packages/react-native-livechart/tests/components/ChartOverlayLayer.test.tsx
+++ b/packages/react-native-livechart/tests/components/ChartOverlayLayer.test.tsx
@@ -1,0 +1,55 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { Text } from "react-native";
+
+import { ChartOverlayLayer } from "../../src/components/ChartOverlayLayer";
+import type { ChartOverlayContext } from "../../src/types";
+
+// ChartOverlayLayer only forwards the context to `render`; a minimal stub is fine.
+const context = {
+  scale: {
+    value: {
+      min: 0,
+      max: 100,
+      window: 30,
+      now: 0,
+      plot: { left: 12, top: 12, right: 320, bottom: 272, width: 400, height: 300 },
+    },
+  },
+  priceToY: () => 0,
+  yToPrice: () => 0,
+  timeToX: () => 0,
+  xToTime: () => 0,
+} as unknown as ChartOverlayContext;
+
+describe("ChartOverlayLayer", () => {
+  it("mounts the element the consumer returns", () => {
+    const { getByTestId } = render(
+      <ChartOverlayLayer
+        context={context}
+        render={() => <Text testID="overlay">tag</Text>}
+      />,
+    );
+    expect(getByTestId("overlay")).toBeTruthy();
+  });
+
+  it("passes the bridge context to the render callback", () => {
+    const render_ = jest.fn(() => null);
+    render(<ChartOverlayLayer context={context} render={render_} />);
+    expect(render_).toHaveBeenCalledWith(context);
+  });
+
+  it("renders nothing when the callback returns null", () => {
+    const { toJSON } = render(
+      <ChartOverlayLayer context={context} render={() => null} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders nothing when the callback returns undefined", () => {
+    const { toJSON } = render(
+      <ChartOverlayLayer context={context} render={() => undefined} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/packages/react-native-livechart/tests/hooks/overlayScale.test.ts
+++ b/packages/react-native-livechart/tests/hooks/overlayScale.test.ts
@@ -1,0 +1,84 @@
+import {
+  priceToY,
+  timeToX,
+  xToTime,
+  yToPrice,
+} from "../../src/hooks/overlayScale";
+import type { ChartScale } from "../../src/types";
+
+// plot: left=12, top=12, right=320, bottom=272 → chartH=260, chartW=308.
+// range 0..100, window 30s ending at now=0 (winStart=-30).
+const SCALE: ChartScale = {
+  min: 0,
+  max: 100,
+  window: 30,
+  now: 0,
+  plot: { left: 12, top: 12, right: 320, bottom: 272, width: 400, height: 300 },
+};
+
+/** A scale whose plot has no height/width (canvas not laid out yet). */
+const UNLAID: ChartScale = {
+  ...SCALE,
+  plot: { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 },
+};
+
+describe("priceToY", () => {
+  it("maps the range bounds to the plot top / bottom", () => {
+    expect(priceToY(100, SCALE)).toBeCloseTo(12); // max → top
+    expect(priceToY(0, SCALE)).toBeCloseTo(272); // min → bottom
+    expect(priceToY(50, SCALE)).toBeCloseTo(142); // mid
+  });
+
+  it("returns -1 when the canvas is not laid out", () => {
+    expect(priceToY(50, UNLAID)).toBe(-1);
+  });
+
+  it("pins to the plot center for a degenerate range", () => {
+    expect(priceToY(50, { ...SCALE, min: 50, max: 50 })).toBeCloseTo(142);
+  });
+});
+
+describe("yToPrice", () => {
+  it("is the inverse of priceToY", () => {
+    for (const price of [0, 25, 50, 75, 100]) {
+      expect(yToPrice(priceToY(price, SCALE), SCALE)).toBeCloseTo(price);
+    }
+  });
+
+  it("clamps to the visible range outside the plot", () => {
+    expect(yToPrice(-100, SCALE)).toBeCloseTo(100); // above top → max
+    expect(yToPrice(9999, SCALE)).toBeCloseTo(0); // below bottom → min
+  });
+
+  it("returns null when the canvas is not laid out", () => {
+    expect(yToPrice(50, UNLAID)).toBeNull();
+  });
+
+  it("collapses to the single value for a degenerate range", () => {
+    expect(yToPrice(142, { ...SCALE, min: 50, max: 50 })).toBe(50);
+  });
+});
+
+describe("timeToX / xToTime", () => {
+  it("map the plot edges to the window start and now", () => {
+    expect(timeToX(-30, SCALE)).toBeCloseTo(12); // winStart → left
+    expect(timeToX(0, SCALE)).toBeCloseTo(320); // now → right
+    expect(xToTime(12, SCALE)).toBeCloseTo(-30);
+    expect(xToTime(320, SCALE)).toBeCloseTo(0);
+  });
+
+  it("round-trip across the plot", () => {
+    for (const x of [12, 100, 200, 320]) {
+      expect(timeToX(xToTime(x, SCALE), SCALE)).toBeCloseTo(x);
+    }
+  });
+
+  it("return -1 when the canvas is not laid out", () => {
+    expect(timeToX(0, UNLAID)).toBe(-1);
+    expect(xToTime(0, UNLAID)).toBe(-1);
+  });
+
+  it("timeToX pins to the left edge when the window is degenerate", () => {
+    expect(timeToX(0, { ...SCALE, window: 0 })).toBe(12);
+  });
+});

--- a/packages/react-native-livechart/tests/hooks/useChartOverlayContext.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useChartOverlayContext.test.ts
@@ -1,0 +1,105 @@
+import { renderHook } from "@testing-library/react-native";
+
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import {
+  useChartOverlayContext,
+  usePriceY,
+  useTimeX,
+} from "../../src/hooks/useChartOverlayContext";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+// padding: top=12, right=80, bottom=28, left=12 → plot right=320, bottom=272,
+// chartH=260. Window 30s ending at timestamp 0.
+const PADDING = { top: 12, right: 80, bottom: 28, left: 12 };
+
+function engine(
+  partial: Partial<{
+    canvasWidth: number;
+    canvasHeight: number;
+    displayMin: number;
+    displayMax: number;
+    timestamp: number;
+    displayWindow: number;
+  }> = {},
+): ChartEngineLayout {
+  // Bare `{ value }` doubles + `.get()/.set()` so the hook's `.get()` reads work.
+  return withSharedValueAccessors({
+    displayMin: { value: partial.displayMin ?? 0 },
+    displayMax: { value: partial.displayMax ?? 100 },
+    displayWindow: { value: partial.displayWindow ?? 30 },
+    timeWindow: { value: partial.displayWindow ?? 30 },
+    canvasWidth: { value: partial.canvasWidth ?? 400 },
+    canvasHeight: { value: partial.canvasHeight ?? 300 },
+    timestamp: { value: partial.timestamp ?? 0 },
+  }) as unknown as ChartEngineLayout;
+}
+
+describe("useChartOverlayContext", () => {
+  it("derives the live scale snapshot from the engine + padding", () => {
+    const { result } = renderHook(() =>
+      useChartOverlayContext(engine(), PADDING),
+    );
+    const s = result.current.scale.get();
+    expect(s).toEqual({
+      min: 0,
+      max: 100,
+      window: 30,
+      now: 0,
+      plot: { left: 12, top: 12, right: 320, bottom: 272, width: 400, height: 300 },
+    });
+  });
+
+  it("exposes mapping worklets that project against a scale snapshot", () => {
+    const { result } = renderHook(() =>
+      useChartOverlayContext(engine(), PADDING),
+    );
+    const { priceToY, yToPrice, timeToX, xToTime, scale } = result.current;
+    const s = scale.get();
+    // max → plot top, min → plot bottom.
+    expect(priceToY(100, s)).toBeCloseTo(12);
+    expect(priceToY(0, s)).toBeCloseTo(272);
+    expect(yToPrice(priceToY(50, s), s)).toBeCloseTo(50);
+    // right plot edge is "now" (timestamp 0); left edge is the window start.
+    expect(timeToX(0, s)).toBeCloseTo(320);
+    expect(xToTime(320, s)).toBeCloseTo(0);
+  });
+
+  it("tracks engine changes through the scale snapshot", () => {
+    const eng = engine({ displayMin: 20, displayMax: 120, timestamp: 1000 });
+    const { result } = renderHook(() => useChartOverlayContext(eng, PADDING));
+    const s = result.current.scale.get();
+    expect(s.min).toBe(20);
+    expect(s.max).toBe(120);
+    expect(s.now).toBe(1000);
+  });
+
+  it("returns a stable context identity across re-renders", () => {
+    const eng = engine();
+    const { result, rerender } = renderHook(() =>
+      useChartOverlayContext(eng, PADDING),
+    );
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+});
+
+describe("usePriceY / useTimeX", () => {
+  it("usePriceY projects a price to its live canvas Y", () => {
+    const { result } = renderHook(() => {
+      const ctx = useChartOverlayContext(engine(), PADDING);
+      return usePriceY(ctx, 50);
+    });
+    // mid of a 0..100 range over a 260px plot starting at top=12 → 142.
+    expect(result.current.get()).toBeCloseTo(142);
+  });
+
+  it("useTimeX projects a timestamp to its live canvas X", () => {
+    const { result } = renderHook(() => {
+      const ctx = useChartOverlayContext(engine(), PADDING);
+      return useTimeX(ctx, 0);
+    });
+    // now=0 sits at the right plot edge (canvasWidth 400 - right 80 = 320).
+    expect(result.current.get()).toBeCloseTo(320);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the price↔pixel / time↔pixel **overlay bridge** from #140 — the highest-value, lowest-surface piece (the issue estimates it unblocks ~80% of on-chart order overlays). First PR in a planned stack: **bridge → full-width lines (#0) → draggable lines + handle positions (#1/#2)**.

A new `renderOverlay` prop on `LiveChart` hands the consumer a `ChartOverlayContext`: a per-frame **`scale`** `SharedValue` (`{ min, max, window, now, plot }`) plus pure **`priceToY` / `yToPrice` / `timeToX` / `xToTime`** mapping worklets. The returned element mounts as a `box-none` RN sibling of the `<Canvas>` (same model as `renderMarker`/`renderTooltip`), so empty areas still scrub. Single-series.

### Recommended path — `usePriceY` / `useTimeX`

Render a component per level; the hook returns a `SharedValue<number>` that tracks the rescaling axis, read in `useAnimatedStyle` like any SharedValue. The library owns the scale subscription, so reactivity can't be forgotten:

```tsx
function PriceLevel({ ctx, price }) {
  const y = usePriceY(ctx, price);
  const style = useAnimatedStyle(() => ({ transform: [{ translateY: y.get() }] }));
  return <Animated.View style={style} />;
}
```

### Manual path — `scale` + the pure mappings

For one-off math (e.g. a gesture handler) or single-worklet overlays, read `scale.get()` inside the worklet — that read subscribes it — then feed the snapshot to the pure mappings. (Reanimated only observes SharedValues read directly in a worklet's closure, so the bridge can't hide them behind a function call.)

## Changes
- `renderOverlay` prop + `ChartOverlayContext` / `ChartScale` / `ChartPlotRect` types, and `usePriceY` / `useTimeX` hooks — all exported from the package root.
- `useChartOverlayContext` (builds the per-frame `scale`) + pure `overlayScale` mapping worklets.
- `ChartOverlayLayer` RN overlay, wired into `LiveChart`.
- "Overlay bridge" demo (`app/demo/overlay-bridge.tsx`) + API/guide docs.

## Verification
- `npm run verify` (typecheck + lint + **1009 tests**) green; **100%** coverage on the new files.
- Verified on the iOS 26.4 simulator (hook + manual paths): the RN price tags stay glued to their prices as the Y-axis auto-rescales — including a large rescale (price dropped ~20%) where the tags re-clustered correctly.

Part of #140 (bridge phase); the issue stays open for the follow-up phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
