### PR TITLE
feat(badge): style & shape config (radius, border, text color, font, offset)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -138,6 +138,11 @@ const SECTIONS: DemoSection[] = [
         blurb: "Theme, accent, gradient, line, font, grid, palette.",
       },
       {
+        href: "/demo/badge-styling",
+        title: "Badge styling",
+        blurb: "BadgeConfig shape knobs: radius, background, border, text color, font, offset.",
+      },
+      {
         href: "/demo/axes-grid",
         title: "Axes & grid",
         blurb: "Hide X/Y, minGap, insets; LiveChart vs LiveChartSeries.",

--- a/app/demo/badge-styling.tsx
+++ b/app/demo/badge-styling.tsx
@@ -1,0 +1,214 @@
+import { useState } from "react";
+import type {
+  BadgeConfig,
+  FontWeight,
+  LiveChartPalette,
+} from "react-native-livechart";
+import { LiveChart } from "react-native-livechart";
+
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ChipRow } from "../../demo-lib/ChipRow";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Badge styling" };
+
+// ─── Position (tail on "right", plain pill on "left") ───────────────────────
+type Pos = "right" | "left";
+const POSITIONS: { value: Pos; label: string }[] = [
+  { value: "right", label: "Right (tail)" },
+  { value: "left", label: "Left (pill)" },
+];
+
+// ─── Corner radius ──────────────────────────────────────────────────────────
+type RadiusMode = "capsule" | "rounded" | "sharp";
+// The pill is short (~17px tall → capsule radius ~8.5), so "rounded" must be
+// well below that to read as a distinct rounded-rect rather than the capsule.
+const RADIUS: Record<RadiusMode, number | undefined> = {
+  capsule: undefined, // default: pillHeight / 2
+  rounded: 4,
+  sharp: 0,
+};
+const RADIUS_OPTIONS: { value: RadiusMode; label: string }[] = [
+  { value: "capsule", label: "Capsule" },
+  { value: "rounded", label: "Rounded 4" },
+  { value: "sharp", label: "Sharp 0" },
+];
+
+// ─── Background ──────────────────────────────────────────────────────────
+// `undefined` keeps the default momentum tint (green up / red down / accent
+// flat); a string pins a fixed color and overrides the tint.
+type BgMode = "momentum" | "violet" | "slate" | "amber";
+const BACKGROUND: Record<BgMode, string | undefined> = {
+  momentum: undefined,
+  violet: "#7c3aed",
+  slate: "#1e293b",
+  amber: "#f59e0b",
+};
+const BG_OPTIONS: { value: BgMode; label: string }[] = [
+  { value: "momentum", label: "Momentum" },
+  { value: "violet", label: "Violet" },
+  { value: "slate", label: "Slate" },
+  { value: "amber", label: "Amber" },
+];
+
+// ─── Momentum tint (palette) ─────────────────────────────────────────────
+// When Background = "Momentum", the pill is tinted from the chart `palette`:
+// up → dotUp, down → dotDown, flat → badgeBg. Override those keys to recolor
+// the tinted states. (No effect when a fixed Background color is chosen.)
+type TintMode = "default" | "tealRose" | "mono";
+const TINT: Record<TintMode, Partial<LiveChartPalette> | undefined> = {
+  default: undefined,
+  tealRose: { dotUp: "#14b8a6", dotDown: "#f43f5e", badgeBg: "#475569" },
+  mono: { dotUp: "#64748b", dotDown: "#64748b", badgeBg: "#64748b" },
+};
+const TINT_OPTIONS: { value: TintMode; label: string }[] = [
+  { value: "default", label: "Theme" },
+  { value: "tealRose", label: "Teal / Rose" },
+  { value: "mono", label: "Mono" },
+];
+
+// ─── Border ───────────────────────────────────────────────────────────────
+type BorderMode = "none" | "white" | "accent";
+const BORDER: Record<BorderMode, Pick<BadgeConfig, "borderColor" | "borderWidth">> = {
+  none: { borderColor: undefined },
+  white: { borderColor: "#ffffff", borderWidth: 1 },
+  accent: { borderColor: ACCENT, borderWidth: 2.5 },
+};
+const BORDER_OPTIONS: { value: BorderMode; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "white", label: "White 1px" },
+  { value: "accent", label: "Accent 2.5px" },
+];
+
+// ─── Text color ──────────────────────────────────────────────────────────
+type TextMode = "default" | "dark" | "lime";
+const TEXT_COLOR: Record<TextMode, string | undefined> = {
+  default: undefined,
+  dark: "#0f172a",
+  lime: "#a3e635",
+};
+const TEXT_OPTIONS: { value: TextMode; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "dark", label: "Dark" },
+  { value: "lime", label: "Lime" },
+];
+
+// ─── Font ────────────────────────────────────────────────────────────────
+type FontMode = "default" | "large" | "bold";
+const FONT: Record<FontMode, Pick<BadgeConfig, "fontSize" | "fontWeight">> = {
+  default: {},
+  large: { fontSize: 18 },
+  bold: { fontSize: 14, fontWeight: "700" as FontWeight },
+};
+const FONT_OPTIONS: { value: FontMode; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "large", label: "Large 18" },
+  { value: "bold", label: "Bold 14" },
+];
+
+// ─── Offset ──────────────────────────────────────────────────────────────
+type OffsetMode = "none" | "up" | "in";
+const OFFSET: Record<OffsetMode, Pick<BadgeConfig, "offsetX" | "offsetY">> = {
+  none: { offsetX: 0, offsetY: 0 },
+  up: { offsetX: 0, offsetY: -16 },
+  in: { offsetX: -18, offsetY: 0 },
+};
+const OFFSET_OPTIONS: { value: OffsetMode; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "up", label: "Up 16" },
+  { value: "in", label: "In 18" },
+];
+
+export default function BadgeStylingScreen() {
+  const [position, setPosition] = useState<Pos>("right");
+  const [radius, setRadius] = useState<RadiusMode>("rounded");
+  const [bg, setBg] = useState<BgMode>("momentum");
+  const [tint, setTint] = useState<TintMode>("default");
+  const [border, setBorder] = useState<BorderMode>("white");
+  const [text, setText] = useState<TextMode>("default");
+  const [font, setFont] = useState<FontMode>("default");
+  const [offset, setOffset] = useState<OffsetMode>("none");
+
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    historySpanSeconds: 40,
+    historyRange: "1m",
+  });
+
+  const badge: BadgeConfig = {
+    position,
+    radius: RADIUS[radius],
+    background: BACKGROUND[bg],
+    textColor: TEXT_COLOR[text],
+    ...BORDER[border],
+    ...FONT[font],
+    ...OFFSET[offset],
+  };
+
+  return (
+    <DemoScreen
+      title="Badge styling"
+      docs="guides/theming"
+      description="Skia-native badge knobs (radius, background, border, text color, font, offset), plus recoloring the momentum tint via the chart palette."
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          palette={TINT[tint]}
+          badge={badge}
+          scrub={false}
+        />
+      }
+    >
+      <ChipRow
+        label="Position"
+        options={POSITIONS}
+        value={position}
+        onChange={setPosition}
+      />
+      <ChipRow
+        label="Radius"
+        options={RADIUS_OPTIONS}
+        value={radius}
+        onChange={setRadius}
+      />
+      <ChipRow
+        label="Background"
+        options={BG_OPTIONS}
+        value={bg}
+        onChange={setBg}
+      />
+      <ChipRow
+        label="Momentum tint"
+        options={TINT_OPTIONS}
+        value={tint}
+        onChange={setTint}
+      />
+      <ChipRow
+        label="Border"
+        options={BORDER_OPTIONS}
+        value={border}
+        onChange={setBorder}
+      />
+      <ChipRow
+        label="Text color"
+        options={TEXT_OPTIONS}
+        value={text}
+        onChange={setText}
+      />
+      <ChipRow label="Font" options={FONT_OPTIONS} value={font} onChange={setFont} />
+      <ChipRow
+        label="Offset"
+        options={OFFSET_OPTIONS}
+        value={offset}
+        onChange={setOffset}
+      />
+    </DemoScreen>
+  );
+}

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -73,7 +73,12 @@ provided; everything else has a default.
 </ParamField>
 
 <ParamField body="badge" type="boolean | BadgeConfig" default="true">
