### PR TITLE
feat(time-scroll): two-finger pan to scroll back through history (prototype)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -82,6 +82,11 @@ const SECTIONS: DemoSection[] = [
         title: "Order ticket",
         blurb: "scrubAction: tap to drop a price, drag to adjust, press + to place a limit order.",
       },
+      {
+        href: "/demo/time-scroll",
+        title: "Time scroll",
+        blurb: "timeScroll: two-finger drag to pan back through candle history; release at the live edge to resume.",
+      },
     ],
   },
   {

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { LiveChart } from "react-native-livechart";
+
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Time scroll" };
+
+// 5-minute window of 15s candles (20 visible), but seed ~5 windows of history so
+// there's somewhere to scroll back into. `maxPoints` (tick buffer) stays well
+// longer than the seed so the oldest committed candles don't re-bucket as you
+// scroll into them. (Prototype — see the `timeScroll` prop.)
+const WINDOW_SECS = 300;
+const CANDLE_WIDTH_SECS = 15;
+const HISTORY_SPAN_SECS = WINDOW_SECS * 5;
+
+const MODE_OPTIONS: { value: "candle" | "line"; label: string }[] = [
+  { value: "candle", label: "Candles" },
+  { value: "line", label: "Line" },
+];
+
+export default function TimeScrollScreen() {
+  const [mode, setMode] = useState<"candle" | "line">("candle");
+  const [timeScroll, setTimeScroll] = useState(true);
+  const [scrub, setScrub] = useState(true);
+
+  // candleAggregation gives us both the line `data` and `candles`; the toggle
+  // just switches which the chart renders. Time-scroll is mode-agnostic — it
+  // pans the window regardless of line vs candle.
+  const { data, value, candles, liveCandle } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: true,
+    tradeStream: false,
+    candleWidth: CANDLE_WIDTH_SECS,
+    historySpanSeconds: HISTORY_SPAN_SECS,
+    historyRange: "1m",
+    volatilityMode: "volatile",
+    tradesPerSecond: 2,
+    maxPoints: 10000,
+  });
+
+  const isCandle = mode === "candle";
+
+  return (
+    <DemoScreen
+      title="Time scroll"
+      description="Drag with TWO fingers to pan back through history — the chart stops auto-scrolling. Release (or fling) back to the live edge to resume. Works for both line and candle; one-finger scrub is unchanged."
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          mode={mode}
+          candles={isCandle ? candles : undefined}
+          liveCandle={isCandle ? liveCandle : undefined}
+          candleWidth={CANDLE_WIDTH_SECS}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={WINDOW_SECS}
+          timeScroll={timeScroll}
+          scrub={scrub ? { tooltip: true } : false}
+        />
+      }
+    >
+      <ChipRow
+        label="Chart type"
+        options={MODE_OPTIONS}
+        value={mode}
+        onChange={setMode}
+      />
+
+      <ControlRow label="Two-finger pan">
+        <ToggleChip
+          label="timeScroll"
+          value={timeScroll}
+          onChange={setTimeScroll}
+        />
+      </ControlRow>
+
+      <ControlRow label="One-finger scrub">
+        <ToggleChip label="scrub" value={scrub} onChange={setScrub} />
+      </ControlRow>
+    </DemoScreen>
+  );
+}

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -22,18 +22,16 @@ const MODE_OPTIONS: { value: "candle" | "line"; label: string }[] = [
   { value: "line", label: "Line" },
 ];
 
-type Gesture = "twoFinger" | "axisDrag" | "holdToScrub";
+type Gesture = "holdToScrub" | "axisDrag";
 
 const GESTURE_OPTIONS: { value: Gesture; label: string }[] = [
   { value: "holdToScrub", label: "Drag / hold" },
-  { value: "twoFinger", label: "Two-finger" },
   { value: "axisDrag", label: "Drag axis" },
 ];
 
 const GESTURE_HINT: Record<Gesture, string> = {
   holdToScrub:
     "Drag with ONE finger to pan back through history; press and hold to scrub.",
-  twoFinger: "Drag with TWO fingers to pan back through history.",
   axisDrag:
     "Drag the bottom time-axis strip with ONE finger to pan back through history.",
 };

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -38,9 +38,16 @@ const GESTURE_HINT: Record<Gesture, string> = {
     "Drag the bottom time-axis strip with ONE finger to pan back through history.",
 };
 
