### PR TITLE
docs: candlestick styling + volume, time-scroll guide, float axis

### DIFF
--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -39,6 +39,15 @@ provided; everything else has a default.
   In-progress candle, updated each tick; `null` between buckets.
 </ParamField>
 
+<ParamField body="volume" type="boolean | VolumeConfig" default="false">
+  Volume bars in a reserved band below the candles (candle mode only). The
+  candle plot shrinks by the band height so candles are never cut off; the x-axis
+  stays pinned to the bottom. Reads each [`CandlePoint.volume`](/api-reference/types#data);
+  bars normalize to the largest visible volume. Pass a
+  [`VolumeConfig`](/api-reference/types#config-objects) for `upColor` / `downColor`,
+  `maxHeight`, `radius`, `opacity`. See [Candlestick](/guides/candlestick#volume-bars).
+</ParamField>
+
 ## Line, fill & tip
 
 <ParamField body="line" type="LineConfig">
@@ -230,6 +239,15 @@ provided; everything else has a default.
 <ParamField body="onGestureEnd" type="() => void">
   JS-thread callback fired once when the user stops scrubbing. Fires only if a
   scrub actually started — a tap that never activates emits neither callback.
+</ParamField>
+
+<ParamField body="timeScroll" type="boolean | TimeScrollConfig" default="false">
+  Pan back through history: drag (or fling) to scroll, and the chart stops
+  auto-following until you return to the live edge. `true` uses the default
+  drag-to-scroll gesture (`"holdToScrub"` — drag scrolls, press-and-hold scrubs);
+  pass a [`TimeScrollConfig`](/api-reference/types#config-objects) to pick
+  `"axisDrag"` (drag the x-axis strip) or set `scrubHoldMs`. Single-series only.
+  **@experimental.** See [Time-scroll](/guides/time-scroll).
 </ParamField>
 
 ## Axes, grid & range

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -27,6 +27,7 @@ interface CandlePoint {
   high: number;
   low: number;
   close: number;
+  volume?: number; // optional traded volume; drives the volume bars (candle mode)
 }
 
 interface SeriesConfig {
@@ -221,6 +222,8 @@ interface BadgeConfig {
   tail?: boolean;
   background?: string;
   position?: "right" | "left";
+  followViewEdge?: boolean; // while time-scrolled, track the price at the visible
+                            // window's right edge (badge + value line + dot); default false
 }
 interface PulseConfig {
   interval?: number; duration?: number; maxRadius?: number;
@@ -264,8 +267,28 @@ interface SelectionDotConfig {
   component?: ComponentType<SelectionDotProps>; // custom Skia dot; ignores size/color/ring
 }
 interface GridStyleConfig { color?: string; strokeWidth?: number; intervals?: number[]; opacity?: number }
-interface YAxisConfig { minGap?: number } // default 36
+interface YAxisConfig {
+  minGap?: number; // min px gap between grid lines; default 36
+  // Float the price axis over a full-width plot instead of reserving a right
+  // gutter — the line/candles run to the edge and the labels float on top.
+  // Pairs with `timeScroll` (see the Time-scroll guide). Default false. @experimental
+  float?: boolean;
+}
 interface XAxisConfig { minGap?: number } // default 60
+// Volume bars below the candles (candle mode only). Bars normalize to the largest
+// visible volume; the candle plot shrinks by `maxHeight` to make room. @see CandlePoint.volume
+interface VolumeConfig {
+  upColor?: string;    // bars for up (close ≥ open) candles; default palette.candleUp
+  downColor?: string;  // bars for down candles; default palette.candleDown
+  maxHeight?: number;  // reserved band height (px) = the tallest bar; default 48
+  radius?: number;     // bar-top corner radius (px); default 2
+  opacity?: number;    // opacity of the whole band (0..1); default 0.6
+}
+// Horizontal time-scrolling (pan back through history). @experimental
+interface TimeScrollConfig {
+  gesture?: "holdToScrub" | "axisDrag"; // activation; default "holdToScrub"
+  scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
+}
 // Edge label (topLabel / bottomLabel). Default off — both opt-in.
 interface AxisLabelConfig {
   format?: (v: number) => string; // built-in value formatter; defaults to formatValue
@@ -495,6 +518,8 @@ interface CandleMetrics {
   minBodyPx: number;      // min body height so dojis stay visible, default 1
   maxBodyPx: number;      // max body width, default 40
   bodyWidthRatio: number; // body width as a fraction of the slot, default 0.8
+  bodyRadius: number;     // body corner radius (px); 0 = sharp, default 0
+  wickWidth: number;      // wick (high–low line) stroke width (px), default 1
 }
 
 interface GridMetrics {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,7 @@
               "guides/candlestick",
               "guides/multi-series",
               "guides/scrubbing",
+              "guides/time-scroll",
               "guides/momentum-and-degen",
               "guides/markers-and-references",
               "guides/theming"

--- a/docs/guides/candlestick.mdx
+++ b/docs/guides/candlestick.mdx
@@ -45,6 +45,7 @@ interface CandlePoint {
   high: number;
   low: number;
   close: number;
+  volume?: number; // optional — drives the volume bars (see below)
 }
 ```
 
@@ -62,6 +63,72 @@ interface CandlePoint {
 Bullish/bearish body and wick colors come from the palette derived from `accentColor` + `theme`.
 Override them precisely via the [`palette`](/guides/theming) prop (`candleUp`, `candleDown`,
 `wickUp`, `wickDown`).
+
+## Body & wick shape
+
+The candle body radius and wick thickness live in the `metrics.candle`
+[sizing tokens](/api-reference/types#metrics). Round the body corners with `bodyRadius`
+(clamped to half the body so thin candles stay sane) and set the wick stroke with `wickWidth`:
+
+```tsx
+<LiveChart
+  mode="candle"
+  candles={candles}
+  liveCandle={liveCandle}
+  candleWidth={60}
+  metrics={{ candle: { bodyRadius: 3, wickWidth: 2 } }}
+/>
+```
+
+`bodyRadius` defaults to `0` (sharp corners); `wickWidth` defaults to `1`. Width/spacing tokens
+(`bodyWidthRatio`, `maxBodyPx`, `minBodyPx`) live in the same namespace — see
+[`CandleMetrics`](/api-reference/types#metrics).
+
+## Volume bars
+
+Pass `volume` to draw volume bars in a reserved band **below** the candles. The candle/price plot
+shrinks by the band height to make room (candles are never cut off) and the x-axis stays pinned to
+the bottom. Each bar reads its candle's `volume`; bar heights are normalized to the **largest
+visible volume**, so the tallest visible bar fills the band. Candles without a `volume` draw no bar.
+
+```tsx
+const candles = useSharedValue<CandlePoint[]>([
+  { time: 1700000000, open: 48, high: 52, low: 47, close: 50, volume: 1200 },
+  // …
+]);
+
+<LiveChart
+  mode="candle"
+  candles={candles}
+  liveCandle={liveCandle}
+  candleWidth={60}
+  volume // `true` = defaults, or pass a VolumeConfig
+/>;
+```
+
+Configure colors, band height, rounding, and opacity with a
+[`VolumeConfig`](/api-reference/types#config-objects):
+
+```tsx
+<LiveChart
+  mode="candle"
+  candles={candles}
+  liveCandle={liveCandle}
+  candleWidth={60}
+  volume={{
+    maxHeight: 64,        // reserved band height (px) = the tallest bar; default 48
+    radius: 2,            // bar-top corner radius; default 2
+    opacity: 0.6,         // opacity of the whole band; default 0.6
+    upColor: "#16a34a",   // default: palette.candleUp
+    downColor: "#dc2626", // default: palette.candleDown
+  }}
+/>;
+```
+
+<Note>
+  Volume is **candle mode only**. Bars align under the candle bodies (same width + center), colored
+  by candle direction (up/down) unless you override `upColor` / `downColor`.
+</Note>
 
 ## Scrubbing & the OHLC tooltip
 

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -1,0 +1,95 @@
+---
+title: Time-scroll
+icon: "clock-rotate-left"
+description: "Pan back through history; auto-follow resumes at the live edge."
+---
+
+<Warning>
+  **Experimental.** `timeScroll` is a prototype — the gesture model and API may still change.
+  Single-series (`LiveChart`) only; line and candle modes both work.
+</Warning>
+
+By default the chart follows the live edge. Enable `timeScroll` to **pan back through history**:
+drag (or fling) to scroll the window into the past, and the chart stops auto-following until you
+return to the live edge, where live-following resumes. One-finger plot scrubbing is unchanged.
+
+<Note>
+  **Live example:**
+  [`app/demo/time-scroll.tsx`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/demo/time-scroll.tsx)
+  in the example app.
+</Note>
+
+```tsx
+<LiveChart data={data} value={value} timeScroll />
+```
+
+Panning is clamped to the earliest retained point, so keep enough history in `data` (or `candles`)
+to scroll into — seed a few windows' worth and keep your buffer longer than the visible window.
+
+## Gestures
+
+`timeScroll: true` uses the default **drag-to-scroll** gesture. Pass a `TimeScrollConfig` to pick the
+activation:
+
+```tsx
+<LiveChart data={data} value={value} timeScroll={{ gesture: "axisDrag" }} />
+```
+
+- **`"holdToScrub"`** (default) — a one-finger drag **anywhere** scrolls the timeline; scrubbing
+  moves to a **press-and-hold** (Rainbow-style). A quick drag scrolls; hold, then drag, to scrub.
+- **`"axisDrag"`** — only a drag that **starts on the bottom x-axis strip** ("grab the time ruler")
+  scrolls. The plot area stays free, so a one-finger drag there scrubs immediately.
+
+### Hold duration (`scrubHoldMs`)
+
+In `holdToScrub`, `scrubHoldMs` sets how long to press before scrub engages (so a quicker drag
+scrolls instead). Higher = more deliberate scrub, fewer accidental scrubs while scrolling. Default
+`500`.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  scrub
+  timeScroll={{ gesture: "holdToScrub", scrubHoldMs: 350 }}
+/>
+```
+
+## Full-width plot while scrolled (`yAxis.float`)
+
+A normal chart reserves a right gutter for the price axis, so candles stop short of the edge. Pair
+`timeScroll` with [`yAxis: { float: true }`](/api-reference/types#config-objects) and the plot runs
+**full-width under a floating price axis** — but only while you're scrolled back. At the live edge
+(the default state) the chart keeps its normal gutter so the latest candle and the badge don't sit
+under the floating labels; as soon as you scroll back, the plot expands under the axis so panned-in
+candles aren't cut off, and it reverts when you return to live.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  mode="candle"
+  candles={candles}
+  liveCandle={liveCandle}
+  timeScroll
+  yAxis={{ float: true }}
+  badge={{ followViewEdge: true }}
+/>
+```
+
+## Track the visible edge (`badge.followViewEdge`)
+
+While scrolled back, the live-price indicators normally stay at the (off-screen, still-advancing)
+live value. Set [`badge.followViewEdge`](/api-reference/types#config-objects) so the **badge, value
+line, and live dot** instead track the price at the **visible window's right edge** — the last
+price you can see — and snap back to the live value when you return to the live edge.
+
+## Notes
+
+- **Single-series only.** `timeScroll` is wired into `LiveChart`; `LiveChartSeries` doesn't support
+  it yet.
+- **Coexists with scrubbing.** Plot-area scrub (and the [order ticket](/guides/scrubbing#order-ticket-scrubaction))
+  work alongside time-scroll — the gestures are disambiguated by region (`axisDrag`) or press-hold
+  (`holdToScrub`).
+- See the [`LiveChart` reference](/api-reference/livechart#scrubbing) and
+  [`TimeScrollConfig`](/api-reference/types#config-objects) for every field.


### PR DESCRIPTION
## Docs for the candlestick / time-scroll feature stack (stacked on #149)

Documents the features added across #145 (time-scroll), #147 (floating y-axis), #148 (candle styling), and #149 (volume bars). Docs-only — no library code changes.

### Guides
- **Candlestick** ([`candlestick.mdx`](docs/guides/candlestick.mdx)): new **Body & wick shape** section (`metrics.candle.bodyRadius` / `wickWidth`) and a **Volume bars** section (`volume` prop, `VolumeConfig`, `CandlePoint.volume`, reserved-band behavior).
- **Time-scroll** ([`time-scroll.mdx`](docs/guides/time-scroll.mdx), new): `timeScroll`, the two gestures (`holdToScrub` default vs `axisDrag`), `scrubHoldMs`, the full-width-while-scrolled `yAxis.float` pairing, and `badge.followViewEdge`. Flagged `@experimental`. Registered in the nav (`docs.json`).

### API reference
- **`livechart.mdx`**: `volume` (Display mode) and `timeScroll` (Scrubbing) `ParamField`s.
- **`types.mdx`**: `CandlePoint.volume`; `CandleMetrics.bodyRadius` / `wickWidth`; `YAxisConfig.float`; `BadgeConfig.followViewEdge`; new `VolumeConfig` and `TimeScrollConfig` interfaces.

### Notes
- Text + code only — no new media (no volume/time-scroll videos exist yet); guides link to the live example demos like the others.
- Cross-links resolve to existing anchors (`#config-objects`, `#metrics`, `#data`, `#volume-bars`, `/guides/time-scroll`).
- `npm test` green via the pre-commit hook (docs don't touch the TS build/tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
