### PR TITLE
feat(reference-line): draggable lines, custom render, center badge, grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Interactive reference lines** (`LiveChart`). Form-A `ReferenceLine`s gain a full
+  interaction model for working orders, alerts, and targets:
+  - **Draggable** — `draggable` lets you grab a line and drag it along the Y-axis,
+    with `snap` (round to a tick), `bounds` (hard clamp), and per-line callbacks
+    `onChange` (during), `onCommit` (on release), and `onDragIn` / `onDragOut`
+    (value crossing the visible range or a bound, from a drag or the axis
+    rescaling). Uncontrolled by default; pair `onCommit` with `value` for a
+    controlled line. Dragging a line toward the edge expands the Y-axis so it
+    follows the finger in one motion (no release-and-re-grab).
+  - **Custom tags** — `renderReferenceLine` floats any React Native view at a line's
+    value (the `renderMarker` / `renderTooltip` model), tracking the axis and any
+    drag on the UI thread via the `ReferenceLineRenderProps` SharedValues. Replaces
+    the built-in pill / gutter label (return `null` to keep the built-in; works with
+    `badge: false`).
+  - **Center badge** — `ReferenceLineBadgeConfig.position` accepts `"center"`,
+    floating the pill at the value with no connector.
+  - **Grouping** — `referenceLineGrouping` collapses lines whose handles sit near
+    the same value into a single count handle. Custom-rendered lines are excluded
+    (the count reflects only collapsed built-in tags).
+
 ## [3.12.0] - 2026-06-17
 
 ### Added

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -113,6 +113,12 @@ const SECTIONS: DemoSection[] = [
         blurb: "referenceLines: lines, value/time bands, off-axis badge.",
       },
       {
+        href: "/demo/working-orders",
+        title: "Working orders",
+        blurb:
+          "Draggable order lines (snap + bounds + onCommit), custom RN tags via renderReferenceLine, center badge, near-value grouping.",
+      },
+      {
         href: "/demo/overlay-bridge",
         title: "Overlay bridge",
         blurb: "renderOverlay: hand-rolled RN order overlay via the priceToY / yToPrice / timeToX bridge.",

--- a/app/demo/working-orders.tsx
+++ b/app/demo/working-orders.tsx
@@ -1,0 +1,274 @@
+import { useRef, useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import {
+  LiveChart,
+  type ReferenceLine,
+  type ReferenceLineRenderProps,
+} from "react-native-livechart";
+
+import { AnimatedTrendTextInput } from "../../demo-lib/AnimatedTrendTextInput";
+import { ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME, colors } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Working orders" };
+
+const START = 100;
+const BUY_COLOR = "#34d399";
+const SELL_COLOR = "#f87171";
+
+type Side = "BUY" | "SELL";
+
+/**
+ * Custom draggable order tag (`renderReferenceLine`) — a glassy RN pill whose price
+ * updates live on the UI thread as you drag, bound to `ctx.value` via
+ * {@link AnimatedTrendTextInput} (no JS re-render per frame).
+ */
+function OrderTag({ ctx }: { ctx: ReferenceLineRenderProps }) {
+  const color = ctx.line.color ?? "#fff";
+  // Drive the tag chrome off `ctx.dragging` (UI thread) — brightens while held.
+  const animatedStyle = useAnimatedStyle(() => ({
+    borderWidth: ctx.dragging.get() ? 2 : 1,
+    opacity: ctx.dragging.get() ? 1 : 0.92,
+  }));
+  return (
+    <Animated.View style={[styles.tag, { borderColor: color }, animatedStyle]}>
+      <Text style={[styles.tagSide, { color }]}>{ctx.line.label}</Text>
+      <AnimatedTrendTextInput
+        sharedValue={ctx.value}
+        maximumFractionDigits={2}
+        baseColor="#e5e7eb"
+        style={styles.tagPrice}
+      />
+    </Animated.View>
+  );
+}
+
+/** Custom replacement for a plain (badge-less) line's gutter label. */
+function PlainTag({ ctx }: { ctx: ReferenceLineRenderProps }) {
+  return (
+    <View style={styles.plainTag}>
+      <Text style={styles.plainTagText}>⛔ {ctx.line.label}</Text>
+    </View>
+  );
+}
+
+export default function WorkingOrdersScreen() {
+  const [custom, setCustom] = useState(true);
+  const [grouping, setGrouping] = useState(false);
+
+  // Committed order prices (set by onCommit → controlled lines).
+  const [buy, setBuy] = useState(round(START * 0.97));
+  const [sell, setSell] = useState(round(START * 1.03));
+
+  // Live drag feedback (from onChange, throttled) + an event log (discrete events).
+  const [live, setLive] = useState<{ side: Side; value: number } | null>(null);
+  const [events, setEvents] = useState<string[]>([]);
+  const lastChangeAt = useRef(0);
+
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    startValue: START,
+    historySpanSeconds: 40,
+    historyRange: "1m",
+  });
+
+  const log = (msg: string) =>
+    setEvents((prev) => [msg, ...prev].slice(0, 5));
+
+  /** Build the per-line drag callbacks for one side. */
+  const handlers = (side: Side, commit: (v: number) => void) => ({
+    onChange: (v: number) => {
+      // Throttle the live readout so the JS panel re-renders ~10×/s, not per frame.
+      const now = Date.now();
+      if (now - lastChangeAt.current < 100) return;
+      lastChangeAt.current = now;
+      setLive({ side, value: v });
+    },
+    onCommit: (v: number) => {
+      commit(v);
+      setLive(null);
+      log(`✓ commit ${side} @ ${v.toFixed(2)}`);
+    },
+    onDragIn: (v: number) => log(`▶ ${side} back in range @ ${v.toFixed(2)}`),
+    onDragOut: (v: number) => log(`◀ ${side} hit bound @ ${v.toFixed(2)}`),
+  });
+
+  const referenceLines: ReferenceLine[] = [
+    {
+      value: buy,
+      label: "BUY",
+      color: BUY_COLOR,
+      draggable: true,
+      snap: 0.05,
+      bounds: [START * 0.9, START], // drag to either end → onDragOut / onDragIn
+      badge: { position: "left" },
+      ...handlers("BUY", setBuy),
+    },
+    {
+      value: sell,
+      label: "SELL",
+      color: SELL_COLOR,
+      draggable: true,
+      snap: 0.05,
+      bounds: [START, START * 1.1],
+      badge: { position: "right" },
+      ...handlers("SELL", setSell),
+    },
+    // Center badge placement (non-draggable).
+    { value: START, label: "VWAP", color: "#fbbf24", badge: { position: "center" } },
+    // Badge-less line: plain gutter label when custom is off, PlainTag when on.
+    { value: START * 1.04, label: "Stop", color: "#94a3b8" },
+    // A tight stack of alerts → collapses into one count handle when grouping is on.
+    { value: START * 1.055, label: "alert", color: "#a855f7", badge: true },
+    { value: START * 1.07, label: "alert", color: "#a855f7", badge: true },
+    { value: START * 1.085, label: "alert", color: "#a855f7", badge: true },
+  ];
+
+  const renderReferenceLine = (ctx: ReferenceLineRenderProps) => {
+    if (ctx.line.draggable) return <OrderTag ctx={ctx} />;
+    if (ctx.line.label === "Stop") return <PlainTag ctx={ctx} />;
+    return null; // VWAP + alerts keep their built-in tags
+  };
+
+  return (
+    <DemoScreen
+      title="Working orders"
+      docs="guides/markers-and-references"
+      description="Drag BUY / SELL to set a price (snap 0.05, clamped to bounds). Watch the live value, committed value, and the drag-callback log. Toggle custom RN tags and near-value grouping."
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          referenceLines={referenceLines}
+          referenceLineGrouping={grouping ? { radius: 26 } : false}
+          renderReferenceLine={custom ? renderReferenceLine : undefined}
+          scrub={false}
+        />
+      }
+    >
+      <ControlRow label="Reference lines">
+        <ToggleChip label="Custom tags" value={custom} onChange={setCustom} />
+        <ToggleChip label="Group alerts" value={grouping} onChange={setGrouping} />
+      </ControlRow>
+
+      <View style={styles.panel}>
+        <View style={styles.row}>
+          <OrderStat side="BUY" color={BUY_COLOR} committed={buy} live={live} />
+          <OrderStat side="SELL" color={SELL_COLOR} committed={sell} live={live} />
+        </View>
+        <Text style={styles.logTitle}>Drag callbacks</Text>
+        {events.length === 0 ? (
+          <Text style={styles.logEmpty}>
+            Drag an order to a bound, then release — events appear here.
+          </Text>
+        ) : (
+          events.map((e, i) => (
+            <Text key={`${e}-${i}`} style={styles.logLine}>
+              {e}
+            </Text>
+          ))
+        )}
+      </View>
+    </DemoScreen>
+  );
+}
+
+function OrderStat({
+  side,
+  color,
+  committed,
+  live,
+}: {
+  side: Side;
+  color: string;
+  committed: number;
+  live: { side: Side; value: number } | null;
+}) {
+  const dragging = live?.side === side;
+  return (
+    <View style={styles.stat}>
+      <View style={styles.statHead}>
+        <View style={[styles.dot, { backgroundColor: color }]} />
+        <Text style={[styles.statSide, { color }]}>{side}</Text>
+        {dragging ? <Text style={styles.dragging}>● dragging</Text> : null}
+      </View>
+      <Text style={styles.statValue}>
+        {(dragging ? live!.value : committed).toFixed(2)}
+      </Text>
+      <Text style={styles.statSub}>
+        {dragging ? "onChange (live)" : "onCommit (committed)"}
+      </Text>
+    </View>
+  );
+}
+
+const round = (v: number) => Math.round(v / 0.05) * 0.05;
+
+const styles = StyleSheet.create({
+  tag: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 8,
+    borderWidth: 1,
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  tagSide: { fontSize: 11, fontWeight: "700" },
+  tagPrice: { fontSize: 11, color: "#e5e7eb" },
+  plainTag: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+    backgroundColor: "rgba(0,0,0,0.06)",
+    borderWidth: 1,
+    borderColor: "rgba(0,0,0,0.12)",
+  },
+  plainTagText: { fontSize: 11, color: "#334155", fontWeight: "600" },
+
+  panel: {
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: colors.chipBackground,
+    gap: 8,
+  },
+  row: { flexDirection: "row", gap: 12 },
+  stat: {
+    flex: 1,
+    padding: 10,
+    borderRadius: 10,
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  statHead: { flexDirection: "row", alignItems: "center", gap: 6 },
+  dot: { width: 8, height: 8, borderRadius: 4 },
+  statSide: { fontSize: 12, fontWeight: "700" },
+  dragging: { fontSize: 10, color: "#b45309", marginLeft: "auto" },
+  statValue: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: colors.text,
+    fontVariant: ["tabular-nums"],
+    marginTop: 2,
+  },
+  statSub: { fontSize: 10, color: colors.textMuted },
+
+  logTitle: { fontSize: 12, fontWeight: "600", color: colors.text },
+  logEmpty: { fontSize: 12, color: colors.textMuted },
+  logLine: {
+    fontSize: 12,
+    color: colors.text,
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -179,7 +179,27 @@ provided; everything else has a default.
 </ParamField>
 
 <ParamField body="referenceLines" type="ReferenceLine[]">
-  Reference lines / bands (horizontal line, value band, or time band).
+  Reference lines / bands (horizontal line, value band, or time band). Form-A lines
+  can be `draggable` (drag to set a price, with `snap` / `bounds` and `onChange` /
+  `onCommit` / `onDragIn` / `onDragOut` callbacks). See
+  [Reference lines](/guides/markers-and-references#reference-lines--bands).
+</ParamField>
+
+<ParamField body="renderReferenceLine" type="(ctx: ReferenceLineRenderProps) => ReactElement | null">
+  Render a reference line's tag as a custom **React Native** element instead of the
+  built-in Skia pill / gutter label — the same model as `renderMarker` /
+  `renderTooltip`. The chart floats it over the canvas and pins it to the line's
+  value on the UI thread (see
+  [`ReferenceLineRenderProps`](/api-reference/types#annotations)), so it tracks the
+  rescaling axis and any drag without JS re-renders. Called per Form-A line; return
+  `null` to keep that line's built-in tag (works with `badge: false` too).
+  Single-series only.
+</ParamField>
+
+<ParamField body="referenceLineGrouping" type="boolean | ReferenceLineGroupingConfig" default="false">
+  Collapse Form-A lines whose handles sit near the same value into a single count
+  handle — a stack of working orders at adjacent prices reads as one tag. Pass an
+  object to tune the proximity `radius` (px). Single-series only.
 </ParamField>
 
 <ParamField body="segments" type="ChartSegment[]">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -114,15 +114,39 @@ interface ReferenceLine {
   // Legacy off-axis badge (prefer `badge`, which also shows in-range + supports an icon):
   offAxisBadge?: boolean;
   offAxisBadgeLabel?: string;
+  // Draggable (Form A only) — grab the line and drag it along the Y-axis:
+  draggable?: boolean;             // default false
+  snap?: number;                   // round the dragged value to this increment
+  bounds?: [number, number];       // hard-clamp the draggable value
+  onChange?: (value: number) => void;  // during drag (de-duped to value changes)
+  onCommit?: (value: number) => void;  // on release — pair with a controlled `value`
+  onDragIn?: (value: number) => void;  // value entered the visible range / bounds
+  onDragOut?: (value: number) => void; // value left the visible range / hit a bound
 }
 
 interface ReferenceLineBadgeConfig {
-  position?: "left" | "right"; // edge to pin to; default "left"
+  position?: "left" | "center" | "right"; // edge to pin to ("center" floats at the
+                                          //   value, no connector); default "left"
   icon?: string;               // leading glyph (chart font), like Marker.icon
   text?: boolean;              // show the label/value; default true. false → icon-only
   background?: string;         // falls back to badgeBackground, then theme tooltipBg
   borderColor?: string;        // falls back to badgeBorderColor, then the line color
   radius?: number;             // corner radius; falls back to badgeRadius, then 5
+}
+
+interface ReferenceLineRenderProps {
+  line: ReferenceLine;            // the line being rendered
+  index: number;                  // its index in `referenceLines`
+  value: SharedValue<number>;     // live Y-axis value (tracks dragging)
+  valueStr: SharedValue<string>;  // value formatted with the chart's formatValue
+  y: SharedValue<number>;         // canvas Y px of the line (-1 when not laid out)
+  inRange: SharedValue<boolean>;  // whether the value is within the visible range
+  edge: SharedValue<"above" | "in" | "below">; // for a directional off-axis chevron
+  dragging: SharedValue<boolean>; // whether this line is currently being dragged
+}
+
+interface ReferenceLineGroupingConfig {
+  radius?: number;             // collapse lines whose value-Y are within this many px; default 18
 }
 
 interface ChartSegment {

--- a/docs/guides/markers-and-references.mdx
+++ b/docs/guides/markers-and-references.mdx
@@ -176,9 +176,76 @@ referenceLines={[
 ```
 
 `badge: true` uses the defaults (left-pinned, the line's label/value); pass a
-[`ReferenceLineBadgeConfig`](/api-reference/types#annotations) for `position`, an `icon`,
+[`ReferenceLineBadgeConfig`](/api-reference/types#annotations) for `position` (`"left"` /
+`"center"` / `"right"` — `"center"` floats the pill at the value with no connector), an `icon`,
 `text: false` (icon-only), and `background` / `borderColor` / `radius`. It supersedes the legacy
 `offAxisBadge` (still supported), which only appears once the value is off-screen and takes no icon.
+
+### Draggable lines (`draggable`)
+
+Make a Form-A line draggable along the Y-axis — grab it near its value and drag to set a new price
+(a working order, alert level, or target). The line tracks the finger on the UI thread; per-line
+callbacks report the value to JS:
+
+```tsx
+referenceLines={[
+  {
+    value: limitPrice,            // controlled: write `onCommit` back into this
+    label: "Limit buy",
+    draggable: true,
+    snap: 0.05,                   // round drops to a tick size
+    bounds: [0, lastPrice],       // hard-clamp the drag range
+    onChange: (v) => {},          // during drag (de-duped to value changes)
+    onCommit: setLimitPrice,      // on release — persist the move
+    onDragIn: (v) => {},          // value (re-)entered the visible range / bounds
+    onDragOut: (v) => {},         // value left the visible range / hit a bound
+  },
+]}
+```
+
+The line is **uncontrolled** by default (it stays where you drop it); pair `onCommit` with writing
+the value back into `value` to make it controlled. `onDragIn` / `onDragOut` are edge-triggered and
+also fire when the axis rescales under a fixed value (e.g. an order scrolling off the top), so
+they're a clean "is my order still on screen" signal even without dragging.
+
+### Custom tags (`renderReferenceLine`)
+
+Replace a line's built-in pill / gutter label with any **React Native** view — the same model as
+`renderMarker` / `renderTooltip`. The chart floats your element over the canvas and pins it to the
+line's value (vertically centered, horizontally at the badge / label position), tracking the
+rescaling axis and any drag without JS re-renders. Called per Form-A line; return `null` to keep
+that line's built-in tag (works with `badge: false` too). Bind the `ctx.value` / `ctx.valueStr`
+SharedValues to animated text for a live readout:
+
+```tsx
+renderReferenceLine={(ctx) =>
+  ctx.line.draggable ? (
+    <View style={styles.tag}>
+      <Text>{ctx.line.label}</Text>
+      {/* live price, updated on the UI thread while dragging */}
+      <AnimatedTrendTextInput sharedValue={ctx.value} maximumFractionDigits={2} />
+    </View>
+  ) : null
+}
+```
+
+`ctx` ([`ReferenceLineRenderProps`](/api-reference/types#annotations)) also carries `y`, `inRange`,
+`edge` (`"above"` / `"in"` / `"below"`, for a directional chevron), and `dragging` as SharedValues.
+
+### Grouping near-value lines (`referenceLineGrouping`)
+
+When a stack of orders or alerts sits near the same price, their tags pile up illegibly. Pass
+`referenceLineGrouping` to collapse Form-A lines whose handles fall within `radius` px of each other
+into a single count handle:
+
+```tsx
+referenceLineGrouping={{ radius: 18 }}   // or `true` for the default
+```
+
+The clustered lines' individual tags are suppressed and replaced by one "count" pill at the
+cluster's center; the lines themselves still draw. Lines you render with `renderReferenceLine`
+are excluded from grouping (their custom tag draws itself), so the count reflects only collapsed
+built-in tags.
 
 ## Overlay bridge (`renderOverlay`)
 

--- a/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
@@ -1,0 +1,250 @@
+import { StyleSheet, View, type LayoutChangeEvent } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { computeScrubDotY } from "../hooks/crosshairShared";
+import {
+  classifyReferenceEdge,
+  referenceLineForm,
+  resolveReferenceBadge,
+} from "../math/referenceLines";
+import type { ReferenceLine, ReferenceLineRenderProps } from "../types";
+
+/** Horizontal anchor for the floated tag, mirroring the built-in badge/label. */
+type HAnchor = "left" | "center" | "right";
+
+/** Pin gap from the anchored plot edge, in px (matches the badge edge inset). */
+const ANCHOR_INSET = 2;
+/** Off-screen edge inset for the pinned handle, in px (matches the off-axis badge). */
+const EDGE_INSET = 12;
+
+/** Where a custom tag pins horizontally: the badge position, else the label
+ *  position, else inside the left edge. */
+function resolveAnchor(line: ReferenceLine): HAnchor {
+  const badge = resolveReferenceBadge(line);
+  if (badge) return badge.position;
+  return line.labelPosition ?? "left";
+}
+
+/** Lightweight stand-in SharedValue for the suppression probe (see
+ *  {@link customReferenceLineFlags}); never bound to the UI thread, so only the
+ *  read accessors a render might touch are provided. */
+function stub<T>(v: T): SharedValue<T> {
+  return { value: v, get: () => v } as unknown as SharedValue<T>;
+}
+
+/**
+ * Which Form-A reference lines a `renderReferenceLine` returns an element for —
+ * the set whose built-in Skia tag is suppressed (so there's no double-draw). The
+ * render fn is probed with placeholder SharedValues; it must decide null-ness from
+ * `line` / `index`, not from live values (mirrors how `renderMarker` is probed for
+ * the marker-atlas exclusion set). Index-aligned with `lines`.
+ */
+export function customReferenceLineFlags(
+  lines: ReferenceLine[],
+  render?: (
+    ctx: ReferenceLineRenderProps,
+  ) => React.ReactElement | null | undefined,
+): boolean[] {
+  if (!render) return lines.map(() => false);
+  return lines.map((line, index) => {
+    if (referenceLineForm(line) !== "line") return false;
+    return (
+      render({
+        line,
+        index,
+        value: stub(line.value ?? 0),
+        valueStr: stub(""),
+        y: stub(-1),
+        inRange: stub(true),
+        edge: stub<"above" | "in" | "below">("in"),
+        dragging: stub(false),
+      }) != null
+    );
+  });
+}
+
+/**
+ * One custom-rendered reference-line tag: a React Native element floated over the
+ * canvas, vertically centered on the line's value-Y and horizontally pinned to the
+ * badge / label position. Mirrors `CustomMarkerView` — each tag projects its own
+ * value every frame, so the transform runs on the UI thread with no JS re-render
+ * as the chart rescales or the line is dragged. `pointerEvents="box-none"` lets
+ * empty space fall through to the chart gestures while an interactive leaf inside
+ * the custom element can still be touched.
+ */
+function CustomReferenceLineView({
+  line,
+  index,
+  render,
+  engine,
+  padding,
+  formatValue,
+  dragValues,
+  dragActive,
+}: {
+  line: ReferenceLine;
+  index: number;
+  render: (
+    ctx: ReferenceLineRenderProps,
+  ) => React.ReactElement | null | undefined;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  formatValue: (v: number) => string;
+  dragValues: SharedValue<number[]>;
+  dragActive: SharedValue<boolean[]>;
+}) {
+  const staticValue = line.value ?? 0;
+
+  // Live value: a drag override (if present) else the static prop value.
+  const value = useDerivedValue<number>(() => {
+    const dv = dragValues.get()[index];
+    return dv != null ? dv : staticValue;
+  });
+  const valueStr = useDerivedValue(() => formatValue(value.get()));
+  const edge = useDerivedValue<"above" | "in" | "below">(() =>
+    classifyReferenceEdge(
+      value.get(),
+      engine.displayMin.get(),
+      engine.displayMax.get(),
+    ),
+  );
+  const inRange = useDerivedValue(() => edge.get() === "in");
+  const dragging = useDerivedValue(() => dragActive.get()[index] === true);
+
+  // Canvas Y of the value (the element's vertical center). Off-screen values pin
+  // to the nearest plot edge (inset), matching the built-in off-axis badge.
+  const y = useDerivedValue(() => {
+    const ch = engine.canvasHeight.get();
+    const raw = computeScrubDotY(
+      value.get(),
+      engine.displayMin.get(),
+      engine.displayMax.get(),
+      ch,
+      padding.top,
+      padding.bottom,
+    );
+    if (raw < 0) return -1;
+    const top = padding.top + EDGE_INSET;
+    const bottom = ch - padding.bottom - EDGE_INSET;
+    return Math.min(bottom, Math.max(top, raw));
+  });
+
+  // Measured element size, so the transform can center / pin it.
+  const size = useSharedValue({ width: 0, height: 0 });
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    size.value = { width, height };
+  };
+
+  const anchor = resolveAnchor(line);
+  const animatedStyle = useAnimatedStyle(() => {
+    const yy = y.get();
+    const s = size.get();
+    const w = engine.canvasWidth.get();
+    const visible = yy >= 0 && w > 0;
+    const x1 = padding.left;
+    const x2 = w - padding.right;
+    let tx: number;
+    if (anchor === "right") tx = x2 - ANCHOR_INSET - s.width;
+    else if (anchor === "center") tx = (x1 + x2) / 2 - s.width / 2;
+    else tx = x1 + ANCHOR_INSET;
+    return {
+      opacity: visible ? 1 : 0,
+      transform: [{ translateX: tx }, { translateY: yy - s.height / 2 }],
+    };
+  });
+
+  const element = render({
+    line,
+    index,
+    value,
+    valueStr,
+    y,
+    inRange,
+    edge,
+    dragging,
+  });
+  if (element == null) return null;
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      onLayout={onLayout}
+      style={[styles.anchor, animatedStyle]}
+    >
+      {element}
+    </Animated.View>
+  );
+}
+
+/**
+ * React Native overlay (NOT Skia) that floats `renderReferenceLine` elements over
+ * the canvas, one per Form-A line the consumer customizes. Rendered as a sibling
+ * of `<Canvas>` (like {@link CustomMarkerOverlay}) so the tags can be any RN view
+ * and stay crisp at native resolution. Lines whose render returns an element have
+ * their built-in Skia tag suppressed upstream (see {@link customReferenceLineFlags}),
+ * so there's no double-draw.
+ */
+export function CustomReferenceLineOverlay({
+  lines,
+  renderReferenceLine,
+  custom,
+  engine,
+  padding,
+  formatValue,
+  dragValues,
+  dragActive,
+}: {
+  lines: ReferenceLine[];
+  renderReferenceLine: (
+    ctx: ReferenceLineRenderProps,
+  ) => React.ReactElement | null | undefined;
+  /**
+   * Index-aligned flags (from {@link customReferenceLineFlags}) marking which
+   * lines the render owns — only these get a floated view, matching the built-in
+   * tags suppressed upstream. Avoids re-probing the render here.
+   */
+  custom: boolean[];
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  formatValue: (v: number) => string;
+  dragValues: SharedValue<number[]>;
+  dragActive: SharedValue<boolean[]>;
+}) {
+  const children: React.ReactElement[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!custom[i]) continue;
+    children.push(
+      <CustomReferenceLineView
+        key={i}
+        line={lines[i]}
+        index={i}
+        render={renderReferenceLine}
+        engine={engine}
+        padding={padding}
+        formatValue={formatValue}
+        dragValues={dragValues}
+        dragActive={dragActive}
+      />,
+    );
+  }
+  if (children.length === 0) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // top/left 0 + translate so the measured element can be pinned to the value.
+  anchor: { position: "absolute", top: 0, left: 0 },
+});

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import {
@@ -62,6 +62,7 @@ import { useDegen } from "../hooks/useDegen";
 import { useLiveChartHasData } from "../hooks/useLiveChartHasData";
 import { useLiveDot } from "../hooks/useLiveDot";
 import { useMarkers } from "../hooks/useMarkers";
+import { useReferenceDrag } from "../hooks/useReferenceDrag";
 import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
 import { useMomentum } from "../hooks/useMomentum";
@@ -77,7 +78,15 @@ import {
   formatValue as defaultFormatValue,
 } from "../lib/format";
 import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
-import { collectReferenceValues } from "../math/referenceLines";
+import { computeScrubDotY } from "../hooks/crosshairShared";
+import {
+  groupReferenceLines,
+  type ReferenceGrouping,
+} from "../math/referenceGroup";
+import {
+  collectReferenceValues,
+  referenceLineForm,
+} from "../math/referenceLines";
 import {
   applyPaletteOverride,
   leftEdgeFadeColorsFromBgRgb,
@@ -102,6 +111,10 @@ import {
   labelConnector,
 } from "./ExtremaConnectorOverlay";
 import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
+import {
+  CustomReferenceLineOverlay,
+  customReferenceLineFlags,
+} from "./CustomReferenceLineOverlay";
 import { CustomTooltipOverlay } from "./CustomTooltipOverlay";
 import { BadgeOverlay } from "./BadgeOverlay";
 import { ChartOverlayLayer } from "./ChartOverlayLayer";
@@ -113,6 +126,7 @@ import { LoadingOverlay } from "./LoadingOverlay";
 import { MarkerOverlay } from "./MarkerOverlay";
 import { MultiSeriesTooltipStack } from "./MultiSeriesTooltipStack";
 import { ValueTextOverlay } from "./ValueTextOverlay";
+import { ReferenceLineGroupOverlay } from "./ReferenceLineGroupOverlay";
 import { ReferenceLineOverlay } from "./ReferenceLineOverlay";
 import { ScrubActionOverlay } from "./ScrubActionOverlay";
 import { SegmentDividerOverlay } from "./SegmentDividerOverlay";
@@ -123,6 +137,14 @@ import { YAxisOverlay } from "./YAxisOverlay";
 
 /** Translucent fill alpha for the threshold profit/loss band. */
 const THRESHOLD_FILL_OPACITY = 0.16;
+
+/** Stable empty grouping result (identity-stable so downstream worklets don't
+ *  re-run) used when reference-line grouping is off. */
+const EMPTY_GROUPING: ReferenceGrouping = { hidden: [], groups: [] };
+
+/** Stable empty number array so the live-reference-values worklet stays
+ *  referentially stable (no engine re-fit) when no line is draggable. */
+const EMPTY_NUMS: number[] = [];
 
 /**
  * Color stops for the threshold's hard-split vertical gradient. Both arrays pair
@@ -228,6 +250,8 @@ function useLiveChartController({
   renderMarker,
   renderTooltip,
   renderOverlay,
+  renderReferenceLine,
+  referenceLineGrouping,
   leftEdgeFade = true,
 
   // ── Callbacks ───────────────────────────────────────────────────────────
@@ -284,6 +308,71 @@ function useLiveChartController({
 
   const allRefLines = referenceLines ?? [];
   const refValues = collectReferenceValues(allRefLines);
+
+  // Per-line live value overrides + drag flags for draggable lines and the custom
+  // `renderReferenceLine` slot. One array SharedValue each (the line count varies,
+  // so a single SharedValue beats N hooks). Seeded from each line's static `value`;
+  // the drag gesture overwrites a slot, and the effect re-seeds slots not being
+  // dragged when the props change (so a controlled `value` flows back in).
+  const dragValues = useSharedValue<number[]>([]);
+  const dragActive = useSharedValue<boolean[]>([]);
+  // Last `value` props used to seed each slot, so reconciliation can tell a
+  // controlled prop change (adopt it) from an unchanged prop (keep the dragged
+  // value — uncontrolled persistence) without resetting a drop on every re-render.
+  const seededRef = useRef<(number | undefined)[]>([]);
+  const refValueSig = allRefLines.map((l) => l.value ?? "_").join(",");
+  useEffect(() => {
+    const active = dragActive.value;
+    const cur = dragValues.value;
+    const seeded = seededRef.current;
+    dragValues.value = allRefLines.map((l, i) => {
+      const prop = l.value ?? 0;
+      if (active[i]) return cur[i] ?? prop; // mid-drag → keep the dragged value
+      if (l.value !== seeded[i]) return prop; // prop changed → adopt (controlled)
+      return cur[i] ?? prop; // unchanged → keep current (uncontrolled persist)
+    });
+    seededRef.current = allRefLines.map((l) => l.value);
+    if (dragActive.value.length !== allRefLines.length) {
+      dragActive.value = allRefLines.map((_, i) => active[i] ?? false);
+    }
+    // allRefLines is rebuilt every render; key off the value signature + length.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refValueSig, allRefLines.length]);
+
+  // Form-A lines a custom `renderReferenceLine` owns → suppress their built-in tag
+  // (no double-draw). Probed on the JS thread, index-aligned with `allRefLines`.
+  const refLineCustom = customReferenceLineFlags(allRefLines, renderReferenceLine);
+
+  // Live Y values of the *draggable* Form-A lines, folded into the engine's
+  // axis-range fit so dragging a line toward / past the visible edge expands the
+  // range and the axis follows the finger in one motion (the committed values are
+  // already in `refValues`). `excludeFromRange` lines opt out, matching the static
+  // fit. Identity-stable (no re-fit) when nothing is draggable.
+  const draggableRefIdx = allRefLines
+    .map((l, i) =>
+      l.draggable && !l.excludeFromRange && referenceLineForm(l) === "line"
+        ? i
+        : -1,
+    )
+    .filter((i) => i >= 0);
+  const liveRefValues = useDerivedValue<number[]>(() => {
+    if (draggableRefIdx.length === 0) return EMPTY_NUMS;
+    const dv = dragValues.get();
+    const out: number[] = [];
+    for (let k = 0; k < draggableRefIdx.length; k++) {
+      const v = dv[draggableRefIdx[k]];
+      if (v != null) out.push(v);
+    }
+    return out;
+  });
+
+  // Reference-line grouping (collapse near-value handles). Resolved once; the
+  // per-frame clustering runs on the UI thread (see ReferenceLineGroupOverlay).
+  const refGroupingRadius = referenceLineGrouping
+    ? typeof referenceLineGrouping === "object"
+      ? (referenceLineGrouping.radius ?? 18)
+      : 18
+    : null;
 
   const badgeUsesRightGutter =
     badgeCfg !== null && (badgeCfg.position ?? "right") === "right";
@@ -433,6 +522,7 @@ function useLiveChartController({
     adaptiveSpeedBoost: metricsCfg.motion.adaptiveSpeedBoost,
     exaggerate,
     referenceValues: refValues,
+    liveReferenceValues: liveRefValues,
     nonNegative,
     maxValue,
     windowBuffer,
@@ -463,6 +553,41 @@ function useLiveChartController({
 
   // ── Per-frame derived values ───────────────────────────────────────────
   const { layoutWidth, layoutHeight, onLayout } = useCanvasLayout(engine);
+
+  // Reference-line grouping: cluster Form-A lines by their per-frame value-Y so a
+  // stack of nearby orders collapses into one count handle. `groupHidden` suppresses
+  // the clustered lines' individual tags; the count pills read `refGroupResult`.
+  // Identity-stable (no work) when grouping is off.
+  const refGroupResult = useDerivedValue<ReferenceGrouping>(() => {
+    if (refGroupingRadius == null) return EMPTY_GROUPING;
+    const ch = engine.canvasHeight.get();
+    const dMin = engine.displayMin.get();
+    const dMax = engine.displayMax.get();
+    const top = effectivePadding.top;
+    const bottom = ch - effectivePadding.bottom;
+    const ys: number[] = [];
+    for (let i = 0; i < allRefLines.length; i++) {
+      const l = allRefLines[i];
+      // Skip bands and lines a custom `renderReferenceLine` owns — a custom tag
+      // draws itself and isn't suppressed by grouping, so folding it into a
+      // built-in count pill would double-count it (counted *and* still shown).
+      if (
+        referenceLineForm(l) !== "line" ||
+        l.value === undefined ||
+        refLineCustom[i]
+      ) {
+        ys.push(-1);
+        continue;
+      }
+      const v = dragValues.get()[i] ?? l.value;
+      const y = computeScrubDotY(v, dMin, dMax, ch, top, effectivePadding.bottom);
+      ys.push(y < 0 ? -1 : Math.min(bottom, Math.max(top, y)));
+    }
+    return groupReferenceLines(ys, refGroupingRadius);
+  });
+  const groupHidden = useDerivedValue<boolean[]>(
+    () => refGroupResult.get().hidden,
+  );
 
   // Threshold split geometry (shared by stroke gradient, fill band, marker line).
   // Called unconditionally with a stand-in value when no threshold is set.
@@ -633,6 +758,7 @@ function useLiveChartController({
       !isStatic && refPressActive,
       markerHitRadius,
       onReferenceLinePress,
+      dragValues,
     );
 
   // Combined "defer" hit-test for the scrub-action place-tap: yield to a marker or
@@ -713,6 +839,21 @@ function useLiveChartController({
     },
   });
 
+  // Draggable reference lines: a per-line vertical pan that grabs a line near its
+  // value and drags it along the Y-axis (with snap / bounds / callbacks). Built
+  // unconditionally for stable hook order; the gesture self-disables when no line
+  // opts in, and it's only composed into the root when `refDragEnabled`.
+  const refDragEnabled =
+    !isStatic && allRefLines.some((l) => l.draggable === true);
+  const refDragGesture = useReferenceDrag(
+    engine,
+    effectivePadding,
+    allRefLines,
+    dragValues,
+    dragActive,
+    !isStatic,
+  );
+
   // Scrub-action composes a Tap (place/move the reticle, press the badge, dismiss)
   // ahead of the pan via Exclusive, so a tap is tried first and only becomes a
   // drag (live-scrub, or lock-adjust once placed) if the finger moves. `Exclusive`
@@ -755,6 +896,13 @@ function useLiveChartController({
       scrollGestureMode === "axisDrag"
         ? Gesture.Exclusive(panScrollGesture, rootGesture)
         : Gesture.Race(panScrollGesture, rootGesture);
+  }
+
+  // Draggable reference lines take priority: a vertical grab on a line drags it.
+  // The manual-activation pan fails fast off any line (or on horizontal intent), so
+  // Exclusive falls through to scrub / scroll everywhere else.
+  if (refDragEnabled) {
+    rootGesture = Gesture.Exclusive(refDragGesture, rootGesture);
   }
 
   // ── Derived render values ──────────────────────────────────────────────
@@ -830,6 +978,13 @@ function useLiveChartController({
     leftEdgeFadeCfg,
     metricsCfg,
     allRefLines,
+    refLineCustom,
+    dragValues,
+    dragActive,
+    renderReferenceLine,
+    refGroupingActive: refGroupingRadius != null,
+    refGroupResult,
+    groupHidden,
     resolvedSegments,
     hasRecolorSegments,
     segmentGradient,
@@ -1028,6 +1183,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     valueLineCfg,
     dotY,
     allRefLines,
+    dragValues,
     resolvedSegments,
     hasRecolorSegments,
     segmentGradient,
@@ -1114,6 +1270,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
           palette={palette}
           formatValue={formatValue}
           font={skiaFont}
+          dragValues={dragValues}
+          index={i}
         />
       ))}
 
@@ -1482,6 +1640,11 @@ function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
 function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
   const {
     allRefLines,
+    refLineCustom,
+    dragValues,
+    groupHidden,
+    refGroupResult,
+    refGroupingActive,
     engine,
     effectivePadding,
     palette,
@@ -1502,8 +1665,21 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
           formatValue={formatValue}
           font={skiaFont}
           badgeLayer
+          dragValues={dragValues}
+          index={i}
+          suppressTag={refLineCustom[i]}
+          groupHidden={refGroupingActive ? groupHidden : undefined}
         />
       ))}
+      {/* Collapsed count handles for grouped (near-value) lines. */}
+      {refGroupingActive && (
+        <ReferenceLineGroupOverlay
+          grouping={refGroupResult}
+          padding={effectivePadding}
+          palette={palette}
+          font={skiaFont}
+        />
+      )}
     </Group>
   );
 }
@@ -1563,6 +1739,11 @@ export function LiveChart(props: LiveChartProps) {
     renderMarker,
     renderTooltip,
     renderOverlay,
+    renderReferenceLine,
+    allRefLines,
+    refLineCustom,
+    dragValues,
+    dragActive,
     overlayContext,
     scrubCfg,
     crosshair,
@@ -1648,6 +1829,22 @@ export function LiveChart(props: LiveChartProps) {
             padding={effectivePadding}
             lineData={engine.data}
             lineLinear={lineIsLinear}
+          />
+        )}
+
+        {/* Custom-rendered reference-line tags — RN views floated over the canvas
+            (non-Skia), pinned to each Form-A line's value. Sibling of <Canvas>.
+            Built-in Skia tags for these lines are suppressed (no double-draw). */}
+        {renderReferenceLine && allRefLines.length > 0 && (
+          <CustomReferenceLineOverlay
+            lines={allRefLines}
+            renderReferenceLine={renderReferenceLine}
+            custom={refLineCustom}
+            engine={engine}
+            padding={effectivePadding}
+            formatValue={formatValue}
+            dragValues={dragValues}
+            dragActive={dragActive}
           />
         )}
 

--- a/packages/react-native-livechart/src/components/ReferenceLineGroupOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineGroupOverlay.tsx
@@ -1,0 +1,159 @@
+import {
+  Group,
+  RoundedRect,
+  Text as SkiaText,
+  type SkFont,
+} from "@shopify/react-native-skia";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+
+import type { ChartPadding } from "../draw/line";
+import { measureFontTextWidth } from "../lib/measureFontTextWidth";
+import type { ReferenceGrouping } from "../math/referenceGroup";
+import type { LiveChartPalette } from "../types";
+
+/** Max simultaneous group handles (a fixed Skia slot pool — the per-frame group
+ *  count varies, so we draw a fixed set of slots and hide the unused ones). */
+const MAX_GROUP_PILLS = 12;
+/** Horizontal padding inside the count pill, in px. */
+const PILL_PAD_X = 6;
+/** Vertical padding inside the count pill, in px. */
+const PILL_PAD_Y = 3;
+/** Pill inset from the plot's left edge, in px. */
+const EDGE_INSET = 2;
+const PILL_RADIUS = 5;
+
+interface PillLayout {
+  visible: boolean;
+  x: number;
+  top: number;
+  w: number;
+  text: string;
+  textX: number;
+  textY: number;
+}
+
+const HIDDEN_PILL: PillLayout = {
+  visible: false,
+  x: 0,
+  top: -1,
+  w: 0,
+  text: "",
+  textX: 0,
+  textY: -1,
+};
+
+/** One collapsed-group count pill (slot `index` of the fixed pool). Reads the
+ *  cluster at `grouping.groups[index]`; hidden when fewer groups exist this frame. */
+function GroupCountPill({
+  grouping,
+  index,
+  padding,
+  font,
+  baselineOffset,
+  pillH,
+  color,
+  background,
+  textColor,
+}: {
+  grouping: SharedValue<ReferenceGrouping>;
+  index: number;
+  padding: ChartPadding;
+  font: SkFont;
+  baselineOffset: number;
+  pillH: number;
+  color: string;
+  background: string;
+  textColor: string;
+}) {
+  const layout = useDerivedValue<PillLayout>(() => {
+    const gs = grouping.get().groups;
+    if (index >= gs.length) return HIDDEN_PILL;
+    const g = gs[index];
+    const text = String(g.count);
+    const w = measureFontTextWidth(font, text) + PILL_PAD_X * 2;
+    const x = padding.left + EDGE_INSET;
+    return {
+      visible: true,
+      x,
+      top: g.cy - pillH / 2,
+      w,
+      text,
+      textX: x + PILL_PAD_X,
+      textY: g.cy - baselineOffset,
+    };
+  });
+
+  const opacity = useDerivedValue(() => (layout.get().visible ? 1 : 0));
+  const x = useDerivedValue(() => layout.get().x);
+  const top = useDerivedValue(() => layout.get().top);
+  const w = useDerivedValue(() => layout.get().w);
+  const text = useDerivedValue(() => layout.get().text);
+  const textX = useDerivedValue(() => layout.get().textX);
+  const textY = useDerivedValue(() => layout.get().textY);
+
+  return (
+    <Group opacity={opacity}>
+      <RoundedRect
+        x={x}
+        y={top}
+        width={w}
+        height={pillH}
+        r={PILL_RADIUS}
+        color={background}
+      />
+      <RoundedRect
+        x={x}
+        y={top}
+        width={w}
+        height={pillH}
+        r={PILL_RADIUS}
+        color={color}
+        style="stroke"
+        strokeWidth={1}
+      />
+      <SkiaText x={textX} y={textY} text={text} font={font} color={textColor} />
+    </Group>
+  );
+}
+
+/**
+ * Draws the collapsed-group count handles (e.g. a "×3" pill) for reference-line
+ * grouping — one pill per multi-line cluster, pinned to the plot's left edge at the
+ * cluster centroid. The individual tags of clustered lines are suppressed upstream
+ * (via `groupHidden`), so a stack of nearby orders reads as one handle. A fixed
+ * slot pool keeps the Skia tree stable while the per-frame group count varies.
+ */
+export function ReferenceLineGroupOverlay({
+  grouping,
+  padding,
+  palette,
+  font,
+}: {
+  grouping: SharedValue<ReferenceGrouping>;
+  padding: ChartPadding;
+  palette: LiveChartPalette;
+  font: SkFont;
+}) {
+  const fm = font.getMetrics();
+  const baselineOffset = (fm.ascent + fm.descent) / 2;
+  const pillH = fm.descent - fm.ascent + PILL_PAD_Y * 2;
+
+  const slots: React.ReactElement[] = [];
+  for (let i = 0; i < MAX_GROUP_PILLS; i++) {
+    slots.push(
+      <GroupCountPill
+        key={i}
+        grouping={grouping}
+        index={i}
+        padding={padding}
+        font={font}
+        baselineOffset={baselineOffset}
+        pillH={pillH}
+        color={palette.refLine}
+        background={palette.tooltipBg}
+        textColor={palette.refLabel}
+      />,
+    );
+  }
+  return <Group>{slots}</Group>;
+}

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -6,7 +6,7 @@ import {
   Text as SkiaText,
   type SkFont,
 } from "@shopify/react-native-skia";
-import { useDerivedValue } from "react-native-reanimated";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
@@ -36,6 +36,10 @@ export function ReferenceLineOverlay({
   formatValue,
   font,
   badgeLayer = false,
+  suppressTag = false,
+  groupHidden,
+  dragValues,
+  index = 0,
 }: {
   engine: ChartEngineLayout;
   padding: ChartPadding;
@@ -50,10 +54,34 @@ export function ReferenceLineOverlay({
    * of being erased by the fade's `dstOut` blend.
    */
   badgeLayer?: boolean;
+  /**
+   * Suppress the built-in tag (badge pill + connector + chevron + icon + gutter
+   * label) for this line — used when a custom `renderReferenceLine` element owns
+   * the tag. The line / band stroke still draws. No effect on the base pass.
+   */
+  suppressTag?: boolean;
+  /**
+   * Per-frame grouping flags (index-aligned): when this line's slot is `true` it's
+   * collapsed into a group count handle, so its tag is suppressed (the line / band
+   * stroke still draws).
+   */
+  groupHidden?: SharedValue<boolean[]>;
+  /** Per-line live value overrides (dragged values), index-aligned with `referenceLines`. */
+  dragValues?: SharedValue<number[]>;
+  /** This line's index into {@link dragValues}. */
+  index?: number;
 }) {
   const form = referenceLineForm(line);
   const isBand = form === "value-band" || form === "time-band";
-  const layout = useReferenceLine(engine, padding, line, formatValue, font);
+  const layout = useReferenceLine(
+    engine,
+    padding,
+    line,
+    formatValue,
+    font,
+    dragValues,
+    index,
+  );
 
   const color = line.color ?? palette.refLine;
   const labelColor = line.labelColor ?? line.color ?? palette.refLabel;
@@ -165,12 +193,14 @@ export function ReferenceLineOverlay({
   );
   const badgeOpacity = useDerivedValue(() => {
     const l = layout.get();
-    return l.visible && l.badge ? 1 : 0;
+    const grouped = groupHidden ? groupHidden.get()[index] === true : false;
+    return !suppressTag && !grouped && l.visible && l.badge ? 1 : 0;
   });
   // Text + icon ride in the badge pass too, so they stay crisp above the fade.
   const labelOpacity = useDerivedValue(() => {
     const l = layout.get();
-    return l.visible && l.label.length > 0 ? 1 : 0;
+    const grouped = groupHidden ? groupHidden.get()[index] === true : false;
+    return !suppressTag && !grouped && l.visible && l.label.length > 0 ? 1 : 0;
   });
   const iconOpacity = useDerivedValue(() => {
     const l = layout.get();

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -27,6 +27,13 @@ export interface EngineConfig {
   exaggerate?: boolean;
   referenceValue?: number;
   referenceValues?: number[];
+  /**
+   * Live, per-frame Y values to fold into the axis-range fit on top of the static
+   * {@link referenceValues} — used so a *dragging* reference line expands the range
+   * and the axis follows the finger smoothly (the committed values already sit in
+   * `referenceValues`). Read on the UI thread each frame; omit for non-draggable charts.
+   */
+  liveReferenceValues?: SharedValue<number[]>;
   nonNegative?: boolean;
   maxValue?: number;
   nowOverride?: number;
@@ -234,7 +241,15 @@ export function useLiveChartEngine(
   const adaptiveSpeedBoostSV = useDerivedValue(() => config.adaptiveSpeedBoost);
   const exaggerateSV = useDerivedValue(() => config.exaggerate ?? false);
   const referenceValue = useDerivedValue(() => config.referenceValue);
-  const referenceValues = useDerivedValue(() => config.referenceValues);
+  // Captured directly (not via `config.`) so Reanimated tracks the SharedValue and
+  // the merge re-runs each frame while a line is dragged; stable when idle.
+  const liveReferenceValuesSV = config.liveReferenceValues;
+  const referenceValues = useDerivedValue(() => {
+    const base = config.referenceValues;
+    const live = liveReferenceValuesSV?.value;
+    if (!live || live.length === 0) return base;
+    return base && base.length > 0 ? base.concat(live) : live;
+  });
   const nonNegativeSV = useDerivedValue(() => config.nonNegative ?? false);
   const maxValueSV = useDerivedValue(() => config.maxValue);
   const nowOverrideSV = useDerivedValue(() => config.nowOverride);

--- a/packages/react-native-livechart/src/hooks/useReferenceDrag.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceDrag.ts
@@ -1,0 +1,254 @@
+import { Gesture } from "react-native-gesture-handler";
+import {
+  useAnimatedReaction,
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import {
+  clampToBounds,
+  nearestDraggableIndex,
+  referenceValueOut,
+} from "../math/referenceDrag";
+import { referenceLineForm } from "../math/referenceLines";
+import type { ReferenceLine } from "../types";
+import {
+  computeScrubDotY,
+  computeValueAtY,
+  snapPrice,
+} from "./crosshairShared";
+
+/** Vertical reach (px) around a line within which a touch grabs it. */
+const GRAB_SLOP = 14;
+/** Travel (px) that resolves drag (vertical) vs. fall-through (horizontal) intent. */
+const DRAG_ACTIVATE_PX = 4;
+
+/** Stable empty array so the handle / out-state worklets stay referentially stable
+ *  (and the onDragIn/Out reaction never fires) when the feature is unused. */
+const EMPTY: never[] = [];
+
+/**
+ * Builds the per-line **drag** gesture for draggable Form-A reference lines: grab a
+ * line near its value-Y and drag vertically to set a new value, with optional
+ * `snap` + `bounds` clamp. Mirrors the order-ticket reticle in {@link useCrosshair}
+ * (value↔Y via `computeValueAtY` / `computeScrubDotY`, frozen value re-projected
+ * each frame) but per line, writing into the shared `dragValues` array the layout
+ * and overlays read.
+ *
+ * The pan uses `manualActivation`: it grabs only when a touch starts within
+ * {@link GRAB_SLOP} of a draggable line **and** the motion is vertical — a
+ * horizontal drag (scrub) or a touch off every line fails fast so the chart's other
+ * gestures run (compose this ahead of them via `Gesture.Exclusive`).
+ *
+ * Also fires the per-line drag callbacks: `onChange` (de-duped during drag),
+ * `onCommit` (on release), and `onDragIn` / `onDragOut` (value crossing the visible
+ * range or a `bounds`, from a drag or the axis rescaling — edge-detected each frame).
+ */
+export function useReferenceDrag(
+  engine: ChartEngineLayout,
+  padding: ChartPadding,
+  lines: ReferenceLine[],
+  dragValues: SharedValue<number[]>,
+  dragActive: SharedValue<boolean[]>,
+  enabled: boolean,
+): ReturnType<typeof Gesture.Pan> {
+  const anyDraggable =
+    enabled &&
+    lines.some((l) => l.draggable && referenceLineForm(l) === "line");
+  const anyDragInOut = lines.some(
+    (l) =>
+      referenceLineForm(l) === "line" &&
+      (l.onDragIn != null || l.onDragOut != null),
+  );
+
+  // Per-line handle Y (canvas px), index-aligned with `lines`; -1 when the line
+  // isn't draggable or the canvas isn't laid out. Off-screen lines pin to the
+  // nearest plot edge so they stay grabbable. Recomputed each frame (UI thread).
+  /* istanbul ignore next -- worklet runs on the UI thread, not in Jest */
+  const handleYs = useDerivedValue<number[]>(() => {
+    if (!anyDraggable) return EMPTY;
+    const ch = engine.canvasHeight.get();
+    const dMin = engine.displayMin.get();
+    const dMax = engine.displayMax.get();
+    const top = padding.top;
+    const bottom = ch - padding.bottom;
+    const out: number[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i];
+      if (
+        !l.draggable ||
+        referenceLineForm(l) !== "line" ||
+        l.value === undefined
+      ) {
+        out.push(-1);
+        continue;
+      }
+      const v = dragValues.get()[i] ?? l.value;
+      const y = computeScrubDotY(v, dMin, dMax, ch, top, padding.bottom);
+      out.push(y < 0 ? -1 : Math.min(bottom, Math.max(top, y)));
+    }
+    return out;
+  });
+
+  const dragIndex = useSharedValue(-1);
+  const startX = useSharedValue(0);
+  const startY = useSharedValue(0);
+  const activated = useSharedValue(false);
+  const lastChange = useSharedValue(0);
+
+  // JS-thread callback dispatch — closes over the latest `lines` each render.
+  /* istanbul ignore next -- runs via scheduleOnRN from the UI-thread gesture */
+  function emitChange(i: number, v: number) {
+    lines[i]?.onChange?.(v);
+  }
+  /* istanbul ignore next -- runs via scheduleOnRN from the UI-thread gesture */
+  function emitCommit(i: number, v: number) {
+    lines[i]?.onCommit?.(v);
+  }
+  /* istanbul ignore next -- runs via scheduleOnRN from the UI-thread reaction */
+  function emitDragOut(i: number, v: number) {
+    lines[i]?.onDragOut?.(v);
+  }
+  /* istanbul ignore next -- runs via scheduleOnRN from the UI-thread reaction */
+  function emitDragIn(i: number, v: number) {
+    lines[i]?.onDragIn?.(v);
+  }
+
+  // onDragIn / onDragOut — edge-detect each line's "out of the watched interval"
+  // state (from a drag or the axis rescaling under a fixed value).
+  useAnimatedReaction(
+    /* istanbul ignore next -- worklet runs on the UI thread, not in Jest */
+    () => {
+      if (!anyDragInOut) return EMPTY as boolean[];
+      const dMin = engine.displayMin.get();
+      const dMax = engine.displayMax.get();
+      const out: boolean[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        const l = lines[i];
+        if (
+          referenceLineForm(l) !== "line" ||
+          l.value === undefined ||
+          (l.onDragIn == null && l.onDragOut == null)
+        ) {
+          out.push(false);
+          continue;
+        }
+        const v = dragValues.get()[i] ?? l.value;
+        out.push(referenceValueOut(v, dMin, dMax, l.bounds));
+      }
+      return out;
+    },
+    /* istanbul ignore next -- worklet runs on the UI thread, not in Jest */
+    (curr, prev) => {
+      if (!prev || curr === prev) return;
+      for (let i = 0; i < curr.length; i++) {
+        if (prev[i] === undefined || curr[i] === prev[i]) continue;
+        const l = lines[i];
+        const v = dragValues.get()[i] ?? l.value ?? 0;
+        if (curr[i]) scheduleOnRN(emitDragOut, i, v);
+        else scheduleOnRN(emitDragIn, i, v);
+      }
+    },
+    [lines, anyDragInOut],
+  );
+
+  // ── Gesture callbacks (UI-thread worklets — excluded from Jest coverage) ──────
+  /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+  const onTouchesDown = (
+    e: { changedTouches: { x: number; y: number }[] },
+    manager: { fail: () => void },
+  ) => {
+    "worklet";
+    const t = e.changedTouches[0];
+    if (!t) return;
+    const i = nearestDraggableIndex(handleYs.get(), t.y, GRAB_SLOP);
+    if (i < 0) {
+      manager.fail();
+      return;
+    }
+    dragIndex.set(i);
+    startX.set(t.x);
+    startY.set(t.y);
+  };
+
+  /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+  const onTouchesMove = (
+    e: { allTouches: { x: number; y: number }[] },
+    manager: { activate: () => void; fail: () => void },
+  ) => {
+    "worklet";
+    if (dragIndex.get() < 0) return;
+    const t = e.allTouches[0];
+    if (!t) return;
+    const dx = Math.abs(t.x - startX.get());
+    const dy = Math.abs(t.y - startY.get());
+    if (dy > DRAG_ACTIVATE_PX && dy >= dx) manager.activate();
+    else if (dx > DRAG_ACTIVATE_PX) manager.fail();
+  };
+
+  /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+  const onStart = () => {
+    "worklet";
+    const i = dragIndex.get();
+    if (i < 0) return;
+    activated.set(true);
+    const arr = dragActive.get().slice();
+    arr[i] = true;
+    dragActive.set(arr);
+    lastChange.set(dragValues.get()[i] ?? lines[i].value ?? 0);
+  };
+
+  /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+  const onUpdate = (e: { y: number }) => {
+    "worklet";
+    const i = dragIndex.get();
+    if (i < 0) return;
+    const l = lines[i];
+    const raw = computeValueAtY(
+      e.y,
+      engine.displayMin.get(),
+      engine.displayMax.get(),
+      engine.canvasHeight.get(),
+      padding.top,
+      padding.bottom,
+    );
+    if (raw === null) return;
+    const v = clampToBounds(snapPrice(raw, l.snap), l.bounds);
+    const arr = dragValues.get().slice();
+    arr[i] = v;
+    dragValues.set(arr);
+    if (v !== lastChange.get()) {
+      lastChange.set(v);
+      if (l.onChange) scheduleOnRN(emitChange, i, v);
+    }
+  };
+
+  /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+  const onFinalize = () => {
+    "worklet";
+    const i = dragIndex.get();
+    if (i >= 0 && activated.get()) {
+      const v = dragValues.get()[i] ?? lines[i].value ?? 0;
+      const arr = dragActive.get().slice();
+      arr[i] = false;
+      dragActive.set(arr);
+      if (lines[i].onCommit) scheduleOnRN(emitCommit, i, v);
+    }
+    dragIndex.set(-1);
+    activated.set(false);
+  };
+
+  return Gesture.Pan()
+    .enabled(anyDraggable)
+    .maxPointers(1)
+    .manualActivation(true)
+    .onTouchesDown(onTouchesDown)
+    .onTouchesMove(onTouchesMove)
+    .onStart(onStart)
+    .onUpdate(onUpdate)
+    .onFinalize(onFinalize);
+}

--- a/packages/react-native-livechart/src/hooks/useReferenceLine.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLine.ts
@@ -109,7 +109,7 @@ interface BadgeGeometry {
  * inside the pill, with a dashed connector running to the opposite edge.
  */
 function badgeGeometry(
-  position: "left" | "right",
+  position: "left" | "center" | "right",
   icon: string,
   text: string,
   hasChevron: boolean,
@@ -147,7 +147,9 @@ function badgeGeometry(
   const pillX =
     position === "right"
       ? x2 - BADGE_EDGE_INSET - pillW
-      : x1 + BADGE_EDGE_INSET;
+      : position === "center"
+        ? (x1 + x2) / 2 - pillW / 2
+        : x1 + BADGE_EDGE_INSET;
 
   let cursor = pillX + BADGE_PAD_X;
   let chevronCx = -1;
@@ -172,13 +174,14 @@ function badgeGeometry(
       connStart = x1;
       connEnd = end;
     }
-  } else {
+  } else if (position === "left") {
     const start = pillX + pillW + 4;
     if (start < x2) {
       connStart = start;
       connEnd = x2;
     }
   }
+  // "center" floats the pill at the value with no connector.
 
   return { pillX, pillW, iconX, textX, chevronCx, connStart, connEnd };
 }
@@ -226,6 +229,8 @@ export function computeReferenceBadgeRect(
   dMax: number,
   font: SkFont,
   formatValue: (value: number) => string,
+  /** Live value override (e.g. a dragged value), defaulting to `line.value`. */
+  valueOverride?: number,
 ): ReferenceBadgeRect | null {
   "worklet";
   const badge = resolveReferenceBadge(line);
@@ -241,7 +246,7 @@ export function computeReferenceBadgeRect(
 
   const x1 = padding.left;
   const x2 = canvasWidth - padding.right;
-  const v = line.value;
+  const v = valueOverride ?? line.value;
   const edge = classifyReferenceEdge(v, dMin, dMax);
 
   let y: number;
@@ -280,6 +285,14 @@ export function useReferenceLine(
   line: ReferenceLine | undefined,
   formatValue: (v: number) => string,
   font: SkFont,
+  /**
+   * Per-line live value overrides (e.g. dragged values), index-aligned with the
+   * chart's `referenceLines`. When provided and the slot at {@link index} holds a
+   * number, the Form-A line tracks that value instead of the static `line.value`,
+   * so a drag updates the rendered line/badge on the UI thread. Omit for static lines.
+   */
+  dragValues?: SharedValue<number[]>,
+  index = 0,
 ): SharedValue<ReferenceLineLayout> {
   const form = line ? referenceLineForm(line) : "none";
   // Badge presentation depends only on the (stable) line props — resolve once.
@@ -392,7 +405,11 @@ export function useReferenceLine(
 
     // ── Form A — horizontal line (with optional pill badge) ──────────────────
     if (line.value === undefined) return INVISIBLE;
-    const v = line.value;
+    // Effective value: a live drag override (if present) else the static prop.
+    const v =
+      dragValues && dragValues.value[index] != null
+        ? dragValues.value[index]
+        : line.value;
     const edge = classifyReferenceEdge(v, dMin, dMax);
 
     // Off-screen: pin the badge to the nearest edge with a chevron (when a badge

--- a/packages/react-native-livechart/src/hooks/useReferenceLinePress.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLinePress.ts
@@ -1,6 +1,6 @@
 import type { SkFont } from "@shopify/react-native-skia";
 import { Gesture } from "react-native-gesture-handler";
-import { useDerivedValue } from "react-native-reanimated";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
@@ -33,6 +33,9 @@ export function useReferenceLinePress(
   /** Touch-target inflation around each pill, in px. */
   hitSlop: number,
   onPress?: (line: ReferenceLine, index: number) => void,
+  /** Per-line live value overrides (dragged values) so a draggable line's hit-rect
+   *  tracks the drag, index-aligned with `lines`. */
+  dragValues?: SharedValue<number[]>,
 ): {
   tapGesture: ReturnType<typeof Gesture.Tap>;
   hitTest: (x: number, y: number) => boolean;
@@ -47,9 +50,20 @@ export function useReferenceLinePress(
     const dMin = engine.displayMin.value;
     const dMax = engine.displayMax.value;
     const out: (ReferenceBadgeRect | null)[] = [];
+    const dv = dragValues?.value;
     for (let i = 0; i < lines.length; i++) {
       out.push(
-        computeReferenceBadgeRect(lines[i], w, h, padding, dMin, dMax, font, formatValue),
+        computeReferenceBadgeRect(
+          lines[i],
+          w,
+          h,
+          padding,
+          dMin,
+          dMax,
+          font,
+          formatValue,
+          dv ? dv[i] : undefined,
+        ),
       );
     }
     return out;

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -73,6 +73,8 @@ export type {
   PulseConfig,
   ReferenceLine,
   ReferenceLineBadgeConfig,
+  ReferenceLineGroupingConfig,
+  ReferenceLineRenderProps,
   ScrubActionConfig,
   ScrubActionPoint,
   ScrubConfig,

--- a/packages/react-native-livechart/src/math/referenceDrag.ts
+++ b/packages/react-native-livechart/src/math/referenceDrag.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure, worklet-safe helpers for dragging a Form-A reference line along the
+ * Y-axis. Kept free of hooks / SharedValues so they unit-test without Reanimated
+ * (the gesture wiring lives in {@link useReferenceDrag}).
+ */
+
+/** Clamp a value to an optional `[min, max]` bound (order-independent). No-op when
+ *  `bounds` is omitted. */
+export function clampToBounds(
+  value: number,
+  bounds?: [number, number],
+): number {
+  "worklet";
+  if (!bounds) return value;
+  const lo = Math.min(bounds[0], bounds[1]);
+  const hi = Math.max(bounds[0], bounds[1]);
+  return Math.min(hi, Math.max(lo, value));
+}
+
+/**
+ * Index of the draggable line whose handle-Y is nearest the touch `y`, within
+ * `slop` px — or `-1` when none is in reach. `handleYs` is index-aligned with the
+ * chart's `referenceLines`; entries `< 0` (not draggable / off-screen / not laid
+ * out) are skipped. Ties favor the later (topmost-drawn) line.
+ */
+export function nearestDraggableIndex(
+  handleYs: number[],
+  y: number,
+  slop: number,
+): number {
+  "worklet";
+  let best = -1;
+  let bestDist = slop;
+  for (let i = 0; i < handleYs.length; i++) {
+    const hy = handleYs[i];
+    if (hy < 0) continue;
+    const d = Math.abs(hy - y);
+    if (d <= bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/**
+ * Whether a line's value sits **outside** its watched interval — the trigger for
+ * `onDragOut` / `onDragIn` (edge-detected by the caller). When `bounds` is set the
+ * watched interval is `bounds` (at-or-past a bound counts as out, since the drag
+ * clamps there); otherwise it's the visible `[min, max]` Y-range (out = scrolled /
+ * dragged off-screen).
+ */
+export function referenceValueOut(
+  value: number,
+  min: number,
+  max: number,
+  bounds?: [number, number],
+): boolean {
+  "worklet";
+  if (bounds) {
+    const lo = Math.min(bounds[0], bounds[1]);
+    const hi = Math.max(bounds[0], bounds[1]);
+    return value <= lo || value >= hi;
+  }
+  return value < min || value > max;
+}

--- a/packages/react-native-livechart/src/math/referenceGroup.ts
+++ b/packages/react-native-livechart/src/math/referenceGroup.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure, worklet-safe clustering for reference-line grouping — collapse Form-A
+ * lines whose value-Y positions sit near each other into one count handle. Free of
+ * hooks / SharedValues so it unit-tests without Reanimated; the per-frame call +
+ * rendering live in the controller / `ReferenceLineGroupOverlay`.
+ */
+
+/** One collapsed cluster of nearby reference lines. */
+export interface ReferenceGroup {
+  /** Centroid Y (canvas px) of the cluster — where the count handle is drawn. */
+  cy: number;
+  /** Number of lines collapsed into the cluster (≥ 2). */
+  count: number;
+}
+
+/** Result of clustering a frame's reference-line Y positions. */
+export interface ReferenceGrouping {
+  /**
+   * Index-aligned with the input Ys: `true` when this line's individual tag is
+   * collapsed into a cluster (a multi-line group) and should be suppressed.
+   */
+  hidden: boolean[];
+  /** One entry per multi-line cluster (singletons render normally, never here). */
+  groups: ReferenceGroup[];
+}
+
+/**
+ * Single-linkage cluster of reference-line handle Ys: lines whose sorted Y gaps are
+ * all `<= radius` chain into one group. Entries `< 0` (not a Form-A line / off the
+ * canvas) are ignored. Returns which lines are collapsed (`hidden`) plus a centroid
+ * + count per multi-line cluster. A non-positive `radius` disables grouping.
+ */
+export function groupReferenceLines(
+  ys: number[],
+  radius: number,
+): ReferenceGrouping {
+  "worklet";
+  const hidden: boolean[] = [];
+  for (let i = 0; i < ys.length; i++) hidden.push(false);
+  const groups: ReferenceGroup[] = [];
+  if (radius <= 0) return { hidden, groups };
+
+  const pts: { i: number; y: number }[] = [];
+  for (let i = 0; i < ys.length; i++) {
+    if (ys[i] >= 0) pts.push({ i, y: ys[i] });
+  }
+  pts.sort((a, b) => a.y - b.y);
+
+  let c = 0;
+  while (c < pts.length) {
+    let j = c;
+    let sum = pts[c].y;
+    while (j + 1 < pts.length && pts[j + 1].y - pts[j].y <= radius) {
+      j++;
+      sum += pts[j].y;
+    }
+    const count = j - c + 1;
+    if (count > 1) {
+      for (let k = c; k <= j; k++) hidden[pts[k].i] = true;
+      groups.push({ cy: sum / count, count });
+    }
+    c = j + 1;
+  }
+  return { hidden, groups };
+}

--- a/packages/react-native-livechart/src/math/referenceLines.ts
+++ b/packages/react-native-livechart/src/math/referenceLines.ts
@@ -42,7 +42,7 @@ export function collectReferenceValues(lines: ReferenceLine[]): number[] {
 
 /** Fully-resolved badge presentation for a Form-A reference line. */
 export interface ResolvedReferenceBadge {
-  position: "left" | "right";
+  position: "left" | "center" | "right";
   /** Leading glyph, or "" for none. */
   icon: string;
   /** Whether the text label is shown. */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -135,6 +135,55 @@ export interface ReferenceLine {
   badgeBorderColor?: string;
   /** Badge pill corner radius in pixels. Default `5`. (Fallback for `badge.radius`.) */
   badgeRadius?: number;
+
+  // ── Draggable (Form A only) ───────────────────────────────────────────────
+  /**
+   * Make this Form-A line **draggable** along the Y-axis — grab its handle / badge
+   * and drag to set a new value (a working-order price, alert level, or target).
+   * The line tracks the finger on the UI thread; {@link onChange} / {@link onCommit}
+   * report the value to JS. The line is *uncontrolled* by default (it stays where
+   * you drop it); pair `onCommit` with writing the value back into `value` to make
+   * it controlled. No effect on bands / time bands. Default `false`.
+   */
+  draggable?: boolean;
+  /**
+   * Snap the dragged value to this increment (e.g. `0.01` for cents, `0.5` for a
+   * tick size) so drops land on round levels. Omit for free dragging. Applies only
+   * while {@link draggable}.
+   */
+  snap?: number;
+  /**
+   * Hard-clamp the draggable value to `[min, max]` in Y-axis units — the line
+   * can't be dragged past either end. Omit for unbounded (clamped only to the
+   * visible range). Reaching a bound fires {@link onDragOut}. Applies only while
+   * {@link draggable}.
+   */
+  bounds?: [number, number];
+  /**
+   * Fired on the JS thread *while* dragging, each time the (snapped, clamped)
+   * value changes. De-duplicated to value changes — not every frame. Form-A
+   * draggable only.
+   */
+  onChange?: (value: number) => void;
+  /**
+   * Fired once on the JS thread when the drag ends (finger up), with the final
+   * (snapped, clamped) value. Pair with a controlled `value` to persist the move.
+   * Form-A draggable only.
+   */
+  onCommit?: (value: number) => void;
+  /**
+   * Fired on the JS thread when the line's value crosses **into** its watched
+   * interval — the visible Y-range, or {@link bounds} when set. Triggers from
+   * dragging *or* the axis rescaling under a fixed value (e.g. a target scrolling
+   * back into view). Edge-triggered: once per crossing. Form-A only.
+   */
+  onDragIn?: (value: number) => void;
+  /**
+   * Fired on the JS thread when the line's value crosses **out of** its watched
+   * interval (the visible Y-range, or {@link bounds}) — dragged/scrolled off-screen
+   * or pinned at a bound. Edge-triggered: once per crossing. Form-A only.
+   */
+  onDragOut?: (value: number) => void;
 }
 
 /**
@@ -144,8 +193,12 @@ export interface ReferenceLine {
  * nearest edge with a chevron once the value scrolls off-screen.
  */
 export interface ReferenceLineBadgeConfig {
-  /** Which plot edge the badge pins to. Default `"left"`. */
-  position?: "left" | "right";
+  /**
+   * Where the badge pins horizontally. `"left"` / `"right"` pin to that plot edge
+   * with a dashed connector running to the opposite edge; `"center"` floats the
+   * pill centered in the plot at the line's value (no connector). Default `"left"`.
+   */
+  position?: "left" | "center" | "right";
   /**
    * Leading glyph drawn in the badge — rendered with the chart font, so pass an
    * emoji-capable font (via the chart `font` prop) for emoji. Like `Marker.icon`.
@@ -161,6 +214,54 @@ export interface ReferenceLineBadgeConfig {
   /** Pill border color. Falls back to `badgeBorderColor`, then the line `color`. */
   borderColor?: string;
   /** Pill corner radius in pixels. Falls back to `badgeRadius`, then `5`. */
+  radius?: number;
+}
+
+/**
+ * Context passed to a custom {@link LiveChartProps.renderReferenceLine}. The chart
+ * floats the element you return over the canvas and pins it to the line's value on
+ * the UI thread (vertically centered on the line, horizontally at the badge /
+ * label position) — so it tracks the rescaling axis and any drag smoothly without
+ * JS re-renders, just like {@link TooltipRenderProps}. Replaces the built-in pill
+ * badge / gutter label for that line; return `null`/`undefined` to keep the
+ * built-in. Bind the SharedValues to animated text (e.g. an animated `TextInput`)
+ * for the value to update on the UI thread too.
+ */
+export interface ReferenceLineRenderProps {
+  /** The reference line being rendered. */
+  line: ReferenceLine;
+  /** Its index in the `referenceLines` array. */
+  index: number;
+  /** Live Y-axis value of the line — tracks dragging when {@link ReferenceLine.draggable}. */
+  value: SharedValue<number>;
+  /** The value formatted with the chart's `formatValue` (computed UI-side). */
+  valueStr: SharedValue<string>;
+  /** Canvas Y pixel of the line, recomputed each frame (`-1` when not laid out). */
+  y: SharedValue<number>;
+  /** Whether the value currently sits within the visible plot range. */
+  inRange: SharedValue<boolean>;
+  /**
+   * Which visible edge the value is pinned to when off-screen: `"above"` (past the
+   * top), `"below"` (past the bottom), or `"in"`. Use it to flip a directional
+   * chevron on a custom off-axis handle.
+   */
+  edge: SharedValue<"above" | "in" | "below">;
+  /** Whether this line is currently being dragged. */
+  dragging: SharedValue<boolean>;
+}
+
+/**
+ * Grouping behavior for reference lines (single-series). When enabled, Form-A
+ * lines whose handles fall within {@link ReferenceLineGroupingConfig.radius} px of
+ * each other collapse into a single count handle, so a cluster of nearby orders /
+ * alerts reads as one tag instead of an unreadable pile. Pass `true` for defaults
+ * or an object to tune the proximity radius.
+ */
+export interface ReferenceLineGroupingConfig {
+  /**
+   * Collapse lines whose value-Y positions are within this many px of each other.
+   * Default `18`.
+   */
   radius?: number;
 }
 
@@ -1575,6 +1676,28 @@ export interface LiveChartProps extends LiveChartCoreProps {
    * routed here, not to reticle placement). Single-series only.
    */
   onReferenceLinePress?: (line: ReferenceLine, index: number) => void;
+  /**
+   * Render a reference line's tag as a custom **React Native** element instead of
+   * the built-in Skia pill / gutter label — the same model as `renderMarker` /
+   * `renderTooltip`. The chart floats the returned element over the canvas and
+   * pins it to the line's value on the UI thread (see {@link ReferenceLineRenderProps}),
+   * so it tracks the rescaling axis and any drag without JS re-renders. Called per
+   * Form-A line; return `null`/`undefined` to keep that line's built-in tag. Works
+   * with `badge: false` too (replace the plain gutter label). Single-series only.
+   */
+  renderReferenceLine?: (
+    ctx: ReferenceLineRenderProps,
+  ) => ReactElement | null | undefined;
+  /**
+   * Collapse Form-A reference lines whose handles sit near the same value into a
+   * single count handle (e.g. a stack of working orders at adjacent prices reads
+   * as one "×3" tag). `true` = defaults, `false`/omitted = off, or pass a
+   * {@link ReferenceLineGroupingConfig} to tune the proximity radius. Lines a
+   * {@link LiveChartProps.renderReferenceLine} owns are excluded (their custom tag
+   * draws itself), so the count reflects only collapsed built-in tags. Single-series
+   * only. Default off.
+   */
+  referenceLineGrouping?: boolean | ReferenceLineGroupingConfig;
   /**
    * Volume bars below the candles (candle mode only). `true` = defaults,
    * `false`/omitted = off, or pass a {@link VolumeConfig} for colors, band

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -270,6 +270,43 @@ describe("LiveChart", () => {
     render(<ComboHarness />);
   });
 
+  it("renders draggable, custom-rendered, and grouped reference lines", () => {
+    const screen = render(
+      <Harness
+        referenceLines={[
+          {
+            value: 50,
+            draggable: true,
+            snap: 0.5,
+            bounds: [0, 100],
+            onChange: jest.fn(),
+            onCommit: jest.fn(),
+            onDragIn: jest.fn(),
+            onDragOut: jest.fn(),
+          },
+          { value: 51 }, // near 50 → collapses into a group
+          { value: 52, badge: true }, // custom-rendered tag
+        ]}
+        renderReferenceLine={({ line }) =>
+          line.value === 52 ? <View testID="custom-ref" /> : null
+        }
+        referenceLineGrouping={{ radius: 40 }}
+      />,
+    );
+    // The custom-rendered tag is floated as an RN view (built-in tag suppressed).
+    expect(screen.queryByTestId("custom-ref")).toBeTruthy();
+  });
+
+  it("accepts a boolean referenceLineGrouping and a non-draggable custom line", () => {
+    render(
+      <Harness
+        referenceLines={[{ value: 50 }, { value: 50.2 }]}
+        referenceLineGrouping
+        renderReferenceLine={() => <View testID="rl" />}
+      />,
+    );
+  });
+
   it("accepts custom formatters", () => {
     render(
       <Harness formatValue={(v) => v.toFixed(4)} formatTime={() => "x"} />,

--- a/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { Text, View } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+
+import {
+  CustomReferenceLineOverlay,
+  customReferenceLineFlags,
+} from "../../src/components/CustomReferenceLineOverlay";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import type { ReferenceLine } from "../../src/types";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+function engine(
+  partial: Partial<{ canvasHeight: number; displayMin: number; displayMax: number }> = {},
+): ChartEngineLayout {
+  return withSharedValueAccessors({
+    displayMin: { value: partial.displayMin ?? 0 },
+    displayMax: { value: partial.displayMax ?? 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: partial.canvasHeight ?? 300 },
+    timestamp: { value: 1000 },
+  }) as unknown as ChartEngineLayout;
+}
+
+const fmt = (v: number) => v.toFixed(2);
+
+describe("customReferenceLineFlags", () => {
+  it("returns all-false when no render is provided", () => {
+    expect(
+      customReferenceLineFlags([{ value: 5 }, { valueFrom: 1, valueTo: 2 }]),
+    ).toEqual([false, false]);
+  });
+
+  it("flags only the Form-A lines the render returns an element for", () => {
+    const flags = customReferenceLineFlags(
+      [
+        { value: 5 }, // → element
+        { value: 9 }, // → null (falls back)
+        { valueFrom: 1, valueTo: 2 }, // band → never custom
+        { from: 1, to: 2 }, // time band → never custom
+      ],
+      ({ line }) => (line.value === 5 ? <Text>{line.value}</Text> : null),
+    );
+    expect(flags).toEqual([true, false, false, false]);
+  });
+
+  it("exposes readable ctx SharedValue stubs to the probe", () => {
+    const flags = customReferenceLineFlags([{ value: 42 }], (ctx) =>
+      ctx.value.get() === 42 && ctx.edge.get() === "in" ? <Text>ok</Text> : null,
+    );
+    expect(flags).toEqual([true]);
+  });
+});
+
+describe("CustomReferenceLineOverlay", () => {
+  function Fixture({
+    lines,
+    render,
+    eng = engine(),
+  }: {
+    lines: ReferenceLine[];
+    render: Parameters<typeof CustomReferenceLineOverlay>[0]["renderReferenceLine"];
+    eng?: ChartEngineLayout;
+  }) {
+    const dragValues = useSharedValue<number[]>(lines.map((l) => l.value ?? 0));
+    const dragActive = useSharedValue<boolean[]>(lines.map(() => false));
+    return (
+      <CustomReferenceLineOverlay
+        lines={lines}
+        renderReferenceLine={render}
+        custom={customReferenceLineFlags(lines, render)}
+        engine={eng}
+        padding={DEFAULT_PADDING}
+        formatValue={fmt}
+        dragValues={dragValues}
+        dragActive={dragActive}
+      />
+    );
+  }
+
+  it("floats a custom element for each Form-A line the render handles", () => {
+    const { getByTestId } = render(
+      <Fixture
+        lines={[{ value: 30 }, { value: 60 }]}
+        render={({ index }) => <Text testID={`rl-${index}`}>{index}</Text>}
+      />,
+    );
+    expect(getByTestId("rl-0")).toBeTruthy();
+    expect(getByTestId("rl-1")).toBeTruthy();
+  });
+
+  it("skips bands and time bands (Form-A only)", () => {
+    const { queryByTestId } = render(
+      <Fixture
+        lines={[{ valueFrom: 10, valueTo: 20 }, { from: 1, to: 2 }]}
+        render={({ index }) => <Text testID={`rl-${index}`}>{index}</Text>}
+      />,
+    );
+    expect(queryByTestId("rl-0")).toBeNull();
+    expect(queryByTestId("rl-1")).toBeNull();
+  });
+
+  it("renders nothing when the render opts out of every line", () => {
+    const { toJSON } = render(
+      <Fixture lines={[{ value: 30 }]} render={() => null} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders only the lines the render returns an element for", () => {
+    const { getByTestId, queryByTestId } = render(
+      <Fixture
+        lines={[{ value: 30 }, { value: 60 }]}
+        render={({ line, index }) =>
+          line.value === 30 ? <Text testID={`rl-${index}`}>{index}</Text> : null
+        }
+      />,
+    );
+    expect(getByTestId("rl-0")).toBeTruthy();
+    expect(queryByTestId("rl-1")).toBeNull();
+  });
+
+  it("pins across left / center / right anchors and an off-screen value", () => {
+    const { getByTestId } = render(
+      <Fixture
+        lines={[
+          { value: 30, badge: { position: "left" } },
+          { value: 50, badge: { position: "center" } },
+          { value: 70, badge: { position: "right" } },
+          { value: 150 }, // off-screen above → pinned to the top edge
+        ]}
+        render={({ index }) => (
+          <View testID={`rl-${index}`} style={{ width: 40, height: 16 }} />
+        )}
+      />,
+    );
+    // Drive onLayout so the measure + transform branches execute for each anchor.
+    for (let i = 0; i < 4; i++) {
+      fireEvent(getByTestId(`rl-${i}`).parent!, "layout", {
+        nativeEvent: { layout: { x: 0, y: 0, width: 40, height: 16 } },
+      });
+      expect(getByTestId(`rl-${i}`)).toBeTruthy();
+    }
+  });
+
+  it("hides the element when the canvas is not laid out", () => {
+    const { getByTestId } = render(
+      <Fixture
+        lines={[{ value: 30 }]}
+        render={({ index }) => <Text testID={`rl-${index}`}>{index}</Text>}
+        eng={engine({ canvasHeight: 0 })}
+      />,
+    );
+    // Still mounted (opacity 0), exercising the raw < 0 branch.
+    expect(getByTestId("rl-0")).toBeTruthy();
+  });
+});

--- a/packages/react-native-livechart/tests/components/ReferenceLineGroupOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ReferenceLineGroupOverlay.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react-native";
+
+import { ReferenceLineGroupOverlay } from "../../src/components/ReferenceLineGroupOverlay";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import type { ReferenceGrouping } from "../../src/math/referenceGroup";
+import { resolveTheme } from "../../src/theme";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+const font = {
+  getSize: () => 12,
+  measureText: (s: string) => ({ x: 0, y: 0, width: s.length * 7, height: 12 }),
+  getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+} as never;
+
+const palette = resolveTheme("#3b82f6", "dark");
+
+function sv(value: ReferenceGrouping) {
+  return withSharedValueAccessors({ v: { value } }).v as never;
+}
+
+describe("ReferenceLineGroupOverlay", () => {
+  it("renders a count pill for each multi-line cluster", () => {
+    const grouping = sv({
+      hidden: [true, true, true],
+      groups: [{ cy: 150, count: 3 }],
+    });
+    render(
+      <ReferenceLineGroupOverlay
+        grouping={grouping}
+        padding={DEFAULT_PADDING}
+        palette={palette}
+        font={font}
+      />,
+    );
+  });
+
+  it("renders nothing visible when there are no groups", () => {
+    const grouping = sv({ hidden: [], groups: [] });
+    render(
+      <ReferenceLineGroupOverlay
+        grouping={grouping}
+        padding={DEFAULT_PADDING}
+        palette={palette}
+        font={font}
+      />,
+    );
+  });
+
+  it("renders multiple clusters at once", () => {
+    const grouping = sv({
+      hidden: [true, true, true, true],
+      groups: [
+        { cy: 80, count: 2 },
+        { cy: 220, count: 2 },
+      ],
+    });
+    render(
+      <ReferenceLineGroupOverlay
+        grouping={grouping}
+        padding={DEFAULT_PADDING}
+        palette={palette}
+        font={font}
+      />,
+    );
+  });
+});

--- a/packages/react-native-livechart/tests/hooks/useReferenceDrag.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useReferenceDrag.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react-native";
+import { useSharedValue } from "react-native-reanimated";
+
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import { useReferenceDrag } from "../../src/hooks/useReferenceDrag";
+import type { ReferenceLine } from "../../src/types";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+function engine(): ChartEngineLayout {
+  return withSharedValueAccessors({
+    displayMin: { value: 0 },
+    displayMax: { value: 100 },
+    displayWindow: { value: 30 },
+    canvasWidth: { value: 400 },
+    canvasHeight: { value: 300 },
+    timestamp: { value: 0 },
+  }) as unknown as ChartEngineLayout;
+}
+
+function setup(lines: ReferenceLine[], enabled = true) {
+  return renderHook(() => {
+    const dragValues = useSharedValue<number[]>(lines.map((l) => l.value ?? 0));
+    const dragActive = useSharedValue<boolean[]>(lines.map(() => false));
+    return useReferenceDrag(
+      engine(),
+      DEFAULT_PADDING,
+      lines,
+      dragValues,
+      dragActive,
+      enabled,
+    );
+  });
+}
+
+describe("useReferenceDrag", () => {
+  it("returns a gesture for a draggable line", () => {
+    const { result } = setup([{ value: 50, draggable: true }]);
+    expect(result.current).toBeTruthy();
+  });
+
+  it("returns a gesture when nothing is draggable", () => {
+    const { result } = setup([{ value: 50 }, { valueFrom: 10, valueTo: 20 }]);
+    expect(result.current).toBeTruthy();
+  });
+
+  it("sets up the onDragIn/Out reaction when those callbacks exist", () => {
+    const { result } = setup([
+      { value: 50, draggable: true, snap: 1, bounds: [0, 90], onDragOut: () => {} },
+      { value: 70, onDragIn: () => {} },
+    ]);
+    expect(result.current).toBeTruthy();
+  });
+
+  it("is inert for a static chart (enabled = false)", () => {
+    const { result } = setup([{ value: 50, draggable: true }], false);
+    expect(result.current).toBeTruthy();
+  });
+});

--- a/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
@@ -469,6 +469,45 @@ describe("useReferenceLine", () => {
     expect(l.chevronUp).toBe(true);
     expect(l.chevronCx).toBeGreaterThanOrEqual(0);
   });
+
+  it("center-floats the pill at the value with no connector", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, badge: { position: "center" } },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.badge).toBe(true);
+    // Pill centered between the plot edges (x1=12, x2=320 → mid 166).
+    const plotMid = (12 + 320) / 2;
+    expect(l.pillX + l.pillW / 2).toBeCloseTo(plotMid);
+    // No connector for a center badge.
+    expect(l.connStart).toBe(-1);
+    expect(l.connEnd).toBe(-1);
+    // Not a plain line (badge owns the rendering).
+    expect(l.drawLine).toBe(false);
+  });
+
+  it("center-floats an off-screen badge centered at the pinned edge", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 150, badge: { position: "center" } },
+        fmt,
+        font,
+      ),
+    );
+    const l = result.current.value;
+    expect(l.offAxis).toBe(true);
+    expect(l.badge).toBe(true);
+    expect(l.pillX + l.pillW / 2).toBeCloseTo((12 + 320) / 2);
+    expect(l.connStart).toBe(-1);
+  });
 });
 
 describe("computeReferenceBadgeRect", () => {
@@ -512,5 +551,12 @@ describe("computeReferenceBadgeRect", () => {
     expect(r).not.toBeNull();
     // Off-axis above → y = chartTop + 12 = 24; centered pill top = 15.
     expect(r.y).toBeCloseTo(15);
+  });
+
+  it("centers the hit rect for a center-positioned badge", () => {
+    const r = call({ value: 50, badge: { position: "center" } })!;
+    expect(r).not.toBeNull();
+    // Centered between plot edges (x1=12, x2=320).
+    expect(r.x + r.w / 2).toBeCloseTo((12 + 320) / 2);
   });
 });

--- a/packages/react-native-livechart/tests/math/referenceDrag.test.ts
+++ b/packages/react-native-livechart/tests/math/referenceDrag.test.ts
@@ -1,0 +1,72 @@
+import {
+  clampToBounds,
+  nearestDraggableIndex,
+  referenceValueOut,
+} from "../../src/math/referenceDrag";
+
+describe("clampToBounds", () => {
+  it("returns the value unchanged without bounds", () => {
+    expect(clampToBounds(5)).toBe(5);
+    expect(clampToBounds(-100)).toBe(-100);
+  });
+
+  it("clamps below min and above max", () => {
+    expect(clampToBounds(-1, [0, 10])).toBe(0);
+    expect(clampToBounds(11, [0, 10])).toBe(10);
+    expect(clampToBounds(5, [0, 10])).toBe(5);
+  });
+
+  it("accepts reversed bounds", () => {
+    expect(clampToBounds(5, [10, 0])).toBe(5);
+    expect(clampToBounds(-1, [10, 0])).toBe(0);
+    expect(clampToBounds(99, [10, 0])).toBe(10);
+  });
+});
+
+describe("nearestDraggableIndex", () => {
+  it("returns -1 when none is within slop", () => {
+    expect(nearestDraggableIndex([100, 200], 10, 14)).toBe(-1);
+  });
+
+  it("returns -1 for an empty list", () => {
+    expect(nearestDraggableIndex([], 10, 14)).toBe(-1);
+  });
+
+  it("skips -1 (non-draggable / off-screen) entries", () => {
+    expect(nearestDraggableIndex([-1, 50], 52, 14)).toBe(1);
+  });
+
+  it("picks the nearest line within slop", () => {
+    expect(nearestDraggableIndex([40, 60], 58, 14)).toBe(1);
+    expect(nearestDraggableIndex([40, 60], 44, 14)).toBe(0);
+  });
+
+  it("favors the later (topmost-drawn) index on a tie", () => {
+    expect(nearestDraggableIndex([50, 50], 50, 14)).toBe(1);
+  });
+});
+
+describe("referenceValueOut", () => {
+  it("uses the visible range when no bounds are given", () => {
+    expect(referenceValueOut(5, 0, 10)).toBe(false);
+    expect(referenceValueOut(-1, 0, 10)).toBe(true);
+    expect(referenceValueOut(11, 0, 10)).toBe(true);
+  });
+
+  it("treats the exact visible bounds as in-range", () => {
+    expect(referenceValueOut(0, 0, 10)).toBe(false);
+    expect(referenceValueOut(10, 0, 10)).toBe(false);
+  });
+
+  it("watches the bounds interval when provided (at-or-past a bound is out)", () => {
+    expect(referenceValueOut(5, 0, 100, [0, 10])).toBe(false);
+    expect(referenceValueOut(10, 0, 100, [0, 10])).toBe(true);
+    expect(referenceValueOut(0, 0, 100, [0, 10])).toBe(true);
+    expect(referenceValueOut(11, 0, 100, [0, 10])).toBe(true);
+  });
+
+  it("accepts reversed bounds", () => {
+    expect(referenceValueOut(5, 0, 100, [10, 0])).toBe(false);
+    expect(referenceValueOut(10, 0, 100, [10, 0])).toBe(true);
+  });
+});

--- a/packages/react-native-livechart/tests/math/referenceGroup.test.ts
+++ b/packages/react-native-livechart/tests/math/referenceGroup.test.ts
@@ -1,0 +1,52 @@
+import { groupReferenceLines } from "../../src/math/referenceGroup";
+
+describe("groupReferenceLines", () => {
+  it("returns all-visible with no groups when lines are far apart", () => {
+    const r = groupReferenceLines([10, 100, 200], 18);
+    expect(r.hidden).toEqual([false, false, false]);
+    expect(r.groups).toEqual([]);
+  });
+
+  it("collapses two near lines into one group at their centroid", () => {
+    const r = groupReferenceLines([100, 110], 18);
+    expect(r.hidden).toEqual([true, true]);
+    expect(r.groups).toEqual([{ cy: 105, count: 2 }]);
+  });
+
+  it("chains three near lines into a single group", () => {
+    const r = groupReferenceLines([100, 110, 120], 18);
+    expect(r.hidden).toEqual([true, true, true]);
+    expect(r.groups).toHaveLength(1);
+    expect(r.groups[0].count).toBe(3);
+    expect(r.groups[0].cy).toBeCloseTo(110);
+  });
+
+  it("keeps a distant singleton out of a nearby cluster (order-independent)", () => {
+    // Indices 0 and 2 are near; index 1 is far — clustering sorts by Y first.
+    const r = groupReferenceLines([100, 300, 110], 18);
+    expect(r.hidden).toEqual([true, false, true]);
+    expect(r.groups).toHaveLength(1);
+    expect(r.groups[0].count).toBe(2);
+  });
+
+  it("skips -1 (non-Form-A / off-canvas) entries", () => {
+    const r = groupReferenceLines([-1, 100, 110, -1], 18);
+    expect(r.hidden).toEqual([false, true, true, false]);
+    expect(r.groups).toHaveLength(1);
+  });
+
+  it("groups at exactly the radius gap, but not beyond", () => {
+    expect(groupReferenceLines([100, 118], 18).groups).toHaveLength(1); // gap == radius
+    expect(groupReferenceLines([100, 119], 18).groups).toHaveLength(0); // gap > radius
+  });
+
+  it("disables grouping for a non-positive radius", () => {
+    const r = groupReferenceLines([100, 105], 0);
+    expect(r.hidden).toEqual([false, false]);
+    expect(r.groups).toEqual([]);
+  });
+
+  it("returns empty for no lines", () => {
+    expect(groupReferenceLines([], 18)).toEqual({ hidden: [], groups: [] });
+  });
+});


### PR DESCRIPTION
## What

Adds a full interaction model to Form-A `ReferenceLine`s — for working orders, price alerts, and targets. Four capabilities, all backward-compatible and opt-in:

- **Draggable lines** — `draggable` lets you grab a line and drag it along the Y-axis, with `snap` (round to a tick), `bounds` (hard clamp), and per-line callbacks `onChange` (during), `onCommit` (on release), and `onDragIn` / `onDragOut` (value crossing the visible range or a bound — from a drag *or* the axis rescaling under a fixed value). Uncontrolled by default; pair `onCommit` with `value` for a controlled line.
- **Custom tags** — `renderReferenceLine(ctx)` floats any React Native view at a line's value (the `renderMarker` / `renderTooltip` model), tracking the axis and any drag on the UI thread via the `ReferenceLineRenderProps` SharedValues. Replaces the built-in pill / gutter label (return `null` to keep it; works with `badge: false`).
- **Center badge** — `ReferenceLineBadgeConfig.position` accepts `"center"`, floating the pill at the value with no connector.
- **Grouping** — `referenceLineGrouping` collapses lines whose handles sit near the same value into a single count handle.

## How

- Value flows through a controller-owned `dragValues` array (one SharedValue for a variable line count) feeding the Skia line, the custom overlay, and the press hit-rect. Reconciliation distinguishes a controlled prop change from an uncontrolled dropped value.
- The drag gesture (`useReferenceDrag`) is a manual-activation vertical `Pan` gated on grabbing near a line, composed as the outermost `Gesture.Exclusive` so it fails fast and falls through to scrub / scroll.
- Built-in Skia tags are suppressed per-line for custom-rendered lines (a `renderMarker`-style probe) and for grouped lines (per-frame proximity clustering).

## Test plan

- New unit tests for all pure logic (`referenceDrag`, `referenceGroup`, center-badge geometry, the custom-overlay probe, the grouping overlay) plus a `LiveChart` integration test. **86 suites / 1122 tests green; coverage above the 95 / 90 / 95 / 95 thresholds.**
- **Manual:** the new **Working orders** demo (`app/demo/working-orders.tsx` → Annotations → Working orders) exercises every change — drag / snap / bounds, all four callbacks (live value + committed value + event log), every badge position, custom replacement of both a badge and a plain gutter label, and grouping. Gesture / UI-thread behavior should be sanity-checked on a device, since Jest can't run the gesture worklets.

## Notes

- Docs updated: guide + API reference + `CHANGELOG.md` (Unreleased).
- The example-app typecheck flags the new demo route in the expo-router `Href` union — the generated `.expo/types/router.d.ts` is stale (it's missing the existing `/demo/time-scroll` route too) and regenerates on `expo start`; runtime navigation is unaffected. CI runs `npm test`, which passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Post-review fixes (folded into this branch)

- **Smooth drag past the axis edge** — dragging a line toward/past the visible edge now expands the Y-axis so the line follows the finger in one motion (live drag values feed the engine's auto-fit), instead of needing release-and-re-grab.
- **Grouping count accuracy** — custom-rendered lines (`renderReferenceLine`) are excluded from grouping, so the count pill reflects only the built-in tags that actually collapse (no double-count).

Both verified on the iOS 26.4 simulator.
