### PR TITLE
feat(zoom): pinch-to-zoom, multi-series pan/zoom, and paging callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `fontFamily` / `fontWeight`, and `offsetX` / `offsetY` (on top of the existing
   `position` / `background` / `borderColor` / `radius`). The grouping config also
   gains a `format` fn for the count label (e.g. `n => \`×${n}\``).
+- **Pinch-to-zoom (`zoom`)** on `LiveChart` and `LiveChartSeries`. A new `zoom`
+  prop (`boolean | ZoomConfig`) enables two-finger pinch-to-zoom of the visible
+  time window, anchored at the focal point between your fingers (the time under
+  your fingers stays put). It composes with `timeScroll` — zoom level and scroll
+  position are independent — and is two-finger, so it never competes with the
+  one-finger pan/scrub. `ZoomConfig` tunes `minTimeWindow` (max zoom-in, default
+  `timeWindow / 8`) and `maxTimeWindow` (max zoom-out, default the full data
+  span). The Y-range auto-fits the visible window and candle bars re-flow as you
+  zoom. **@experimental.**
+- **`timeScroll` + `zoom` on `LiveChartSeries`.** Pan-back-through-history and
+  pinch-zoom now work in multi-series too (previously single-series only). While
+  scrolled back, each series' dot and value label track its value at the visible
+  window's right edge — the dot rides the end of each line instead of the live
+  price.
+- **Paging callbacks** `onVisibleRangeChange` and `onReachStart` (both charts).
+  `onVisibleRangeChange(range)` reports the visible window (`{ startSec, endSec,
+  following }`, throttled to ~1 Hz); `onReachStart()` fires once when the left
+  edge nears the earliest retained data — the cue to lazily page in older
+  history. `VisibleRange` is exported. **@experimental.**
 
 ## [3.12.0] - 2026-06-17
 

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -89,6 +89,7 @@ export default function MultiSeriesScreen() {
 
   const [empty, setEmpty] = useState(false);
   const [paused, setPaused] = useState(false);
+  const [panZoom, setPanZoom] = useState(true);
   const [loading, setLoading] = useState(false);
   const [windowSecs, setWindowSecs] = useState(30);
   const [smoothing, setSmoothing] = useState(0.12);
@@ -216,6 +217,8 @@ export default function MultiSeriesScreen() {
             }
             yAxis={yOn}
             xAxis={xOn}
+            timeScroll={panZoom}
+            zoom={panZoom}
             emptyText="No series"
             dot={dotConfig}
             legend={legendConfig}
@@ -353,6 +356,11 @@ export default function MultiSeriesScreen() {
           label="Ref line"
           value={showRef}
           onChange={() => setShowRef((r) => !r)}
+        />
+        <ToggleChip
+          label="Pan + zoom"
+          value={panZoom}
+          onChange={() => setPanZoom((p) => !p)}
         />
       </ControlRow>
       <ChipRow options={THEME_OPTIONS} value={theme} onChange={setTheme} />

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -48,9 +48,11 @@ export default function TimeScrollScreen() {
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [holdMs, setHoldMs] = useState(500);
   const [enabled, setEnabled] = useState(true);
+  const [zoomOn, setZoomOn] = useState(true);
   const [scrub, setScrub] = useState(true);
   const [orderTicket, setOrderTicket] = useState(true);
   const [floatAxis, setFloatAxis] = useState(true);
+  const [reachedStart, setReachedStart] = useState(false);
 
   // candleAggregation gives us both the line `data` and `candles`; the toggle
   // just switches which the chart renders. Time-scroll is mode-agnostic — it
@@ -80,7 +82,7 @@ export default function TimeScrollScreen() {
   return (
     <DemoScreen
       title="Time scroll"
-      description={`${hint} The chart stops auto-scrolling while panned; release (or fling) back to the live edge to resume. Works for line and candle; one-finger plot scrub is unchanged.`}
+      description={`${hint} Pinch with two fingers to zoom the window in/out (anchored at your fingers). The chart stops auto-scrolling while panned; release (or fling) back to the live edge to resume. Works for line and candle; one-finger plot scrub is unchanged.${reachedStart ? "  ● Reached oldest data (onReachStart fired — page here)" : ""}`}
       chart={
         <LiveChart
           data={data}
@@ -96,6 +98,19 @@ export default function TimeScrollScreen() {
           // Pill tracks the last visible price as you scroll back.
           badge={{ followViewEdge: true }}
           timeScroll={enabled ? { gesture, scrubHoldMs: holdMs } : false}
+          zoom={zoomOn}
+          // Paging callbacks (Phase 3): log the visible range (~1 Hz) and show an
+          // indicator while the left edge is near the oldest seeded candle. The
+          // indicator persists until you scroll back to the live edge (clears on
+          // `following`), rather than flashing — `onReachStart` is a one-shot
+          // edge trigger (it fires once to cue a page-in, then re-arms).
+          onVisibleRangeChange={(r) => {
+            console.log(
+              `visible range: ${r.startSec.toFixed(0)}–${r.endSec.toFixed(0)} following=${r.following}`,
+            );
+            if (r.following) setReachedStart(false);
+          }}
+          onReachStart={() => setReachedStart(true)}
           scrub={scrub ? { tooltip: true } : false}
           scrubAction={orderTicket}
           onScrubAction={onScrubAction}
@@ -127,6 +142,10 @@ export default function TimeScrollScreen() {
 
       <ControlRow label="Pan to scroll">
         <ToggleChip label="timeScroll" value={enabled} onChange={setEnabled} />
+      </ControlRow>
+
+      <ControlRow label="Pinch to zoom">
+        <ToggleChip label="zoom" value={zoomOn} onChange={setZoomOn} />
       </ControlRow>
 
       <ControlRow label="One-finger scrub">

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -85,6 +85,29 @@ default off.
   scrub actually started — a tap that never activates emits neither callback.
 </ParamField>
 
+<ParamField body="timeScroll" type="boolean | TimeScrollConfig" default="false">
+  Pan back through history (same as `LiveChart`). Drag (or fling) to scroll; the
+  chart stops auto-following until you return to the live edge. Per-series dots /
+  value labels track each series' value at the visible right edge while scrolled.
+  **@experimental.** See [Time-scroll](/guides/time-scroll).
+</ParamField>
+
+<ParamField body="zoom" type="boolean | ZoomConfig" default="false">
+  Pinch-to-zoom the visible window (same as `LiveChart`), anchored at the focal
+  point. Composes with `timeScroll`. **@experimental.** See
+  [Time-scroll](/guides/time-scroll#pinch-to-zoom-zoom).
+</ParamField>
+
+<ParamField body="onVisibleRangeChange" type="(range: VisibleRange) => void">
+  Called as the visible window changes (~1 Hz) with `{ startSec, endSec,
+  following }`. **@experimental.**
+</ParamField>
+
+<ParamField body="onReachStart" type="() => void">
+  Called once when the left edge nears the earliest retained data — the cue to
+  page in older history. **@experimental.**
+</ParamField>
+
 ## Degen
 
 <ParamField body="degen" type="boolean | DegenOptions">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -271,8 +271,29 @@ provided; everything else has a default.
   auto-following until you return to the live edge. `true` uses the default
   drag-to-scroll gesture (`"holdToScrub"` — drag scrolls, press-and-hold scrubs);
   pass a [`TimeScrollConfig`](/api-reference/types#config-objects) to pick
-  `"axisDrag"` (drag the x-axis strip) or set `scrubHoldMs`. Single-series only.
+  `"axisDrag"` (drag the x-axis strip) or set `scrubHoldMs`.
   **@experimental.** See [Time-scroll](/guides/time-scroll).
+</ParamField>
+
+<ParamField body="zoom" type="boolean | ZoomConfig" default="false">
+  Pinch-to-zoom the visible time window. Two-finger pinch in/out narrows or
+  widens the window, anchored at the focal point between your fingers. Composes
+  with `timeScroll` (zoom level and scroll position are independent). `true` uses
+  sensible default bounds; pass a [`ZoomConfig`](/api-reference/types#config-objects)
+  to set `minTimeWindow` / `maxTimeWindow`. **@experimental.** See
+  [Time-scroll](/guides/time-scroll#pinch-to-zoom-zoom).
+</ParamField>
+
+<ParamField body="onVisibleRangeChange" type="(range: VisibleRange) => void">
+  Called as the visible window changes (throttled to ~1 Hz) with
+  `{ startSec, endSec, following }`. Useful for paging a data source alongside
+  `timeScroll` / `zoom`. **@experimental.**
+</ParamField>
+
+<ParamField body="onReachStart" type="() => void">
+  Called once when the window's left edge comes within one window-width of the
+  earliest retained data — the cue to lazily load older history. Re-arms after
+  the edge moves back out. **@experimental.**
 </ParamField>
 
 ## Axes, grid & range

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -334,6 +334,17 @@ interface TimeScrollConfig {
   gesture?: "holdToScrub" | "axisDrag"; // activation; default "holdToScrub"
   scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
 }
+// Pinch-to-zoom the visible time window (two-finger, focal-anchored). @experimental
+interface ZoomConfig {
+  minTimeWindow?: number; // tightest window in seconds (max zoom-in); default timeWindow / 8
+  maxTimeWindow?: number; // widest window in seconds (max zoom-out); default the full data span
+}
+// Visible window reported by onVisibleRangeChange (unix seconds). @experimental
+interface VisibleRange {
+  startSec: number;   // left-edge time of the visible window
+  endSec: number;     // right-edge time of the visible window
+  following: boolean; // true when at the live edge (not scrolled back / paused)
+}
 // Edge label (topLabel / bottomLabel). Default off — both opt-in.
 interface AxisLabelConfig {
   format?: (v: number) => string; // built-in value formatter; defaults to formatValue

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -5,8 +5,8 @@ description: "Pan back through history; auto-follow resumes at the live edge."
 ---
 
 <Warning>
-  **Experimental.** `timeScroll` is a prototype — the gesture model and API may still change.
-  Single-series (`LiveChart`) only; line and candle modes both work.
+  **Experimental.** `timeScroll` and `zoom` are prototypes — the gesture model and API may still
+  change. Both work on `LiveChart` (line and candle) and `LiveChartSeries` (multi-series line).
 </Warning>
 
 By default the chart follows the live edge. Enable `timeScroll` to **pan back through history**:
@@ -55,6 +55,53 @@ scrolls instead). Higher = more deliberate scrub, fewer accidental scrubs while 
 />
 ```
 
+## Pinch-to-zoom (`zoom`)
+
+Enable `zoom` for **two-finger pinch-to-zoom** of the visible window. Pinch out to zoom in (a
+narrower window), pinch in to zoom out — anchored at the **focal point** between your fingers, so
+the time under your fingers stays put. It composes with `timeScroll`: zoom level and scroll position
+are independent, and you can pan a zoomed-in window. Pinch is two-finger, so it never competes with
+the one-finger pan / scrub.
+
+```tsx
+<LiveChart data={data} value={value} timeScroll zoom />
+```
+
+Bounds default sensibly — you can zoom in to `timeWindow / 8` and out to the full retained data span.
+Pass a `ZoomConfig` to set them explicitly:
+
+```tsx
+<LiveChart data={data} value={value} zoom={{ minTimeWindow: 5, maxTimeWindow: 3600 }} />
+```
+
+The Y-range auto-fits the visible window as you zoom, and candle bars re-flow to the new width.
+
+## Paging callbacks (`onVisibleRangeChange`, `onReachStart`)
+
+To lazily page in history as the user scrolls/zooms back, two callbacks report the visible window:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  timeScroll
+  zoom
+  onVisibleRangeChange={({ startSec, endSec, following }) => {
+    // throttled to ~1 Hz; `following` is true at the live edge
+  }}
+  onReachStart={() => {
+    // fires once when the left edge nears the oldest data — fetch older history here
+  }}
+/>
+```
+
+- **`onVisibleRangeChange`** fires (throttled to ~1 Hz) with the window's `startSec` / `endSec` and
+  whether the chart is `following` the live edge.
+- **`onReachStart`** is a **one-shot edge trigger**: it fires once when the left edge comes within one
+  window-width of the earliest retained point, then re-arms after you move back out — the cue to load
+  the next page of older data. When the fetched data extends `data` / `candles` further back, it can
+  fire again as you keep scrolling.
+
 ## Full-width plot while scrolled (`yAxis.float`)
 
 A normal chart reserves a right gutter for the price axis, so candles stop short of the edge. Pair
@@ -86,10 +133,14 @@ price you can see — and snap back to the live value when you return to the liv
 
 ## Notes
 
-- **Single-series only.** `timeScroll` is wired into `LiveChart`; `LiveChartSeries` doesn't support
-  it yet.
+- **Both charts.** `timeScroll` and `zoom` are wired into `LiveChart` and `LiveChartSeries`. In
+  multi-series, each series' dot / value label tracks its value at the visible right edge while
+  scrolled (the dot rides the end of each line, not the live price).
 - **Coexists with scrubbing.** Plot-area scrub (and the [order ticket](/guides/scrubbing#order-ticket-scrubaction))
   work alongside time-scroll — the gestures are disambiguated by region (`axisDrag`) or press-hold
-  (`holdToScrub`).
+  (`holdToScrub`). Pinch-zoom is two-finger, so it stays out of the one-finger gestures' way.
+- **`axisDrag` in multi-series** doesn't yet exclude the bottom-band from scrub; `holdToScrub` (the
+  default) is the recommended gesture for `LiveChartSeries`.
 - See the [`LiveChart` reference](/api-reference/livechart#scrubbing) and
-  [`TimeScrollConfig`](/api-reference/types#config-objects) for every field.
+  [`TimeScrollConfig`](/api-reference/types#config-objects) / [`ZoomConfig`](/api-reference/types#config-objects)
+  for every field.

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -22,7 +22,7 @@ import {
   vec,
 } from "@shopify/react-native-skia";
 
-import { DEFAULT_ACCENT_COLOR } from "../constants";
+import { DEFAULT_ACCENT_COLOR, HOLD_TO_SCRUB_MS } from "../constants";
 import {
   resolveAreaDots,
   resolveAxisLabel,
@@ -41,6 +41,7 @@ import {
   resolveTradeStream,
   resolveValueLine,
   resolveVolume,
+  resolveZoom,
   resolveXAxis,
   resolveYAxis,
 } from "../core/resolveConfig";
@@ -67,6 +68,8 @@ import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
 import { useMomentum } from "../hooks/useMomentum";
 import { AXIS_GRAB_MIN_PX, usePanScroll } from "../hooks/usePanScroll";
+import { usePinchZoom } from "../hooks/usePinchZoom";
+import { useVisibleRange } from "../hooks/useVisibleRange";
 import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
 import { useSingleChartReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
 import { useThreshold } from "../hooks/useThreshold";
@@ -176,10 +179,6 @@ function thresholdStops(
  * here so the rendered pieces (`ChartStack`, `ChartScrubLayer`, `LiveChart`) stay
  * small and presentational.
  */
-/** Default press-and-hold (ms) before scrub engages in the `holdToScrub`
- *  time-scroll mode, so a quick one-finger drag scrolls instead. Overridden by
- *  `timeScroll.scrubHoldMs`, then `scrub.panGestureDelay`. */
-const HOLD_TO_SCRUB_MS = 500;
 
 function useLiveChartController({
   // ── Data ────────────────────────────────────────────────────────────────
@@ -216,6 +215,7 @@ function useLiveChartController({
   windowBuffer = 0,
   nowOverride,
   timeScroll = false,
+  zoom = false,
   accessibilityLabel,
   accessibilityRole = "image",
   emptyText = "No data",
@@ -261,6 +261,8 @@ function useLiveChartController({
   onReferenceLinePress,
   onGestureStart,
   onGestureEnd,
+  onVisibleRangeChange,
+  onReachStart,
   onDegenShake,
 }: LiveChartProps) {
   const emptyTradeStream = useSharedValue<TradeEvent[]>([]);
@@ -490,6 +492,8 @@ function useLiveChartController({
   // onto the JS thread (set by the reaction below, after the engine exists).
   const [scrolledBack, setScrolledBack] = useState(false);
   const timeScrollEnabled = Boolean(timeScroll) && !isStatic;
+  const zoomCfg = resolveZoom(zoom);
+  const zoomEnabled = zoomCfg !== null && !isStatic;
 
   const yAxisFloat = yAxisCfg?.float ?? false;
   // With timeScroll, the floating full-width plot engages only while scrolled
@@ -882,6 +886,32 @@ function useLiveChartController({
     !isStatic,
   );
 
+  // Pinch-to-zoom the visible window (two-finger). Anchors at the focal point and
+  // writes viewWindow + viewEnd; composes via Simultaneous (it's two-finger, so
+  // disjoint from the one-finger pan/scrub). See `zoom`.
+  const pinchZoomGesture = usePinchZoom({
+    engine,
+    padding: effectivePadding,
+    minTime: scrollMinTime,
+    timeWindow,
+    enabled: zoomEnabled,
+    minTimeWindow: zoomCfg?.minTimeWindow,
+    maxTimeWindow: zoomCfg?.maxTimeWindow,
+    onZoomStart: () => {
+      "worklet";
+      crosshair.scrubActive.set(false);
+    },
+  });
+
+  // Paging callbacks: report the visible range / proximity to the oldest data so
+  // a host can lazily load history. Inert unless a callback is supplied.
+  useVisibleRange({
+    engine,
+    minTime: scrollMinTime,
+    onVisibleRangeChange,
+    onReachStart,
+  });
+
   // Scrub-action composes a Tap (place/move the reticle, press the badge, dismiss)
   // ahead of the pan via Exclusive, so a tap is tried first and only becomes a
   // drag (live-scrub, or lock-adjust once placed) if the finger moves. `Exclusive`
@@ -931,6 +961,12 @@ function useLiveChartController({
   // Exclusive falls through to scrub / scroll everywhere else.
   if (refDragEnabled) {
     rootGesture = Gesture.Exclusive(refDragGesture, rootGesture);
+  }
+
+  // Pinch runs alongside everything else (two-finger, so it never competes with
+  // the one-finger pan/scrub/tap gestures for the same touch).
+  if (zoomEnabled) {
+    rootGesture = Gesture.Simultaneous(rootGesture, pinchZoomGesture);
   }
 
   // ── Derived render values ──────────────────────────────────────────────

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -15,7 +15,11 @@ import {
   type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
-import { DEFAULT_ACCENT_COLOR, MAX_MULTI_SERIES } from "../constants";
+import {
+  DEFAULT_ACCENT_COLOR,
+  HOLD_TO_SCRUB_MS,
+  MAX_MULTI_SERIES,
+} from "../constants";
 import {
   lineColorsSignatureFromArray,
   lineStyleSignatureFromArray,
@@ -35,6 +39,7 @@ import {
   resolveSelectionDot,
   resolveXAxis,
   resolveYAxis,
+  resolveZoom,
 } from "../core/resolveConfig";
 import { useLiveChartSeriesEngine } from "../core/useLiveChartSeriesEngine";
 import { pulseRadialOutset } from "../draw/line";
@@ -46,7 +51,10 @@ import { useCrosshairSeries } from "../hooks/useCrosshairSeries";
 import { useMarkers } from "../hooks/useMarkers";
 import { useMultiSeriesDegen } from "../hooks/useMultiSeriesDegen";
 import { useMultiSeriesLinePaths } from "../hooks/useMultiSeriesLinePaths";
+import { usePanScroll } from "../hooks/usePanScroll";
+import { usePinchZoom } from "../hooks/usePinchZoom";
 import { useMultiSeriesReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
+import { useVisibleRange } from "../hooks/useVisibleRange";
 import { useXAxis } from "../hooks/useXAxis";
 import { useYAxis } from "../hooks/useYAxis";
 import {
@@ -137,9 +145,13 @@ function useLiveChartSeriesController({
   metrics,
   scrub = true,
   selectionDot,
+  timeScroll = false,
+  zoom = false,
   onScrub,
   onGestureStart,
   onGestureEnd,
+  onVisibleRangeChange,
+  onReachStart,
   onSeriesToggle,
   dot: dotProp,
   legend: legendProp,
@@ -160,6 +172,27 @@ function useLiveChartSeriesController({
   const bottomLabelCfg = resolveAxisLabel(bottomLabel);
   const scrubCfg = resolveScrub(scrub);
   const scrubEnabled = scrubCfg !== null;
+
+  // Time-scroll + pinch-zoom (mirrors LiveChart). LiveChartSeries has no static
+  // mode, so these gate on the props alone. `holdToScrub` requires the scrub
+  // gesture to wait for a press-and-hold so a quick drag scrolls instead — the
+  // hold delay is threaded into `useCrosshairSeries` below.
+  const timeScrollEnabled = Boolean(timeScroll);
+  const zoomCfg = resolveZoom(zoom);
+  const zoomEnabled = zoomCfg !== null;
+  const scrollGestureMode =
+    typeof timeScroll === "object"
+      ? (timeScroll.gesture ?? "holdToScrub")
+      : "holdToScrub";
+  const timeScrollHoldMs =
+    typeof timeScroll === "object" ? timeScroll.scrubHoldMs : undefined;
+  // Precedence: explicit scrubHoldMs, then scrub.panGestureDelay, then default.
+  // `||` (not `??`) skips the resolved panGestureDelay's 0 default.
+  const scrubHoldMs =
+    timeScrollEnabled && scrollGestureMode === "holdToScrub"
+      ? (timeScrollHoldMs ?? (scrubCfg?.panGestureDelay || HOLD_TO_SCRUB_MS))
+      : (scrubCfg?.panGestureDelay ?? 0);
+
   const selectionDotCfg = resolveSelectionDot(selectionDot);
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
@@ -323,7 +356,7 @@ function useLiveChartSeriesController({
     effectivePadding,
     scrubEnabled,
     onScrub,
-    scrubCfg?.panGestureDelay ?? 0,
+    scrubHoldMs,
     onGestureStart,
     onGestureEnd,
   );
@@ -340,9 +373,68 @@ function useLiveChartSeriesController({
     series,
   );
 
-  const rootGesture = markersActive
+  // Earliest retained time across all series — clamps how far the window pans
+  // back, and the `onReachStart` reference. Falls back to the live edge (no
+  // scrollable history) so panning is a no-op.
+  const scrollMinTime = useDerivedValue(() => {
+    const s = engine.series.get();
+    let min = Infinity;
+    for (let i = 0; i < s.length; i++) {
+      const d = s[i].data;
+      if (d.length > 0 && d[0].time < min) min = d[0].time;
+    }
+    return min === Infinity ? engine.liveEdge.get() : min;
+  });
+
+  const panScrollGesture = usePanScroll({
+    engine,
+    padding: effectivePadding,
+    minTime: scrollMinTime,
+    enabled: timeScrollEnabled,
+    mode: scrollGestureMode,
+    onScrollStart: () => {
+      "worklet";
+      crosshair.scrubActive.set(false);
+    },
+  });
+
+  const pinchZoomGesture = usePinchZoom({
+    engine,
+    padding: effectivePadding,
+    minTime: scrollMinTime,
+    timeWindow,
+    enabled: zoomEnabled,
+    minTimeWindow: zoomCfg?.minTimeWindow,
+    maxTimeWindow: zoomCfg?.maxTimeWindow,
+    onZoomStart: () => {
+      "worklet";
+      crosshair.scrubActive.set(false);
+    },
+  });
+
+  useVisibleRange({
+    engine,
+    minTime: scrollMinTime,
+    onVisibleRangeChange,
+    onReachStart,
+  });
+
+  let rootGesture = markersActive
     ? Gesture.Race(crosshair.gesture, markerTapGesture)
     : crosshair.gesture;
+
+  // holdToScrub races the scrub (quick drag scrolls; press-hold scrubs);
+  // axisDrag goes first via Exclusive (fails fast outside the bottom band).
+  if (timeScrollEnabled) {
+    rootGesture =
+      scrollGestureMode === "axisDrag"
+        ? Gesture.Exclusive(panScrollGesture, rootGesture)
+        : Gesture.Race(panScrollGesture, rootGesture);
+  }
+  // Pinch runs alongside (two-finger, disjoint from the one-finger gestures).
+  if (zoomEnabled) {
+    rootGesture = Gesture.Simultaneous(rootGesture, pinchZoomGesture);
+  }
 
   const backgroundColor = `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
 
@@ -520,6 +612,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
             ringColor={palette.badgeOuterBg}
             color={dotCfg.color}
             pulse={dotCfg.pulse}
+            viewEnd={engine.viewEnd}
           />
         </Group>
       )}

--- a/packages/react-native-livechart/src/components/MultiSeriesDots.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesDots.tsx
@@ -1,6 +1,6 @@
 import { Circle, Group } from "@shopify/react-native-skia";
 
-import { useDerivedValue } from "react-native-reanimated";
+import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
 import type {
@@ -21,6 +21,7 @@ function SeriesDotAtIndex({
   ring,
   ringColor,
   pulse,
+  viewEnd,
 }: {
   index: number;
   engine: MultiEngineState;
@@ -32,6 +33,8 @@ function SeriesDotAtIndex({
   /** Fallback ring color when `ring.color` is unset (theme `badgeOuterBg`). */
   ringColor: string;
   pulse: ResolvedPulseConfig | null;
+  /** Pan/zoom right-edge override — pulse is frozen-out while scrolled back. */
+  viewEnd?: SharedValue<number | null>;
 }) {
   const dotX = useDerivedValue(() => {
     const w = engine.canvasWidth.value;
@@ -62,7 +65,9 @@ function SeriesDotAtIndex({
   });
 
   const pulseRadius = useDerivedValue(() => {
-    if (!pulse) return 0;
+    // A live heartbeat on a frozen historical point is wrong (and `timestamp` is
+    // frozen, so it wouldn't animate) — suppress the pulse while scrolled back.
+    if (!pulse || viewEnd?.value != null) return 0;
     const nowMs = engine.timestamp.value * 1000 + index * PULSE_STAGGER_MS;
     const t = (nowMs % pulse.interval) / pulse.duration;
     if (t >= 1) return 0;
@@ -70,7 +75,7 @@ function SeriesDotAtIndex({
   });
 
   const pulseOpacity = useDerivedValue(() => {
-    if (!pulse) return 0;
+    if (!pulse || viewEnd?.value != null) return 0;
     const nowMs = engine.timestamp.value * 1000 + index * PULSE_STAGGER_MS;
     const t = (nowMs % pulse.interval) / pulse.duration;
     if (t >= 1) return 0;
@@ -112,6 +117,7 @@ export function MultiSeriesDots({
   ringColor,
   color,
   pulse,
+  viewEnd,
 }: {
   engine: MultiEngineState;
   padding: ChartPadding;
@@ -124,6 +130,8 @@ export function MultiSeriesDots({
   /** Fill color override; falls back to each series' line color. */
   color: string | undefined;
   pulse: ResolvedPulseConfig | null;
+  /** Pan/zoom right-edge override — pulse is frozen-out while scrolled back. */
+  viewEnd?: SharedValue<number | null>;
 }) {
   return (
     <Group>
@@ -138,6 +146,7 @@ export function MultiSeriesDots({
           ring={ring}
           ringColor={ringColor}
           pulse={pulse}
+          viewEnd={viewEnd}
         />
       ))}
     </Group>

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -9,6 +9,14 @@ import type {
 /** Milliseconds per frame at 60 fps — baseline for frame-rate-independent lerp. */
 export const MS_PER_FRAME_60FPS = 16.67;
 
+/**
+ * Default press-and-hold (ms) before scrub engages in the `holdToScrub`
+ * time-scroll mode, so a quick one-finger drag scrolls instead. Overridden by
+ * `timeScroll.scrubHoldMs`, then `scrub.panGestureDelay`. Shared by `LiveChart`
+ * and `LiveChartSeries`.
+ */
+export const HOLD_TO_SCRUB_MS = 500;
+
 // ─── Metric default tokens (single source of truth for LiveChartMetrics) ─────
 // The resolved `metrics` config (see resolveMetrics) is assembled from these
 // objects. Draw/worklet helpers default their metric params to the matching

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -69,6 +69,14 @@ export interface EngineTickInput {
    * resumes following. Takes precedence over {@link paused}.
    */
   viewEnd?: number | null;
+  /**
+   * Absolute visible-window width (seconds) to freeze at, or `null`/`undefined`
+   * to follow the configured {@link timeWindow}. Set by the pinch-zoom gesture
+   * (see `usePinchZoom` / the `zoom` prop). The symmetric counterpart of
+   * {@link viewEnd}: `viewEnd` overrides the window's right edge, `viewWindow`
+   * overrides its width. `displayWindow` eases toward this when set.
+   */
+  viewWindow?: number | null;
   /** Chart mode — `"candle"` uses OHLC bars for Y range instead of line points. */
   mode?: "line" | "candle";
   /** Committed OHLC bars (sorted by time). Used when mode is `"candle"`. */
@@ -123,12 +131,10 @@ export function tickLiveChartEngineFrame(
     input.dt,
   );
 
-  state.displayWindow = lerp(
-    state.displayWindow,
-    input.timeWindow,
-    speed,
-    input.dt,
-  );
+  // Pinch-zoom: ease toward the zoom override when set, else the configured
+  // window. Mirrors the viewEnd freeze above (width vs. right edge).
+  const targetWindow = input.viewWindow ?? input.timeWindow;
+  state.displayWindow = lerp(state.displayWindow, targetWindow, speed, input.dt);
 
   const winStart = state.timestamp - state.displayWindow;
 

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -56,6 +56,12 @@ export interface MultiEngineTickInput {
    * precedence over {@link paused}.
    */
   viewEnd?: number | null;
+  /**
+   * Absolute visible-window width (seconds) to freeze at, or `null`/`undefined`
+   * to follow {@link timeWindow}. Drives pinch-zoom (see `usePinchZoom`); the
+   * symmetric counterpart of {@link viewEnd}.
+   */
+  viewWindow?: number | null;
 }
 
 /**
@@ -97,18 +103,33 @@ export function tickLiveChartSeriesEngineFrame(
     state.opacities.length = n;
   }
 
-  state.displayWindow = lerp(
-    state.displayWindow,
-    input.timeWindow,
-    speed,
-    input.dt,
-  );
+  // Pinch-zoom: ease toward the zoom override when set, else the configured
+  // window (mirrors the single-series tick).
+  const targetWindow = input.viewWindow ?? input.timeWindow;
+  state.displayWindow = lerp(state.displayWindow, targetWindow, speed, input.dt);
 
   const winStart = state.timestamp - state.displayWindow;
   const range = state.displayMax - state.displayMin;
 
+  // Scrolled back in time (pan/zoom): the per-series tips/dots sit at the
+  // window's right edge, so they must track each series' value AT that edge
+  // (`timestamp`), not the live value — otherwise the dot floats at the current
+  // price while the line ends in the past. Mirrors single-series `edgeValue`.
+  const scrolledBack = viewEnd != null && viewEnd < liveEdge;
+
   for (let i = 0; i < n; i++) {
-    const target = series[i].value;
+    let target = series[i].value;
+    if (scrolledBack) {
+      const pts = series[i].data;
+      let elo = 0;
+      let ehi = pts.length;
+      while (elo < ehi) {
+        const m = (elo + ehi) >> 1;
+        if (pts[m].time <= state.timestamp) elo = m + 1;
+        else ehi = m;
+      }
+      if (elo > 0) target = pts[elo - 1].value;
+    }
     const cur = state.displayValues[i];
     const gapRatio =
       range > 0 ? Math.min(Math.abs(target - cur) / range, 1) : 0;

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -31,6 +31,7 @@ import type {
   VolumeConfig,
   XAxisConfig,
   YAxisConfig,
+  ZoomConfig,
 } from "../types";
 
 import type { ComponentType, ReactElement } from "react";
@@ -420,6 +421,28 @@ export function resolveVolume(
   prop: boolean | VolumeConfig | undefined,
 ): ResolvedVolumeConfig | null {
   return resolveToggle(prop, VOLUME_DEFAULTS, false);
+}
+
+export interface ResolvedZoomConfig {
+  /** Tightest window (max zoom-in), seconds. `undefined` → `timeWindow / 8`. */
+  minTimeWindow: number | undefined;
+  /** Widest window (max zoom-out), seconds. `undefined` → full data span. */
+  maxTimeWindow: number | undefined;
+}
+
+const ZOOM_DEFAULTS: ResolvedZoomConfig = {
+  minTimeWindow: undefined,
+  maxTimeWindow: undefined,
+};
+
+/**
+ * Resolves the `zoom` prop to a config or null (disabled). `true` → defaults
+ * (bounds derived at gesture time), object → merged, falsy → null.
+ */
+export function resolveZoom(
+  prop: boolean | ZoomConfig | undefined,
+): ResolvedZoomConfig | null {
+  return resolveToggle(prop, ZOOM_DEFAULTS, false);
 }
 
 const AXIS_LABEL_DEFAULTS: ResolvedAxisLabelConfig = {

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -57,12 +57,14 @@ export interface ChartEngineLayout {
   /** Animating window (lerps toward {@link timeWindow}); use for positioning. */
   displayWindow: SharedValue<number>;
   /**
-   * The target window from props — the exact value `displayWindow` eases toward.
-   * Tick *selection* (which X-axis labels exist) must read this, not
-   * `displayWindow`: the lerp is asymptotic and never reaches the target, so it
-   * settles just above or just below it depending on the prior window. Bucketing
-   * that off-by-epsilon value (e.g. via `niceTimeInterval`) would otherwise make
-   * the tick cadence depend on where you came from. See issue #126.
+   * The *effective* target window — the value `displayWindow` eases toward: the
+   * pinch-zoom override ({@link ChartEngineScroll.viewWindow}) when active, else
+   * the `timeWindow` prop. Tick *selection* (which X-axis labels exist) must read
+   * this, not `displayWindow`: the lerp is asymptotic and never reaches the
+   * target, so it settles just above or just below it depending on the prior
+   * window. Bucketing that off-by-epsilon value (e.g. via `niceTimeInterval`)
+   * would otherwise make the tick cadence depend on where you came from. See
+   * issue #126.
    */
   timeWindow: SharedValue<number>;
   canvasWidth: SharedValue<number>;
@@ -100,6 +102,14 @@ export interface ChartEngineScroll {
    * frame even while {@link ChartEngineLayout.timestamp} is frozen by a pan.
    */
   liveEdge: SharedValue<number>;
+  /**
+   * Absolute visible-window width (seconds) to freeze at, or `null` to follow
+   * the configured `timeWindow`. Written by the pinch-zoom gesture; the
+   * symmetric counterpart of {@link viewEnd} (width vs. right edge). Folded into
+   * {@link ChartEngineLayout.timeWindow}, so downstream selection/positioning
+   * picks up the zoom for free.
+   */
+  viewWindow: SharedValue<number | null>;
 }
 
 /** Single-series only: smoothed price at the visible window's right edge. */
@@ -156,6 +166,8 @@ export interface EngineFrameRefs {
   pausedSV: SharedValue<boolean>;
   /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
   viewEndSV?: SharedValue<number | null>;
+  /** Pinch-zoom window-width override (null = follow timeWindow). Optional for callers/tests. */
+  viewWindowSV?: SharedValue<number | null>;
   /** Receives the computed live edge each frame. Optional for callers/tests. */
   liveEdgeSV?: SharedValue<number>;
   /** Receives the smoothed right-edge value each frame. Optional for callers/tests. */
@@ -211,6 +223,7 @@ export function applyLiveChartEngineFrame(
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
     viewEnd: sv.viewEndSV?.value,
+    viewWindow: sv.viewWindowSV?.value,
     mode: sv.modeSV.value,
     candles: sv.candles?.value,
     liveCandle: sv.liveCandle?.value,
@@ -231,8 +244,16 @@ export function applyLiveChartEngineFrame(
 export function useLiveChartEngine(
   config: EngineConfig,
 ): SingleEngineState & ChartEngineScroll & ChartEngineEdge {
-  // Low-frequency config → UI thread via useDerivedValue
-  const timeWindow = useDerivedValue(() => config.timeWindow);
+  // Pinch-zoom window-width override (null = follow the configured window).
+  // Declared first so `timeWindow` below can fold it in. Defaults to null so
+  // charts without `zoom` behave exactly as before.
+  const viewWindow = useSharedValue<number | null>(null);
+
+  // Low-frequency config → UI thread via useDerivedValue. `timeWindow` is the
+  // *effective* target window: the zoom override when set, else the prop. Both
+  // the tick's window lerp and the X-axis tick selection read it, so zoom flows
+  // downstream for free (mirrors how viewEnd drives `timestamp`).
+  const timeWindow = useDerivedValue(() => viewWindow.value ?? config.timeWindow);
   // Static charts snap to their target in one tick (smoothing=1), so the single
   // settle reaction below produces the final state with no per-frame easing.
   const smoothing = useDerivedValue(() =>
@@ -315,6 +336,7 @@ export function useLiveChartEngine(
     windowBufferSV,
     pausedSV,
     viewEndSV: viewEnd,
+    viewWindowSV: viewWindow,
     liveEdgeSV: liveEdge,
     edgeValueSV: edgeValue,
     modeSV,
@@ -375,6 +397,7 @@ export function useLiveChartEngine(
     canvasHeight,
     timestamp,
     viewEnd,
+    viewWindow,
     liveEdge,
     edgeValue,
     extremaMinValue,

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -49,6 +49,8 @@ export interface MultiEngineFrameRefs {
   pausedSV: SharedValue<boolean>;
   /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
   viewEndSV?: SharedValue<number | null>;
+  /** Pinch-zoom window-width override (null = follow timeWindow). Optional for callers/tests. */
+  viewWindowSV?: SharedValue<number | null>;
   /** Receives the computed live edge each frame. Optional for callers/tests. */
   liveEdgeSV?: SharedValue<number>;
   extremaMinValue: SharedValue<number>;
@@ -135,6 +137,7 @@ export function applyLiveChartSeriesEngineFrame(
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
     viewEnd: sv.viewEndSV?.value,
+    viewWindow: sv.viewWindowSV?.value,
   });
   sv.displayMin.value = state.displayMin;
   sv.displayMax.value = state.displayMax;
@@ -156,7 +159,10 @@ export function applyLiveChartSeriesEngineFrame(
 export function useLiveChartSeriesEngine(
   config: MultiSeriesEngineConfig,
 ): MultiEngineState & ChartEngineScroll {
-  const timeWindow = useDerivedValue(() => config.timeWindow);
+  // Pinch-zoom window-width override (null = follow the configured window).
+  // Declared first so `timeWindow` folds it in — see useLiveChartEngine.
+  const viewWindow = useSharedValue<number | null>(null);
+  const timeWindow = useDerivedValue(() => viewWindow.value ?? config.timeWindow);
   const smoothing = useDerivedValue(() => config.smoothing);
   const adaptiveSpeedBoostSV = useDerivedValue(() => config.adaptiveSpeedBoost);
   const exaggerateSV = useDerivedValue(() => config.exaggerate ?? false);
@@ -229,6 +235,7 @@ export function useLiveChartSeriesEngine(
         windowBufferSV,
         pausedSV,
         viewEndSV: viewEnd,
+        viewWindowSV: viewWindow,
         liveEdgeSV: liveEdge,
         extremaMinValue,
         extremaMaxValue,
@@ -251,6 +258,7 @@ export function useLiveChartSeriesEngine(
     canvasHeight,
     timestamp,
     viewEnd,
+    viewWindow,
     liveEdge,
     series,
     displaySeriesValues,

--- a/packages/react-native-livechart/src/hooks/usePinchZoom.ts
+++ b/packages/react-native-livechart/src/hooks/usePinchZoom.ts
@@ -1,0 +1,189 @@
+import { Gesture } from "react-native-gesture-handler";
+import {
+  cancelAnimation,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+
+import type { ChartPadding } from "../draw/line";
+import { panLowerBound } from "./usePanScroll";
+
+/** Engine SharedValues the pinch-zoom gesture reads/writes. */
+export interface PinchZoomEngineRefs {
+  /** Visible-window width override in seconds, or `null` to follow `timeWindow`. */
+  viewWindow: SharedValue<number | null>;
+  /** Absolute right-edge time, or `null` to follow the live edge (shared with pan). */
+  viewEnd: SharedValue<number | null>;
+  /** Right-edge time the engine would use if following live (advances each frame). */
+  liveEdge: SharedValue<number>;
+  /**
+   * Animating visible window width in seconds. Written directly during a pinch so
+   * the displayed window tracks the fingers 1:1 (the frame-loop lerp toward
+   * `timeWindow` would otherwise lag a fast pinch and the focal anchor would drift).
+   */
+  displayWindow: SharedValue<number>;
+  /** Canvas width in px. */
+  canvasWidth: SharedValue<number>;
+}
+
+export interface UsePinchZoomOptions {
+  engine: PinchZoomEngineRefs;
+  padding: ChartPadding;
+  /**
+   * Earliest selectable time (unix seconds) — typically the first data point /
+   * candle. Caps how far the (now wider) window can pan back when zooming out.
+   */
+  minTime: SharedValue<number>;
+  /** The configured `timeWindow` prop (seconds) — the anchor for the zoom bounds. */
+  timeWindow: number;
+  /** Master switch. When false the gesture is disabled. */
+  enabled: boolean;
+  /** Tightest window (max zoom-in), seconds. Default `timeWindow / 8`. */
+  minTimeWindow?: number;
+  /** Widest window (max zoom-out), seconds. Default: the full data span, ≥ `timeWindow`. */
+  maxTimeWindow?: number;
+  /** Worklet fired when a pinch activates — e.g. to clear a lingering crosshair. */
+  onZoomStart?: () => void;
+}
+
+/** Clamp a window width to `[minWin, maxWin]`. */
+export function clampWindow(
+  win: number,
+  minWin: number,
+  maxWin: number,
+): number {
+  "worklet";
+  if (win < minWin) return minWin;
+  if (win > maxWin) return maxWin;
+  return win;
+}
+
+/**
+ * Resolve the zoom bounds for a gesture. `maxWin` defaults to the data span but
+ * never goes below the configured window (so you can always zoom back out to the
+ * starting view); `minWin` defaults to an 8× zoom-in of the configured window.
+ * Guards against an inverted range (min ≤ max).
+ */
+export function zoomWindowBounds(
+  configWindow: number,
+  span: number,
+  minCfg: number | undefined,
+  maxCfg: number | undefined,
+): [number, number] {
+  "worklet";
+  const maxWin = Math.max(maxCfg ?? span, configWindow);
+  let minWin = minCfg ?? configWindow / 8;
+  if (minWin > maxWin) minWin = maxWin;
+  return [minWin, maxWin];
+}
+
+/**
+ * Absolute time under a pixel x, given the visible window. Inverse of the chart's
+ * time→x projection: `x = chartLeft + (t - winStart)/window * chartW`.
+ */
+export function focalTime(
+  focalX: number,
+  chartLeft: number,
+  chartW: number,
+  winStart: number,
+  windowSecs: number,
+): number {
+  "worklet";
+  return winStart + ((focalX - chartLeft) / chartW) * windowSecs;
+}
+
+/**
+ * The new right-edge time that keeps `focalT` pinned under `focalX` after the
+ * window width changes to `newWindow` — i.e. zoom around the focal point. Derived
+ * from the projection above by solving for the right edge (`winStart + window`):
+ * the right edge sits `(fraction of the window to the right of the focal)` past
+ * `focalT`.
+ */
+export function zoomViewEnd(
+  focalT: number,
+  focalX: number,
+  chartLeft: number,
+  chartW: number,
+  newWindow: number,
+): number {
+  "worklet";
+  const rightFraction = (chartLeft + chartW - focalX) / chartW;
+  return focalT + rightFraction * newWindow;
+}
+
+/**
+ * Pinch-to-zoom the visible time window, anchored at the focal point between the
+ * two fingers (the time under your fingers stays put). Writes `engine.viewWindow`
+ * (the window width) and `engine.viewEnd` (the right edge, so the focal anchor
+ * holds) — the symmetric counterpart of {@link usePanScroll}, which only moves the
+ * right edge. Pinch is two-finger, so it composes with the one-finger pan/scrub
+ * via `Gesture.Simultaneous`.
+ *
+ * Reaching the live edge resumes following (`viewEnd → null`); the zoom level
+ * (`viewWindow`) is independent of scroll position and persists.
+ */
+export function usePinchZoom({
+  engine,
+  padding,
+  minTime,
+  timeWindow,
+  enabled,
+  minTimeWindow,
+  maxTimeWindow,
+  onZoomStart,
+}: UsePinchZoomOptions): ReturnType<typeof Gesture.Pinch> {
+  const { viewWindow, viewEnd, liveEdge, displayWindow, canvasWidth } = engine;
+  const padLeft = padding.left;
+  const padRight = padding.right;
+
+  // Snapshot at gesture start so the cumulative `scale`/`focalX` map from a fixed
+  // origin (no compounding drift while pinching).
+  const startWindow = useSharedValue(timeWindow);
+  const startViewEnd = useSharedValue(0);
+
+  const onStart =
+    /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+    () => {
+      "worklet";
+      cancelAnimation(viewEnd);
+      cancelAnimation(viewWindow);
+      const edge = liveEdge.get();
+      startWindow.set(viewWindow.get() ?? timeWindow);
+      startViewEnd.set(viewEnd.get() ?? edge);
+      onZoomStart?.();
+    };
+
+  const onChange =
+    /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+    (e: { scale: number; focalX: number }) => {
+      "worklet";
+      const chartW = canvasWidth.get() - padLeft - padRight;
+      if (chartW <= 0 || e.scale <= 0) return;
+      const edge = liveEdge.get();
+      const sWin = startWindow.get();
+      const sEnd = startViewEnd.get();
+      const span = edge - minTime.get();
+      const [minWin, maxWin] = zoomWindowBounds(
+        timeWindow,
+        span,
+        minTimeWindow,
+        maxTimeWindow,
+      );
+      // Pinch out (scale > 1) ⇒ narrower window ⇒ zoom in.
+      const newWin = clampWindow(sWin / e.scale, minWin, maxWin);
+      // Time under the fingers, mapped through the START window so the anchor
+      // doesn't compound; the right edge then keeps it under the (live) focal.
+      const focalT = focalTime(e.focalX, padLeft, chartW, sEnd - sWin, sWin);
+      let newEnd = zoomViewEnd(focalT, e.focalX, padLeft, chartW, newWin);
+      const lo = panLowerBound(minTime.get(), newWin, edge);
+      if (newEnd < lo) newEnd = lo;
+      if (newEnd > edge) newEnd = edge;
+      viewWindow.set(newWin);
+      // Track the displayed window 1:1 (bypass the frame-loop lerp lag) so the
+      // focal anchor is pixel-accurate during the gesture.
+      displayWindow.set(newWin);
+      viewEnd.set(newEnd >= edge ? null : newEnd);
+    };
+
+  return Gesture.Pinch().enabled(enabled).onStart(onStart).onChange(onChange);
+}

--- a/packages/react-native-livechart/src/hooks/useVisibleRange.ts
+++ b/packages/react-native-livechart/src/hooks/useVisibleRange.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  useAnimatedReaction,
+  type SharedValue,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+
+import type { VisibleRange } from "../types";
+
+export type { VisibleRange };
+
+/** Engine SharedValues the visible-range reaction reads. */
+export interface VisibleRangeEngineRefs {
+  timestamp: SharedValue<number>;
+  displayWindow: SharedValue<number>;
+  viewEnd: SharedValue<number | null>;
+}
+
+export interface UseVisibleRangeOptions {
+  engine: VisibleRangeEngineRefs;
+  /** Earliest retained time (unix seconds) — used for the `onReachStart` trigger. */
+  minTime: SharedValue<number>;
+  /** Fires (throttled to ~1 Hz) when the visible window's edges change. */
+  onVisibleRangeChange?: (range: VisibleRange) => void;
+  /**
+   * Fires once when the window's left edge comes within one window-width of the
+   * earliest retained data — the cue to lazily page in older history. Re-arms
+   * after the edge moves back out.
+   */
+  onReachStart?: () => void;
+}
+
+/**
+ * Throttle key for a visible range: integer seconds of each edge plus the
+ * near-start flag. The reaction emits only when this changes, so a live chart
+ * (whose right edge slides every frame) notifies at most ~once per second rather
+ * than per frame, and `onReachStart` edge-triggers off the trailing flag.
+ */
+export function rangeSignature(
+  startSec: number,
+  endSec: number,
+  near: boolean,
+): string {
+  "worklet";
+  return `${Math.round(startSec)}|${Math.round(endSec)}|${near ? 1 : 0}`;
+}
+
+/** Whether the window's left edge is within `threshold` seconds of the oldest data. */
+export function isNearStart(
+  winStart: number,
+  minTime: number,
+  threshold: number,
+): boolean {
+  "worklet";
+  return winStart <= minTime + threshold;
+}
+
+/**
+ * Bridges the UI-thread visible window to JS paging callbacks. A reaction watches
+ * the window edges and `scheduleOnRN`s `onVisibleRangeChange` (throttled) and
+ * `onReachStart` (edge-triggered near the oldest data). Inert when both callbacks
+ * are absent. Used by both `LiveChart` and `LiveChartSeries`.
+ */
+export function useVisibleRange({
+  engine,
+  minTime,
+  onVisibleRangeChange,
+  onReachStart,
+}: UseVisibleRangeOptions): void {
+  // Latest callbacks behind refs so the (deps-stable) dispatchers below always
+  // call the current prop without re-subscribing the reaction each render.
+  const rangeCb = useRef(onVisibleRangeChange);
+  const reachCb = useRef(onReachStart);
+  useEffect(() => {
+    rangeCb.current = onVisibleRangeChange;
+    reachCb.current = onReachStart;
+  }, [onVisibleRangeChange, onReachStart]);
+
+  const emitRange = useCallback(
+    /* istanbul ignore next -- dispatched via scheduleOnRN from the UI thread, not in Jest */
+    (startSec: number, endSec: number, following: boolean) => {
+      rangeCb.current?.({ startSec, endSec, following });
+    },
+    [],
+  );
+  const emitReachStart = useCallback(
+    /* istanbul ignore next -- dispatched via scheduleOnRN from the UI thread, not in Jest */
+    () => {
+      reachCb.current?.();
+    },
+    [],
+  );
+
+  const active = onVisibleRangeChange != null || onReachStart != null;
+
+  useAnimatedReaction(
+    /* istanbul ignore next -- Reanimated reaction worklet; runs on the UI thread, not in Jest */
+    () => {
+      if (!active) return ""; // inert — never changes, so the reaction never fires
+      const end = engine.timestamp.value;
+      const win = engine.displayWindow.value;
+      const start = end - win;
+      return rangeSignature(start, end, isNearStart(start, minTime.value, win));
+    },
+    /* istanbul ignore next -- Reanimated reaction; dispatches on the JS thread, not exercised under Jest */
+    (curr, prev) => {
+      if (!active || curr === "" || curr === prev) return;
+      const end = engine.timestamp.value;
+      const win = engine.displayWindow.value;
+      const start = end - win;
+      const following = engine.viewEnd.value == null;
+      const near = isNearStart(start, minTime.value, win);
+      const wasNear = typeof prev === "string" && prev.endsWith("|1");
+      scheduleOnRN(emitRange, start, end, following);
+      if (near && !wasNear) scheduleOnRN(emitReachStart);
+    },
+    [active, emitRange, emitReachStart],
+  );
+}

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -93,7 +93,9 @@ export type {
   TooltipRenderProps,
   TradeEvent,
   ValueLineConfig,
+  VisibleRange,
   VolumeConfig,
   XAxisConfig,
   YAxisConfig,
+  ZoomConfig,
 } from "./types";

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1415,6 +1415,37 @@ export interface TimeScrollConfig {
   scrubHoldMs?: number;
 }
 
+/**
+ * Pinch-to-zoom the visible time window (see {@link LiveChartCoreProps.zoom}).
+ *
+ * @experimental Prototype — gesture model and API may change.
+ */
+export interface ZoomConfig {
+  /**
+   * Tightest visible window in seconds (max zoom-in). Default `timeWindow / 8`.
+   */
+  minTimeWindow?: number;
+  /**
+   * Widest visible window in seconds (max zoom-out). Defaults to the full data
+   * span (you can zoom out to all retained history), never below `timeWindow`.
+   */
+  maxTimeWindow?: number;
+}
+
+/**
+ * The visible time range reported by {@link LiveChartCoreProps.onVisibleRangeChange}.
+ *
+ * @experimental
+ */
+export interface VisibleRange {
+  /** Left-edge time of the visible window (unix seconds). */
+  startSec: number;
+  /** Right-edge time of the visible window (unix seconds). */
+  endSec: number;
+  /** True when the window is at the live edge (not scrolled back / paused). */
+  following: boolean;
+}
+
 /** Props shared between `LiveChart` and `LiveChartSeries`. */
 export interface LiveChartCoreProps {
   /** Color scheme. Default `"dark"`. */
@@ -1563,6 +1594,18 @@ export interface LiveChartCoreProps {
    * @experimental Prototype — gesture model and API may change.
    */
   timeScroll?: boolean | TimeScrollConfig;
+  /**
+   * Pinch-to-zoom the visible time window. Two-finger pinch in/out narrows or
+   * widens the window, anchored at the focal point between your fingers. Composes
+   * with `timeScroll` (zoom level and scroll position are independent). Seed extra
+   * history in `data` / `candles` to have room to zoom out into.
+   *
+   * `true` uses sensible default bounds; pass a {@link ZoomConfig} to set
+   * `minTimeWindow` / `maxTimeWindow`. Default `false`.
+   *
+   * @experimental Prototype — gesture model and API may change.
+   */
+  zoom?: boolean | ZoomConfig;
   /** Accessibility label for the chart container. */
   accessibilityLabel?: string;
   /** Accessibility role for the chart container. Default `"image"`. */
@@ -1579,6 +1622,22 @@ export interface LiveChartCoreProps {
   onGestureStart?: () => void;
   /** Called once when the user stops scrubbing/panning the chart. */
   onGestureEnd?: () => void;
+  /**
+   * Called as the visible time window changes (throttled to ~1 Hz), with the
+   * window's edges in unix seconds and whether the chart is at the live edge.
+   * Useful for paging data sources alongside `timeScroll` / `zoom`.
+   *
+   * @experimental
+   */
+  onVisibleRangeChange?: (range: VisibleRange) => void;
+  /**
+   * Called once when the visible window's left edge comes within one
+   * window-width of the earliest retained data — the cue to lazily load older
+   * history. Re-arms after the edge moves back out.
+   *
+   * @experimental
+   */
+  onReachStart?: () => void;
   /**
    * Fade out chart content on the left (destination-out style). `true` = defaults, `false` = off,
    * or pass `LeftEdgeFadeConfig`. Default `true`.

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -29,6 +29,35 @@ describe("LiveChartSeries", () => {
     await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
   });
 
+  it("renders with timeScroll + zoom + paging callbacks wired", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          timeScroll={{ gesture: "holdToScrub", scrubHoldMs: 400 }}
+          zoom={{ minTimeWindow: 5 }}
+          onVisibleRangeChange={jest.fn()}
+          onReachStart={jest.fn()}
+        />
+      );
+    }
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+  });
+
   it("renders with scrub, reference line, and compact chips", async () => {
     const initial: SeriesConfig[] = [
       {

--- a/packages/react-native-livechart/tests/hooks/usePinchZoom.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePinchZoom.test.ts
@@ -1,0 +1,84 @@
+import {
+  clampWindow,
+  focalTime,
+  zoomViewEnd,
+  zoomWindowBounds,
+} from "../../src/hooks/usePinchZoom";
+
+describe("clampWindow", () => {
+  it("passes a value already in range through", () => {
+    expect(clampWindow(50, 10, 100)).toBe(50);
+  });
+
+  it("clamps below the minimum (max zoom-in)", () => {
+    expect(clampWindow(5, 10, 100)).toBe(10);
+  });
+
+  it("clamps above the maximum (max zoom-out)", () => {
+    expect(clampWindow(200, 10, 100)).toBe(100);
+  });
+});
+
+describe("zoomWindowBounds", () => {
+  it("defaults max to the data span and min to an 8× zoom-in", () => {
+    expect(zoomWindowBounds(80, 800, undefined, undefined)).toEqual([10, 800]);
+  });
+
+  it("never lets max fall below the configured window", () => {
+    // span (50) < configWindow (80) ⇒ you can always zoom back out to 80.
+    expect(zoomWindowBounds(80, 50, undefined, undefined)).toEqual([10, 80]);
+  });
+
+  it("honours explicit min/max overrides", () => {
+    expect(zoomWindowBounds(80, 800, 20, 400)).toEqual([20, 400]);
+  });
+
+  it("guards against an inverted range (min clamped to max)", () => {
+    expect(zoomWindowBounds(80, 800, 1000, 500)).toEqual([500, 500]);
+  });
+});
+
+describe("focalTime", () => {
+  // window [1000, 1100] over a 200px plot starting at x=0.
+  it("maps the left edge to winStart", () => {
+    expect(focalTime(0, 0, 200, 1000, 100)).toBe(1000);
+  });
+
+  it("maps the right edge to winStart + window", () => {
+    expect(focalTime(200, 0, 200, 1000, 100)).toBe(1100);
+  });
+
+  it("maps a mid-plot x to the proportional time", () => {
+    expect(focalTime(50, 0, 200, 1000, 100)).toBe(1025);
+  });
+});
+
+describe("zoomViewEnd", () => {
+  it("keeps the focal time under the focal x after a zoom-in", () => {
+    // focalT=1025 under x=50; halving the window to 50 ⇒ right edge 1062.5.
+    expect(zoomViewEnd(1025, 50, 0, 200, 50)).toBe(1062.5);
+  });
+
+  // Round-trip invariant: after zooming to any window, the focal time still
+  // projects back to the original focal x.
+  it.each([10, 25, 50, 100, 250])(
+    "is the inverse of focalTime for newWindow=%p",
+    (newWindow) => {
+      const chartLeft = 0;
+      const chartW = 200;
+      const focalX = 73;
+      const focalT = focalTime(focalX, chartLeft, chartW, 1000, 100);
+      const newEnd = zoomViewEnd(focalT, focalX, chartLeft, chartW, newWindow);
+      const newWinStart = newEnd - newWindow;
+      const projectedX =
+        chartLeft + ((focalT - newWinStart) / newWindow) * chartW;
+      expect(projectedX).toBeCloseTo(focalX, 9);
+    },
+  );
+
+  it("anchors at the right edge when the focal is at the right edge", () => {
+    // focal at right edge ⇒ right edge stays put regardless of window.
+    const focalT = focalTime(200, 0, 200, 1000, 100); // 1100
+    expect(zoomViewEnd(focalT, 200, 0, 200, 40)).toBe(1100);
+  });
+});

--- a/packages/react-native-livechart/tests/hooks/useVisibleRange.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useVisibleRange.test.ts
@@ -1,0 +1,38 @@
+import { isNearStart, rangeSignature } from "../../src/hooks/useVisibleRange";
+
+describe("rangeSignature", () => {
+  it("rounds each edge to integer seconds (throttle key)", () => {
+    expect(rangeSignature(1000.2, 1100.8, false)).toBe("1000|1101|0");
+  });
+
+  it("encodes the near-start flag", () => {
+    expect(rangeSignature(1000, 1100, true)).toBe("1000|1100|1");
+  });
+
+  it("is stable across sub-second drift (so a live chart throttles)", () => {
+    expect(rangeSignature(1000.1, 1100.1, false)).toBe(
+      rangeSignature(1000.4, 1099.6, false),
+    );
+  });
+
+  it("changes once the edges cross a whole second", () => {
+    expect(rangeSignature(1000.4, 1100, false)).not.toBe(
+      rangeSignature(1001.4, 1100, false),
+    );
+  });
+});
+
+describe("isNearStart", () => {
+  it("is true when the left edge is within the threshold of the oldest data", () => {
+    // winStart 1010 ≤ minTime 1000 + threshold 30.
+    expect(isNearStart(1010, 1000, 30)).toBe(true);
+  });
+
+  it("is true exactly at the threshold boundary", () => {
+    expect(isNearStart(1030, 1000, 30)).toBe(true);
+  });
+
+  it("is false when the left edge is still far from the oldest data", () => {
+    expect(isNearStart(1031, 1000, 30)).toBe(false);
+  });
+});

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -504,6 +504,59 @@ describe("tickLiveChartEngineFrame", () => {
     expect(s.displayWindow).toBeLessThan(60);
   });
 
+  // ── Pinch-zoom (viewWindow) ──────────────────────────────────────────────
+  describe("pinch-zoom", () => {
+    function zinput(
+      extra: Partial<Parameters<typeof tickLiveChartEngineFrame>[1]>,
+    ) {
+      return {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.5,
+        exaggerate: false,
+        referenceValue: undefined,
+        targetValue: 1,
+        points: [],
+        nowSeconds: 1000,
+        ...extra,
+      };
+    }
+
+    it("eases displayWindow toward viewWindow when set (zoom in)", () => {
+      const s = { ...baseState(), displayWindow: 30 };
+      tickLiveChartEngineFrame(s, zinput({ viewWindow: 10 }));
+      // lerps from 30 toward 10 ⇒ between the two, below the configured 30.
+      expect(s.displayWindow).toBeLessThan(30);
+      expect(s.displayWindow).toBeGreaterThan(10);
+    });
+
+    it("eases displayWindow toward viewWindow when set (zoom out)", () => {
+      const s = { ...baseState(), displayWindow: 30 };
+      tickLiveChartEngineFrame(s, zinput({ viewWindow: 90 }));
+      expect(s.displayWindow).toBeGreaterThan(30);
+      expect(s.displayWindow).toBeLessThan(90);
+    });
+
+    it("follows the configured timeWindow when viewWindow is null/undefined", () => {
+      const sNull = { ...baseState(), displayWindow: 10 };
+      tickLiveChartEngineFrame(sNull, zinput({ viewWindow: null }));
+      expect(sNull.displayWindow).toBeGreaterThan(10); // toward 30
+
+      const sUndef = { ...baseState(), displayWindow: 10 };
+      tickLiveChartEngineFrame(sUndef, zinput({}));
+      expect(sUndef.displayWindow).toBe(sNull.displayWindow);
+    });
+
+    it("zoom and pan compose: freezes the right edge AND narrows the window", () => {
+      const s = { ...baseState(), displayWindow: 30 };
+      tickLiveChartEngineFrame(s, zinput({ viewEnd: 950, viewWindow: 10 }));
+      expect(s.timestamp).toBe(950); // right edge frozen by the pan
+      expect(s.displayWindow).toBeLessThan(30); // window narrowed by the zoom
+    });
+  });
+
   // ── Time-scroll (viewEnd / liveEdge) ─────────────────────────────────────
   describe("time-scroll", () => {
     function input(extra: Partial<Parameters<typeof tickLiveChartEngineFrame>[1]>) {

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -601,6 +601,43 @@ describe("tickLiveChartSeriesEngineFrame", () => {
     });
   });
 
+  describe("pinch-zoom", () => {
+    it("eases displayWindow toward viewWindow when set", () => {
+      const s = { ...baseMulti(), displayWindow: 30 };
+      tickLiveChartSeriesEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.5,
+        exaggerate: false,
+        referenceValue: undefined,
+        series: [],
+        nowSeconds: 1000,
+        viewWindow: 10,
+      });
+      expect(s.displayWindow).toBeLessThan(30);
+      expect(s.displayWindow).toBeGreaterThan(10);
+    });
+
+    it("follows the configured window when viewWindow is null", () => {
+      const s = { ...baseMulti(), displayWindow: 10 };
+      tickLiveChartSeriesEngineFrame(s, {
+        dt: 16.67,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        timeWindow: 30,
+        smoothing: 0.5,
+        exaggerate: false,
+        referenceValue: undefined,
+        series: [],
+        nowSeconds: 1000,
+        viewWindow: null,
+      });
+      expect(s.displayWindow).toBeGreaterThan(10); // toward 30
+    });
+  });
+
   describe("time-scroll", () => {
     function input(
       extra: Partial<Parameters<typeof tickLiveChartSeriesEngineFrame>[1]>,
@@ -643,6 +680,39 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       const s = { ...baseMulti(), timestamp: 999 };
       tickLiveChartSeriesEngineFrame(s, input({ viewEnd: 950, paused: true }));
       expect(s.timestamp).toBe(950);
+    });
+
+    // Regression: while scrolled back, each series' tip/dot must track its value
+    // AT the visible right edge, not the live value — otherwise the dot floats at
+    // the current price while the line ends in the past.
+    it("tracks each series' value at the right edge while scrolled back", () => {
+      const seriesWithData = [
+        {
+          id: "a",
+          color: "#00f",
+          value: 99, // live value (latest)
+          data: [
+            { time: 970, value: 10 },
+            { time: 990, value: 50 },
+          ],
+        },
+      ];
+      // viewEnd 985 < liveEdge 1000 ⇒ frozen at 985; last point ≤ 985 is value 10.
+      const scrolled = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        scrolled,
+        input({ series: seriesWithData, viewEnd: 985, smoothing: 0.5 }),
+      );
+      // Display value eases from the live 99 toward the edge value 10, not 99.
+      expect(scrolled.displayValues[0]).toBeLessThan(99);
+
+      // Following live (viewEnd null) ⇒ tracks the live value 99 (stays put).
+      const live = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        live,
+        input({ series: seriesWithData, viewEnd: null, smoothing: 0.5 }),
+      );
+      expect(live.displayValues[0]).toBe(99);
     });
   });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -24,6 +24,7 @@ import {
   resolveVolume,
   resolveXAxis,
   resolveYAxis,
+  resolveZoom,
 } from "../src/core/resolveConfig";
 
 import {
@@ -241,6 +242,32 @@ describe("resolveVolume", () => {
       upColor: "#0f0",
       downColor: "#f00",
       opacity: 0.4,
+    });
+  });
+});
+
+// ─── resolveZoom ─────────────────────────────────────────────────────────────
+
+describe("resolveZoom", () => {
+  const defaults = { minTimeWindow: undefined, maxTimeWindow: undefined };
+
+  it("returns null for undefined and false", () => {
+    expect(resolveZoom(undefined)).toBeNull();
+    expect(resolveZoom(false)).toBeNull();
+  });
+
+  it("returns defaults for true", () => {
+    expect(resolveZoom(true)).toEqual(defaults);
+  });
+
+  it("merges a partial config with defaults", () => {
+    expect(resolveZoom({ minTimeWindow: 5 })).toEqual({
+      ...defaults,
+      minTimeWindow: 5,
+    });
+    expect(resolveZoom({ minTimeWindow: 5, maxTimeWindow: 600 })).toEqual({
+      minTimeWindow: 5,
+      maxTimeWindow: 600,
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements the "pan / zoom (the big one)" feature request. Pan-through-history (`timeScroll`) already shipped, so this adds the genuinely-missing pieces:

- **Pinch-to-zoom (`zoom`)** — two-finger, focal-anchored (the time under your fingers stays put), the symmetric counterpart of the existing time-scroll pan. Composes with `timeScroll`.
- **`timeScroll`** **\+** **`zoom`** **on** **`LiveChartSeries`** — both gestures now work in multi-series (were single-series only). While scrolled, per-series dots/value-labels track each series' value at the visible right edge.
- **Paging callbacks** — `onVisibleRangeChange` (throttled ~1 Hz) + one-shot `onReachStart` for lazily loading older history.

All three are marked `@experimental`.

## How it works

The visible window is `[timestamp - displayWindow, timestamp]`. Pan added `viewEnd` to override the right edge; zoom adds **`viewWindow`** to override the width — folded into the effective `timeWindow` SharedValue, so X-axis label selection and every path/overlay's positioning pick up zoom for free (they already read `timestamp` + `displayWindow`). A pinch is focal-anchored, so it writes **both** `viewWindow` and `viewEnd` to keep the focal time fixed.

## Changes

- **Engine:** `viewWindow` override in both ticks + both engine hooks.
- **`usePinchZoom`:** focal-anchored pinch; pure helpers (`clampWindow` / `zoomWindowBounds` / `focalTime` / `zoomViewEnd`) at 100% coverage + istanbul-ignored gesture worklets. `zoom?: boolean | ZoomConfig` prop + `resolveZoom`.
- **`useVisibleRange`:** `onVisibleRangeChange` / `onReachStart`; `VisibleRange` exported.
- **`LiveChartSeries`:** wired pan + pinch + paging; per-series tips track the visible right-edge value while scrolled (dot rides the line end, not the live price); pulse frozen while scrolled.
- **Demos:** pinch in the Time-scroll + Multi-series demos; a paging-callback indicator in the Time-scroll demo.
- **Docs:** Time-scroll guide (pinch-zoom + paging sections) + API reference (`LiveChart`, `LiveChartSeries`, types); **CHANGELOG** under `[Unreleased]`.

## Test plan

- `npm run verify:coverage` green — 83 suites, 1122 tests, coverage above thresholds (`usePinchZoom` / `useVisibleRange` / `MultiSeriesDots` at 100%).
- QA'd on the iOS 26.4 simulator: single-series pinch, multi-series pan/zoom + the dot-at-edge fix, and the paging-callback indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)