-  Value badge pill at the tip.
+  Value badge pill at the tip. Pass a [`BadgeConfig`](/api-reference/types) to
+  shape it — `radius` (escape the capsule), `borderColor` / `borderWidth`,
+  `textColor`, per-badge `fontSize` / `fontFamily` / `fontWeight`, and
+  `offsetX` / `offsetY`. All are Skia-native and drawn in the batched canvas
+  pass, so there's no per-frame view cost. See [Theming → Customizing the
+  badge](/guides/theming#customizing-the-badge).
 </ParamField>
 
 <ParamField body="pulse" type="boolean | PulseConfig" default="true">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -222,6 +222,16 @@ interface BadgeConfig {
   tail?: boolean;
   background?: string;
   position?: "right" | "left";
+  // Shape / style — all Skia-native, drawn in the batched canvas pass (no perf cost):
+  radius?: number;          // corner radius (px); default capsule (pillHeight/2), clamped to that max
+  borderColor?: string;     // pill border color; default none
+  borderWidth?: number;     // border stroke width (px), only drawn with borderColor; default 1
+  textColor?: string;       // label text color override; default variant/theme rule
+  fontSize?: number;        // badge font size (px); falls back to the chart `font`
+  fontFamily?: string;      // badge font family; falls back to the chart `font`
+  fontWeight?: FontWeight;  // badge font weight; falls back to the chart `font`
+  offsetX?: number;         // nudge the whole badge horizontally (px); default 0
+  offsetY?: number;         // nudge the whole badge vertically (px); default 0
   followViewEdge?: boolean; // while time-scrolled, track the price at the visible
                             // window's right edge (badge + value line + dot); default false
 }

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -99,6 +99,41 @@ The five namespaces:
 `metrics` is available on both `LiveChart` and `LiveChartSeries`. See the
 [types reference](/api-reference/types) for the full `LiveChartMetrics` shape and every default.
 
+## Customizing the badge
+
+The value badge at the live edge is drawn in Skia, so its shape and style are
+**config knobs on `badge`** rather than a custom React element — they cost
+nothing per frame. Pass a `BadgeConfig` to reshape it:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  badge={{
+    radius: 6, // square off the capsule into a rounded rect (0 = sharp corners)
+    borderColor: "#ffffff",
+    borderWidth: 1,
+    textColor: "#0f172a",
+    fontSize: 13,
+    fontWeight: "700",
+    offsetX: -2, // nudge off the live-dot / y-axis anchor
+    offsetY: 0,
+  }}
+/>
+```
+
+`radius` is clamped to the capsule (`pillHeight / 2`), which stays the maximum;
+`0` gives sharp corners. `textColor` mirrors `background` (set either or both).
+The font knobs fall back to the chart [`font`](#fonts) when omitted.
+
+<Note>
+  A badge `fontSize` larger than the chart font can crowd the reserved right
+  gutter (the badge text and y-axis labels share that space and are aligned to
+  the chart font). If a bigger badge font overflows, pair it with
+  `badge={{ position: "left" }}` or `yAxis={{ float: true }}`, which don't use
+  the gutter.
+</Note>
+
 ## Grid & axes
 
 ```tsx

--- a/packages/react-native-livechart/src/components/BadgeOverlay.tsx
+++ b/packages/react-native-livechart/src/components/BadgeOverlay.tsx
@@ -19,9 +19,21 @@ interface BadgeData {
 export function BadgeOverlay({
   badge,
   font,
+  borderColor,
+  borderWidth = 1,
+  offsetX = 0,
+  offsetY = 0,
 }: {
   badge: SharedValue<BadgeData>;
   font: SkFont;
+  /** Pill border color. When unset, no border is drawn. */
+  borderColor?: string;
+  /** Border stroke width (px) — only used when `borderColor` is set. */
+  borderWidth?: number;
+  /** Horizontal nudge from the badge's anchor (px). */
+  offsetX?: number;
+  /** Vertical nudge from the badge's anchor (px). */
+  offsetY?: number;
 }) {
   const badgePath = useDerivedValue(() => badge.value.path);
   const bgColor = useDerivedValue(() => badge.value.bgColor);
@@ -30,9 +42,22 @@ export function BadgeOverlay({
   const text = useDerivedValue(() => badge.value.text);
   const textColor = useDerivedValue(() => badge.value.textColor);
 
+  const transform =
+    offsetX !== 0 || offsetY !== 0
+      ? [{ translateX: offsetX }, { translateY: offsetY }]
+      : undefined;
+
   return (
-    <Group>
+    <Group transform={transform}>
       <Path path={badgePath} style="fill" color={bgColor} />
+      {borderColor != null && (
+        <Path
+          path={badgePath}
+          style="stroke"
+          strokeWidth={borderWidth}
+          color={borderColor}
+        />
+      )}
       <SkiaText x={textX} y={textY} text={text} font={font} color={textColor} />
     </Group>
   );

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -326,6 +326,26 @@ function useLiveChartController({
     palette.valueFontSize * 2,
   );
 
+  // Per-badge font (size/family/weight) override; reuses the chart font when
+  // none of the badge font knobs are set, so the gutter sizing is unchanged.
+  const badgeHasFontOverride =
+    badgeCfg?.fontSize != null ||
+    badgeCfg?.fontFamily != null ||
+    badgeCfg?.fontWeight != null;
+  const badgeFontOverride = useChartSkiaFont(
+    badgeHasFontOverride
+      ? {
+          ...fontProp,
+          fontFamily: badgeCfg?.fontFamily ?? fontProp?.fontFamily,
+          fontSize: badgeCfg?.fontSize ?? fontProp?.fontSize,
+          fontWeight: badgeCfg?.fontWeight ?? fontProp?.fontWeight,
+        }
+      : fontProp,
+    MONO_FONT_FAMILY,
+    palette.labelFontSize,
+  );
+  const badgeFont = badgeHasFontOverride ? badgeFontOverride : skiaFont;
+
   const pulseConfig = pulseCfg
     ? {
         maxRadius: pulseCfg.maxRadius,
@@ -558,7 +578,7 @@ function useLiveChartController({
     effectivePadding,
     palette,
     formatValue,
-    skiaFont,
+    badgeFont,
     badgeCfg?.variant ?? "default",
     badgeCfg?.tail ?? true,
     momentumSV,
@@ -569,6 +589,8 @@ function useLiveChartController({
     effectiveYAxisFloat,
     engine.edgeValue,
     badgeCfg?.followViewEdge ?? false,
+    badgeCfg?.radius,
+    badgeCfg?.textColor,
   );
 
   // Scrub/crosshair must see the same stash-backed candles as the engine.
@@ -820,6 +842,7 @@ function useLiveChartController({
     palette,
     skiaFont,
     valueFont,
+    badgeFont,
     strokeWidth,
     effectivePadding,
     // engine + reveal
@@ -1434,12 +1457,19 @@ function ChartValueOverlay({ model }: { model: LiveChartModel }) {
 /** Live-price badge, drawn above the scrub dim so the dim never clips its left
  *  edge. Shares the degen shake transform so it tracks the shaken stack. */
 function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
-  const { badgeCfg, badgeData, skiaFont, reveal, degenShakeTransform } = model;
+  const { badgeCfg, badgeData, badgeFont, reveal, degenShakeTransform } = model;
   if (!badgeCfg) return null;
   return (
     <Group transform={degenShakeTransform}>
       <Group opacity={reveal.badgeOpacity}>
-        <BadgeOverlay badge={badgeData} font={skiaFont} />
+        <BadgeOverlay
+          badge={badgeData}
+          font={badgeFont}
+          borderColor={badgeCfg.borderColor}
+          borderWidth={badgeCfg.borderWidth}
+          offsetX={badgeCfg.offsetX}
+          offsetY={badgeCfg.offsetY}
+        />
       </Group>
     </Group>
   );

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -58,6 +58,18 @@ export interface ResolvedBadgeConfig {
   tail: boolean;
   position: "right" | "left";
   background: string | undefined;
+  /** undefined → capsule (pillHeight / 2) at render time */
+  radius: number | undefined;
+  /** undefined → no border */
+  borderColor: string | undefined;
+  borderWidth: number;
+  /** undefined → variant/theme text color at render time */
+  textColor: string | undefined;
+  fontSize: number | undefined;
+  fontFamily: string | undefined;
+  fontWeight: FontWeight | undefined;
+  offsetX: number;
+  offsetY: number;
   /** Track the visible window's right-edge price while scrolled back. */
   followViewEdge: boolean;
 }
@@ -354,6 +366,15 @@ const BADGE_DEFAULTS: ResolvedBadgeConfig = {
   tail: true,
   position: "right",
   background: undefined,
+  radius: undefined,
+  borderColor: undefined,
+  borderWidth: 1,
+  textColor: undefined,
+  fontSize: undefined,
+  fontFamily: undefined,
+  fontWeight: undefined,
+  offsetX: 0,
+  offsetY: 0,
   followViewEdge: false,
 };
 

--- a/packages/react-native-livechart/src/hooks/useBadge.ts
+++ b/packages/react-native-livechart/src/hooks/useBadge.ts
@@ -52,6 +52,14 @@ export function useBadge(
   edgeValue?: SharedValue<number>,
   /** Track the visible window's right-edge price while scrolled back. */
   followViewEdge = false,
+  /**
+   * Pill corner radius in pixels. `undefined` → capsule (`pillHeight / 2`).
+   * Clamped to `[0, pillHeight / 2]`. The pointed tail (right-gutter mode) keeps
+   * anchoring on the vertical center regardless of this value.
+   */
+  radius?: number,
+  /** Label text color override; falls back to the variant/theme rule. */
+  textColorOverride?: string,
 ) {
   const colorR = useSharedValue(0);
   const colorG = useSharedValue(0);
@@ -98,7 +106,10 @@ export function useBadge(
     const textW = measureFontTextWidth(font, text);
 
     const pillH = font.getSize() + badgeMetrics.padY * 2;
-    const r = pillH / 2;
+    // `midY` is the pill's vertical center (the tail anchors here); `capR` is the
+    // corner radius — the capsule (midY) by default, or a clamped custom radius.
+    const midY = pillH / 2;
+    const capR = radius == null ? midY : Math.max(0, Math.min(radius, midY));
     const badgeY = dotY - pillH / 2;
     let textX: number;
 
@@ -112,8 +123,8 @@ export function useBadge(
       textX = (bodyLeft + bodyRight - textW) / 2;
       b.addRRect({
         rect: { x: bodyLeft, y: badgeY, width: pillW, height: pillH },
-        rx: r,
-        ry: r,
+        rx: capR,
+        ry: capR,
       });
     } else if (position === "left") {
       // Pill to the left of the live dot; no tail (`showTail` applies to right gutter only).
@@ -125,8 +136,8 @@ export function useBadge(
       textX = (bodyLeft + bodyRight - textW) / 2;
       b.addRRect({
         rect: { x: bodyLeft, y: badgeY, width: pillBodyW, height: pillH },
-        rx: r,
-        ry: r,
+        rx: capR,
+        ry: capR,
       });
     } else {
       // Right-gutter badge (default): asymmetric layout with optional tail.
@@ -145,28 +156,54 @@ export function useBadge(
 
       if (showTail) {
         const badgeX = w - padding.right + badgeMetrics.dotGap;
-        const cx = tl + pillW - r;
+        const bodyRightX = badgeX + tl + pillW;
 
         b.moveTo(badgeX + tl, badgeY);
-        b.lineTo(badgeX + cx, badgeY);
-        b.arcToOval(
-          { x: badgeX + cx - r, y: badgeY, width: r * 2, height: pillH },
-          -90,
-          180,
-          false,
-        );
+        if (capR >= midY) {
+          // Capsule cap: a single right-hand semicircle (the default badge).
+          const cx = tl + pillW - capR;
+          b.lineTo(badgeX + cx, badgeY);
+          b.arcToOval(
+            { x: badgeX + cx - capR, y: badgeY, width: capR * 2, height: pillH },
+            -90,
+            180,
+            false,
+          );
+        } else {
+          // Custom (smaller) corner radius: square body with rounded right corners.
+          b.lineTo(bodyRightX - capR, badgeY);
+          b.arcToOval(
+            { x: bodyRightX - capR * 2, y: badgeY, width: capR * 2, height: capR * 2 },
+            -90,
+            90,
+            false,
+          );
+          b.lineTo(bodyRightX, badgeY + pillH - capR);
+          b.arcToOval(
+            {
+              x: bodyRightX - capR * 2,
+              y: badgeY + pillH - capR * 2,
+              width: capR * 2,
+              height: capR * 2,
+            },
+            0,
+            90,
+            false,
+          );
+        }
         b.lineTo(badgeX + tl, badgeY + pillH);
+        // Tail tip stays on the vertical center (`midY`) regardless of corner radius.
         b.cubicTo(
           badgeX + badgeMetrics.tailLength + 2,
           badgeY + pillH,
           badgeX + 3,
-          badgeY + r + badgeMetrics.tailSpread,
+          badgeY + midY + badgeMetrics.tailSpread,
           badgeX,
-          badgeY + r,
+          badgeY + midY,
         );
         b.cubicTo(
           badgeX + 3,
-          badgeY + r - badgeMetrics.tailSpread,
+          badgeY + midY - badgeMetrics.tailSpread,
           badgeX + badgeMetrics.tailLength + 2,
           badgeY,
           badgeX + tl,
@@ -176,8 +213,8 @@ export function useBadge(
       } else {
         b.addRRect({
           rect: { x: bodyLeft, y: badgeY, width: pillW, height: pillH },
-          rx: r,
-          ry: r,
+          rx: capR,
+          ry: capR,
         });
       }
     }
@@ -212,7 +249,8 @@ export function useBadge(
     }
 
     const textColor =
-      variant === "minimal" ? "rgba(100,100,100,1)" : palette.badgeText;
+      textColorOverride ??
+      (variant === "minimal" ? "rgba(100,100,100,1)" : palette.badgeText);
 
     return { path: b.detach(), textX, textY, text, bgColor, textColor };
   });

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -376,6 +376,35 @@ export interface BadgeConfig {
   /** Which side of the chart the badge appears on. Default `"right"`. */
   position?: "right" | "left";
   /**
+   * Pill corner radius in pixels. Default: half the pill height (a full
+   * capsule). Clamped to `[0, pillHeight / 2]`, so the maximum is always the
+   * capsule. `0` gives square corners.
+   */
+  radius?: number;
+  /** Pill border color. When unset, the badge has no border. */
+  borderColor?: string;
+  /** Border stroke width in pixels — only drawn when `borderColor` is set. Default `1`. */
+  borderWidth?: number;
+  /**
+   * Label text color override. Mirrors `background`; when unset the text color
+   * follows the `variant` / theme rule.
+   */
+  textColor?: string;
+  /**
+   * Badge font size in pixels. Falls back to the chart `font`. Note: a size
+   * larger than the chart font can crowd the reserved right gutter — pair with
+   * `position: "left"` or `yAxis.float` if it overflows.
+   */
+  fontSize?: number;
+  /** Badge font family. Falls back to the chart `font`. */
+  fontFamily?: string;
+  /** Badge font weight. Falls back to the chart `font`. */
+  fontWeight?: FontWeight;
+  /** Nudge the whole badge horizontally from its anchor, in pixels. Default `0`. */
+  offsetX?: number;
+  /** Nudge the whole badge vertically from its anchor, in pixels. Default `0`. */
+  offsetY?: number;
+  /**
    * When the chart is scrolled back (see `timeScroll`), move the live-price
    * indicators — the badge, the value line, and the live dot — to the price at
    * the visible window's right edge instead of the live price, so they track the

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -81,6 +81,30 @@ describe("BadgeOverlay", () => {
     }
     render(<Fixture />);
   });
+
+  it("renders a bordered, offset badge (stroke path + transform branch)", () => {
+    function Fixture() {
+      const badge = useSharedValue({
+        path: Skia.Path.Make(),
+        textX: 10,
+        textY: 20,
+        text: "9.99",
+        bgColor: "#000",
+        textColor: "#fff",
+      });
+      return (
+        <BadgeOverlay
+          badge={badge}
+          font={font}
+          borderColor="#ff00ff"
+          borderWidth={2}
+          offsetX={-4}
+          offsetY={6}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
 });
 
 describe("YAxisOverlay", () => {

--- a/packages/react-native-livechart/tests/hooks/useBadge.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useBadge.test.tsx
@@ -277,4 +277,105 @@ describe("useBadge", () => {
     );
     expect(result.current.value.bgColor).toBe("#ff0000");
   });
+
+  // pillH = font size (12) + padY*2 (6) = 18, so the capsule radius (midY) is 9.
+  it("applies a small custom corner radius in tail mode (rounded-corner branch)", () => {
+    const { result } = renderHook(() =>
+      useBadge(
+        makeEngine(400, 300),
+        DEFAULT_PADDING,
+        palette,
+        (v) => v.toFixed(2),
+        font,
+        "default",
+        true,
+        undefined,
+        "right",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        3, // radius < midY → square body with rounded right corners
+      ),
+    );
+    expect(result.current.value.text).toBe("50.00");
+    expect(result.current.value.path).toBeDefined();
+  });
+
+  it("clamps a large radius back to the capsule (semicircle branch)", () => {
+    const { result } = renderHook(() =>
+      useBadge(
+        makeEngine(400, 300),
+        DEFAULT_PADDING,
+        palette,
+        (v) => v.toFixed(2),
+        font,
+        "default",
+        true,
+        undefined,
+        "right",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        999, // radius > midY → clamped to the capsule cap
+      ),
+    );
+    expect(result.current.value.text).toBe("50.00");
+    expect(result.current.value.path).toBeDefined();
+  });
+
+  it("clamps a negative radius to square corners on the no-tail pill", () => {
+    const { result } = renderHook(() =>
+      useBadge(
+        makeEngine(400, 300),
+        { ...DEFAULT_PADDING, right: 76 },
+        palette,
+        (v) => v.toFixed(2),
+        font,
+        "default",
+        false, // no tail → addRRect with the clamped radius
+        undefined,
+        "right",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        -5, // clamped to 0 (square corners)
+      ),
+    );
+    expect(result.current.value.text).toBe("50.00");
+    expect(result.current.value.path).toBeDefined();
+  });
+
+  it("uses the text color override when provided", () => {
+    const { result } = renderHook(() =>
+      useBadge(
+        makeEngine(400, 300),
+        DEFAULT_PADDING,
+        palette,
+        (v) => v.toFixed(2),
+        font,
+        "default",
+        true,
+        undefined,
+        "right",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "#00ff00", // textColor override
+      ),
+    );
+    expect(result.current.value.textColor).toBe("#00ff00");
+  });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -87,6 +87,15 @@ describe("resolveBadge", () => {
       tail: true,
       position: "right",
       background: undefined,
+      radius: undefined,
+      borderColor: undefined,
+      borderWidth: 1,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
       followViewEdge: false,
     });
   });
@@ -97,6 +106,15 @@ describe("resolveBadge", () => {
       tail: true,
       position: "right",
       background: undefined,
+      radius: undefined,
+      borderColor: undefined,
+      borderWidth: 1,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
       followViewEdge: false,
     });
   });
@@ -115,7 +133,47 @@ describe("resolveBadge", () => {
       tail: false,
       position: "left",
       background: "#f00",
+      radius: undefined,
+      borderColor: undefined,
+      borderWidth: 1,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
       followViewEdge: true,
+    });
+  });
+
+  it("merges the shape/style knobs (radius, border, textColor, font, offset)", () => {
+    expect(
+      resolveBadge({
+        radius: 8,
+        borderColor: "#fff",
+        borderWidth: 2,
+        textColor: "#0f0",
+        fontSize: 14,
+        fontFamily: "Inter",
+        fontWeight: "700",
+        offsetX: -4,
+        offsetY: 6,
+      }),
+    ).toEqual({
+      variant: "default",
+      tail: true,
+      position: "right",
+      background: undefined,
+      radius: 8,
+      borderColor: "#fff",
+      borderWidth: 2,
+      textColor: "#0f0",
+      fontSize: 14,
+      fontFamily: "Inter",
+      fontWeight: "700",
+      offsetX: -4,
+      offsetY: 6,
+      followViewEdge: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #139 — customizing the value badge. As [@joernroeder noted](https://github.com/brandtnewlabs/react-native-livechart/issues/139#issuecomment-4730883437), the other custom renderers (`renderMarker`, `renderTooltip`, `topLabel/bottomLabel.render`) are React Native views layered over the canvas, whereas the badge is drawn **entirely in Skia and rebuilt every frame** — so a `renderBadge` RN escape hatch would put a per-frame view on the hot path. Instead this expands `BadgeConfig` with Skia-native style/shape knobs that cost nothing extra per frame.

## New `badge` options

| Prop | Type | Default | Effect |
|---|---|---|---|
| `radius` | `number` | capsule (`pillHeight/2`) | Corner radius; clamped to the capsule, `0` = sharp |
| `borderColor` | `string` | none | Pill border color |
| `borderWidth` | `number` | `1` | Border stroke width (only with `borderColor`) |
| `textColor` | `string` | variant/theme | Label color override (mirrors `background`) |
| `fontSize` / `fontFamily` / `fontWeight` | — | chart `font` | Per-badge font; falls back to the chart font |
| `offsetX` / `offsetY` | `number` | `0` | Nudge the badge off its anchor |

These compose with the existing `background` (fixed fill) and, for the momentum-tinted states, the chart `palette` (`dotUp` / `dotDown` / `badgeBg`).

## Implementation notes

- **Radius/tail decoupling** — the pill's corner radius (`capR`) is separated from the tail's vertical anchor (`midY = pillHeight/2`). The default capsule path is byte-identical; a sub-capsule radius rebuilds the right cap as two corner arcs so the tail still meets the live dot. ([useBadge.ts](packages/react-native-livechart/src/hooks/useBadge.ts))
- **Font** — a per-badge `SkFont` is built by reusing the existing `useChartSkiaFont` hook; when no font knob is set it reuses the chart font (no extra font). ([LiveChart.tsx](packages/react-native-livechart/src/components/LiveChart.tsx))
- **Border + offset** — a stroked `<Path>` over the fill, plus a `Group` transform, in [BadgeOverlay.tsx](packages/react-native-livechart/src/components/BadgeOverlay.tsx).
- **Resolution** — fields added to `ResolvedBadgeConfig` / `BADGE_DEFAULTS`; the existing `resolveToggle` merge is unchanged. ([resolveConfig.ts](packages/react-native-livechart/src/core/resolveConfig.ts))

> **Caveat (documented):** a badge `fontSize` larger than the chart font can crowd the reserved right gutter (badge text and y-axis labels share it). Pair a large badge font with `position: "left"` or `yAxis.float`.

## Demo & docs

- New **Badge styling** demo screen (`app/demo/badge-styling.tsx`) with a control per knob, plus Background and Momentum-tint presets.
- Docs: `BadgeConfig` reference, the `badge` ParamField, and a new "Customizing the badge" section in the theming guide.

## Testing

- `npm run verify` green — typecheck, lint, **1087 tests** pass (coverage thresholds met). New coverage for `resolveBadge` defaults/merge, radius clamping + both cap branches, text-color override, and the border/offset render path.
- **On-device QA** on the iOS 26.4 simulator (iPhone 17 Pro): verified every knob — radius (capsule/rounded/sharp, tail meets the dot at each), border (color + width), text color, font size, offset, left/right position, fixed background, and palette-recolored momentum tint.

## Demo video

<!-- video: drag badge-styling-demo.mp4 here -->
