### PR TITLE
feat(scrub): "point" tooltip placement that follows the scrub dot

### DIFF
--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -37,10 +37,12 @@ type TooltipPlacement = NonNullable<ScrubConfig["tooltipPlacement"]>;
 
 // Placement applies to BOTH the built-in pill and a custom `renderTooltip` —
 // the chart positions either one on the UI thread per `tooltipPlacement`.
+// `"point"` follows the scrub dot (floats above it, flipping below near the top).
 const PLACEMENT_OPTIONS: { value: TooltipPlacement; label: string }[] = [
   { value: "side", label: "Side" },
   { value: "top", label: "Top" },
   { value: "bottom", label: "Bottom" },
+  { value: "point", label: "Point" },
 ];
 
 // Gap between the tooltip and the plot edge it's pinned to (`tooltipMargin`).

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -249,7 +249,7 @@ interface ScrubConfig {
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;
   tooltipBorderRadius?: number; // pill corner radius; default 5
-  tooltipPlacement?: "side" | "top" | "bottom"; // default "side" (offset/flip); top/bottom center over the line
+  tooltipPlacement?: "side" | "top" | "bottom" | "point"; // default "side" (offset/flip); top/bottom center over the line; point floats above the scrub dot
   tooltipMargin?: number; // gap (px) to the pinned plot edge (top for side/top, bottom for bottom); default 8
   tooltipShowValue?: boolean; tooltipShowTime?: boolean; // default both true; drop a row (e.g. date-only)
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -41,7 +41,7 @@ the crosshair. Reshape it with `ScrubConfig` knobs — no custom rendering requi
   data={data}
   value={value}
   scrub={{
-    tooltipPlacement: "top",     // "side" (default) | "top" | "bottom"
+    tooltipPlacement: "top",     // "side" (default) | "top" | "bottom" | "point"
     tooltipShowValue: false,     // drop the value row → date-only pill
     tooltipBorderRadius: 12,     // pill corner radius; default 5
     tooltipBackground: "#1e293b",
@@ -53,9 +53,12 @@ the crosshair. Reshape it with `ScrubConfig` knobs — no custom rendering requi
 
 - **`tooltipPlacement`** — `"side"` (default) offsets the pill to the right of the scrub line and
   flips it left near the right edge. `"top"` / `"bottom"` center it horizontally over the line,
-  clamped into the plot and pinned to the plot's top or bottom.
+  clamped into the plot and pinned to the plot's top or bottom. `"point"` centers it over the line
+  and floats it just above the scrub dot, flipping below when there isn't room above (single-series
+  line mode; candle mode keeps its top-pinned OHLC stack).
 - **`tooltipMargin`** — the gap (px) between the pill and the plot edge it's pinned to (the top for
-  `"side"` / `"top"`, the bottom for `"bottom"`). Default `8`. Applies to a custom `renderTooltip` too.
+  `"side"` / `"top"`, the bottom for `"bottom"`) — or, for `"point"`, the gap between the scrub dot
+  and the pill. Default `8`. Applies to a custom `renderTooltip` too.
 - **`tooltipShowValue` / `tooltipShowTime`** — both default `true`. Drop a row to show just the date
   (`tooltipShowValue: false`) or just the value. Turning both off keeps the time row.
 - **`tooltipBorderRadius`**, **`tooltipBackground`**, **`tooltipColor`**, **`tooltipBorderColor`** —

