### PR TITLE
fix(grid): guard Y-axis grid loop against non-terminating step

### DIFF
--- a/packages/react-native-livechart/src/draw/grid.ts
+++ b/packages/react-native-livechart/src/draw/grid.ts
@@ -114,7 +114,19 @@ export function computeGridEntries(
   // Phase 1: compute target alpha for every grid line
   const targets: Record<number, number> = {};
   const first = Math.ceil(displayMin / fine) * fine;
-  for (let val = first; val <= displayMax; val += fine) {
+  // Guard against a non-advancing loop. On a near-flat (but not bit-identical)
+  // range, `fine` can drop below ulp(val), so `val += fine === val` and the loop
+  // never terminates — freezing the UI thread, since this runs in a worklet every
+  // frame. `stepResolves` skips the degenerate range (also catches fine === 0);
+  // MAX_GRID_LINES is a hard backstop in case the step stalls mid-loop (real
+  // grids only have a handful of lines, so it never bites normal data).
+  const stepResolves = first + fine !== first;
+  const MAX_GRID_LINES = 1000;
+  for (
+    let val = first, lineCount = 0;
+    stepResolves && val <= displayMax && lineCount < MAX_GRID_LINES;
+    val += fine, lineCount++
+  ) {
     const y = gridValueToY(val, displayMax, valRange, padTop, chartH);
     /* istanbul ignore next -- y stays in chart band for v in [first, displayMax] with consistent toY */
     if (y < padTop - 2 || y > canvasHeight - padBottom + 2) continue;

--- a/packages/react-native-livechart/tests/draw/grid.test.ts
+++ b/packages/react-native-livechart/tests/draw/grid.test.ts
@@ -139,6 +139,27 @@ describe("computeGridEntries", () => {
     computeGridEntries(0, 10, 400, 12, 28, 0, alphas, fmt, 16.67);
     expect(alphas).toBeDefined();
   });
+
+  it("terminates on a near-flat range where the step is below value resolution", () => {
+    // Range ~1 ULP at this magnitude: `fine` falls below ulp(val), so the old
+    // `val += fine` never advanced and the worklet hung the UI thread (issue #146).
+    const v = 1234.56;
+    const alphas: Record<number, number> = {};
+    const r = computeGridEntries(v - 3e-13, v, 250, 0, 0, 0, alphas, fmt, 16.67);
+    // No resolvable grid lines for a degenerate range — it just returns cleanly.
+    expect(r.entries).toEqual([]);
+  });
+
+  it("caps the grid loop at MAX_GRID_LINES as a hard backstop", () => {
+    // Force a huge line count while the step still resolves: an outsized canvas
+    // plus a tiny in-band prevInterval keeps `fine` small enough to exceed 1000
+    // lines, exercising the iteration cap.
+    const alphas: Record<number, number> = {};
+    const r = computeGridEntries(0, 100, 20000, 0, 0, 0.1, alphas, fmt, 16.67);
+    expect(r.entries.length).toBeGreaterThan(0);
+    // Phase-1 stops emitting targets past the cap (would be ~2000 uncapped).
+    expect(Object.keys(alphas).length).toBeLessThanOrEqual(1000);
+  });
 });
 
 describe("computeGridEntries grid-fade metrics", () => {


### PR DESCRIPTION
## Summary

Fixes #146 — the Y-axis grid loop in `computeGridEntries` ([`src/draw/grid.ts`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/packages/react-native-livechart/src/draw/grid.ts)) could spin forever on a near-flat data range, freezing the UI thread (iOS watchdog "App Hang").

## Root cause

The loop steps by `fine = coarse / 2 ≈ valRange / 14`, iterating `val` across the absolute value level (`displayMin … displayMax`). On a range that is flat to within a few ULP but not bit-identical, `fine` drops below `ulp(val)`, so `val += fine === val` and the loop never advances. Because it runs inside a `useDerivedValue` worklet (`useYAxis`) every frame, it hangs the **UI thread**.

Confirmed numerically — for `[1234.56 − 3e-13, 1234.56]`: `fine = 2e-14`, `ulp(val) ≈ 2.7e-13`, and `first + fine === first`. An exactly-flat range was already safe (the caller floors `rawRange === 0` to a minimum); a tiny-nonzero range slipped through.

## Fix

Guard the loop so it always terminates:

- `stepResolves = first + fine !== first` — skip the loop entirely when the step can't make progress (this also catches `fine === 0`). A degenerate range simply fades the grid out, which is the correct outcome.
- `MAX_GRID_LINES = 1000` — hard iteration backstop in case the step stalls mid-loop.

Behaviour is unchanged for any range healthy enough to render grid lines (real grids have only a handful), so this is transparent for normal data.

## Testing

- Added two regression tests in `tests/draw/grid.test.ts`: the near-flat range (which **hung before this change**) and the `MAX_GRID_LINES` cap.
- `grid.ts` at 100% statements/branches/functions/lines; full `npm run verify` green (typecheck + lint + 1011 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
