### PR TITLE
feat(candle): adjustable body radius + wick width

### DIFF
--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -48,10 +48,24 @@ const CUSTOM_CANDLE_PALETTE = {
   wickDown: "#ea580c",
 };
 
+const ROUNDING_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: "Sharp" },
+  { value: 3, label: "3px" },
+  { value: 6, label: "6px" },
+];
+
+const WICK_OPTIONS: { value: number; label: string }[] = [
+  { value: 1, label: "1px" },
+  { value: 2, label: "2px" },
+  { value: 3, label: "3px" },
+];
+
 export default function CandlestickScreen() {
   const [tfLabel, setTfLabel] = useState<TimeframeLabel>("15m · 1m");
   const [stripCandles, setStripCandles] = useState(false);
   const [customColors, setCustomColors] = useState(false);
+  const [rounding, setRounding] = useState(3);
+  const [wickWidth, setWickWidth] = useState(1);
 
   const tf = TIMEFRAMES.find((t) => t.label === tfLabel) ?? TIMEFRAMES[1];
   const candleWidthSecs = tf.candleWidthSecs;
@@ -94,6 +108,7 @@ export default function CandlestickScreen() {
           theme={APP_THEME}
           timeWindow={tf.windowSecs}
           palette={customColors ? CUSTOM_CANDLE_PALETTE : undefined}
+          metrics={{ candle: { bodyRadius: rounding, wickWidth } }}
           scrub={{ tooltip: true }}
         />
       }
@@ -103,6 +118,20 @@ export default function CandlestickScreen() {
         options={TIMEFRAME_OPTIONS}
         value={tfLabel}
         onChange={setTfLabel}
+      />
+
+      <ChipRow
+        label="Body radius"
+        options={ROUNDING_OPTIONS}
+        value={rounding}
+        onChange={setRounding}
+      />
+
+      <ChipRow
+        label="Wick width"
+        options={WICK_OPTIONS}
+        value={wickWidth}
+        onChange={setWickWidth}
       />
 
       <ControlRow label="Candle colors">

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1122,13 +1122,13 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         <Path
           path={upWicksPath}
           style="stroke"
-          strokeWidth={1}
+          strokeWidth={metricsCfg.candle.wickWidth}
           color={palette.wickUp}
         />
         <Path
           path={downWicksPath}
           style="stroke"
-          strokeWidth={1}
+          strokeWidth={metricsCfg.candle.wickWidth}
           color={palette.wickDown}
         />
         <Path path={upBodiesPath} style="fill" color={palette.candleUp} />

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -29,6 +29,8 @@ export const CANDLE_METRICS_DEFAULTS: CandleMetrics = {
   minBodyPx: 1,
   maxBodyPx: 40,
   bodyWidthRatio: 0.8,
+  bodyRadius: 0,
+  wickWidth: 1,
 };
 
 /** Default grid + axis-label fade speeds. */

--- a/packages/react-native-livechart/src/hooks/useCandlePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useCandlePaths.ts
@@ -76,11 +76,20 @@ export function useCandlePaths(
   const upBodiesPath = useDerivedValue(() => {
     const b = upBodiesBuilder.value;
     const { bodies } = geometry.value;
+    const radius = candleMetrics.bodyRadius;
     for (let i = 0; i < bodies.length; i++) {
       if (bodies[i].up) {
-        b.addRect(
-          Skia.XYWHRect(bodies[i].x, bodies[i].y, bodies[i].w, bodies[i].h),
-        );
+        const bd = bodies[i];
+        const rr = radius > 0 ? Math.min(radius, bd.w / 2, bd.h / 2) : 0;
+        if (rr > 0) {
+          b.addRRect({
+            rect: { x: bd.x, y: bd.y, width: bd.w, height: bd.h },
+            rx: rr,
+            ry: rr,
+          });
+        } else {
+          b.addRect(Skia.XYWHRect(bd.x, bd.y, bd.w, bd.h));
+        }
       }
     }
     return b.detach();
@@ -90,11 +99,20 @@ export function useCandlePaths(
   const downBodiesPath = useDerivedValue(() => {
     const b = downBodiesBuilder.value;
     const { bodies } = geometry.value;
+    const radius = candleMetrics.bodyRadius;
     for (let i = 0; i < bodies.length; i++) {
       if (!bodies[i].up) {
-        b.addRect(
-          Skia.XYWHRect(bodies[i].x, bodies[i].y, bodies[i].w, bodies[i].h),
-        );
+        const bd = bodies[i];
+        const rr = radius > 0 ? Math.min(radius, bd.w / 2, bd.h / 2) : 0;
+        if (rr > 0) {
+          b.addRRect({
+            rect: { x: bd.x, y: bd.y, width: bd.w, height: bd.h },
+            rx: rr,
+            ry: rr,
+          });
+        } else {
+          b.addRect(Skia.XYWHRect(bd.x, bd.y, bd.w, bd.h));
+        }
       }
     }
     return b.detach();

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1161,6 +1161,10 @@ export interface CandleMetrics {
   maxBodyPx: number;
   /** Body width as a fraction of the per-candle slot width (0–1). Default `0.8`. */
   bodyWidthRatio: number;
+  /** Corner radius (px) of candle bodies. `0` = sharp corners. Default `0`. */
+  bodyRadius: number;
+  /** Wick (high–low line) stroke width in px. Default `1`. */
+  wickWidth: number;
 }
 
 /** Grid-line and axis-label fade animation speeds. */

--- a/packages/react-native-livechart/tests/draw/candle.test.ts
+++ b/packages/react-native-livechart/tests/draw/candle.test.ts
@@ -214,6 +214,8 @@ describe("candle geometry metrics overrides", () => {
       minBodyPx: 1,
       maxBodyPx: 20,
       bodyWidthRatio: 0.8,
+      bodyRadius: 0,
+      wickWidth: 1,
     });
     expect(narrow.bodies[0].w).toBe(20);
   });
@@ -226,6 +228,8 @@ describe("candle geometry metrics overrides", () => {
       minBodyPx: 1,
       maxBodyPx: 40,
       bodyWidthRatio: 0.5,
+      bodyRadius: 0,
+      wickWidth: 1,
     });
     expect(thin.bodies[0].w).toBe(20); // 40 * 0.5
   });
@@ -238,6 +242,8 @@ describe("candle geometry metrics overrides", () => {
       minBodyPx: 6,
       maxBodyPx: 40,
       bodyWidthRatio: 0.8,
+      bodyRadius: 0,
+      wickWidth: 1,
     });
     expect(tall.bodies[0].h).toBe(6);
   });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1140,6 +1140,8 @@ describe("resolveMetrics", () => {
       minBodyPx: 1,
       maxBodyPx: 40,
       bodyWidthRatio: 0.8,
+      bodyRadius: 0,
+      wickWidth: 1,
     });
     expect(m.grid).toEqual({ fadeInSpeed: 0.18, fadeOutSpeed: 0.12 });
     expect(m.motion).toEqual({
@@ -1175,7 +1177,13 @@ describe("resolveMetrics", () => {
       motion: { adaptiveSpeedBoost: 0 },
       emptyState: { labelOpacity: 1 },
     });
-    expect(m.candle).toEqual({ minBodyPx: 1, maxBodyPx: 12, bodyWidthRatio: 0.8 });
+    expect(m.candle).toEqual({
+      minBodyPx: 1,
+      maxBodyPx: 12,
+      bodyWidthRatio: 0.8,
+      bodyRadius: 0,
+      wickWidth: 1,
+    });
     expect(m.grid).toEqual({ fadeInSpeed: 0.5, fadeOutSpeed: 0.12 });
     expect(m.motion).toEqual({ badgeColorSpeed: 0.08, adaptiveSpeedBoost: 0 });
     expect(m.emptyState).toEqual({


### PR DESCRIPTION
## Summary

Stacked on #147. Candle bodies were sharp rectangles with no styling knobs beyond width — this adds **rounded corners** and **wick width**, both via `metrics.candle`.

## Changes

- `metrics.candle.bodyRadius` — corner radius (px) for candle bodies, rendered with `addRRect` and clamped to half the body's width/height so thin candles and dojis stay clean. `0` = sharp corners (default, unchanged).
- `metrics.candle.wickWidth` — wick (high–low line) stroke width. Default `1`.
- **Candlestick demo**: new **Body radius** (Sharp / 3px / 6px) and **Wick width** (1 / 2 / 3px) chips.

## Verification

- Build + typecheck + lint clean; 1019 tests pass; coverage above gates.
- Verified on the iOS 26.4 sim — rounded bodies render, both chips work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