--- a/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
@@ -48,6 +48,7 @@ export function CustomTooltipOverlay({
   placement,
   margin = 8,
   lineTop,
+  scrubDotY,
 }: {
   renderTooltip: (ctx: TooltipRenderProps) => React.ReactElement | null | undefined;
   scrubX: SharedValue<number>;
@@ -60,13 +61,16 @@ export function CustomTooltipOverlay({
   tooltipLayout: SharedValue<TooltipLayout>;
   engine: ChartEngineLayout;
   padding: ChartPadding;
-  placement: "side" | "top" | "bottom";
+  placement: "side" | "top" | "bottom" | "point";
   /** Gap (px) between the pill and the plot edge it's pinned to. Default 8. */
   margin?: number;
   /** When `placement` is `"top"`, the overlay publishes the label's bottom edge
    *  (canvas Y) here so {@link CrosshairOverlay} can stop the crosshair line at
    *  the label instead of running through it; -1 when not top-pinned/active. */
   lineTop?: SharedValue<number>;
+  /** Scrub intersection Y in canvas px (the value the dot marks) — the anchor
+   *  for `"point"` placement. Omitted / -1 falls back to a top pin. */
+  scrubDotY?: SharedValue<number>;
 }) {
   // Formatted strings come ready-made off the layout (formatted UI-side in
   // computeTooltipLayout / computeCandleTooltipLayout), so consumers don't need
@@ -125,12 +129,28 @@ export function CustomTooltipOverlay({
         Math.max(sx - s.width / 2, leftBound),
         Math.max(leftBound, rightBound),
       );
-      y =
-        placement === "top"
-          ? // Pin to the canvas top edge (not the plot's inner top), so the label
-            // sits above the data and the crosshair line can stop at it.
-            margin
-          : ch - padding.bottom - margin - s.height;
+      if (placement === "point") {
+        // Float just above the scrub dot, flipping below when there's no room
+        // above; clamp into the plot. Mirrors computeTooltipLayout's "point".
+        const dotY = scrubDotY?.get() ?? -1;
+        if (dotY < 0) {
+          y = padding.top + margin;
+        } else {
+          const topLimit = padding.top + EDGE_GAP;
+          const bottomLimit = ch - padding.bottom - EDGE_GAP - s.height;
+          const aboveY = dotY - margin - s.height;
+          const belowY = dotY + margin;
+          y = aboveY >= topLimit ? aboveY : belowY;
+          y = Math.min(Math.max(y, topLimit), Math.max(topLimit, bottomLimit));
+        }
+      } else {
+        y =
+          placement === "top"
+            ? // Pin to the canvas top edge (not the plot's inner top), so the
+              // label sits above the data and the crosshair line can stop at it.
+              margin
+            : ch - padding.bottom - margin - s.height;
+      }
     }
 
     return {

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1669,6 +1669,7 @@ export function LiveChart(props: LiveChartProps) {
             placement={scrubCfg.tooltipPlacement}
             margin={scrubCfg.tooltipMargin}
             lineTop={crosshair.tooltipLineTop}
+            scrubDotY={crosshair.scrubDotY}
           />
         )}
 

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -149,7 +149,7 @@ export interface ResolvedScrubConfig {
   /** Tooltip pill corner radius in px. */
   tooltipBorderRadius: number;
   /** Where the tooltip pill sits relative to the scrub line. */
-  tooltipPlacement: "side" | "top" | "bottom";
+  tooltipPlacement: "side" | "top" | "bottom" | "point";
   /** Gap (px) between the tooltip and the plot edge it's pinned to. */
   tooltipMargin: number;
   /** Show the value row in the default tooltip body. */

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -204,16 +204,22 @@ export function computeTooltipLayout(
   monoCharWidth = 0,
   /** Where the pill sits relative to the scrub line. `"side"` offsets it right
    *  (flipping left near the edge); `"top"`/`"bottom"` center it over the line,
-   *  clamped into the plot and pinned to the plot's top/bottom. */
-  placement: "side" | "top" | "bottom" = "side",
+   *  clamped into the plot and pinned to the plot's top/bottom; `"point"`
+   *  centers it over the line and floats it just above the scrub dot (flipping
+   *  below when there's no room), deriving its Y from `scrubDotY`. */
+  placement: "side" | "top" | "bottom" | "point" = "side",
   /** Render the value row. */
   showValue = true,
   /** Render the time row. */
   showTime = true,
-  /** Canvas height in px — needed to pin `"bottom"` placement. */
+  /** Canvas height in px — needed to pin `"bottom"`/`"point"` placement. */
   canvasHeight = 0,
-  /** Gap in px between the pill and the plot edge it's pinned to. */
+  /** Gap in px between the pill and the plot edge it's pinned to — and, for
+   *  `"point"`, between the scrub dot's center and the pill's nearest edge. */
   margin = TOOLTIP_TOP_MARGIN,
+  /** Scrub intersection Y in canvas px (see {@link computeScrubDotY}) — the
+   *  anchor for `"point"` placement. -1 (default) falls back to a top pin. */
+  scrubDotY = -1,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || scrubValue === null) return HIDDEN_TOOLTIP;
@@ -267,10 +273,30 @@ export function computeTooltipLayout(
       Math.max(scrubX - pillW / 2, leftBound),
       Math.max(leftBound, rightBound),
     );
-    pillY =
-      placement === "top"
-        ? padding.top + margin
-        : canvasHeight - padding.bottom - margin - totalH;
+    if (placement === "point") {
+      // Float just above the scrub dot, flipping below when there's no room
+      // above; clamp into the plot so the pill never spills past the top/bottom.
+      // A missing dot Y (canvas not laid out) falls back to a top pin.
+      if (scrubDotY < 0) {
+        pillY = padding.top + margin;
+      } else {
+        const topLimit = padding.top + TOOLTIP_EDGE_GAP;
+        const bottomLimit =
+          canvasHeight - padding.bottom - TOOLTIP_EDGE_GAP - totalH;
+        const aboveY = scrubDotY - margin - totalH;
+        const belowY = scrubDotY + margin;
+        pillY = aboveY >= topLimit ? aboveY : belowY;
+        pillY = Math.min(
+          Math.max(pillY, topLimit),
+          Math.max(topLimit, bottomLimit),
+        );
+      }
+    } else {
+      pillY =
+        placement === "top"
+          ? padding.top + margin
+          : canvasHeight - padding.bottom - margin - totalH;
+    }
   }
 
   // line1Y = first rendered row's baseline; line2Y = second (when both shown).
@@ -679,11 +705,12 @@ export function deriveCrosshairTooltipSingle(
   formatTime: (t: number) => string,
   font: SkFont,
   monoCharWidth = 0,
-  placement: "side" | "top" | "bottom" = "side",
+  placement: "side" | "top" | "bottom" | "point" = "side",
   showValue = true,
   showTime = true,
   canvasHeight = 0,
   margin = TOOLTIP_TOP_MARGIN,
+  scrubDotY = -1,
 ): TooltipLayout {
   "worklet";
   if (!scrubActive || scrubTime < 0) return HIDDEN_TOOLTIP;
@@ -703,5 +730,6 @@ export function deriveCrosshairTooltipSingle(
     showTime,
     canvasHeight,
     margin,
+    scrubDotY,
   );
 }

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -130,7 +130,7 @@ export function useCrosshair(
    */
   deferTapHit?: (x: number, y: number) => boolean,
   /** Where the tooltip pill sits relative to the scrub line. Default `"side"`. */
-  tooltipPlacement: "side" | "top" | "bottom" = "side",
+  tooltipPlacement: "side" | "top" | "bottom" | "point" = "side",
   /** Render the value row in the default tooltip. Default `true`. */
   tooltipShowValue = true,
   /** Render the time row in the default tooltip. Default `true`. */
@@ -271,6 +271,7 @@ export function useCrosshair(
       tooltipShowTime,
       engine.canvasHeight.get(),
       tooltipMargin,
+      scrubDotY.get(),
     );
   });
 

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -559,11 +559,13 @@ export interface ScrubConfig {
    * Where the tooltip pill sits relative to the vertical scrub line.
    * `"side"` (default) offsets it to the right of the line and flips left near
    * the right edge. `"top"` / `"bottom"` center it horizontally over the line,
-   * clamped into the plot and pinned to the plot's top or bottom. This also
-   * drives a custom {@link LiveChartProps.renderTooltip} so it gets the same
-   * placement for free.
+   * clamped into the plot and pinned to the plot's top or bottom. `"point"`
+   * centers it over the line and floats it just above the scrub dot, flipping
+   * below the dot when there isn't room above (single-series line mode; candle
+   * mode keeps its top-pinned OHLC stack). This also drives a custom
+   * {@link LiveChartProps.renderTooltip} so it gets the same placement for free.
    */
-  tooltipPlacement?: "side" | "top" | "bottom";
+  tooltipPlacement?: "side" | "top" | "bottom" | "point";
   /**
    * Gap in px between the tooltip and the plot edge it's pinned to — the top for
    * `"side"`/`"top"`, the bottom for `"bottom"`. Applies to the built-in pill and

--- a/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
@@ -41,11 +41,13 @@ function Fixture({
   placement = "side",
   candle,
   captureLineTop,
+  scrubDotY,
 }: {
   renderTooltip: (ctx: TooltipRenderProps) => React.ReactElement | null | undefined;
-  placement?: "side" | "top" | "bottom";
+  placement?: "side" | "top" | "bottom" | "point";
   candle?: CandlePoint | null;
   captureLineTop?: (lineTop: SharedValue<number>) => void;
+  scrubDotY?: number;
 }) {
   const scrubX = useSharedValue(100);
   const scrubValue = useSharedValue<number | null>(42);
@@ -55,6 +57,7 @@ function Fixture({
   const tooltipLayout = useSharedValue<TooltipLayout>(LAYOUT);
   const scrubCandle = useSharedValue<CandlePoint | null>(candle ?? null);
   const lineTop = useSharedValue(-1);
+  const scrubDotYSV = useSharedValue(scrubDotY ?? -1);
   captureLineTop?.(lineTop);
   return (
     <CustomTooltipOverlay
@@ -72,6 +75,7 @@ function Fixture({
       padding={DEFAULT_PADDING}
       placement={placement}
       lineTop={lineTop}
+      scrubDotY={scrubDotYSV}
     />
   );
 }
@@ -197,5 +201,60 @@ describe("CustomTooltipOverlay", () => {
       />,
     );
     expect(bottom.getByTestId("tip-bottom")).toBeTruthy();
+  });
+
+  it("positions for 'point' placement (anchored above the dot) without error", () => {
+    const { getByTestId } = render(
+      <Fixture
+        placement="point"
+        scrubDotY={150}
+        renderTooltip={() => <Text testID="tip-point">tip</Text>}
+      />,
+    );
+    fireEvent(getByTestId("tip-point").parent!, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 80, height: 40 } },
+    });
+    expect(getByTestId("tip-point")).toBeTruthy();
+  });
+
+  it("leaves the crosshair line-stop unset (-1) for 'point' placement", () => {
+    let lineTop: SharedValue<number> | undefined;
+    const { getByTestId } = render(
+      <Fixture
+        placement="point"
+        scrubDotY={150}
+        captureLineTop={(sv) => {
+          lineTop = sv;
+        }}
+        renderTooltip={() => <Text testID="tip-point">tip</Text>}
+      />,
+    );
+    fireEvent(getByTestId("tip-point").parent!, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 80, height: 40 } },
+    });
+    // The pill floats over the line (not above it), so the line runs full height.
+    expect(lineTop!.value).toBe(-1);
+  });
+
+  it("'point' placement flips below / falls back at edge dot positions without error", () => {
+    // Dot near the top → the pill flips below it.
+    const flip = render(
+      <Fixture
+        placement="point"
+        scrubDotY={4}
+        renderTooltip={() => <Text testID="tip-flip">tip</Text>}
+      />,
+    );
+    expect(flip.getByTestId("tip-flip")).toBeTruthy();
+
+    // Unknown dot Y (-1) → top-pin fallback.
+    const fallback = render(
+      <Fixture
+        placement="point"
+        scrubDotY={-1}
+        renderTooltip={() => <Text testID="tip-fallback">tip</Text>}
+      />,
+    );
+    expect(fallback.getByTestId("tip-fallback")).toBeTruthy();
   });
 });

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -431,6 +431,99 @@ describe("computeTooltipLayout", () => {
     expect(right.x + right.w).toBeLessThanOrEqual(400 - padding.right - 4);
   });
 
+  it("placement 'point' floats the pill just above the scrub dot", () => {
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8, // mono advance → deterministic width
+      "point",
+      true,
+      true,
+      300, // canvasHeight
+      8, // margin
+      150, // scrubDotY
+    );
+    // Centered horizontally over scrubX (200)…
+    expect(layout.x + layout.w / 2).toBeCloseTo(200);
+    // …with the pill bottom sitting `margin` above the dot (room above → no flip).
+    expect(layout.y + layout.h).toBe(150 - 8);
+  });
+
+  it("placement 'point' flips below the dot when there's no room above", () => {
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "point",
+      true,
+      true,
+      300,
+      8,
+      20, // scrubDotY near the top → the pill won't fit above it
+    );
+    // Top edge sits `margin` below the dot.
+    expect(layout.y).toBe(20 + 8);
+  });
+
+  it("placement 'point' clamps the pill into the plot near the bottom edge", () => {
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "point",
+      true,
+      true,
+      300,
+      8,
+      295, // scrubDotY near the bottom edge
+    );
+    // Clamped so the pill bottom never crosses the plot's bottom inset.
+    expect(layout.y + layout.h).toBe(300 - padding.bottom - 4);
+  });
+
+  it("placement 'point' falls back to a top pin when the dot Y is unknown (-1)", () => {
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      formatTime,
+      font,
+      8,
+      "point",
+      true,
+      true,
+      300,
+      8,
+      -1, // no dot (canvas not laid out / degenerate range)
+    );
+    expect(layout.y).toBe(padding.top + 8);
+  });
+
   it("drops the value row when showValue is false (date-only, single-row height)", () => {
     const layout = computeTooltipLayout(
       true,


### PR DESCRIPTION
Adds a fourth scrub.tooltipPlacement value, "point", deriving the tooltip's Y from the scrub dot (via the existing computeScrubDotY) instead of pinning it to a plot edge. The pill centers over the crosshair line and floats just above the dot, flipping below when there isn't room above and clamping into the plot.

computeTooltipLayout / deriveCrosshairTooltipSingle take a scrubDotY arg and gain a "point" branch; the built-in Skia pill follows automatically. CustomTooltipOverlay mirrors the math in its UI-thread worklet (new scrubDotY prop), wired from LiveChart. Type union widened in types.ts / resolveConfig.ts / useCrosshair.

Scope: single-series line mode (same as top/bottom); candle mode keeps its top-pinned OHLC stack, multi-series has no library-rendered tooltip. Tests: 4 layout cases + 3 overlay render cases. Demo toggle + docs updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>