### PR TITLE
feat(reference-lines): opt-in full-width lines through the Y-axis gutter (#140)

### DIFF
--- a/app/demo/reference-lines.tsx
+++ b/app/demo/reference-lines.tsx
@@ -17,6 +17,8 @@ export default function ReferenceLinesScreen() {
   const [timeBand, setTimeBand] = useState(false);
   const [offAxis, setOffAxis] = useState(false);
   const [valueLine, setValueLine] = useState(true);
+  // Span lines/bands edge-to-edge through the Y-axis gutter (vs stop at the plot).
+  const [fullWidth, setFullWidth] = useState(false);
 
   const { data, value } = useSimulatedChartData({
     multiSeries: false,
@@ -49,13 +51,19 @@ export default function ReferenceLinesScreen() {
 
   const referenceLines: ReferenceLine[] = [];
   if (lines) {
-    referenceLines.push({ value: START * 1.05, label: "+5%", color: "#34d399" });
+    referenceLines.push({
+      value: START * 1.05,
+      label: "+5%",
+      color: "#34d399",
+      fullWidth,
+    });
     referenceLines.push({
       value: START * 0.95,
       label: "-5%",
       color: "#f87171",
       strokeWidth: 2,
       intervals: [6, 4],
+      fullWidth,
     });
   }
   if (valueBand) {
@@ -68,6 +76,7 @@ export default function ReferenceLinesScreen() {
       strokeWidth: 1,
       intervals: [4, 3],
       fillOpacity: 0.18,
+      fullWidth,
     });
   }
   if (timeBand && timeWindow) {
@@ -130,6 +139,11 @@ export default function ReferenceLinesScreen() {
           label="Value line"
           value={valueLine}
           onChange={setValueLine}
+        />
+        <ToggleChip
+          label="Full width"
+          value={fullWidth}
+          onChange={setFullWidth}
         />
       </ControlRow>
     </DemoScreen>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -98,6 +98,8 @@ interface ReferenceLine {
   intervals?: [number, number];
   color?: string;
   fillOpacity?: number;          // default 0.16
+  fullWidth?: boolean;           // span edge-to-edge through the Y-axis gutter (Form A/B);
+                                 //   label/badge stay in the plot. default false
   labelColor?: string;
   labelPosition?: "left" | "center" | "right";
   showValue?: boolean;

--- a/docs/guides/markers-and-references.mdx
+++ b/docs/guides/markers-and-references.mdx
@@ -144,6 +144,20 @@ interface TradeEvent {
 Lines support labels, dashes (`intervals`), and excluding their value from the axis range
 (`excludeFromRange`). See the [types reference](/api-reference/types) for every field.
 
+### Full-width lines (`fullWidth`)
+
+By default a line/band stops at the plot's right edge. Set `fullWidth: true` to span it
+**edge to edge through the Y-axis gutter**, so it connects visually to its value on the axis
+(like a price tag). Only the line/band extends — any `label` or `badge` stays anchored inside
+the plot. For a Form-A line with a `badge`, the full-width line replaces the dashed connector.
+
+```tsx
+referenceLines={[
+  { value: 142.5, label: "Avg entry", fullWidth: true }, // runs through the gutter
+  { value: 150.0 },                                      // stops at the plot edge (default)
+]}
+```
+
 ### Pill badges (working orders, alerts, targets)
 
 For a Form-A line, `badge` renders the value as a **pill** pinned to a plot edge with a dashed

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -79,11 +79,11 @@ export function ReferenceLineOverlay({
   const linePath = useDerivedValue(() => {
     const b = lineBuilder.value;
     const l = layout.get();
-    // A plain full-width line. A badge instead draws a pill + a connector to the
-    // opposite edge, below.
-    if (l.visible && !l.badge && !isBand) {
-      b.moveTo(l.x1, l.y);
-      b.lineTo(l.x2, l.y);
+    // A plain horizontal line, drawn at the line extent (full-width when opted in).
+    // A non-full-width badge instead draws a pill + connector to the edge, below.
+    if (l.visible && l.drawLine && !isBand) {
+      b.moveTo(l.lineX1, l.y);
+      b.lineTo(l.lineX2, l.y);
     }
     return b.detach();
   });
@@ -92,10 +92,10 @@ export function ReferenceLineOverlay({
     const b = bandBuilder.value;
     const l = layout.get();
     if (l.visible && isBand) {
-      b.moveTo(l.x1, l.y);
-      b.lineTo(l.x2, l.y);
-      b.lineTo(l.x2, l.yBottom);
-      b.lineTo(l.x1, l.yBottom);
+      b.moveTo(l.lineX1, l.y);
+      b.lineTo(l.lineX2, l.y);
+      b.lineTo(l.lineX2, l.yBottom);
+      b.lineTo(l.lineX1, l.yBottom);
       b.close();
     }
     return b.detach();
@@ -107,16 +107,16 @@ export function ReferenceLineOverlay({
     if (l.visible && hasBandBorder) {
       if (form === "time-band") {
         // Vertical edges at the band's left / right.
-        b.moveTo(l.x1, l.y);
-        b.lineTo(l.x1, l.yBottom);
-        b.moveTo(l.x2, l.y);
-        b.lineTo(l.x2, l.yBottom);
+        b.moveTo(l.lineX1, l.y);
+        b.lineTo(l.lineX1, l.yBottom);
+        b.moveTo(l.lineX2, l.y);
+        b.lineTo(l.lineX2, l.yBottom);
       } else {
         // Horizontal edges at the band's top / bottom.
-        b.moveTo(l.x1, l.y);
-        b.lineTo(l.x2, l.y);
-        b.moveTo(l.x1, l.yBottom);
-        b.lineTo(l.x2, l.yBottom);
+        b.moveTo(l.lineX1, l.y);
+        b.lineTo(l.lineX2, l.y);
+        b.moveTo(l.lineX1, l.yBottom);
+        b.lineTo(l.lineX2, l.yBottom);
       }
     }
     return b.detach();
@@ -155,7 +155,7 @@ export function ReferenceLineOverlay({
 
   const lineOpacity = useDerivedValue(() => {
     const l = layout.get();
-    return l.visible && !l.badge && !isBand ? 1 : 0;
+    return l.visible && l.drawLine && !isBand ? 1 : 0;
   });
   const bandOpacity = useDerivedValue(() =>
     layout.get().visible && isBand ? bandFillOpacity : 0,

--- a/packages/react-native-livechart/src/hooks/useReferenceLine.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLine.ts
@@ -18,10 +18,20 @@ export interface ReferenceLineLayout {
   y: number;
   /** Band bottom-edge y (value/time band); equals `y` for a plain line. */
   yBottom: number;
-  /** Left x extent. */
+  /** Left x extent of the plot (badge / label / connector anchor). */
   x1: number;
-  /** Right x extent. */
+  /** Right x extent of the plot (badge / label / connector anchor). */
   x2: number;
+  /**
+   * Left x of the **drawn** line / band. Equals {@link x1} normally, or `0`
+   * (canvas edge) when the line is full-width. Decoupled from {@link x1} so the
+   * line can run through the gutter while the badge/label stays in the plot.
+   */
+  lineX1: number;
+  /** Right x of the drawn line / band: {@link x2} normally, or the canvas width when full-width. */
+  lineX2: number;
+  /** Stroke the plain horizontal line (true for a plain Form-A line, or a full-width badged line). */
+  drawLine: boolean;
   /** Resolved label text (with appended value when `showValue`); "" when hidden. */
   label: string;
   labelX: number;
@@ -54,6 +64,9 @@ const INVISIBLE: ReferenceLineLayout = {
   yBottom: -1,
   x1: 0,
   x2: 0,
+  lineX1: 0,
+  lineX2: 0,
+  drawLine: false,
   label: "",
   labelX: 0,
   labelY: -1,
@@ -284,6 +297,11 @@ export function useReferenceLine(
     const chartH = chartBottom - chartTop;
     const x1 = padding.left;
     const x2 = w - padding.right;
+    // Full-width lines/bands run edge-to-edge through the gutters (0..canvas);
+    // the badge/label anchor (x1/x2) stays at the plot edges either way.
+    const fullWidth = line.fullWidth ?? false;
+    const lineX1 = fullWidth ? 0 : x1;
+    const lineX2 = fullWidth ? w : x2;
 
     const fm = font.getMetrics();
     const baselineOffset = (fm.ascent + fm.descent) / 2;
@@ -320,6 +338,9 @@ export function useReferenceLine(
         yBottom: chartBottom,
         x1: bx1,
         x2: bx2,
+        // Time band is vertical and time-bounded — full-width does not apply.
+        lineX1: bx1,
+        lineX2: bx2,
         label,
         labelX,
         labelY: chartTop - fm.ascent + 2,
@@ -361,6 +382,8 @@ export function useReferenceLine(
         yBottom: yBot,
         x1,
         x2,
+        lineX1,
+        lineX2,
         label,
         labelX,
         labelY: yTop - fm.ascent + 2,
@@ -418,6 +441,10 @@ export function useReferenceLine(
         yBottom: y,
         x1,
         x2,
+        lineX1,
+        lineX2,
+        // Full-width: the edge-to-edge line replaces the dashed connector.
+        drawLine: fullWidth,
         label: text,
         labelX: g.textX,
         labelY: y - baselineOffset,
@@ -426,8 +453,8 @@ export function useReferenceLine(
         pillW: g.pillW,
         iconX: g.iconX,
         icon: badge.icon,
-        connStart: g.connStart,
-        connEnd: g.connEnd,
+        connStart: fullWidth ? -1 : g.connStart,
+        connEnd: fullWidth ? -1 : g.connEnd,
       };
     }
 
@@ -449,6 +476,9 @@ export function useReferenceLine(
       yBottom: y,
       x1,
       x2,
+      lineX1,
+      lineX2,
+      drawLine: true,
       label,
       labelX,
       labelY: y - baselineOffset,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -79,6 +79,15 @@ export interface ReferenceLine {
   strokeWidth?: number;
   /** Dash pattern as `[dashLength, gapLength]` in pixels (line stroke + band border). */
   intervals?: [number, number];
+  /**
+   * Span the **full chart width** — edge to edge through the Y-axis gutter, not
+   * clipped at the plot's right edge — so the line/band visually connects to its
+   * value on the axis (like a price tag). Only the line/band extends; any
+   * `label`/`badge` stays anchored inside the plot. For a Form-A line with a
+   * `badge`, the full-width line replaces the dashed connector. No effect on a
+   * vertical time band. Default `false` (stops at the plot edge). Form A / B.
+   */
+  fullWidth?: boolean;
   /** Line / band color override. Defaults to palette `refLine`. */
   color?: string;
   /** Fill opacity for a value / time band (0–1). Default `0.16`. */

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -880,8 +880,26 @@ describe("ReferenceLineOverlay", () => {
     renderLine({ value: 5, label: "mid" });
   });
 
+  it("renders a full-width Form-A line (edge to edge through the gutter)", () => {
+    renderLine({ value: 5, label: "mid", fullWidth: true });
+  });
+
+  it("renders a full-width badged line (line drawn + connector dropped)", () => {
+    renderLine({ value: 5, badge: true, fullWidth: true });
+  });
+
   it("renders a horizontal value band (Form B)", () => {
     renderLine({ valueFrom: 2, valueTo: 8, color: "#fbbf24", label: "band" });
+  });
+
+  it("renders a full-width value band", () => {
+    renderLine({
+      valueFrom: 2,
+      valueTo: 8,
+      color: "#fbbf24",
+      strokeWidth: 1,
+      fullWidth: true,
+    });
   });
 
   it("renders a vertical time band (Form C)", () => {

--- a/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
@@ -124,6 +124,75 @@ describe("useReferenceLine", () => {
     expect(layout.x2).toBe(400 - PADDING.right);
   });
 
+  it("draws a plain line at the plot edges by default (not full-width)", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 50 }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.drawLine).toBe(true);
+    expect(l.lineX1).toBe(PADDING.left);
+    expect(l.lineX2).toBe(400 - PADDING.right);
+  });
+
+  it("extends the line edge-to-edge through the gutter when fullWidth", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 50, fullWidth: true }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.drawLine).toBe(true);
+    expect(l.lineX1).toBe(0);
+    expect(l.lineX2).toBe(400);
+    // badge / label anchor stays at the plot edges.
+    expect(l.x1).toBe(PADDING.left);
+    expect(l.x2).toBe(400 - PADDING.right);
+  });
+
+  it("extends a value band edge-to-edge when fullWidth (label stays in plot)", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { valueFrom: 20, valueTo: 60, fullWidth: true },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.lineX1).toBe(0);
+    expect(l.lineX2).toBe(400);
+    expect(l.x1).toBe(PADDING.left);
+  });
+
+  it("full-width badged line draws the line and drops the connector", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, badge: true, fullWidth: true },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.badge).toBe(true);
+    expect(l.drawLine).toBe(true);
+    expect(l.lineX1).toBe(0);
+    expect(l.lineX2).toBe(400);
+    expect(l.connStart).toBe(-1);
+    expect(l.connEnd).toBe(-1);
+    // pill still anchored inside the plot.
+    expect(l.pillX).toBeGreaterThanOrEqual(PADDING.left);
+  });
+
+  it("a default badged line keeps the connector and draws no plain line", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(engine(), PADDING, { value: 50, badge: true }, fmt, font),
+    );
+    const l = result.current.value;
+    expect(l.drawLine).toBe(false);
+    expect(l.connStart).toBeGreaterThanOrEqual(0);
+  });
+
   it("uses the explicit label when provided", () => {
     const { result } = renderHook(() =>
       useReferenceLine(


### PR DESCRIPTION
## Summary

Phase B of #140 — **opt-in full-width reference lines** (issue item #0). Stacked on #143 (the overlay bridge); review/merge that first.

Adds `ReferenceLine.fullWidth?: boolean` (default **off**). When set, a Form-A line or value band spans **edge to edge through the Y-axis gutter** — connecting visually to its value on the axis like a price tag — instead of stopping at the plot's right edge. Only the line/band extends; the `label`/`badge` stay anchored inside the plot. For a Form-A line with a `badge`, the full-width line replaces the dashed connector. No effect on vertical time bands.

```tsx
referenceLines={[
  { value: 142.5, label: "Avg entry", fullWidth: true }, // runs through the gutter
  { value: 150.0 },                                      // stops at the plot edge (default)
]}
```

**Opt-in per line, not default** — a deliberate call (vs the issue's "baseline rule") so existing charts render unchanged; full-width lines cross the Y-axis tick labels, which not everyone wants. Phase C's draggable lines can default it on. Non-breaking → minor.

## Implementation
- The drawn extent (`lineX1`/`lineX2`) is decoupled from the plot/badge anchor (`x1`/`x2`) in `ReferenceLineLayout`: `fullWidth` sets `lineX1=0`, `lineX2=canvasWidth`; `x1`/`x2` stay at the plot edges so labels/pills don't move.
- A new `drawLine` flag drives the line stroke (true for a plain line, or a full-width badged line that drops its connector).
- `ReferenceLineOverlay` strokes `lineX1→lineX2` and the band rect uses the same extent.

## Verification
- `npm run verify` (typecheck + lint + **1017 tests**) green; global coverage thresholds hold.
- iOS 26.4 sim (reference-lines demo "Full width" toggle): off → lines stop at the plot edge; on → ±5% lines run edge-to-edge through the gutter over the `105.0`/`95.00` labels, while the `+5%`/`−5%` labels stay in the plot and the live `valueLine` stays plot-width.

Part of #140 (full-width phase). Next: Phase C — draggable lines + `left`/`center`/`right` handle positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