+const HOLD_OPTIONS: { value: number; label: string }[] = [
+  { value: 350, label: "350ms" },
+  { value: 500, label: "500ms" },
+  { value: 750, label: "750ms" },
+];
+
 export default function TimeScrollScreen() {
   const [mode, setMode] = useState<"candle" | "line">("candle");
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
+  const [holdMs, setHoldMs] = useState(500);
   const [enabled, setEnabled] = useState(true);
   const [scrub, setScrub] = useState(true);
 
@@ -77,7 +84,7 @@ export default function TimeScrollScreen() {
           accentColor={ACCENT}
           theme={APP_THEME}
           timeWindow={WINDOW_SECS}
-          timeScroll={enabled ? { gesture } : false}
+          timeScroll={enabled ? { gesture, scrubHoldMs: holdMs } : false}
           scrub={scrub ? { tooltip: true } : false}
         />
       }
@@ -95,6 +102,15 @@ export default function TimeScrollScreen() {
         value={gesture}
         onChange={setGesture}
       />
+
+      {gesture === "holdToScrub" ? (
+        <ChipRow
+          label="Hold to scrub"
+          options={HOLD_OPTIONS}
+          value={holdMs}
+          onChange={setHoldMs}
+        />
+      ) : null}
 
       <ControlRow label="Pan to scroll">
         <ToggleChip label="timeScroll" value={enabled} onChange={setEnabled} />

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -22,14 +22,25 @@ const MODE_OPTIONS: { value: "candle" | "line"; label: string }[] = [
   { value: "line", label: "Line" },
 ];
 
-const GESTURE_OPTIONS: { value: "twoFinger" | "axisDrag"; label: string }[] = [
+type Gesture = "twoFinger" | "axisDrag" | "holdToScrub";
+
+const GESTURE_OPTIONS: { value: Gesture; label: string }[] = [
+  { value: "holdToScrub", label: "Drag / hold" },
   { value: "twoFinger", label: "Two-finger" },
   { value: "axisDrag", label: "Drag axis" },
 ];
 
+const GESTURE_HINT: Record<Gesture, string> = {
+  holdToScrub:
+    "Drag with ONE finger to pan back through history; press and hold to scrub.",
+  twoFinger: "Drag with TWO fingers to pan back through history.",
+  axisDrag:
+    "Drag the bottom time-axis strip with ONE finger to pan back through history.",
+};
+
 export default function TimeScrollScreen() {
   const [mode, setMode] = useState<"candle" | "line">("candle");
-  const [gesture, setGesture] = useState<"twoFinger" | "axisDrag">("twoFinger");
+  const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [enabled, setEnabled] = useState(true);
   const [scrub, setScrub] = useState(true);
 
@@ -49,10 +60,7 @@ export default function TimeScrollScreen() {
   });
 
   const isCandle = mode === "candle";
-  const hint =
-    gesture === "axisDrag"
-      ? "Drag the bottom time-axis strip with ONE finger to pan back through history."
-      : "Drag with TWO fingers to pan back through history.";
+  const hint = GESTURE_HINT[gesture];
 
   return (
     <DemoScreen

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { LiveChart } from "react-native-livechart";
+import { Alert } from "react-native";
+import { LiveChart, type ScrubActionPoint } from "react-native-livechart";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
@@ -48,6 +49,7 @@ export default function TimeScrollScreen() {
   const [holdMs, setHoldMs] = useState(500);
   const [enabled, setEnabled] = useState(true);
   const [scrub, setScrub] = useState(true);
+  const [orderTicket, setOrderTicket] = useState(true);
 
   // candleAggregation gives us both the line `data` and `candles`; the toggle
   // just switches which the chart renders. Time-scroll is mode-agnostic — it
@@ -67,6 +69,13 @@ export default function TimeScrollScreen() {
   const isCandle = mode === "candle";
   const hint = GESTURE_HINT[gesture];
 
+  // Default "order ticket" (scrubAction): tap to drop a price reticle, drag to
+  // adjust, press the gutter badge to fire this. Here it just echoes the chosen
+  // price — enough to confirm the reticle/badge coexist with time-scroll + scrub.
+  const onScrubAction = (point: ScrubActionPoint) => {
+    Alert.alert("Order ticket", `Price level: ${point.price.toFixed(2)}`);
+  };
+
   return (
     <DemoScreen
       title="Time scroll"
@@ -84,6 +93,8 @@ export default function TimeScrollScreen() {
           timeWindow={WINDOW_SECS}
           timeScroll={enabled ? { gesture, scrubHoldMs: holdMs } : false}
           scrub={scrub ? { tooltip: true } : false}
+          scrubAction={orderTicket}
+          onScrubAction={onScrubAction}
         />
       }
     >
@@ -116,6 +127,14 @@ export default function TimeScrollScreen() {
 
       <ControlRow label="One-finger scrub">
         <ToggleChip label="scrub" value={scrub} onChange={setScrub} />
+      </ControlRow>
+
+      <ControlRow label="Order ticket">
+        <ToggleChip
+          label="scrubAction"
+          value={orderTicket}
+          onChange={setOrderTicket}
+        />
       </ControlRow>
     </DemoScreen>
   );

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -22,9 +22,15 @@ const MODE_OPTIONS: { value: "candle" | "line"; label: string }[] = [
   { value: "line", label: "Line" },
 ];
 
+const GESTURE_OPTIONS: { value: "twoFinger" | "axisDrag"; label: string }[] = [
+  { value: "twoFinger", label: "Two-finger" },
+  { value: "axisDrag", label: "Drag axis" },
+];
+
 export default function TimeScrollScreen() {
   const [mode, setMode] = useState<"candle" | "line">("candle");
-  const [timeScroll, setTimeScroll] = useState(true);
+  const [gesture, setGesture] = useState<"twoFinger" | "axisDrag">("twoFinger");
+  const [enabled, setEnabled] = useState(true);
   const [scrub, setScrub] = useState(true);
 
   // candleAggregation gives us both the line `data` and `candles`; the toggle
@@ -43,11 +49,15 @@ export default function TimeScrollScreen() {
   });
 
   const isCandle = mode === "candle";
+  const hint =
+    gesture === "axisDrag"
+      ? "Drag the bottom time-axis strip with ONE finger to pan back through history."
+      : "Drag with TWO fingers to pan back through history.";
 
   return (
     <DemoScreen
       title="Time scroll"
-      description="Drag with TWO fingers to pan back through history — the chart stops auto-scrolling. Release (or fling) back to the live edge to resume. Works for both line and candle; one-finger scrub is unchanged."
+      description={`${hint} The chart stops auto-scrolling while panned; release (or fling) back to the live edge to resume. Works for line and candle; one-finger plot scrub is unchanged.`}
       chart={
         <LiveChart
           data={data}
@@ -59,7 +69,7 @@ export default function TimeScrollScreen() {
           accentColor={ACCENT}
           theme={APP_THEME}
           timeWindow={WINDOW_SECS}
-          timeScroll={timeScroll}
+          timeScroll={enabled ? { gesture } : false}
           scrub={scrub ? { tooltip: true } : false}
         />
       }
@@ -71,12 +81,15 @@ export default function TimeScrollScreen() {
         onChange={setMode}
       />
 
-      <ControlRow label="Two-finger pan">
-        <ToggleChip
-          label="timeScroll"
-          value={timeScroll}
-          onChange={setTimeScroll}
-        />
+      <ChipRow
+        label="Scroll gesture (A/B)"
+        options={GESTURE_OPTIONS}
+        value={gesture}
+        onChange={setGesture}
+      />
+
+      <ControlRow label="Pan to scroll">
+        <ToggleChip label="timeScroll" value={enabled} onChange={setEnabled} />
       </ControlRow>
 
       <ControlRow label="One-finger scrub">

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -145,6 +145,11 @@ function thresholdStops(
  * here so the rendered pieces (`ChartStack`, `ChartScrubLayer`, `LiveChart`) stay
  * small and presentational.
  */
+/** Press-and-hold (ms) before scrub engages in the `holdToScrub` time-scroll
+ *  mode, so a quick one-finger drag scrolls instead. Overridden by an explicit
+ *  `scrub.panGestureDelay`. */
+const HOLD_TO_SCRUB_MS = 220;
+
 function useLiveChartController({
   // ── Data ────────────────────────────────────────────────────────────────
   data,
@@ -551,6 +556,20 @@ function useLiveChartController({
     return markerHitTest(x, y) || refLineHitTest(x, y);
   };
 
+  // Time-scroll activation. `holdToScrub`: a quick one-finger drag scrolls while
+  // scrub engages on press-and-hold — so the scrub gesture needs a long-press
+  // delay (unless the caller set its own `panGestureDelay`).
+  const timeScrollEnabled = Boolean(timeScroll) && !isStatic;
+  const scrollGestureMode =
+    typeof timeScroll === "object"
+      ? (timeScroll.gesture ?? "twoFinger")
+      : "twoFinger";
+  const scrubHoldMs =
+    scrubCfg?.panGestureDelay ??
+    (timeScrollEnabled && scrollGestureMode === "holdToScrub"
+      ? HOLD_TO_SCRUB_MS
+      : 0);
+
   const crosshair = useCrosshair(
     engine,
     effectivePadding,
@@ -563,7 +582,7 @@ function useLiveChartController({
     !isStatic && (scrubCfg !== null || scrubActionCfg !== null),
     onScrub,
     candleOpts,
-    scrubCfg?.panGestureDelay ?? 0,
+    scrubHoldMs,
     onGestureStart,
     onGestureEnd,
     scrubActionCfg,
@@ -584,9 +603,6 @@ function useLiveChartController({
     const src = isCandle ? candlesEngine.get() : lineEngineData.get();
     return src.length > 0 ? src[0].time : engine.liveEdge.get();
   });
-  const timeScrollEnabled = Boolean(timeScroll) && !isStatic;
-  const scrollGestureMode =
-    typeof timeScroll === "object" ? (timeScroll.gesture ?? "twoFinger") : "twoFinger";
   const panScrollGesture = usePanScroll({
     engine,
     padding: effectivePadding,

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -58,6 +58,7 @@ import { useMarkers } from "../hooks/useMarkers";
 import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
 import { useMomentum } from "../hooks/useMomentum";
+import { usePanScroll } from "../hooks/usePanScroll";
 import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
 import { useSingleChartReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
 import { useThreshold } from "../hooks/useThreshold";
@@ -177,6 +178,7 @@ function useLiveChartController({
   maxValue,
   windowBuffer = 0,
   nowOverride,
+  timeScroll = false,
   accessibilityLabel,
   accessibilityRole = "image",
   emptyText = "No data",
@@ -574,6 +576,27 @@ function useLiveChartController({
     scrubCfg?.tooltipMargin ?? 8,
   );
 
+  // ── Time-scroll (two-finger pan back through history) ─────────────────────
+  // Experimental: a two-finger pan freezes the window at an absolute time and
+  // resumes following once dragged back to the live edge. One-finger scrub is
+  // untouched. Pan is clamped to the earliest retained point (line or candle).
+  const scrollMinTime = useDerivedValue(() => {
+    const src = isCandle ? candlesEngine.get() : lineEngineData.get();
+    return src.length > 0 ? src[0].time : engine.liveEdge.get();
+  });
+  const timeScrollEnabled = timeScroll && !isStatic;
+  const panScrollGesture = usePanScroll({
+    engine,
+    padding: effectivePadding,
+    minTime: scrollMinTime,
+    enabled: timeScrollEnabled,
+    // Clear any live crosshair when a scroll drag takes over.
+    onScrollStart: () => {
+      "worklet";
+      crosshair.scrubActive.set(false);
+    },
+  });
+
   // Scrub-action composes a Tap (place/move the reticle, press the badge, dismiss)
   // ahead of the pan via Exclusive, so a tap is tried first and only becomes a
   // drag (live-scrub, or lock-adjust once placed) if the finger moves. `Exclusive`
@@ -605,6 +628,12 @@ function useLiveChartController({
       scrubActionCfg !== null
         ? Gesture.Simultaneous(baseGesture, tapGroup)
         : Gesture.Race(baseGesture, tapGroup);
+  }
+
+  // Two-finger pan-scroll races the scrub/tap gestures. The pointer-count split
+  // (2 = scroll, 1 = scrub) keeps them from fighting; Race cancels the loser.
+  if (timeScrollEnabled) {
+    rootGesture = Gesture.Race(panScrollGesture, rootGesture);
   }
 
   // ── Derived render values ──────────────────────────────────────────────

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -145,10 +145,10 @@ function thresholdStops(
  * here so the rendered pieces (`ChartStack`, `ChartScrubLayer`, `LiveChart`) stay
  * small and presentational.
  */
-/** Press-and-hold (ms) before scrub engages in the `holdToScrub` time-scroll
- *  mode, so a quick one-finger drag scrolls instead. Overridden by an explicit
- *  `scrub.panGestureDelay`. */
-const HOLD_TO_SCRUB_MS = 220;
+/** Default press-and-hold (ms) before scrub engages in the `holdToScrub`
+ *  time-scroll mode, so a quick one-finger drag scrolls instead. Overridden by
+ *  `timeScroll.scrubHoldMs`, then `scrub.panGestureDelay`. */
+const HOLD_TO_SCRUB_MS = 500;
 
 function useLiveChartController({
   // ── Data ────────────────────────────────────────────────────────────────
@@ -565,11 +565,13 @@ function useLiveChartController({
       ? (timeScroll.gesture ?? "twoFinger")
       : "twoFinger";
   // In holdToScrub the scrub MUST require a hold so a quick drag scrolls instead.
-  // The resolved scrub config defaults panGestureDelay to 0 (not undefined), so
-  // use `||` to fall back to the hold default when the caller didn't set one.
+  // Precedence: explicit timeScroll.scrubHoldMs, then scrub.panGestureDelay, then
+  // the default. `||` (not `??`) skips the resolved panGestureDelay's 0 default.
+  const timeScrollHoldMs =
+    typeof timeScroll === "object" ? timeScroll.scrubHoldMs : undefined;
   const scrubHoldMs =
     timeScrollEnabled && scrollGestureMode === "holdToScrub"
-      ? scrubCfg?.panGestureDelay || HOLD_TO_SCRUB_MS
+      ? (timeScrollHoldMs ?? (scrubCfg?.panGestureDelay || HOLD_TO_SCRUB_MS))
       : (scrubCfg?.panGestureDelay ?? 0);
 
   const crosshair = useCrosshair(

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -564,11 +564,13 @@ function useLiveChartController({
     typeof timeScroll === "object"
       ? (timeScroll.gesture ?? "twoFinger")
       : "twoFinger";
+  // In holdToScrub the scrub MUST require a hold so a quick drag scrolls instead.
+  // The resolved scrub config defaults panGestureDelay to 0 (not undefined), so
+  // use `||` to fall back to the hold default when the caller didn't set one.
   const scrubHoldMs =
-    scrubCfg?.panGestureDelay ??
-    (timeScrollEnabled && scrollGestureMode === "holdToScrub"
-      ? HOLD_TO_SCRUB_MS
-      : 0);
+    timeScrollEnabled && scrollGestureMode === "holdToScrub"
+      ? scrubCfg?.panGestureDelay || HOLD_TO_SCRUB_MS
+      : (scrubCfg?.panGestureDelay ?? 0);
 
   const crosshair = useCrosshair(
     engine,

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -584,12 +584,15 @@ function useLiveChartController({
     const src = isCandle ? candlesEngine.get() : lineEngineData.get();
     return src.length > 0 ? src[0].time : engine.liveEdge.get();
   });
-  const timeScrollEnabled = timeScroll && !isStatic;
+  const timeScrollEnabled = Boolean(timeScroll) && !isStatic;
+  const scrollGestureMode =
+    typeof timeScroll === "object" ? (timeScroll.gesture ?? "twoFinger") : "twoFinger";
   const panScrollGesture = usePanScroll({
     engine,
     padding: effectivePadding,
     minTime: scrollMinTime,
     enabled: timeScrollEnabled,
+    mode: scrollGestureMode,
     // Clear any live crosshair when a scroll drag takes over.
     onScrollStart: () => {
       "worklet";
@@ -630,10 +633,14 @@ function useLiveChartController({
         : Gesture.Race(baseGesture, tapGroup);
   }
 
-  // Two-finger pan-scroll races the scrub/tap gestures. The pointer-count split
-  // (2 = scroll, 1 = scrub) keeps them from fighting; Race cancels the loser.
+  // Compose the pan-scroll gesture. Two-finger races the scrub/tap gestures
+  // (pointer count keeps them apart). Axis-drag goes first via Exclusive: it
+  // fails instantly outside the axis band, so scrub runs everywhere else.
   if (timeScrollEnabled) {
-    rootGesture = Gesture.Race(panScrollGesture, rootGesture);
+    rootGesture =
+      scrollGestureMode === "axisDrag"
+        ? Gesture.Exclusive(panScrollGesture, rootGesture)
+        : Gesture.Race(panScrollGesture, rootGesture);
   }
 
   // ── Derived render values ──────────────────────────────────────────────

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -58,7 +58,7 @@ import { useMarkers } from "../hooks/useMarkers";
 import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
 import { useMomentum } from "../hooks/useMomentum";
-import { usePanScroll } from "../hooks/usePanScroll";
+import { AXIS_GRAB_MIN_PX, usePanScroll } from "../hooks/usePanScroll";
 import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
 import { useSingleChartReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
 import { useThreshold } from "../hooks/useThreshold";
@@ -597,6 +597,11 @@ function useLiveChartController({
     scrubCfg?.tooltipShowValue ?? true,
     scrubCfg?.tooltipShowTime ?? true,
     scrubCfg?.tooltipMargin ?? 8,
+    // Axis-drag time-scroll: keep the bottom "time ruler" band scroll-only so a
+    // drag there never trips the scrub crosshair.
+    timeScrollEnabled && scrollGestureMode === "axisDrag"
+      ? Math.max(effectivePadding.bottom, AXIS_GRAB_MIN_PX)
+      : 0,
   );
 
   // ── Time-scroll (drag back through history) ───────────────────────────────

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -562,8 +562,8 @@ function useLiveChartController({
   const timeScrollEnabled = Boolean(timeScroll) && !isStatic;
   const scrollGestureMode =
     typeof timeScroll === "object"
-      ? (timeScroll.gesture ?? "twoFinger")
-      : "twoFinger";
+      ? (timeScroll.gesture ?? "holdToScrub")
+      : "holdToScrub";
   // In holdToScrub the scrub MUST require a hold so a quick drag scrolls instead.
   // Precedence: explicit timeScroll.scrubHoldMs, then scrub.panGestureDelay, then
   // the default. `||` (not `??`) skips the resolved panGestureDelay's 0 default.
@@ -599,10 +599,10 @@ function useLiveChartController({
     scrubCfg?.tooltipMargin ?? 8,
   );
 
-  // ── Time-scroll (two-finger pan back through history) ─────────────────────
-  // Experimental: a two-finger pan freezes the window at an absolute time and
-  // resumes following once dragged back to the live edge. One-finger scrub is
-  // untouched. Pan is clamped to the earliest retained point (line or candle).
+  // ── Time-scroll (drag back through history) ───────────────────────────────
+  // Experimental: a pan freezes the window at an absolute time and resumes
+  // following once dragged back to the live edge. Pan is clamped to the earliest
+  // retained point (line or candle). See `timeScroll` for the gesture model.
   const scrollMinTime = useDerivedValue(() => {
     const src = isCandle ? candlesEngine.get() : lineEngineData.get();
     return src.length > 0 ? src[0].time : engine.liveEdge.get();
@@ -653,9 +653,10 @@ function useLiveChartController({
         : Gesture.Race(baseGesture, tapGroup);
   }
 
-  // Compose the pan-scroll gesture. Two-finger races the scrub/tap gestures
-  // (pointer count keeps them apart). Axis-drag goes first via Exclusive: it
-  // fails instantly outside the axis band, so scrub runs everywhere else.
+  // Compose the pan-scroll gesture. holdToScrub races the scrub/tap gestures (a
+  // quick drag scrolls; a still press-hold falls through to scrub). Axis-drag
+  // goes first via Exclusive: it fails instantly outside the axis band, so scrub
+  // runs everywhere else.
   if (timeScrollEnabled) {
     rootGesture =
       scrollGestureMode === "axisDrag"

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -10,6 +10,14 @@ export interface EngineTickMutable {
   displayWindow: number;
   timestamp: number;
   /**
+   * The right-edge time the engine would use if it were following live —
+   * `now (+ windowBuffer)`. Equals {@link timestamp} while following; when
+   * scrolled back in time (see {@link EngineTickInput.viewEnd}) it keeps
+   * advancing while `timestamp` stays frozen. Exposed so the pan-scroll gesture
+   * can clamp against the live edge and detect catch-up.
+   */
+  liveEdge: number;
+  /**
    * Value + time of the lowest / highest data point in the visible window —
    * the actual extrema, NOT the smoothed display bounds (which carry margin and
    * fold in the live value / reference lines). `NaN` when the window holds no
@@ -48,6 +56,13 @@ export interface EngineTickInput {
   windowBuffer?: number;
   /** When true, freeze the viewport timestamp and skip displayWindow lerp */
   paused?: boolean;
+  /**
+   * Absolute right-edge time (unix seconds) to freeze the window at, or
+   * `null`/`undefined` to follow the live edge. Set by the pan-scroll gesture
+   * to scroll back in time; once it reaches (or passes) the live edge the engine
+   * resumes following. Takes precedence over {@link paused}.
+   */
+  viewEnd?: number | null;
   /** Chart mode — `"candle"` uses OHLC bars for Y range instead of line points. */
   mode?: "line" | "candle";
   /** Committed OHLC bars (sorted by time). Used when mode is `"candle"`. */
@@ -66,9 +81,18 @@ export function tickLiveChartEngineFrame(
 ): void {
   "worklet";
   const baseNow = input.nowOverride ?? input.nowSeconds ?? Date.now() / 1000;
-  if (!input.paused) {
-    state.timestamp = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
+  const liveEdge = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
+  state.liveEdge = liveEdge;
+  const viewEnd = input.viewEnd;
+  if (viewEnd != null && viewEnd < liveEdge) {
+    // Scrolled back in time: freeze the right edge at an absolute timestamp so
+    // the window stops tracking "now" (see usePanScroll / the `timeScroll` prop).
+    state.timestamp = viewEnd;
+  } else if (!input.paused) {
+    // Following the live edge — viewEnd is null/undefined or has caught back up.
+    state.timestamp = liveEdge;
   }
+  // else: paused with no active pan → leave the frozen timestamp untouched.
 
   if (input.canvasWidth === 0 || input.canvasHeight === 0) return;
 

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -7,6 +7,12 @@ export interface MultiEngineTickMutable {
   displayMax: number;
   displayWindow: number;
   timestamp: number;
+  /**
+   * The right-edge time the engine would use if following live (`now (+ buffer)`).
+   * Equals {@link timestamp} while following; keeps advancing while `timestamp`
+   * stays frozen when scrolled back (see {@link MultiEngineTickInput.viewEnd}).
+   */
+  liveEdge: number;
   displayValues: number[];
   opacities: number[];
   /**
@@ -44,6 +50,12 @@ export interface MultiEngineTickInput {
   /** Right-edge buffer as a fraction of the time window. */
   windowBuffer?: number;
   paused?: boolean;
+  /**
+   * Absolute right-edge time (unix seconds) to freeze the window at, or
+   * `null`/`undefined` to follow the live edge. Drives pan-scroll; takes
+   * precedence over {@link paused}.
+   */
+  viewEnd?: number | null;
 }
 
 /**
@@ -57,9 +69,17 @@ export function tickLiveChartSeriesEngineFrame(
 ): void {
   "worklet";
   const baseNow = input.nowOverride ?? input.nowSeconds ?? Date.now() / 1000;
-  if (!input.paused) {
-    state.timestamp = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
+  const liveEdge = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
+  state.liveEdge = liveEdge;
+  const viewEnd = input.viewEnd;
+  if (viewEnd != null && viewEnd < liveEdge) {
+    // Scrolled back in time: freeze the right edge (see usePanScroll).
+    state.timestamp = viewEnd;
+  } else if (!input.paused) {
+    // Following the live edge — viewEnd is null/undefined or has caught back up.
+    state.timestamp = liveEdge;
   }
+  // else: paused with no active pan → leave the frozen timestamp untouched.
 
   if (input.canvasWidth === 0 || input.canvasHeight === 0) return;
 

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -76,6 +76,25 @@ export interface ChartEngineExtrema {
   extremaMaxTime: SharedValue<number>;
 }
 
+/**
+ * Time-scroll state: lets a pan gesture freeze the window at an absolute time
+ * and resume following the live edge. Returned by both engines (intersected onto
+ * the state) but kept off {@link ChartEngineLayout} so overlay components — which
+ * only read the layout — don't have to carry it.
+ */
+export interface ChartEngineScroll {
+  /**
+   * Absolute right-edge time (unix seconds) to freeze at, or `null` to follow
+   * the live edge. Written by the pan-scroll gesture; read by the engine tick.
+   */
+  viewEnd: SharedValue<number | null>;
+  /**
+   * The right-edge time the engine would use if following live — advances each
+   * frame even while {@link ChartEngineLayout.timestamp} is frozen by a pan.
+   */
+  liveEdge: SharedValue<number>;
+}
+
 export interface SingleEngineState extends ChartEngineLayout, ChartEngineExtrema {
   data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
@@ -119,6 +138,10 @@ export interface EngineFrameRefs {
   nowOverrideSV?: SharedValue<number | undefined>;
   windowBufferSV?: SharedValue<number>;
   pausedSV: SharedValue<boolean>;
+  /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
+  viewEndSV?: SharedValue<number | null>;
+  /** Receives the computed live edge each frame. Optional for callers/tests. */
+  liveEdgeSV?: SharedValue<number>;
   modeSV: SharedValue<"line" | "candle">;
   candles?: SharedValue<CandlePoint[]>;
   liveCandle?: SharedValue<CandlePoint | null>;
@@ -144,6 +167,7 @@ export function applyLiveChartEngineFrame(
     displayMax: sv.displayMax.value,
     displayWindow: sv.displayWindow.value,
     timestamp: sv.timestamp.value,
+    liveEdge: sv.liveEdgeSV?.value ?? 0,
     extremaMinValue: sv.extremaMinValue.value,
     extremaMaxValue: sv.extremaMaxValue.value,
     extremaMinTime: sv.extremaMinTime.value,
@@ -167,6 +191,7 @@ export function applyLiveChartEngineFrame(
     points: sv.data.value,
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
+    viewEnd: sv.viewEndSV?.value,
     mode: sv.modeSV.value,
     candles: sv.candles?.value,
     liveCandle: sv.liveCandle?.value,
@@ -176,13 +201,16 @@ export function applyLiveChartEngineFrame(
   sv.displayMax.value = state.displayMax;
   sv.displayWindow.value = state.displayWindow;
   sv.timestamp.value = state.timestamp;
+  if (sv.liveEdgeSV) sv.liveEdgeSV.value = state.liveEdge;
   sv.extremaMinValue.value = state.extremaMinValue;
   sv.extremaMaxValue.value = state.extremaMaxValue;
   sv.extremaMinTime.value = state.extremaMinTime;
   sv.extremaMaxTime.value = state.extremaMaxTime;
 }
 
-export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
+export function useLiveChartEngine(
+  config: EngineConfig,
+): SingleEngineState & ChartEngineScroll {
   // Low-frequency config → UI thread via useDerivedValue
   const timeWindow = useDerivedValue(() => config.timeWindow);
   // Static charts snap to their target in one tick (smoothing=1), so the single
@@ -211,6 +239,13 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
   // Seed once; overwritten by the frame callback on the first tick.
   const [initialTimestamp] = useState(() => Date.now() / 1000);
   const timestamp = useSharedValue(initialTimestamp);
+
+  // Pan-scroll state. `viewEnd` null = follow live; a number freezes the right
+  // edge at that absolute time. `liveEdge` mirrors the would-be-live timestamp
+  // each frame so the gesture can clamp / detect catch-up. Both default to
+  // "following" so charts without `timeScroll` behave exactly as before.
+  const viewEnd = useSharedValue<number | null>(null);
+  const liveEdge = useSharedValue(initialTimestamp);
 
   // Live data extrema (value + time of the visible high / low). NaN until the
   // first tick finds data — the extrema label stays hidden until then.
@@ -250,6 +285,8 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
     nowOverrideSV,
     windowBufferSV,
     pausedSV,
+    viewEndSV: viewEnd,
+    liveEdgeSV: liveEdge,
     modeSV,
     candles,
     liveCandle,
@@ -307,6 +344,8 @@ export function useLiveChartEngine(config: EngineConfig): SingleEngineState {
     canvasWidth,
     canvasHeight,
     timestamp,
+    viewEnd,
+    liveEdge,
     extremaMinValue,
     extremaMaxValue,
     extremaMinTime,

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -8,7 +8,7 @@ import {
 import { MS_PER_FRAME_60FPS } from "../constants";
 import type { LiveChartPoint, SeriesConfig } from "../types";
 import { tickLiveChartSeriesEngineFrame } from "./liveChartSeriesEngineTick";
-import type { MultiEngineState } from "./useLiveChartEngine";
+import type { ChartEngineScroll, MultiEngineState } from "./useLiveChartEngine";
 
 export interface MultiSeriesEngineConfig {
   series: SharedValue<SeriesConfig[]>;
@@ -47,6 +47,10 @@ export interface MultiEngineFrameRefs {
   nowOverrideSV?: SharedValue<number | undefined>;
   windowBufferSV?: SharedValue<number>;
   pausedSV: SharedValue<boolean>;
+  /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
+  viewEndSV?: SharedValue<number | null>;
+  /** Receives the computed live edge each frame. Optional for callers/tests. */
+  liveEdgeSV?: SharedValue<number>;
   extremaMinValue: SharedValue<number>;
   extremaMaxValue: SharedValue<number>;
   extremaMinTime: SharedValue<number>;
@@ -105,6 +109,7 @@ export function applyLiveChartSeriesEngineFrame(
     displayMax: sv.displayMax.value,
     displayWindow: sv.displayWindow.value,
     timestamp: sv.timestamp.value,
+    liveEdge: sv.liveEdgeSV?.value ?? 0,
     displayValues,
     opacities,
     extremaMinValue: sv.extremaMinValue.value,
@@ -129,11 +134,13 @@ export function applyLiveChartSeriesEngineFrame(
     series: seriesSnap,
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
+    viewEnd: sv.viewEndSV?.value,
   });
   sv.displayMin.value = state.displayMin;
   sv.displayMax.value = state.displayMax;
   sv.displayWindow.value = state.displayWindow;
   sv.timestamp.value = state.timestamp;
+  if (sv.liveEdgeSV) sv.liveEdgeSV.value = state.liveEdge;
   sv.displaySeriesValues.value = state.displayValues;
   sv.seriesOpacities.value = state.opacities;
   sv.extremaMinValue.value = state.extremaMinValue;
@@ -148,7 +155,7 @@ export function applyLiveChartSeriesEngineFrame(
  */
 export function useLiveChartSeriesEngine(
   config: MultiSeriesEngineConfig,
-): MultiEngineState {
+): MultiEngineState & ChartEngineScroll {
   const timeWindow = useDerivedValue(() => config.timeWindow);
   const smoothing = useDerivedValue(() => config.smoothing);
   const adaptiveSpeedBoostSV = useDerivedValue(() => config.adaptiveSpeedBoost);
@@ -169,6 +176,10 @@ export function useLiveChartSeriesEngine(
   // Seed once; overwritten by the frame callback on the first tick.
   const [initialTimestamp] = useState(() => Date.now() / 1000);
   const timestamp = useSharedValue(initialTimestamp);
+
+  // Pan-scroll state (see useLiveChartEngine). Defaults to following live.
+  const viewEnd = useSharedValue<number | null>(null);
+  const liveEdge = useSharedValue(initialTimestamp);
 
   const displaySeriesValues = useSharedValue<number[]>([]);
   const seriesOpacities = useSharedValue<number[]>([]);
@@ -217,6 +228,8 @@ export function useLiveChartSeriesEngine(
         nowOverrideSV,
         windowBufferSV,
         pausedSV,
+        viewEndSV: viewEnd,
+        liveEdgeSV: liveEdge,
         extremaMinValue,
         extremaMaxValue,
         extremaMinTime,
@@ -237,6 +250,8 @@ export function useLiveChartSeriesEngine(
     canvasWidth,
     canvasHeight,
     timestamp,
+    viewEnd,
+    liveEdge,
     series,
     displaySeriesValues,
     seriesOpacities,

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -137,6 +137,13 @@ export function useCrosshair(
   tooltipShowTime = true,
   /** Gap (px) between the tooltip and the plot edge it's pinned to. Default `8`. */
   tooltipMargin = 8,
+  /**
+   * Height (px) of a bottom band to exclude from scrub recognition — the
+   * axis-drag "grab the time ruler" strip, so a drag there scrolls instead of
+   * scrubbing (and a vertical drag falls through to the parent). `0` = no
+   * exclusion (the default; scrub covers the whole plot).
+   */
+  scrubBottomExclude = 0,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -562,6 +569,14 @@ export function useCrosshair(
     gesture = gesture.activeOffsetX([-25, 25]).failOffsetY([-25, 25]);
   }
 
+  // Axis-drag time-scroll: carve the bottom "time ruler" band out of the scrub's
+  // hit area so a drag starting there scrolls (the pan-scroll gesture owns it)
+  // and never trips the crosshair. `shouldCancelWhenOutside(false)` above keeps a
+  // scrub that *started* in the plot tracking on into the band.
+  if (scrubBottomExclude > 0) {
+    gesture = gesture.hitSlop({ bottom: -scrubBottomExclude });
+  }
+
   // Tap: place/move the reticle, press the action badge, or dismiss the lock.
   // Composed ahead of the pan by the controller, so a tap is never swallowed.
   // Built only in scrub-action mode (the plain-scrub path never constructs a Tap).
@@ -626,12 +641,17 @@ export function useCrosshair(
     lockActive.set(true);
   };
 
-  const tapGesture = hasScrubAction
+  let tapGesture = hasScrubAction
     ? Gesture.Tap()
         .maxDuration(250)
         .maxDistance(SCRUB_ACTION_TAP_SLOP)
         .onEnd(handleActionTap)
     : undefined;
+  // Keep the axis-drag band scroll-only for taps too — a tap there shouldn't
+  // drop an order-ticket reticle.
+  if (tapGesture && scrubBottomExclude > 0) {
+    tapGesture = tapGesture.hitSlop({ bottom: -scrubBottomExclude });
+  }
 
   return {
     scrubX,

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -16,7 +16,7 @@ const AXIS_ACTIVATE_PX = 6;
 const HOLD_SCRUB_FAIL_Y_PX = 12;
 
 /** Which gesture activates a time-scroll. */
-export type PanScrollGestureMode = "twoFinger" | "axisDrag" | "holdToScrub";
+export type PanScrollGestureMode = "holdToScrub" | "axisDrag";
 
 /** Engine SharedValues the pan-scroll gesture reads/writes (subset of the engine state). */
 export interface PanScrollEngineRefs {
@@ -45,13 +45,11 @@ export interface UsePanScrollOptions {
   enabled: boolean;
   /**
    * Activation model:
-   *  - `"twoFinger"` (default): a two-finger drag anywhere; one-finger scrub
-   *    untouched.
+   *  - `"holdToScrub"` (default): a one-finger drag anywhere scrolls; scrub moves
+   *    to press-and-hold (Rainbow-style). The caller must give the scrub gesture
+   *    a long-press delay so a quick drag falls through to this one.
    *  - `"axisDrag"`: a one-finger drag starting in the bottom X-axis band ("grab
-   *    the time ruler"); one-finger scrub untouched.
-   *  - `"holdToScrub"`: a one-finger drag anywhere scrolls; scrub moves to
-   *    press-and-hold (Rainbow-style). The caller must give the scrub gesture a
-   *    long-press delay so a quick drag falls through to this one.
+   *    the time ruler"); one-finger plot scrub untouched.
    */
   mode?: PanScrollGestureMode;
   /**
@@ -118,14 +116,12 @@ export function axisBandTop(canvasHeight: number, padBottom: number): number {
 /**
  * Horizontal pan that scrolls the chart back through time. Pick the activation
  * with `mode`:
- *  - `"twoFinger"` — a two-finger drag anywhere (compose with `Gesture.Race`;
- *    pointer count disambiguates it from the one-finger scrub).
- *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band, gated
- *    via `manualActivation` (compose with `Gesture.Exclusive`, this gesture
- *    first: outside the band it fails instantly so scrub runs).
  *  - `"holdToScrub"` — a one-finger drag anywhere (activates on horizontal
  *    travel; vertical falls through). Scrub must be press-and-hold so a quick
  *    drag races past it (compose with `Gesture.Race`).
+ *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band, gated
+ *    via `manualActivation` (compose with `Gesture.Exclusive`, this gesture
+ *    first: outside the band it fails instantly so scrub runs).
  *
  * Writes `engine.viewEnd`: a number freezes the window at that absolute right
  * edge; `null` means "follow live". Dragging (or flinging) back to the live edge
@@ -136,7 +132,7 @@ export function usePanScroll({
   padding,
   minTime,
   enabled,
-  mode = "twoFinger",
+  mode = "holdToScrub",
   onScrollStart,
 }: UsePanScrollOptions): ReturnType<typeof Gesture.Pan> {
   const { viewEnd, liveEdge, displayWindow, canvasWidth, canvasHeight } = engine;
@@ -145,7 +141,7 @@ export function usePanScroll({
   const padBottom = padding.bottom;
 
   // Axis-drag activation tracking (manualActivation). Created unconditionally so
-  // the hook order is stable; unused in two-finger mode.
+  // the hook order is stable; unused in hold-to-scrub mode.
   const startX = useSharedValue(0);
   const startY = useSharedValue(0);
   const armed = useSharedValue(false);
@@ -242,27 +238,15 @@ export function usePanScroll({
       .onEnd(onEnd);
   }
 
-  if (mode === "holdToScrub") {
-    return Gesture.Pan()
-      .enabled(enabled)
-      .maxPointers(1)
-      // Activate on horizontal travel so a quick one-finger drag scrolls; a
-      // still press-hold crosses no offset and falls through to the scrub
-      // gesture (which owns the long-press). Vertical travel fails it so a
-      // parent vertical scroll wins.
-      .activeOffsetX([-AXIS_ACTIVATE_PX, AXIS_ACTIVATE_PX])
-      .failOffsetY([-HOLD_SCRUB_FAIL_Y_PX, HOLD_SCRUB_FAIL_Y_PX])
-      .onStart(onStart)
-      .onChange(onChange)
-      .onEnd(onEnd);
-  }
-
+  // holdToScrub (default): a one-finger drag anywhere scrolls. Activate on
+  // horizontal travel so a quick one-finger drag scrolls; a still press-hold
+  // crosses no offset and falls through to the scrub gesture (which owns the
+  // long-press). Vertical travel fails it so a parent vertical scroll wins.
   return Gesture.Pan()
     .enabled(enabled)
-    // Two fingers only — leaves the one-finger scrub gesture alone.
-    .minPointers(2)
-    .maxPointers(2)
-    .averageTouches(true)
+    .maxPointers(1)
+    .activeOffsetX([-AXIS_ACTIVATE_PX, AXIS_ACTIVATE_PX])
+    .failOffsetY([-HOLD_SCRUB_FAIL_Y_PX, HOLD_SCRUB_FAIL_Y_PX])
     .onStart(onStart)
     .onChange(onChange)
     .onEnd(onEnd);

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -9,7 +9,7 @@ import {
 import type { ChartPadding } from "../draw/line";
 
 /** Minimum height (px) of the bottom "grab the time ruler" band in axis-drag mode. */
-const AXIS_GRAB_MIN_PX = 44;
+export const AXIS_GRAB_MIN_PX = 44;
 /** Horizontal travel (px) before a one-finger drag commits to scrolling vs. falling through. */
 const AXIS_ACTIVATE_PX = 6;
 /** Vertical travel (px) that fails the one-finger scroll so a parent vertical scroll wins. */

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -1,0 +1,160 @@
+import { Gesture } from "react-native-gesture-handler";
+import {
+  cancelAnimation,
+  withDecay,
+  type SharedValue,
+} from "react-native-reanimated";
+
+import type { ChartPadding } from "../draw/line";
+
+/** Engine SharedValues the pan-scroll gesture reads/writes (subset of the engine state). */
+export interface PanScrollEngineRefs {
+  /** Absolute right-edge time to freeze at, or `null` to follow the live edge. */
+  viewEnd: SharedValue<number | null>;
+  /** Right-edge time the engine would use if following live (advances each frame). */
+  liveEdge: SharedValue<number>;
+  /** Animating visible window width in seconds. */
+  displayWindow: SharedValue<number>;
+  /** Canvas width in px. */
+  canvasWidth: SharedValue<number>;
+}
+
+export interface UsePanScrollOptions {
+  engine: PanScrollEngineRefs;
+  padding: ChartPadding;
+  /**
+   * Earliest selectable time (unix seconds) — typically the first data point /
+   * candle. Clamps how far back the window can pan. When there's no scrollable
+   * history this should equal (or exceed) the live edge so panning is a no-op.
+   */
+  minTime: SharedValue<number>;
+  /** Master switch. When false the gesture is disabled and the chart follows live. */
+  enabled: boolean;
+  /**
+   * Worklet fired when a scroll drag activates — e.g. to clear the crosshair so
+   * a stray scrub doesn't linger behind the pan.
+   */
+  onScrollStart?: () => void;
+}
+
+/**
+ * Smallest valid right-edge time: keeps the window's left edge
+ * (`rightEdge - window`) from passing `minTime`, and never exceeds the live edge
+ * so the `[lo, liveEdge]` clamp range stays valid when history is short.
+ */
+export function panLowerBound(
+  minTime: number,
+  windowSecs: number,
+  liveEdge: number,
+): number {
+  "worklet";
+  return Math.min(minTime + windowSecs, liveEdge);
+}
+
+/**
+ * Next right-edge time after dragging `changeX` px (drag right ⇒ reveal earlier
+ * time ⇒ smaller right edge), clamped to `[lo, liveEdge]`. Returns `null` once
+ * the drag reaches the live edge — the signal to resume following.
+ */
+export function nextViewEnd(
+  cur: number,
+  changeX: number,
+  chartW: number,
+  windowSecs: number,
+  liveEdge: number,
+  lo: number,
+): number | null {
+  "worklet";
+  let next = cur - (changeX / chartW) * windowSecs;
+  if (next < lo) next = lo;
+  if (next > liveEdge) next = liveEdge;
+  return next >= liveEdge ? null : next;
+}
+
+/** Pan velocity (px/s) → time-seconds/s for `withDecay` (drag right ⇒ earlier). */
+export function flingVelocity(
+  velocityX: number,
+  chartW: number,
+  windowSecs: number,
+): number {
+  "worklet";
+  return -(velocityX / chartW) * windowSecs;
+}
+
+/**
+ * Two-finger horizontal pan that scrolls the chart back through time. One-finger
+ * scrub is left entirely untouched — compose this alongside it (e.g.
+ * `Gesture.Race`); the pointer-count split (2 here, 1 for scrub) disambiguates.
+ *
+ * Writes `engine.viewEnd`: a number freezes the window at that absolute right
+ * edge; `null` means "follow live". Dragging (or flinging) back to the live edge
+ * resumes following so new data scrolls in again.
+ */
+export function usePanScroll({
+  engine,
+  padding,
+  minTime,
+  enabled,
+  onScrollStart,
+}: UsePanScrollOptions): ReturnType<typeof Gesture.Pan> {
+  const { viewEnd, liveEdge, displayWindow, canvasWidth } = engine;
+  const padLeft = padding.left;
+  const padRight = padding.right;
+
+  return (
+    Gesture.Pan()
+      .enabled(enabled)
+      // Two fingers only — leaves the one-finger scrub gesture alone.
+      .minPointers(2)
+      .maxPointers(2)
+      .averageTouches(true)
+      .onStart(
+        /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+        () => {
+          "worklet";
+          cancelAnimation(viewEnd);
+          // Anchor at the current right edge so the first delta is relative to
+          // where the window sits (the live edge when we were following).
+          if (viewEnd.get() == null) viewEnd.set(liveEdge.get());
+          onScrollStart?.();
+        },
+      )
+      .onChange(
+        /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+        (e) => {
+          "worklet";
+          const win = displayWindow.get();
+          const chartW = canvasWidth.get() - padLeft - padRight;
+          if (chartW <= 0) return;
+          const edge = liveEdge.get();
+          const cur = viewEnd.get() ?? edge;
+          const lo = panLowerBound(minTime.get(), win, edge);
+          viewEnd.set(nextViewEnd(cur, e.changeX, chartW, win, edge, lo));
+        },
+      )
+      .onEnd(
+        /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+        (e) => {
+          "worklet";
+          if (viewEnd.get() == null) return;
+          const win = displayWindow.get();
+          const chartW = canvasWidth.get() - padLeft - padRight;
+          if (chartW <= 0) return;
+          const edge = liveEdge.get();
+          const lo = panLowerBound(minTime.get(), win, edge);
+          const velocity = flingVelocity(e.velocityX, chartW, win);
+          cancelAnimation(viewEnd);
+          viewEnd.set(
+            withDecay({ velocity, clamp: [lo, edge] }, (finished) => {
+              "worklet";
+              // Landed on the live-edge clamp → resume following; stopped short
+              // → stay frozen where inertia died.
+              if (finished && (viewEnd.get() ?? edge) >= edge - 1e-3) {
+                viewEnd.set(null);
+              }
+            }),
+          );
+        },
+      )
+  );
+}

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -1,11 +1,20 @@
 import { Gesture } from "react-native-gesture-handler";
 import {
   cancelAnimation,
+  useSharedValue,
   withDecay,
   type SharedValue,
 } from "react-native-reanimated";
 
 import type { ChartPadding } from "../draw/line";
+
+/** Minimum height (px) of the bottom "grab the time ruler" band in axis-drag mode. */
+const AXIS_GRAB_MIN_PX = 44;
+/** Horizontal travel (px) before an axis-drag commits to scrolling vs. falling through. */
+const AXIS_ACTIVATE_PX = 6;
+
+/** Which gesture activates a time-scroll. */
+export type PanScrollGestureMode = "twoFinger" | "axisDrag";
 
 /** Engine SharedValues the pan-scroll gesture reads/writes (subset of the engine state). */
 export interface PanScrollEngineRefs {
@@ -17,6 +26,8 @@ export interface PanScrollEngineRefs {
   displayWindow: SharedValue<number>;
   /** Canvas width in px. */
   canvasWidth: SharedValue<number>;
+  /** Canvas height in px (for the axis-drag band hit-test). */
+  canvasHeight: SharedValue<number>;
 }
 
 export interface UsePanScrollOptions {
@@ -30,6 +41,12 @@ export interface UsePanScrollOptions {
   minTime: SharedValue<number>;
   /** Master switch. When false the gesture is disabled and the chart follows live. */
   enabled: boolean;
+  /**
+   * Activation model. `"twoFinger"` (default): a two-finger drag anywhere.
+   * `"axisDrag"`: a one-finger drag starting in the bottom X-axis band ("grab
+   * the time ruler"). One-finger scrub in the plot area is untouched either way.
+   */
+  mode?: PanScrollGestureMode;
   /**
    * Worklet fired when a scroll drag activates — e.g. to clear the crosshair so
    * a stray scrub doesn't linger behind the pan.
@@ -82,79 +99,146 @@ export function flingVelocity(
 }
 
 /**
- * Two-finger horizontal pan that scrolls the chart back through time. One-finger
- * scrub is left entirely untouched — compose this alongside it (e.g.
- * `Gesture.Race`); the pointer-count split (2 here, 1 for scrub) disambiguates.
+ * Top y (px) of the axis-drag grab band — a touch at or below this row starts a
+ * scroll. The band is the bottom padding (where the time labels sit), widened to
+ * a comfortable touch target.
+ */
+export function axisBandTop(canvasHeight: number, padBottom: number): number {
+  "worklet";
+  return canvasHeight - Math.max(padBottom, AXIS_GRAB_MIN_PX);
+}
+
+/**
+ * Horizontal pan that scrolls the chart back through time. One-finger plot-area
+ * scrub is left untouched; pick the activation with `mode`:
+ *  - `"twoFinger"` — a two-finger drag anywhere (compose with `Gesture.Race`;
+ *    pointer count disambiguates it from the one-finger scrub).
+ *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band, gated
+ *    via `manualActivation` (compose with `Gesture.Exclusive`, this gesture
+ *    first: outside the band it fails instantly so scrub runs).
  *
  * Writes `engine.viewEnd`: a number freezes the window at that absolute right
  * edge; `null` means "follow live". Dragging (or flinging) back to the live edge
- * resumes following so new data scrolls in again.
+ * resumes following.
  */
 export function usePanScroll({
   engine,
   padding,
   minTime,
   enabled,
+  mode = "twoFinger",
   onScrollStart,
 }: UsePanScrollOptions): ReturnType<typeof Gesture.Pan> {
-  const { viewEnd, liveEdge, displayWindow, canvasWidth } = engine;
+  const { viewEnd, liveEdge, displayWindow, canvasWidth, canvasHeight } = engine;
   const padLeft = padding.left;
   const padRight = padding.right;
+  const padBottom = padding.bottom;
 
-  return (
-    Gesture.Pan()
+  // Axis-drag activation tracking (manualActivation). Created unconditionally so
+  // the hook order is stable; unused in two-finger mode.
+  const startX = useSharedValue(0);
+  const startY = useSharedValue(0);
+  const armed = useSharedValue(false);
+
+  const onStart =
+    /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+    () => {
+      "worklet";
+      cancelAnimation(viewEnd);
+      // Anchor at the current right edge so the first delta is relative to where
+      // the window sits (the live edge when we were following).
+      if (viewEnd.get() == null) viewEnd.set(liveEdge.get());
+      onScrollStart?.();
+    };
+
+  const onChange =
+    /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+    (e: { changeX: number }) => {
+      "worklet";
+      const win = displayWindow.get();
+      const chartW = canvasWidth.get() - padLeft - padRight;
+      if (chartW <= 0) return;
+      const edge = liveEdge.get();
+      const cur = viewEnd.get() ?? edge;
+      const lo = panLowerBound(minTime.get(), win, edge);
+      viewEnd.set(nextViewEnd(cur, e.changeX, chartW, win, edge, lo));
+    };
+
+  const onEnd =
+    /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+    (e: { velocityX: number }) => {
+      "worklet";
+      if (viewEnd.get() == null) return;
+      const win = displayWindow.get();
+      const chartW = canvasWidth.get() - padLeft - padRight;
+      if (chartW <= 0) return;
+      const edge = liveEdge.get();
+      const lo = panLowerBound(minTime.get(), win, edge);
+      const velocity = flingVelocity(e.velocityX, chartW, win);
+      cancelAnimation(viewEnd);
+      viewEnd.set(
+        withDecay({ velocity, clamp: [lo, edge] }, (finished) => {
+          "worklet";
+          // Landed on the live-edge clamp → resume following; stopped short →
+          // stay frozen where inertia died.
+          if (finished && (viewEnd.get() ?? edge) >= edge - 1e-3) {
+            viewEnd.set(null);
+          }
+        }),
+      );
+    };
+
+  if (mode === "axisDrag") {
+    return Gesture.Pan()
       .enabled(enabled)
-      // Two fingers only — leaves the one-finger scrub gesture alone.
-      .minPointers(2)
-      .maxPointers(2)
-      .averageTouches(true)
-      .onStart(
+      .maxPointers(1)
+      // Position-gate a one-finger pan: only a drag that starts in the bottom
+      // axis band scrolls; everything else fails fast so scrub/parent gestures run.
+      .manualActivation(true)
+      .onTouchesDown(
         /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
-        () => {
+        (e, manager) => {
           "worklet";
-          cancelAnimation(viewEnd);
-          // Anchor at the current right edge so the first delta is relative to
-          // where the window sits (the live edge when we were following).
-          if (viewEnd.get() == null) viewEnd.set(liveEdge.get());
-          onScrollStart?.();
+          const t = e.changedTouches[0];
+          if (!t) return;
+          if (t.y < axisBandTop(canvasHeight.get(), padBottom)) {
+            armed.set(false);
+            manager.fail();
+            return;
+          }
+          armed.set(true);
+          startX.set(t.x);
+          startY.set(t.y);
         },
       )
-      .onChange(
+      .onTouchesMove(
         /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
-        (e) => {
+        (e, manager) => {
           "worklet";
-          const win = displayWindow.get();
-          const chartW = canvasWidth.get() - padLeft - padRight;
-          if (chartW <= 0) return;
-          const edge = liveEdge.get();
-          const cur = viewEnd.get() ?? edge;
-          const lo = panLowerBound(minTime.get(), win, edge);
-          viewEnd.set(nextViewEnd(cur, e.changeX, chartW, win, edge, lo));
+          if (!armed.get()) return;
+          const t = e.allTouches[0];
+          if (!t) return;
+          const dx = Math.abs(t.x - startX.get());
+          const dy = Math.abs(t.y - startY.get());
+          if (dx > AXIS_ACTIVATE_PX && dx >= dy) {
+            manager.activate(); // horizontal intent → take the gesture
+          } else if (dy > AXIS_ACTIVATE_PX) {
+            manager.fail(); // vertical intent → release to parent/scroll
+          }
         },
       )
-      .onEnd(
-        /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
-        (e) => {
-          "worklet";
-          if (viewEnd.get() == null) return;
-          const win = displayWindow.get();
-          const chartW = canvasWidth.get() - padLeft - padRight;
-          if (chartW <= 0) return;
-          const edge = liveEdge.get();
-          const lo = panLowerBound(minTime.get(), win, edge);
-          const velocity = flingVelocity(e.velocityX, chartW, win);
-          cancelAnimation(viewEnd);
-          viewEnd.set(
-            withDecay({ velocity, clamp: [lo, edge] }, (finished) => {
-              "worklet";
-              // Landed on the live-edge clamp → resume following; stopped short
-              // → stay frozen where inertia died.
-              if (finished && (viewEnd.get() ?? edge) >= edge - 1e-3) {
-                viewEnd.set(null);
-              }
-            }),
-          );
-        },
-      )
-  );
+      .onStart(onStart)
+      .onChange(onChange)
+      .onEnd(onEnd);
+  }
+
+  return Gesture.Pan()
+    .enabled(enabled)
+    // Two fingers only — leaves the one-finger scrub gesture alone.
+    .minPointers(2)
+    .maxPointers(2)
+    .averageTouches(true)
+    .onStart(onStart)
+    .onChange(onChange)
+    .onEnd(onEnd);
 }

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -10,11 +10,13 @@ import type { ChartPadding } from "../draw/line";
 
 /** Minimum height (px) of the bottom "grab the time ruler" band in axis-drag mode. */
 const AXIS_GRAB_MIN_PX = 44;
-/** Horizontal travel (px) before an axis-drag commits to scrolling vs. falling through. */
+/** Horizontal travel (px) before a one-finger drag commits to scrolling vs. falling through. */
 const AXIS_ACTIVATE_PX = 6;
+/** Vertical travel (px) that fails the one-finger scroll so a parent vertical scroll wins. */
+const HOLD_SCRUB_FAIL_Y_PX = 12;
 
 /** Which gesture activates a time-scroll. */
-export type PanScrollGestureMode = "twoFinger" | "axisDrag";
+export type PanScrollGestureMode = "twoFinger" | "axisDrag" | "holdToScrub";
 
 /** Engine SharedValues the pan-scroll gesture reads/writes (subset of the engine state). */
 export interface PanScrollEngineRefs {
@@ -42,9 +44,14 @@ export interface UsePanScrollOptions {
   /** Master switch. When false the gesture is disabled and the chart follows live. */
   enabled: boolean;
   /**
-   * Activation model. `"twoFinger"` (default): a two-finger drag anywhere.
-   * `"axisDrag"`: a one-finger drag starting in the bottom X-axis band ("grab
-   * the time ruler"). One-finger scrub in the plot area is untouched either way.
+   * Activation model:
+   *  - `"twoFinger"` (default): a two-finger drag anywhere; one-finger scrub
+   *    untouched.
+   *  - `"axisDrag"`: a one-finger drag starting in the bottom X-axis band ("grab
+   *    the time ruler"); one-finger scrub untouched.
+   *  - `"holdToScrub"`: a one-finger drag anywhere scrolls; scrub moves to
+   *    press-and-hold (Rainbow-style). The caller must give the scrub gesture a
+   *    long-press delay so a quick drag falls through to this one.
    */
   mode?: PanScrollGestureMode;
   /**
@@ -109,13 +116,16 @@ export function axisBandTop(canvasHeight: number, padBottom: number): number {
 }
 
 /**
- * Horizontal pan that scrolls the chart back through time. One-finger plot-area
- * scrub is left untouched; pick the activation with `mode`:
+ * Horizontal pan that scrolls the chart back through time. Pick the activation
+ * with `mode`:
  *  - `"twoFinger"` — a two-finger drag anywhere (compose with `Gesture.Race`;
  *    pointer count disambiguates it from the one-finger scrub).
  *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band, gated
  *    via `manualActivation` (compose with `Gesture.Exclusive`, this gesture
  *    first: outside the band it fails instantly so scrub runs).
+ *  - `"holdToScrub"` — a one-finger drag anywhere (activates on horizontal
+ *    travel; vertical falls through). Scrub must be press-and-hold so a quick
+ *    drag races past it (compose with `Gesture.Race`).
  *
  * Writes `engine.viewEnd`: a number freezes the window at that absolute right
  * edge; `null` means "follow live". Dragging (or flinging) back to the live edge
@@ -227,6 +237,21 @@ export function usePanScroll({
           }
         },
       )
+      .onStart(onStart)
+      .onChange(onChange)
+      .onEnd(onEnd);
+  }
+
+  if (mode === "holdToScrub") {
+    return Gesture.Pan()
+      .enabled(enabled)
+      .maxPointers(1)
+      // Activate on horizontal travel so a quick one-finger drag scrolls; a
+      // still press-hold crosses no offset and falls through to the scrub
+      // gesture (which owns the long-press). Vertical travel fails it so a
+      // parent vertical scroll wins.
+      .activeOffsetX([-AXIS_ACTIVATE_PX, AXIS_ACTIVATE_PX])
+      .failOffsetY([-HOLD_SCRUB_FAIL_Y_PX, HOLD_SCRUB_FAIL_Y_PX])
       .onStart(onStart)
       .onChange(onChange)
       .onEnd(onEnd);

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1226,6 +1226,15 @@ export interface LiveChartCoreProps {
    * and `timeWindow = maxT - minT` to fill the canvas edge-to-edge with historical data.
    */
   nowOverride?: number;
+  /**
+   * Enable two-finger horizontal time-scrolling: drag with two fingers (or fling)
+   * to pan back through history. The chart stops auto-scrolling while panned and
+   * resumes once you reach the live edge again. One-finger scrub is unchanged.
+   * Requires retained history in `data` / `candles` to scroll into. Default `false`.
+   *
+   * @experimental Prototype — gesture model and API may change.
+   */
+  timeScroll?: boolean;
   /** Accessibility label for the chart container. */
   accessibilityLabel?: string;
   /** Accessibility role for the chart container. Default `"image"`. */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1103,10 +1103,16 @@ export interface TimeScrollConfig {
    *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band
    *    ("grab the time ruler").
    *  - `"holdToScrub"` — a one-finger drag anywhere scrolls; scrub moves to
-   *    press-and-hold (Rainbow-style). Scrub engages after ~220ms unless you set
-   *    your own `scrub.panGestureDelay`.
+   *    press-and-hold (Rainbow-style). See {@link scrubHoldMs} for the hold.
    */
   gesture?: "twoFinger" | "axisDrag" | "holdToScrub";
+  /**
+   * `holdToScrub` only: press-and-hold duration (ms) before scrub engages, so a
+   * quicker one-finger drag scrolls instead. Higher = more deliberate scrub and
+   * fewer accidental scrubs while scrolling. Falls back to `scrub.panGestureDelay`
+   * if set, otherwise `500`.
+   */
+  scrubHoldMs?: number;
 }
 
 /** Props shared between `LiveChart` and `LiveChartSeries`. */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1102,8 +1102,11 @@ export interface TimeScrollConfig {
    *  - `"twoFinger"` (default) — a two-finger drag anywhere on the chart.
    *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band
    *    ("grab the time ruler").
+   *  - `"holdToScrub"` — a one-finger drag anywhere scrolls; scrub moves to
+   *    press-and-hold (Rainbow-style). Scrub engages after ~220ms unless you set
+   *    your own `scrub.panGestureDelay`.
    */
-  gesture?: "twoFinger" | "axisDrag";
+  gesture?: "twoFinger" | "axisDrag" | "holdToScrub";
 }
 
 /** Props shared between `LiveChart` and `LiveChartSeries`. */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1099,13 +1099,13 @@ export interface LiveChartMetricsOverride {
 export interface TimeScrollConfig {
   /**
    * Which gesture pans the timeline:
-   *  - `"twoFinger"` (default) — a two-finger drag anywhere on the chart.
+   *  - `"holdToScrub"` (default) — a one-finger drag anywhere scrolls; scrub
+   *    moves to press-and-hold (Rainbow-style). See {@link scrubHoldMs} for the
+   *    hold duration.
    *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band
-   *    ("grab the time ruler").
-   *  - `"holdToScrub"` — a one-finger drag anywhere scrolls; scrub moves to
-   *    press-and-hold (Rainbow-style). See {@link scrubHoldMs} for the hold.
+   *    ("grab the time ruler"); the plot area stays free for one-finger scrub.
    */
-  gesture?: "twoFinger" | "axisDrag" | "holdToScrub";
+  gesture?: "holdToScrub" | "axisDrag";
   /**
    * `holdToScrub` only: press-and-hold duration (ms) before scrub engages, so a
    * quicker one-finger drag scrolls instead. Higher = more deliberate scrub and
@@ -1256,8 +1256,9 @@ export interface LiveChartCoreProps {
    * live edge again. One-finger plot-area scrub is unchanged. Requires retained
    * history in `data` / `candles` to scroll into.
    *
-   * `true` uses the two-finger gesture; pass a {@link TimeScrollConfig} to pick
-   * the activation (`"twoFinger"` or `"axisDrag"`). Default `false`.
+   * `true` uses the default drag-to-scroll gesture (`"holdToScrub"`); pass a
+   * {@link TimeScrollConfig} to pick the activation (`"holdToScrub"` or
+   * `"axisDrag"`). Default `false`.
    *
    * @experimental Prototype — gesture model and API may change.
    */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1091,6 +1091,21 @@ export interface LiveChartMetricsOverride {
 
 // ── Component Props ──────────────────────────────────────────────────────────
 
+/**
+ * Time-scroll activation (see {@link LiveChartCoreProps.timeScroll}).
+ *
+ * @experimental Prototype — gesture model and API may change.
+ */
+export interface TimeScrollConfig {
+  /**
+   * Which gesture pans the timeline:
+   *  - `"twoFinger"` (default) — a two-finger drag anywhere on the chart.
+   *  - `"axisDrag"` — a one-finger drag starting in the bottom X-axis band
+   *    ("grab the time ruler").
+   */
+  gesture?: "twoFinger" | "axisDrag";
+}
+
 /** Props shared between `LiveChart` and `LiveChartSeries`. */
 export interface LiveChartCoreProps {
   /** Color scheme. Default `"dark"`. */
@@ -1227,14 +1242,17 @@ export interface LiveChartCoreProps {
    */
   nowOverride?: number;
   /**
-   * Enable two-finger horizontal time-scrolling: drag with two fingers (or fling)
-   * to pan back through history. The chart stops auto-scrolling while panned and
-   * resumes once you reach the live edge again. One-finger scrub is unchanged.
-   * Requires retained history in `data` / `candles` to scroll into. Default `false`.
+   * Enable horizontal time-scrolling: drag (or fling) to pan back through history.
+   * The chart stops auto-scrolling while panned and resumes once you reach the
+   * live edge again. One-finger plot-area scrub is unchanged. Requires retained
+   * history in `data` / `candles` to scroll into.
+   *
+   * `true` uses the two-finger gesture; pass a {@link TimeScrollConfig} to pick
+   * the activation (`"twoFinger"` or `"axisDrag"`). Default `false`.
    *
    * @experimental Prototype — gesture model and API may change.
    */
-  timeScroll?: boolean;
+  timeScroll?: boolean | TimeScrollConfig;
   /** Accessibility label for the chart container. */
   accessibilityLabel?: string;
   /** Accessibility role for the chart container. Default `"image"`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -453,4 +453,14 @@ describe("LiveChart", () => {
       nativeEvent: { layout: { width: 400, height: 200 } },
     });
   });
+
+  it("composes the axis-drag pan-scroll gesture via the config form", () => {
+    const screen = render(
+      <CandleHarness timeScroll={{ gesture: "axisDrag" }} scrub />,
+    );
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 200 } },
+    });
+  });
 });

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -438,7 +438,7 @@ describe("LiveChart", () => {
     });
   });
 
-  it("composes the two-finger pan-scroll gesture when timeScroll is on (line)", () => {
+  it("composes the default drag-to-scroll gesture when timeScroll is on (line)", () => {
     const screen = render(<Harness timeScroll scrub />);
     const views = screen.UNSAFE_getAllByType(View);
     fireEvent(views[0], "layout", {

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -464,6 +464,25 @@ describe("LiveChart", () => {
     });
   });
 
+  it("composes the order ticket (scrubAction) with time-scroll", () => {
+    // axisDrag carves the bottom band out of the scrub + tap hit area (so a drag
+    // there scrolls, not scrubs); holdToScrub keeps the whole plot live. Both
+    // compose with scrubAction without crashing.
+    for (const gesture of ["axisDrag", "holdToScrub"] as const) {
+      const screen = render(
+        <CandleHarness
+          timeScroll={{ gesture }}
+          scrubAction
+          onScrubAction={jest.fn()}
+        />,
+      );
+      const views = screen.UNSAFE_getAllByType(View);
+      fireEvent(views[0], "layout", {
+        nativeEvent: { layout: { width: 400, height: 200 } },
+      });
+    }
+  });
+
   it("composes the hold-to-scrub (one-finger drag) gesture", () => {
     // Default hold (no scrubHoldMs) and an explicit override both render cleanly.
     for (const ts of [

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -437,4 +437,20 @@ describe("LiveChart", () => {
       nativeEvent: { layout: { width: 400, height: 200 } },
     });
   });
+
+  it("composes the two-finger pan-scroll gesture when timeScroll is on (line)", () => {
+    const screen = render(<Harness timeScroll scrub />);
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 200 } },
+    });
+  });
+
+  it("enables time-scroll in candle mode", () => {
+    const screen = render(<CandleHarness timeScroll />);
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 200 } },
+    });
+  });
 });

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -465,12 +465,16 @@ describe("LiveChart", () => {
   });
 
   it("composes the hold-to-scrub (one-finger drag) gesture", () => {
-    const screen = render(
-      <CandleHarness timeScroll={{ gesture: "holdToScrub" }} scrub />,
-    );
-    const views = screen.UNSAFE_getAllByType(View);
-    fireEvent(views[0], "layout", {
-      nativeEvent: { layout: { width: 400, height: 200 } },
-    });
+    // Default hold (no scrubHoldMs) and an explicit override both render cleanly.
+    for (const ts of [
+      { gesture: "holdToScrub" } as const,
+      { gesture: "holdToScrub", scrubHoldMs: 600 } as const,
+    ]) {
+      const screen = render(<CandleHarness timeScroll={ts} scrub />);
+      const views = screen.UNSAFE_getAllByType(View);
+      fireEvent(views[0], "layout", {
+        nativeEvent: { layout: { width: 400, height: 200 } },
+      });
+    }
   });
 });

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -463,4 +463,14 @@ describe("LiveChart", () => {
       nativeEvent: { layout: { width: 400, height: 200 } },
     });
   });
+
+  it("composes the hold-to-scrub (one-finger drag) gesture", () => {
+    const screen = render(
+      <CandleHarness timeScroll={{ gesture: "holdToScrub" }} scrub />,
+    );
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 200 } },
+    });
+  });
 });

--- a/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
@@ -1,4 +1,5 @@
 import {
+  axisBandTop,
   flingVelocity,
   nextViewEnd,
   panLowerBound,
@@ -45,5 +46,16 @@ describe("flingVelocity", () => {
 
   it("maps a leftward fling toward the live edge (positive)", () => {
     expect(flingVelocity(-100, 200, 30)).toBe(15);
+  });
+});
+
+describe("axisBandTop", () => {
+  it("widens a thin axis padding to the minimum touch target", () => {
+    // padBottom 28 < 44 ⇒ band height clamps to 44 ⇒ top at 300 - 44.
+    expect(axisBandTop(300, 28)).toBe(256);
+  });
+
+  it("uses the axis padding when it already exceeds the minimum", () => {
+    expect(axisBandTop(300, 60)).toBe(240);
   });
 });

--- a/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
@@ -1,0 +1,49 @@
+import {
+  flingVelocity,
+  nextViewEnd,
+  panLowerBound,
+} from "../../src/hooks/usePanScroll";
+
+describe("panLowerBound", () => {
+  it("keeps the window's left edge from passing minTime", () => {
+    // left edge = rightEdge - window ⇒ smallest right edge = minTime + window.
+    expect(panLowerBound(900, 30, 1000)).toBe(930);
+  });
+
+  it("clamps to the live edge when history is shorter than the window", () => {
+    // minTime + window (1020) would exceed the live edge ⇒ clamp to 1000.
+    expect(panLowerBound(990, 30, 1000)).toBe(1000);
+  });
+});
+
+describe("nextViewEnd", () => {
+  it("moves the right edge back when dragging right (changeX > 0)", () => {
+    // 1000 - (20/200)*30 = 997
+    expect(nextViewEnd(1000, 20, 200, 30, 1000, 930)).toBe(997);
+  });
+
+  it("returns null once the drag reaches the live edge", () => {
+    // 997 - (-20/200)*30 = 1000 ⇒ caught up ⇒ follow.
+    expect(nextViewEnd(997, -20, 200, 30, 1000, 930)).toBeNull();
+  });
+
+  it("clamps to the lower bound (oldest history)", () => {
+    // 940 - (200/200)*30 = 910, below lo 930 ⇒ 930.
+    expect(nextViewEnd(940, 200, 200, 30, 1000, 930)).toBe(930);
+  });
+
+  it("clamps a forward overshoot to the live edge and follows", () => {
+    // 997 + 30 = 1027 > liveEdge ⇒ clamp 1000 ⇒ null.
+    expect(nextViewEnd(997, -200, 200, 30, 1000, 930)).toBeNull();
+  });
+});
+
+describe("flingVelocity", () => {
+  it("maps a rightward fling to a negative (back-in-time) edge velocity", () => {
+    expect(flingVelocity(200, 200, 30)).toBe(-30);
+  });
+
+  it("maps a leftward fling toward the live edge (positive)", () => {
+    expect(flingVelocity(-100, 200, 30)).toBe(15);
+  });
+});

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -7,6 +7,7 @@ function baseState() {
     displayMax: 1,
     displayWindow: 30,
     timestamp: 1000,
+    liveEdge: 0,
     extremaMinValue: NaN,
     extremaMaxValue: NaN,
     extremaMinTime: NaN,
@@ -502,6 +503,61 @@ describe("tickLiveChartEngineFrame", () => {
     expect(s.displayWindow).toBeLessThan(60);
   });
 
+  // ── Time-scroll (viewEnd / liveEdge) ─────────────────────────────────────
+  describe("time-scroll", () => {
+    function input(extra: Partial<Parameters<typeof tickLiveChartEngineFrame>[1]>) {
+      return {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.08,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 1,
+        points: [],
+        nowSeconds: 1000,
+        ...extra,
+      };
+    }
+
+    it("exposes the live edge (now + windowBuffer*timeWindow) each frame", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ windowBuffer: 0.1 }));
+      // liveEdge = 1000 + 0.1 * 30 = 1003; following ⇒ timestamp tracks it.
+      expect(s.liveEdge).toBe(1003);
+      expect(s.timestamp).toBe(1003);
+    });
+
+    it("freezes the right edge at viewEnd when scrolled back in time", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ viewEnd: 950 }));
+      expect(s.timestamp).toBe(950); // frozen at the requested absolute time
+      expect(s.liveEdge).toBe(1000); // live edge keeps tracking "now"
+    });
+
+    it("follows the live edge once viewEnd catches up to it", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ viewEnd: 1000 })); // == liveEdge
+      expect(s.timestamp).toBe(1000);
+      const s2 = baseState();
+      tickLiveChartEngineFrame(s2, input({ viewEnd: 1100 })); // past liveEdge
+      expect(s2.timestamp).toBe(1000);
+    });
+
+    it("treats viewEnd null as following", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ viewEnd: null }));
+      expect(s.timestamp).toBe(1000);
+    });
+
+    it("lets viewEnd override paused (pan wins over freeze)", () => {
+      const s = { ...baseState(), timestamp: 999 };
+      tickLiveChartEngineFrame(s, input({ viewEnd: 950, paused: true }));
+      expect(s.timestamp).toBe(950);
+    });
+  });
+
   // ── Extrema tracking (for "extrema"-positioned axis labels) ──────────────
   describe("extrema tracking", () => {
     it("records the value + time of the lowest and highest point (line mode)", () => {
@@ -735,6 +791,7 @@ describe("tickLiveChartEngineFrame adaptiveSpeedBoost", () => {
       displayMax: 10,
       displayWindow: 30,
       timestamp: 1000,
+      liveEdge: 0,
       extremaMinValue: NaN,
       extremaMaxValue: NaN,
       extremaMinTime: NaN,

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -6,6 +6,7 @@ describe("tickLiveChartSeriesEngineFrame", () => {
     displayMax: number;
     displayWindow: number;
     timestamp: number;
+    liveEdge: number;
     displayValues: number[];
     opacities: number[];
     extremaMinValue: number;
@@ -18,6 +19,7 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       displayMax: 100,
       displayWindow: 30,
       timestamp: 1000,
+      liveEdge: 0,
       displayValues: [],
       opacities: [],
       extremaMinValue: NaN,
@@ -596,6 +598,51 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       expect(s.extremaMaxValue).toBeNaN();
       expect(s.extremaMinTime).toBeNaN();
       expect(s.extremaMaxTime).toBeNaN();
+    });
+  });
+
+  describe("time-scroll", () => {
+    function input(
+      extra: Partial<Parameters<typeof tickLiveChartSeriesEngineFrame>[1]>,
+    ) {
+      return {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.08,
+        exaggerate: false,
+        referenceValue: undefined,
+        series: [],
+        nowSeconds: 1000,
+        ...extra,
+      };
+    }
+
+    it("exposes the live edge and follows it by default", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(s, input({ windowBuffer: 0.1 }));
+      expect(s.liveEdge).toBe(1003);
+      expect(s.timestamp).toBe(1003);
+    });
+
+    it("freezes the right edge at viewEnd when scrolled back", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(s, input({ viewEnd: 950 }));
+      expect(s.timestamp).toBe(950);
+      expect(s.liveEdge).toBe(1000);
+    });
+
+    it("follows the live edge once viewEnd catches up", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(s, input({ viewEnd: 1200 }));
+      expect(s.timestamp).toBe(1000);
+    });
+
+    it("lets viewEnd override paused", () => {
+      const s = { ...baseMulti(), timestamp: 999 };
+      tickLiveChartSeriesEngineFrame(s, input({ viewEnd: 950, paused: true }));
+      expect(s.timestamp).toBe(950);
     });
   });
 });


### PR DESCRIPTION
## Summary

Prototype: **horizontal time-scrolling** for `LiveChart`. A **two-finger** drag (or fling) pans the window back through retained history — the chart stops auto-scrolling while panned and resumes once you reach the live edge again. Works for **both line and candle**; one-finger scrub is unchanged.

> ⚠️ **Draft / prototype.** The two-finger gesture model feels awkward and is under feedback — opening this to save the work, not to merge as-is.

## How it works

- **Engine** — both ticks (`liveChartEngineTick`, `liveChartSeriesEngineTick`) and both hooks gain two SharedValues:
  - `viewEnd` — `null` = follow live; a number `< liveEdge` freezes the right edge at that absolute time.
  - `liveEdge` — the would-be-live timestamp (keeps advancing while frozen).
  - The follow/freeze/pause precedence is a generalization of the existing `paused` flag. Everything downstream (draw, axis, scrub, markers) already reads `timestamp`/`displayWindow`, so it inherits panning with no changes.
- **Gesture** — `usePanScroll`: a two-finger `Gesture.Pan` + `withDecay` inertia, clamped to `[oldest data, liveEdge]`, snapping back to follow at the edge. Composed via `Gesture.Race`; pointer count (2 vs scrub's 1) disambiguates so scrub is untouched.
- **Surface** — `timeScroll?: boolean` (default `false`, `@experimental`) on `LiveChart`, plus a **Time scroll** demo (Interaction section) with a line/candle toggle.

## Notes

- `viewEnd`/`liveEdge` are intersected onto the engine hooks' return types but kept **off** `ChartEngineLayout` so the many overlay / multi-series component test mocks don't break.
- `usePanScroll`'s worklet callbacks are `istanbul ignore`d (repo convention); the pan math is in exported pure helpers, tested to 100%.

## Verification

- `typecheck` + `lint` clean
- 1007 tests pass (19 new); coverage above gates — `liveChartEngineTick.ts` & `usePanScroll.ts` at 100%
- Confirmed working on candles in the sim; line uses the identical engine path

## Deferred (Phase 2)

- Alternative gesture model (two-finger feedback) — e.g. one-finger drag on the X-axis band
- Wire `usePanScroll` into `LiveChartSeries` (the multi engine already supports `viewEnd`)
- `onReachStart` (lazy-load older history), `scrollToLive()` / following indicator
- Pinch-to-zoom the window (reserved for two-finger pinch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
