### PR TITLE
feat(reference-line): badge style/shape parity for line + group badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Grouping** — `referenceLineGrouping` collapses lines whose handles sit near
     the same value into a single count handle. Custom-rendered lines are excluded
     (the count reflects only collapsed built-in tags).
+- **Badge style/shape parity** for reference-line and group badges. Both
+  `ReferenceLineBadgeConfig` and the grouping count pill
+  (`ReferenceLineGroupingConfig.badge`) now take the same style/shape config as the
+  value `badge` (added in #152): `borderWidth`, `textColor`, `fontSize` /
+  `fontFamily` / `fontWeight`, and `offsetX` / `offsetY` (on top of the existing
+  `position` / `background` / `borderColor` / `radius`). The grouping config also
+  gains a `format` fn for the count label (e.g. `n => \`×${n}\``).
 
 ## [3.12.0] - 2026-06-17
 

--- a/app/demo/working-orders.tsx
+++ b/app/demo/working-orders.tsx
@@ -120,8 +120,19 @@ export default function WorkingOrdersScreen() {
       badge: { position: "right" },
       ...handlers("SELL", setSell),
     },
-    // Center badge placement (non-draggable).
-    { value: START, label: "VWAP", color: "#fbbf24", badge: { position: "center" } },
+    // Center badge with style/shape knobs (border, text color, radius, weight).
+    {
+      value: START,
+      label: "VWAP",
+      color: "#fbbf24",
+      badge: {
+        position: "center",
+        borderColor: "#fbbf24",
+        textColor: "#fbbf24",
+        radius: 10,
+        fontWeight: "700",
+      },
+    },
     // Badge-less line: plain gutter label when custom is off, PlainTag when on.
     { value: START * 1.04, label: "Stop", color: "#94a3b8" },
     // A tight stack of alerts → collapses into one count handle when grouping is on.
@@ -148,7 +159,24 @@ export default function WorkingOrdersScreen() {
           accentColor={ACCENT}
           theme={APP_THEME}
           referenceLines={referenceLines}
-          referenceLineGrouping={grouping ? { radius: 26 } : false}
+          referenceLineGrouping={
+            grouping
+              ? {
+                  radius: 26,
+                  // Count pill takes the same style/shape config as a line badge.
+                  badge: {
+                    icon: "⚠",
+                    borderColor: "#a855f7",
+                    textColor: "#a855f7",
+                    fontWeight: "700",
+                  },
+                  format: (n) => {
+                    "worklet";
+                    return `${n} alerts`;
+                  },
+                }
+              : false
+          }
           renderReferenceLine={custom ? renderReferenceLine : undefined}
           scrub={false}
         />

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -131,7 +131,14 @@ interface ReferenceLineBadgeConfig {
   text?: boolean;              // show the label/value; default true. false → icon-only
   background?: string;         // falls back to badgeBackground, then theme tooltipBg
   borderColor?: string;        // falls back to badgeBorderColor, then the line color
+  borderWidth?: number;        // border stroke width; default 1
   radius?: number;             // corner radius; falls back to badgeRadius, then 5
+  textColor?: string;          // label/icon color; falls back to labelColor, then theme
+  fontSize?: number;           // badge font size; falls back to the chart font
+  fontFamily?: string;         // badge font family; falls back to the chart font
+  fontWeight?: FontWeight;     // badge font weight; falls back to the chart font
+  offsetX?: number;            // nudge the whole badge from its anchor; default 0
+  offsetY?: number;            // nudge the whole badge from its anchor; default 0
 }
 
 interface ReferenceLineRenderProps {
@@ -147,6 +154,10 @@ interface ReferenceLineRenderProps {
 
 interface ReferenceLineGroupingConfig {
   radius?: number;             // collapse lines whose value-Y are within this many px; default 18
+  badge?: ReferenceLineBadgeConfig;   // count-pill styling (same style/shape config as a
+                                      //   per-line badge: position, icon, colors, radius,
+                                      //   border, textColor, font, offset)
+  format?: (count: number) => string; // label the count, e.g. n => `×${n}`; default String(n)
 }
 
 interface ChartSegment {

--- a/docs/guides/markers-and-references.mdx
+++ b/docs/guides/markers-and-references.mdx
@@ -178,8 +178,11 @@ referenceLines={[
 `badge: true` uses the defaults (left-pinned, the line's label/value); pass a
 [`ReferenceLineBadgeConfig`](/api-reference/types#annotations) for `position` (`"left"` /
 `"center"` / `"right"` — `"center"` floats the pill at the value with no connector), an `icon`,
-`text: false` (icon-only), and `background` / `borderColor` / `radius`. It supersedes the legacy
-`offAxisBadge` (still supported), which only appears once the value is off-screen and takes no icon.
+`text: false` (icon-only), and the full style/shape config — `background`, `borderColor` /
+`borderWidth`, `radius`, `textColor`, `fontSize` / `fontFamily` / `fontWeight`, and
+`offsetX` / `offsetY` (the same knobs as the value [`badge`](/api-reference/types#annotations)).
+It supersedes the legacy `offAxisBadge` (still supported), which only appears once the value is
+off-screen and takes no icon.
 
 ### Draggable lines (`draggable`)
 
@@ -239,13 +242,21 @@ When a stack of orders or alerts sits near the same price, their tags pile up il
 into a single count handle:
 
 ```tsx
-referenceLineGrouping={{ radius: 18 }}   // or `true` for the default
+referenceLineGrouping={{
+  radius: 18,                       // proximity that collapses into one pill
+  // `format` runs on the UI thread — it MUST be a worklet (like `formatValue`).
+  format: (n) => { "worklet"; return `×${n}`; }, // label the count (default: the bare number)
+  badge: { position: "left", textColor: "#a855f7" }, // same style/shape config as a line badge
+}}
+// or `true` for the defaults
 ```
 
 The clustered lines' individual tags are suppressed and replaced by one "count" pill at the
 cluster's center; the lines themselves still draw. Lines you render with `renderReferenceLine`
 are excluded from grouping (their custom tag draws itself), so the count reflects only collapsed
-built-in tags.
+built-in tags. The count pill takes the same style/shape config as a per-line badge
+([`ReferenceLineBadgeConfig`](/api-reference/types#annotations)) via `badge`, plus a `format` fn
+for the count label.
 
 ## Overlay bridge (`renderOverlay`)
 

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -86,6 +86,7 @@ import {
 import {
   collectReferenceValues,
   referenceLineForm,
+  resolveReferenceGroupBadge,
 } from "../math/referenceLines";
 import {
   applyPaletteOverride,
@@ -368,11 +369,17 @@ function useLiveChartController({
 
   // Reference-line grouping (collapse near-value handles). Resolved once; the
   // per-frame clustering runs on the UI thread (see ReferenceLineGroupOverlay).
+  const refGroupingCfg =
+    typeof referenceLineGrouping === "object"
+      ? referenceLineGrouping
+      : undefined;
   const refGroupingRadius = referenceLineGrouping
-    ? typeof referenceLineGrouping === "object"
-      ? (referenceLineGrouping.radius ?? 18)
-      : 18
+    ? (refGroupingCfg?.radius ?? 18)
     : null;
+  // Count-pill styling (same style/shape config as a per-line badge) + count
+  // formatter. Resolved once; theme color defaults are applied in the overlay.
+  const refGroupBadge = resolveReferenceGroupBadge(refGroupingCfg?.badge);
+  const refGroupFormat = refGroupingCfg?.format;
 
   const badgeUsesRightGutter =
     badgeCfg !== null && (badgeCfg.position ?? "right") === "right";
@@ -434,6 +441,27 @@ function useLiveChartController({
     palette.labelFontSize,
   );
   const badgeFont = badgeHasFontOverride ? badgeFontOverride : skiaFont;
+
+  // Per-badge font for the grouping count pill (same override pattern as above).
+  const refGroupBadgeHasFont =
+    refGroupBadge.fontSize != null ||
+    refGroupBadge.fontFamily != null ||
+    refGroupBadge.fontWeight != null;
+  const refGroupBadgeFontOverride = useChartSkiaFont(
+    refGroupBadgeHasFont
+      ? {
+          ...fontProp,
+          fontFamily: refGroupBadge.fontFamily ?? fontProp?.fontFamily,
+          fontSize: refGroupBadge.fontSize ?? fontProp?.fontSize,
+          fontWeight: refGroupBadge.fontWeight ?? fontProp?.fontWeight,
+        }
+      : fontProp,
+    MONO_FONT_FAMILY,
+    palette.labelFontSize,
+  );
+  const refGroupBadgeFont = refGroupBadgeHasFont
+    ? refGroupBadgeFontOverride
+    : skiaFont;
 
   const pulseConfig = pulseCfg
     ? {
@@ -985,6 +1013,9 @@ function useLiveChartController({
     refGroupingActive: refGroupingRadius != null,
     refGroupResult,
     groupHidden,
+    refGroupBadge,
+    refGroupBadgeFont,
+    refGroupFormat,
     resolvedSegments,
     hasRecolorSegments,
     segmentGradient,
@@ -996,6 +1027,7 @@ function useLiveChartController({
     // theme / layout / fonts
     palette,
     skiaFont,
+    fontProp,
     valueFont,
     badgeFont,
     strokeWidth,
@@ -1179,6 +1211,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     effectivePadding,
     palette,
     skiaFont,
+    fontProp,
     badgeCfg,
     valueLineCfg,
     dotY,
@@ -1270,6 +1303,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
           palette={palette}
           formatValue={formatValue}
           font={skiaFont}
+          fontProp={fontProp}
           dragValues={dragValues}
           index={i}
         />
@@ -1645,11 +1679,15 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
     groupHidden,
     refGroupResult,
     refGroupingActive,
+    refGroupBadge,
+    refGroupBadgeFont,
+    refGroupFormat,
     engine,
     effectivePadding,
     palette,
     formatValue,
     skiaFont,
+    fontProp,
     degenShakeTransform,
   } = model;
   if (allRefLines.length === 0) return null;
@@ -1664,6 +1702,7 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
           palette={palette}
           formatValue={formatValue}
           font={skiaFont}
+          fontProp={fontProp}
           badgeLayer
           dragValues={dragValues}
           index={i}
@@ -1676,8 +1715,11 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
         <ReferenceLineGroupOverlay
           grouping={refGroupResult}
           padding={effectivePadding}
+          canvasWidth={engine.canvasWidth}
           palette={palette}
-          font={skiaFont}
+          font={refGroupBadgeFont}
+          badge={refGroupBadge}
+          format={refGroupFormat}
         />
       )}
     </Group>

--- a/packages/react-native-livechart/src/components/ReferenceLineGroupOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineGroupOverlay.tsx
@@ -9,6 +9,7 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import type { ChartPadding } from "../draw/line";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import type { ReferenceGrouping } from "../math/referenceGroup";
+import type { ResolvedReferenceGroupBadge } from "../math/referenceLines";
 import type { LiveChartPalette } from "../types";
 
 /** Max simultaneous group handles (a fixed Skia slot pool — the per-frame group
@@ -18,9 +19,8 @@ const MAX_GROUP_PILLS = 12;
 const PILL_PAD_X = 6;
 /** Vertical padding inside the count pill, in px. */
 const PILL_PAD_Y = 3;
-/** Pill inset from the plot's left edge, in px. */
+/** Pill inset from the anchored plot edge, in px. */
 const EDGE_INSET = 2;
-const PILL_RADIUS = 5;
 
 interface PillLayout {
   visible: boolean;
@@ -48,9 +48,16 @@ function GroupCountPill({
   grouping,
   index,
   padding,
+  canvasWidth,
   font,
+  position,
+  icon,
+  showText,
+  format,
   baselineOffset,
   pillH,
+  radius,
+  borderWidth,
   color,
   background,
   textColor,
@@ -58,9 +65,16 @@ function GroupCountPill({
   grouping: SharedValue<ReferenceGrouping>;
   index: number;
   padding: ChartPadding;
+  canvasWidth: SharedValue<number>;
   font: SkFont;
+  position: "left" | "center" | "right";
+  icon: string;
+  showText: boolean;
+  format?: (count: number) => string;
   baselineOffset: number;
   pillH: number;
+  radius: number;
+  borderWidth: number;
   color: string;
   background: string;
   textColor: string;
@@ -69,9 +83,16 @@ function GroupCountPill({
     const gs = grouping.get().groups;
     if (index >= gs.length) return HIDDEN_PILL;
     const g = gs[index];
-    const text = String(g.count);
+    const count = showText ? (format ? format(g.count) : String(g.count)) : "";
+    const text = icon ? (count ? `${icon} ${count}` : icon) : count;
     const w = measureFontTextWidth(font, text) + PILL_PAD_X * 2;
-    const x = padding.left + EDGE_INSET;
+    // Anchor the pill horizontally to the chosen plot edge (or center).
+    const x1 = padding.left;
+    const x2 = canvasWidth.get() - padding.right;
+    let x: number;
+    if (position === "right") x = x2 - EDGE_INSET - w;
+    else if (position === "center") x = (x1 + x2) / 2 - w / 2;
+    else x = x1 + EDGE_INSET;
     return {
       visible: true,
       x,
@@ -98,7 +119,7 @@ function GroupCountPill({
         y={top}
         width={w}
         height={pillH}
-        r={PILL_RADIUS}
+        r={radius}
         color={background}
       />
       <RoundedRect
@@ -106,10 +127,10 @@ function GroupCountPill({
         y={top}
         width={w}
         height={pillH}
-        r={PILL_RADIUS}
+        r={radius}
         color={color}
         style="stroke"
-        strokeWidth={1}
+        strokeWidth={borderWidth}
       />
       <SkiaText x={textX} y={textY} text={text} font={font} color={textColor} />
     </Group>
@@ -118,25 +139,45 @@ function GroupCountPill({
 
 /**
  * Draws the collapsed-group count handles (e.g. a "×3" pill) for reference-line
- * grouping — one pill per multi-line cluster, pinned to the plot's left edge at the
- * cluster centroid. The individual tags of clustered lines are suppressed upstream
- * (via `groupHidden`), so a stack of nearby orders reads as one handle. A fixed
- * slot pool keeps the Skia tree stable while the per-frame group count varies.
+ * grouping — one pill per multi-line cluster, pinned to the plot at the cluster
+ * centroid. The individual tags of clustered lines are suppressed upstream (via
+ * `groupHidden`), so a stack of nearby orders reads as one handle. The pill uses the
+ * same style/shape config as a per-line badge (`badge`): `position`, `icon`,
+ * `text` (showText), `background` / `borderColor` / `borderWidth`, `radius` (corner),
+ * `textColor`, per-badge `font`, and `offsetX` / `offsetY`; the `format` fn maps the
+ * count to the label. A fixed slot pool keeps the Skia tree stable while the
+ * per-frame group count varies.
  */
 export function ReferenceLineGroupOverlay({
   grouping,
   padding,
+  canvasWidth,
   palette,
   font,
+  badge,
+  format,
 }: {
   grouping: SharedValue<ReferenceGrouping>;
   padding: ChartPadding;
+  canvasWidth: SharedValue<number>;
   palette: LiveChartPalette;
   font: SkFont;
+  badge: ResolvedReferenceGroupBadge;
+  format?: (count: number) => string;
 }) {
   const fm = font.getMetrics();
   const baselineOffset = (fm.ascent + fm.descent) / 2;
   const pillH = fm.descent - fm.ascent + PILL_PAD_Y * 2;
+
+  // Theme defaults for the unset colors (mirrors the per-line badge resolution).
+  const background = badge.background ?? palette.tooltipBg;
+  const borderColor = badge.borderColor ?? palette.refLine;
+  const textColor = badge.textColor ?? palette.refLabel;
+
+  const transform =
+    badge.offsetX !== 0 || badge.offsetY !== 0
+      ? [{ translateX: badge.offsetX }, { translateY: badge.offsetY }]
+      : undefined;
 
   const slots: React.ReactElement[] = [];
   for (let i = 0; i < MAX_GROUP_PILLS; i++) {
@@ -146,14 +187,21 @@ export function ReferenceLineGroupOverlay({
         grouping={grouping}
         index={i}
         padding={padding}
+        canvasWidth={canvasWidth}
         font={font}
+        position={badge.position}
+        icon={badge.icon}
+        showText={badge.showText}
+        format={format}
         baselineOffset={baselineOffset}
         pillH={pillH}
-        color={palette.refLine}
-        background={palette.tooltipBg}
-        textColor={palette.refLabel}
+        radius={badge.radius}
+        borderWidth={badge.borderWidth}
+        color={borderColor}
+        background={background}
+        textColor={textColor}
       />,
     );
   }
-  return <Group>{slots}</Group>;
+  return <Group transform={transform}>{slots}</Group>;
 }

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -10,10 +10,12 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
+import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
 import { usePathBuilder } from "../hooks/usePathBuilder";
 import { useReferenceLine } from "../hooks/useReferenceLine";
+import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
 import { referenceLineForm, resolveReferenceBadge } from "../math/referenceLines";
-import type { LiveChartPalette, ReferenceLine } from "../types";
+import type { FontConfig, LiveChartPalette, ReferenceLine } from "../types";
 
 /** Translucent fill alpha for value / time bands. */
 const BAND_FILL_OPACITY = 0.16;
@@ -35,6 +37,7 @@ export function ReferenceLineOverlay({
   palette,
   formatValue,
   font,
+  fontProp,
   badgeLayer = false,
   suppressTag = false,
   groupHidden,
@@ -47,6 +50,12 @@ export function ReferenceLineOverlay({
   palette: LiveChartPalette;
   formatValue: (v: number) => string;
   font: SkFont;
+  /**
+   * The chart's raw font config — used to build a per-badge font when the line's
+   * {@link ReferenceLineBadgeConfig} sets `fontSize` / `fontFamily` / `fontWeight`.
+   * When no badge font knob is set, the resolved `font` is used as-is.
+   */
+  fontProp?: FontConfig;
   /**
    * Render only the badge + label (`true`) or only the lines / bands (`false`,
    * default). The caller draws the base pass behind the chart content and the
@@ -73,18 +82,46 @@ export function ReferenceLineOverlay({
 }) {
   const form = referenceLineForm(line);
   const isBand = form === "value-band" || form === "time-band";
+
+  const color = line.color ?? palette.refLine;
+
+  // Resolved badge appearance (badge config → fallback flat fields → theme).
+  const badge = resolveReferenceBadge(line);
+
+  // Per-badge font (size/family/weight) override; reuses the chart `font` when no
+  // badge font knob is set, so plain lines and gutter labels are unchanged. The
+  // built font drives pill measurement (via useReferenceLine) and the badge text.
+  const badgeHasFontOverride =
+    badge != null &&
+    (badge.fontSize != null ||
+      badge.fontFamily != null ||
+      badge.fontWeight != null);
+  const badgeFontOverride = useChartSkiaFont(
+    badgeHasFontOverride
+      ? {
+          ...fontProp,
+          fontFamily: badge?.fontFamily ?? fontProp?.fontFamily,
+          fontSize: badge?.fontSize ?? fontProp?.fontSize,
+          fontWeight: badge?.fontWeight ?? fontProp?.fontWeight,
+        }
+      : fontProp,
+    MONO_FONT_FAMILY,
+    palette.labelFontSize,
+  );
+  const badgeFont = badgeHasFontOverride ? badgeFontOverride : font;
+
   const layout = useReferenceLine(
     engine,
     padding,
     line,
     formatValue,
-    font,
+    badgeFont,
     dragValues,
     index,
   );
 
-  const color = line.color ?? palette.refLine;
-  const labelColor = line.labelColor ?? line.color ?? palette.refLabel;
+  const labelColor =
+    badge?.textColor ?? line.labelColor ?? line.color ?? palette.refLabel;
   const strokeWidth = line.strokeWidth ?? 1;
   const intervals = line.intervals ?? [4, 4];
 
@@ -92,11 +129,17 @@ export function ReferenceLineOverlay({
   const bandFillOpacity = line.fillOpacity ?? BAND_FILL_OPACITY;
   const hasBandBorder = isBand && line.strokeWidth !== undefined;
 
-  // Resolved badge appearance (badge config → fallback flat fields → theme).
-  const badge = resolveReferenceBadge(line);
   const badgeBackground = badge?.background ?? palette.tooltipBg;
   const badgeBorderColor = badge?.borderColor ?? color;
+  const badgeBorderWidth = badge?.borderWidth ?? 1;
   const badgeRadius = badge?.radius ?? BADGE_PILL_RADIUS;
+  // Nudge the whole badge (connector + pill + chevron + icon + label) off its anchor.
+  const badgeOffsetX = badge?.offsetX ?? 0;
+  const badgeOffsetY = badge?.offsetY ?? 0;
+  const badgeTransform =
+    badgeOffsetX !== 0 || badgeOffsetY !== 0
+      ? [{ translateX: badgeOffsetX }, { translateY: badgeOffsetY }]
+      : undefined;
 
   const lineBuilder = usePathBuilder();
   const bandBuilder = usePathBuilder();
@@ -216,7 +259,7 @@ export function ReferenceLineOverlay({
   // Font metrics depend only on the (stable) font, so read them once instead of
   // on every frame inside the pill worklet (`getMetrics` allocates + crosses JSI).
   const { ascent: fontAscent, height: pillH } = (() => {
-    const fm = font.getMetrics();
+    const fm = badgeFont.getMetrics();
     return {
       ascent: fm.ascent,
       height: fm.descent - fm.ascent + BADGE_PILL_PAD_Y * 2,
@@ -268,7 +311,7 @@ export function ReferenceLineOverlay({
 
       {/* Badge pass — connector + pill + chevron + icon, above the left-edge fade. */}
       {badgeLayer && (
-        <Group opacity={badgeOpacity}>
+        <Group opacity={badgeOpacity} transform={badgeTransform}>
           <Path
             path={connPath}
             style="stroke"
@@ -293,7 +336,7 @@ export function ReferenceLineOverlay({
             r={badgeRadius}
             color={badgeBorderColor}
             style="stroke"
-            strokeWidth={1}
+            strokeWidth={badgeBorderWidth}
           />
           <Path
             path={chevronPath}
@@ -308,7 +351,7 @@ export function ReferenceLineOverlay({
               x={iconX}
               y={labelY}
               text={iconText}
-              font={font}
+              font={badgeFont}
               color={labelColor}
             />
           </Group>
@@ -317,12 +360,12 @@ export function ReferenceLineOverlay({
 
       {/* Labels ride in the badge pass too, so they stay crisp above the fade. */}
       {badgeLayer && (
-        <Group opacity={labelOpacity}>
+        <Group opacity={labelOpacity} transform={badgeTransform}>
           <SkiaText
             x={labelX}
             y={labelY}
             text={labelText}
-            font={font}
+            font={badgeFont}
             color={labelColor}
           />
         </Group>

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -36,6 +36,7 @@ export type {
   AxisLabelConfig,
   BadgeConfig,
   BadgeMetrics,
+  BadgeStyleConfig,
   BadgeVariant,
   CandleMetrics,
   CandlePoint,

--- a/packages/react-native-livechart/src/math/referenceLines.ts
+++ b/packages/react-native-livechart/src/math/referenceLines.ts
@@ -1,4 +1,8 @@
-import type { ReferenceLine } from "../types";
+import type {
+  FontWeight,
+  ReferenceLine,
+  ReferenceLineBadgeConfig,
+} from "../types";
 
 /** Which of the three reference-line forms a `ReferenceLine` resolves to. */
 export type ReferenceLineForm = "line" | "value-band" | "time-band" | "none";
@@ -40,22 +44,84 @@ export function collectReferenceValues(lines: ReferenceLine[]): number[] {
   return out;
 }
 
-/** Fully-resolved badge presentation for a Form-A reference line. */
-export interface ResolvedReferenceBadge {
+/**
+ * Fully-resolved badge **style/shape** + anchor — the resolved counterpart of
+ * {@link BadgeStyleConfig} (`position` / `icon` / `showText` plus the style knobs).
+ * Shared by the reference-line badge ({@link ResolvedReferenceBadge}) and the
+ * grouping count pill ({@link ResolvedReferenceGroupBadge}). Unset colors stay
+ * `undefined` so the overlay applies the appropriate theme default at render time.
+ */
+export interface ResolvedReferenceBadgeStyle {
   position: "left" | "center" | "right";
   /** Leading glyph, or "" for none. */
   icon: string;
-  /** Whether the text label is shown. */
+  /** Whether the text label is shown (false → icon-only). */
   showText: boolean;
-  /** undefined → theme tooltipBg at render time. */
   background: string | undefined;
-  /** undefined → the line color at render time. */
   borderColor: string | undefined;
+  /** Border stroke width in px. Default `1`. */
+  borderWidth: number;
   radius: number;
+  textColor: string | undefined;
+  /** Per-badge font knobs; undefined → the chart font. */
+  fontSize: number | undefined;
+  fontFamily: string | undefined;
+  fontWeight: FontWeight | undefined;
+  /** Nudge the whole badge from its anchor, in px. Default `0`. */
+  offsetX: number;
+  offsetY: number;
+}
+
+/** Fully-resolved presentation for a Form-A reference-line badge — the shared
+ *  style/shape plus the in-range / legacy-text flags. */
+export interface ResolvedReferenceBadge extends ResolvedReferenceBadgeStyle {
   /** Show the pill at the value when in range (`badge`) vs only off-screen (legacy `offAxisBadge`). */
   inRange: boolean;
   /** Legacy `"word: value"` text format (off-axis badge) vs the `label`/value format. */
   legacyText: boolean;
+}
+
+/** Fully-resolved styling for the grouping **count pill** — exactly the shared
+ *  badge style/shape (no in-range / legacy concepts). */
+export type ResolvedReferenceGroupBadge = ResolvedReferenceBadgeStyle;
+
+/**
+ * Resolves the shared style/shape + anchor of a {@link BadgeStyleConfig}-shaped
+ * badge config. `flat` supplies a reference line's flat `badge*` fallbacks
+ * (`badgeBackground` / `badgeBorderColor` / `badgeRadius`); omit it for the group
+ * pill. Theme defaults for the unset colors are applied at render time. Worklet —
+ * also called from the {@link resolveReferenceBadge} worklet.
+ */
+function resolveReferenceBadgeStyle(
+  cfg: ReferenceLineBadgeConfig | undefined,
+  flat?: ReferenceLine,
+): ResolvedReferenceBadgeStyle {
+  "worklet";
+  return {
+    position: cfg?.position ?? "left",
+    icon: cfg?.icon ?? "",
+    showText: cfg?.text ?? true,
+    background: cfg?.background ?? flat?.badgeBackground,
+    borderColor: cfg?.borderColor ?? flat?.badgeBorderColor,
+    borderWidth: cfg?.borderWidth ?? 1,
+    radius: cfg?.radius ?? flat?.badgeRadius ?? 5,
+    textColor: cfg?.textColor,
+    fontSize: cfg?.fontSize,
+    fontFamily: cfg?.fontFamily,
+    fontWeight: cfg?.fontWeight,
+    offsetX: cfg?.offsetX ?? 0,
+    offsetY: cfg?.offsetY ?? 0,
+  };
+}
+
+/**
+ * Resolves the grouping count-pill styling from a {@link ReferenceLineBadgeConfig}
+ * (the same shape a per-line badge uses). Pure — driven only by the config.
+ */
+export function resolveReferenceGroupBadge(
+  badge?: ReferenceLineBadgeConfig,
+): ResolvedReferenceGroupBadge {
+  return resolveReferenceBadgeStyle(badge);
 }
 
 /**
@@ -70,24 +136,15 @@ export function resolveReferenceBadge(
   if (rl.badge) {
     const cfg = rl.badge === true ? undefined : rl.badge;
     return {
-      position: cfg?.position ?? "left",
-      icon: cfg?.icon ?? "",
-      showText: cfg?.text ?? true,
-      background: cfg?.background ?? rl.badgeBackground,
-      borderColor: cfg?.borderColor ?? rl.badgeBorderColor,
-      radius: cfg?.radius ?? rl.badgeRadius ?? 5,
+      ...resolveReferenceBadgeStyle(cfg, rl),
       inRange: true,
       legacyText: false,
     };
   }
   if (rl.offAxisBadge) {
+    // Legacy off-axis badge: no config object, but the flat `badge*` fallbacks apply.
     return {
-      position: "left",
-      icon: "",
-      showText: true,
-      background: rl.badgeBackground,
-      borderColor: rl.badgeBorderColor,
-      radius: rl.badgeRadius ?? 5,
+      ...resolveReferenceBadgeStyle(undefined, rl),
       inRange: false,
       legacyText: true,
     };

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -187,12 +187,49 @@ export interface ReferenceLine {
 }
 
 /**
+ * Shared **style & shape** knobs for every badge pill — the value `badge`
+ * ({@link BadgeConfig}), reference-line badges ({@link ReferenceLineBadgeConfig}),
+ * and the grouping count pill. Each badge interface extends this and adds its own
+ * anchor (`position`) / content fields. Unset values fall back to that badge's own
+ * defaults (documented on each interface). One source of truth so every badge is
+ * configured identically.
+ */
+export interface BadgeStyleConfig {
+  /** Pill background color. */
+  background?: string;
+  /** Pill border color. */
+  borderColor?: string;
+  /** Border stroke width in pixels. Default `1`. */
+  borderWidth?: number;
+  /** Pill corner radius in pixels. */
+  radius?: number;
+  /** Label / icon text color override. */
+  textColor?: string;
+  /** Badge font size in pixels. Falls back to the chart `font`. */
+  fontSize?: number;
+  /** Badge font family. Falls back to the chart `font`. */
+  fontFamily?: string;
+  /** Badge font weight. Falls back to the chart `font`. */
+  fontWeight?: FontWeight;
+  /** Nudge the whole badge horizontally from its anchor, in pixels. Default `0`. */
+  offsetX?: number;
+  /** Nudge the whole badge vertically from its anchor, in pixels. Default `0`. */
+  offsetY?: number;
+}
+
+/**
  * Pill-badge presentation for a Form-A {@link ReferenceLine} — a working order,
  * price alert, or target tag. The badge sits at the line's value (pinned to
  * `position`) with a dashed connector to the opposite edge, and pins to the
  * nearest edge with a chevron once the value scrolls off-screen.
+ *
+ * Extends {@link BadgeStyleConfig} for the style/shape knobs. Their reference-line
+ * fallbacks: `background` → `badgeBackground` → theme `tooltipBg`; `borderColor` →
+ * `badgeBorderColor` → the line `color`; `radius` → `badgeRadius` → `5`; `textColor`
+ * → `labelColor` → the line `color` → theme `refLabel`; the `font*` knobs → the
+ * chart `font`.
  */
-export interface ReferenceLineBadgeConfig {
+export interface ReferenceLineBadgeConfig extends BadgeStyleConfig {
   /**
    * Where the badge pins horizontally. `"left"` / `"right"` pin to that plot edge
    * with a dashed connector running to the opposite edge; `"center"` floats the
@@ -209,12 +246,6 @@ export interface ReferenceLineBadgeConfig {
    * Default `true`. Set `false` for an **icon-only** badge.
    */
   text?: boolean;
-  /** Pill background. Falls back to `badgeBackground`, then theme `tooltipBg`. */
-  background?: string;
-  /** Pill border color. Falls back to `badgeBorderColor`, then the line `color`. */
-  borderColor?: string;
-  /** Pill corner radius in pixels. Falls back to `badgeRadius`, then `5`. */
-  radius?: number;
 }
 
 /**
@@ -263,6 +294,23 @@ export interface ReferenceLineGroupingConfig {
    * Default `18`.
    */
   radius?: number;
+  /**
+   * Styling for the collapsed **count pill** — the same style/shape config as a
+   * reference-line badge ({@link ReferenceLineBadgeConfig}): `position`
+   * (`"left"` / `"center"` / `"right"`), `icon` (a leading glyph before the count),
+   * `background`, `borderColor`, `borderWidth`, `radius` (corner radius),
+   * `textColor`, `fontSize` / `fontFamily` / `fontWeight`, and `offsetX` / `offsetY`.
+   * Omit for the theme defaults (left-pinned, `tooltipBg` fill, `refLine` border,
+   * `refLabel` text). The badge's `text: false` hides the count for an icon-only pill.
+   */
+  badge?: ReferenceLineBadgeConfig;
+  /**
+   * Format the collapsed count for the pill label, e.g. `n => \`×${n}\`` or
+   * `n => \`${n} orders\``. Default `String(n)` (the bare count). **Must be a
+   * worklet** (add the `"worklet"` directive) — it runs on the UI thread each
+   * frame, like the chart's `formatValue`. A plain JS closure throws.
+   */
+  format?: (count: number) => string;
 }
 
 /**
@@ -466,45 +514,20 @@ export interface AreaDotsConfig {
   opacity?: number;
 }
 
-/** Value badge pill configuration. */
-export interface BadgeConfig {
+/**
+ * Value badge pill configuration. Extends {@link BadgeStyleConfig} for the
+ * style/shape knobs (`background`, `borderColor` / `borderWidth`, `radius`,
+ * `textColor`, `font*`, `offsetX/Y`). Value-badge specifics: `radius` defaults to a
+ * full capsule (clamped to `[0, pillHeight / 2]`); `borderColor` unset → no border;
+ * `textColor` unset → the `variant` / theme rule.
+ */
+export interface BadgeConfig extends BadgeStyleConfig {
   /** Visual style of the badge pill. Default `"default"`. */
   variant?: BadgeVariant;
   /** Show the pointed tail toward the live dot. Default `true`. */
   tail?: boolean;
-  /** Badge background color override. */
-  background?: string;
   /** Which side of the chart the badge appears on. Default `"right"`. */
   position?: "right" | "left";
-  /**
-   * Pill corner radius in pixels. Default: half the pill height (a full
-   * capsule). Clamped to `[0, pillHeight / 2]`, so the maximum is always the
-   * capsule. `0` gives square corners.
-   */
-  radius?: number;
-  /** Pill border color. When unset, the badge has no border. */
-  borderColor?: string;
-  /** Border stroke width in pixels — only drawn when `borderColor` is set. Default `1`. */
-  borderWidth?: number;
-  /**
-   * Label text color override. Mirrors `background`; when unset the text color
-   * follows the `variant` / theme rule.
-   */
-  textColor?: string;
-  /**
-   * Badge font size in pixels. Falls back to the chart `font`. Note: a size
-   * larger than the chart font can crowd the reserved right gutter — pair with
-   * `position: "left"` or `yAxis.float` if it overflows.
-   */
-  fontSize?: number;
-  /** Badge font family. Falls back to the chart `font`. */
-  fontFamily?: string;
-  /** Badge font weight. Falls back to the chart `font`. */
-  fontWeight?: FontWeight;
-  /** Nudge the whole badge horizontally from its anchor, in pixels. Default `0`. */
-  offsetX?: number;
-  /** Nudge the whole badge vertically from its anchor, in pixels. Default `0`. */
-  offsetY?: number;
   /**
    * When the chart is scrolled back (see `timeScroll`), move the live-price
    * indicators — the badge, the value line, and the live dot — to the price at

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -307,6 +307,47 @@ describe("LiveChart", () => {
     );
   });
 
+  it("renders styled reference-line badges and a styled group count pill", () => {
+    render(
+      <Harness
+        referenceLines={[
+          {
+            value: 50,
+            label: "Target",
+            badge: {
+              position: "center",
+              background: "#111",
+              borderColor: "#fff",
+              borderWidth: 2,
+              radius: 8,
+              textColor: "#0f0",
+              fontSize: 16,
+              fontFamily: "Menlo",
+              fontWeight: "700",
+              offsetX: 4,
+              offsetY: -2,
+            },
+          },
+          { value: 60, badge: true }, // near-value alerts → group
+          { value: 60.4, badge: true },
+        ]}
+        referenceLineGrouping={{
+          radius: 60,
+          badge: {
+            position: "center",
+            icon: "⚠",
+            borderWidth: 2,
+            radius: 9,
+            textColor: "#fbbf24",
+            fontSize: 14,
+            offsetX: 2,
+          },
+          format: (n) => `×${n}`,
+        }}
+      />,
+    );
+  });
+
   it("accepts custom formatters", () => {
     render(
       <Harness formatValue={(v) => v.toFixed(4)} formatTime={() => "x"} />,

--- a/packages/react-native-livechart/tests/components/ReferenceLineGroupOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ReferenceLineGroupOverlay.test.tsx
@@ -3,7 +3,9 @@ import { render } from "@testing-library/react-native";
 import { ReferenceLineGroupOverlay } from "../../src/components/ReferenceLineGroupOverlay";
 import { DEFAULT_PADDING } from "../../src/draw/line";
 import type { ReferenceGrouping } from "../../src/math/referenceGroup";
+import { resolveReferenceGroupBadge } from "../../src/math/referenceLines";
 import { resolveTheme } from "../../src/theme";
+import type { ReferenceLineBadgeConfig } from "../../src/types";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
 const font = {
@@ -13,54 +15,85 @@ const font = {
 } as never;
 
 const palette = resolveTheme("#3b82f6", "dark");
+const canvasWidth = withSharedValueAccessors({ v: { value: 400 } }).v as never;
 
 function sv(value: ReferenceGrouping) {
   return withSharedValueAccessors({ v: { value } }).v as never;
 }
 
+function renderOverlay(
+  grouping: ReferenceGrouping,
+  cfg?: ReferenceLineBadgeConfig,
+  format?: (n: number) => string,
+) {
+  return render(
+    <ReferenceLineGroupOverlay
+      grouping={sv(grouping)}
+      padding={DEFAULT_PADDING}
+      canvasWidth={canvasWidth}
+      palette={palette}
+      font={font}
+      badge={resolveReferenceGroupBadge(cfg)}
+      format={format}
+    />,
+  );
+}
+
 describe("ReferenceLineGroupOverlay", () => {
   it("renders a count pill for each multi-line cluster", () => {
-    const grouping = sv({
-      hidden: [true, true, true],
-      groups: [{ cy: 150, count: 3 }],
-    });
-    render(
-      <ReferenceLineGroupOverlay
-        grouping={grouping}
-        padding={DEFAULT_PADDING}
-        palette={palette}
-        font={font}
-      />,
-    );
+    renderOverlay({ hidden: [true, true, true], groups: [{ cy: 150, count: 3 }] });
   });
 
   it("renders nothing visible when there are no groups", () => {
-    const grouping = sv({ hidden: [], groups: [] });
-    render(
-      <ReferenceLineGroupOverlay
-        grouping={grouping}
-        padding={DEFAULT_PADDING}
-        palette={palette}
-        font={font}
-      />,
-    );
+    renderOverlay({ hidden: [], groups: [] });
   });
 
   it("renders multiple clusters at once", () => {
-    const grouping = sv({
+    renderOverlay({
       hidden: [true, true, true, true],
       groups: [
         { cy: 80, count: 2 },
         { cy: 220, count: 2 },
       ],
     });
-    render(
-      <ReferenceLineGroupOverlay
-        grouping={grouping}
-        padding={DEFAULT_PADDING}
-        palette={palette}
-        font={font}
-      />,
+  });
+
+  it("applies a count formatter", () => {
+    renderOverlay(
+      { hidden: [true, true, true], groups: [{ cy: 150, count: 3 }] },
+      undefined,
+      (n) => `×${n}`,
+    );
+  });
+
+  it("anchors center and right (exercises canvasWidth positioning)", () => {
+    const g: ReferenceGrouping = {
+      hidden: [true, true],
+      groups: [{ cy: 120, count: 2 }],
+    };
+    renderOverlay(g, { position: "center" });
+    renderOverlay(g, { position: "right" });
+  });
+
+  it("renders an icon-only pill (text: false)", () => {
+    renderOverlay(
+      { hidden: [true, true], groups: [{ cy: 90, count: 2 }] },
+      { icon: "⚠", text: false },
+    );
+  });
+
+  it("honors style/shape overrides (radius, border, colors, offset)", () => {
+    renderOverlay(
+      { hidden: [true, true], groups: [{ cy: 100, count: 2 }] },
+      {
+        radius: 0,
+        background: "#111",
+        borderColor: "#f00",
+        borderWidth: 2,
+        textColor: "#0f0",
+        offsetX: 4,
+        offsetY: -3,
+      },
     );
   });
 });

--- a/packages/react-native-livechart/tests/math/referenceLines.test.ts
+++ b/packages/react-native-livechart/tests/math/referenceLines.test.ts
@@ -3,6 +3,7 @@ import {
   collectReferenceValues,
   referenceLineForm,
   resolveReferenceBadge,
+  resolveReferenceGroupBadge,
 } from "../../src/math/referenceLines";
 
 describe("resolveReferenceBadge", () => {
@@ -17,7 +18,14 @@ describe("resolveReferenceBadge", () => {
       showText: true,
       background: undefined,
       borderColor: undefined,
+      borderWidth: 1,
       radius: 5,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
       inRange: true,
       legacyText: false,
     });
@@ -42,9 +50,41 @@ describe("resolveReferenceBadge", () => {
       showText: false,
       background: "#111",
       borderColor: "#fff",
+      borderWidth: 1,
       radius: 8,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
       inRange: true,
       legacyText: false,
+    });
+  });
+
+  it("resolves the new style/shape knobs (border width, text color, font, offset)", () => {
+    const r = resolveReferenceBadge({
+      value: 5,
+      badge: {
+        borderColor: "#fff",
+        borderWidth: 3,
+        textColor: "#0f0",
+        fontSize: 16,
+        fontFamily: "Menlo",
+        fontWeight: "700",
+        offsetX: 4,
+        offsetY: -2,
+      },
+    });
+    expect(r).toMatchObject({
+      borderWidth: 3,
+      textColor: "#0f0",
+      fontSize: 16,
+      fontFamily: "Menlo",
+      fontWeight: "700",
+      offsetX: 4,
+      offsetY: -2,
     });
   });
 
@@ -68,7 +108,14 @@ describe("resolveReferenceBadge", () => {
       showText: true,
       background: undefined,
       borderColor: undefined,
+      borderWidth: 1,
       radius: 5,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
       inRange: false,
       legacyText: true,
     });
@@ -78,6 +125,56 @@ describe("resolveReferenceBadge", () => {
     const r = resolveReferenceBadge({ value: 5, badge: true, offAxisBadge: true });
     expect(r?.inRange).toBe(true);
     expect(r?.legacyText).toBe(false);
+  });
+});
+
+describe("resolveReferenceGroupBadge", () => {
+  it("returns left-pinned theme defaults when no config is given", () => {
+    expect(resolveReferenceGroupBadge()).toEqual({
+      position: "left",
+      icon: "",
+      showText: true,
+      background: undefined,
+      borderColor: undefined,
+      borderWidth: 1,
+      radius: 5,
+      textColor: undefined,
+      fontSize: undefined,
+      fontFamily: undefined,
+      fontWeight: undefined,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  it("passes through the style/shape config", () => {
+    expect(
+      resolveReferenceGroupBadge({
+        position: "center",
+        icon: "★",
+        text: false,
+        background: "#222",
+        borderColor: "#abc",
+        borderWidth: 2,
+        radius: 10,
+        textColor: "#eee",
+        fontSize: 14,
+        offsetX: -5,
+        offsetY: 6,
+      }),
+    ).toMatchObject({
+      position: "center",
+      icon: "★",
+      showText: false,
+      background: "#222",
+      borderColor: "#abc",
+      borderWidth: 2,
+      radius: 10,
+      textColor: "#eee",
+      fontSize: 14,
+      offsetX: -5,
+      offsetY: 6,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Stacked follow-up to #153. Brings the **reference-line badge** and the **grouping count pill** up to the value `badge`'s style/shape config (#152), so every badge is configured identically — and unifies the underlying types so there's a single source of truth.

## Type reuse (the point of this PR)

- New shared **`BadgeStyleConfig`** base — the 10 style/shape knobs (`background`, `borderColor`, `borderWidth`, `radius`, `textColor`, `fontSize`/`fontFamily`/`fontWeight`, `offsetX`/`offsetY`). `BadgeConfig` and `ReferenceLineBadgeConfig` now `extend` it; the group pill reuses `ReferenceLineBadgeConfig` via `ReferenceLineGroupingConfig.badge`. A future knob added once propagates to all three.
- Resolved side deduped: a shared `ResolvedReferenceBadgeStyle` (group badge = it exactly; reference badge = it + `inRange`/`legacyText`) and a single `resolveReferenceBadgeStyle` helper both resolvers delegate to.

## New knobs (parity with the value `badge`)

| Knob | Reference-line badge | Group count pill |
|---|:-:|:-:|
| `borderWidth` | new | new |
| `textColor` | new | new |
| `fontSize` / `fontFamily` / `fontWeight` | new | new |
| `offsetX` / `offsetY` | new | new |
| `position` | existing (`left`/`center`/`right`) | new (`left`/`center`/`right`) |
| `background` / `borderColor` / `radius` | existing | existing |

Plus `ReferenceLineGroupingConfig.format` for the count label (e.g. `n => \`×${n}\``). Like the chart's `formatValue`, it runs on the UI thread and **must be a worklet** (documented; the demo marks it `"worklet"`).

## Implementation notes

- **Per-line badge font** — built in `ReferenceLineOverlay` via `useChartSkiaFont`, reusing the chart font when no font knob is set (so plain lines / gutter labels are unchanged); it drives both pill measurement (`useReferenceLine`) and the badge text. The group pill builds one font in the controller.
- **Border / offset** — border `strokeWidth` is now configurable; `offsetX/Y` nudge the whole badge via a `Group` transform.
- **Group pill anchoring** — `left`/`center`/`right` using `canvasWidth`, mirroring the per-line badge.

## Testing

- `npm run verify` green — typecheck, lint, **1123 tests** (84 suites) pass; coverage thresholds met. New coverage for `resolveReferenceGroupBadge`, the style/shape resolver fields, and the styled group overlay.
- **On-device QA** (iOS 26.4 simulator) on the **Working orders** demo: VWAP styled center badge (yellow border + bold yellow text, no connector), and the grouping count pill renders the `"N alerts"` format with a purple ⚠ icon + purple text/border. Caught and fixed a worklet crash when a non-worklet `format` was supplied (now documented + worklet-marked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
