### PR TITLE
feat(yAxis): fixed Y-axis price count

### DIFF
--- a/app/demo/axes-and-grid.tsx
+++ b/app/demo/axes-and-grid.tsx
@@ -5,6 +5,7 @@ import {
   LiveChartSeries,
   type AxisLabelConfig,
   type GridStyleConfig,
+  type YAxisConfig,
 } from "react-native-livechart";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
@@ -19,6 +20,7 @@ export const options = { title: "Axes & grid" };
 type ChartKind = "single" | "multi";
 type AxisVis = "both" | "noY" | "noX" | "none";
 type GapPreset = "default" | "wide";
+type YCountPreset = "auto" | "3" | "5" | "7";
 type GridLineStyle = "default" | "dotted" | "solid" | "blue";
 
 const CHART_OPTIONS: { value: ChartKind; label: string }[] = [
@@ -36,6 +38,13 @@ const VIS_OPTIONS: { value: AxisVis; label: string }[] = [
 const GAP_OPTIONS: { value: GapPreset; label: string }[] = [
   { value: "default", label: "Default" },
   { value: "wide", label: "Wide minGap" },
+];
+
+const Y_COUNT_OPTIONS: { value: YCountPreset; label: string }[] = [
+  { value: "auto", label: "Auto" },
+  { value: "3", label: "3 prices" },
+  { value: "5", label: "5 prices" },
+  { value: "7", label: "7 prices" },
 ];
 
 const GRID_OPTIONS: { value: GridLineStyle; label: string }[] = [
@@ -58,6 +67,7 @@ const GRID_STYLES: Record<GridLineStyle, GridStyleConfig | undefined> = {
 export default function AxesGridScreen() {
   const [vis, setVis] = useState<AxisVis>("both");
   const [gap, setGap] = useState<GapPreset>("default");
+  const [yCount, setYCount] = useState<YCountPreset>("auto");
   const [which, setWhich] = useState<ChartKind>("single");
   const [highLow, setHighLow] = useState(false);
   const [customLabel, setCustomLabel] = useState(false);
@@ -73,7 +83,17 @@ export default function AxesGridScreen() {
   const yOn = vis !== "noY" && vis !== "none";
   const xOn = vis !== "noX" && vis !== "none";
 
-  const yAxis = !yOn ? false : gap === "wide" ? { minGap: 72 } : true;
+  // `count` shows a fixed number of evenly-spaced prices (high→low) instead of
+  // the dynamic nice-interval grid; `minGap` still acts as a floor on spacing.
+  const yCountVal = yCount === "auto" ? 0 : Number(yCount);
+  const yAxisCfg: YAxisConfig = {};
+  if (gap === "wide") yAxisCfg.minGap = 72;
+  if (yCountVal > 0) yAxisCfg.count = yCountVal;
+  const yAxis = !yOn
+    ? false
+    : Object.keys(yAxisCfg).length > 0
+      ? yAxisCfg
+      : true;
   const xAxis = !xOn ? false : gap === "wide" ? { minGap: 100 } : true;
 
   // An explicit inset overrides the auto-padding — including the live-dot pulse's
@@ -108,7 +128,7 @@ export default function AxesGridScreen() {
     <DemoScreen
       title="Axes & grid"
       docs="guides/axes-and-grid"
-      description="Hide Y, X, or both; axis minGap; explicit insets (bottom 0 fills the plot to the edge). Toggle single vs multi chart, and Robinhood-style high/low edge labels (built-in or a custom render)."
+      description="Hide Y, X, or both; axis minGap; a fixed Y-axis price count; explicit insets (bottom 0 fills the plot to the edge). Toggle single vs multi chart, and Robinhood-style high/low edge labels (built-in or a custom render)."
       chart={
         which === "single" ? (
           <LiveChart
@@ -159,6 +179,12 @@ export default function AxesGridScreen() {
         options={GAP_OPTIONS}
         value={gap}
         onChange={setGap}
+      />
+      <ChipRow
+        label="Fixed Y price count"
+        options={Y_COUNT_OPTIONS}
+        value={yCount}
+        onChange={setYCount}
       />
       <ChipRow
         label="Grid lines (gridStyle)"

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -322,7 +322,8 @@ provided; everything else has a default.
 </ParamField>
 
 <ParamField body="yAxis" type="boolean | YAxisConfig" default="true">
-  Value-axis grid + labels.
+  Value-axis grid + labels. Pass `{ count }` for a fixed number of evenly-spaced
+  prices instead of the dynamic nice-interval grid.
 </ParamField>
 
 <ParamField body="topLabel" type="boolean | AxisLabelConfig" default="false">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -341,6 +341,10 @@ interface SelectionDotConfig {
 interface GridStyleConfig { color?: string; strokeWidth?: number; intervals?: number[]; opacity?: number }
 interface YAxisConfig {
   minGap?: number; // min px gap between grid lines; default 36
+  // Show a fixed number of evenly-spaced prices (top = high, bottom = low)
+  // instead of the dynamic nice-interval grid. Values track the live range each
+  // frame. `minGap` still floors the spacing; clamped to at most 15. Default 0.
+  count?: number;
   // Float the price axis over a full-width plot instead of reserving a right
   // gutter — the line/candles run to the edge and the labels float on top.
   // Pairs with `timeScroll` (see the Time-scroll guide). Default false. @experimental

--- a/docs/guides/axes-and-grid.mdx
+++ b/docs/guides/axes-and-grid.mdx
@@ -29,6 +29,20 @@ description: "Tune the grid lines, hide or space the axes, float edge labels, an
 Pass `yAxis={false}` or `xAxis={false}` to hide an axis. `gridStyle.intervals` of `[]` renders
 solid grid lines.
 
+## Fixed Y-axis price count
+
+By default the Y axis picks a dynamic number of "nice"-value grid lines from `minGap`. Pass
+`yAxis={{ count }}` to instead show a **fixed** number of prices, spaced evenly down the plot —
+top label = current high, bottom = current low. The count stays constant as data streams in;
+the values track the live range each frame (they aren't rounded to nice numbers).
+
+```tsx
+<LiveChart data={data} value={value} yAxis={{ count: 5 }} />
+```
+
+`minGap` still acts as a floor: if `count` labels won't fit at least `minGap` px apart, the count
+drops to what fits. The count is clamped to at most 15.
+
 ## Axis edge labels
 
 `topLabel` and `bottomLabel` float a value at the top / bottom edge of the plot — the

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -723,6 +723,7 @@ function useLiveChartController({
     skiaFont,
     yAxisCfg?.minGap ?? 36,
     metricsCfg.grid,
+    yAxisCfg?.count ?? 0,
   );
 
   const { xAxisEntries } = useXAxis(

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -345,6 +345,7 @@ function useLiveChartSeriesController({
     skiaFont,
     yAxisCfg?.minGap ?? 36,
     metricsCfg.grid,
+    yAxisCfg?.count ?? 0,
   );
 
   const { xAxisEntries } = useXAxis(

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -5,7 +5,7 @@ import {
   type SkFont,
 } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import { BADGE_METRICS_DEFAULTS } from "../constants";
+import { BADGE_METRICS_DEFAULTS, MAX_Y_LABELS } from "../constants";
 import type { ResolvedGridStyleConfig } from "../core/resolveConfig";
 import type { YAxisEntry } from "../draw/grid";
 import {
@@ -21,7 +21,6 @@ import type { BadgeMetrics, LiveChartPalette } from "../types";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import { AnimatedLabel } from "./AnimatedLabel";
 
-const MAX_Y_LABELS = 15;
 /** Right margin (px) for floating labels — keeps them just off the canvas edge. */
 const FLOAT_LABEL_RIGHT_MARGIN = 6;
 

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -10,6 +10,13 @@ import type {
 export const MS_PER_FRAME_60FPS = 16.67;
 
 /**
+ * Size of the pre-allocated Y-axis label pool — the most price labels the axis
+ * ever renders at once. Caps both the dynamic (nice-interval) grid and the
+ * fixed-`count` mode (see {@link YAxisConfig.count}).
+ */
+export const MAX_Y_LABELS = 15;
+
+/**
  * Default press-and-hold (ms) before scrub engages in the `holdToScrub`
  * time-scroll mode, so a quick one-finger drag scrolls instead. Overridden by
  * `timeScroll.scrubHoldMs`, then `scrub.panGestureDelay`. Shared by `LiveChart`

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -79,6 +79,8 @@ export interface ResolvedBadgeConfig {
 
 export interface ResolvedYAxisConfig {
   minGap: number;
+  /** Fixed label count (≥ 2), or 0 for the dynamic nice-interval grid. */
+  count: number;
   /** Float the axis over a full-width plot (no reserved right gutter). */
   float: boolean;
 }
@@ -393,17 +395,22 @@ export function resolveBadge(
 
 const Y_AXIS_DEFAULTS: ResolvedYAxisConfig = {
   minGap: 36,
+  count: 0,
   float: false,
 };
 
 /**
  * Resolves `yAxis` prop to a fully-typed config or null (disabled).
  * `true` → defaults, object → merged with defaults, falsy → null.
+ * `count` is normalized to a non-negative integer (the grid math clamps the
+ * upper bound to the label pool size).
  */
 export function resolveYAxis(
   prop: boolean | YAxisConfig | undefined,
 ): ResolvedYAxisConfig | null {
-  return resolveToggle(prop, Y_AXIS_DEFAULTS, false);
+  const resolved = resolveToggle(prop, Y_AXIS_DEFAULTS, false);
+  if (resolved === null) return null;
+  return { ...resolved, count: Math.max(0, Math.floor(resolved.count)) };
 }
 
 const VOLUME_DEFAULTS: ResolvedVolumeConfig = {

--- a/packages/react-native-livechart/src/draw/grid.ts
+++ b/packages/react-native-livechart/src/draw/grid.ts
@@ -1,4 +1,4 @@
-import { GRID_METRICS_DEFAULTS } from "../constants";
+import { GRID_METRICS_DEFAULTS, MAX_Y_LABELS } from "../constants";
 import { lerp } from "../math/lerp";
 import type { GridMetrics } from "../types";
 
@@ -6,6 +6,43 @@ export interface YAxisEntry {
   y: number;
   label: string;
   alpha: number;
+}
+
+/**
+ * Fixed-count Y-axis: place exactly `count` price labels evenly **in pixels**
+ * across the plot band — top = `displayMax`, bottom = `displayMin`. Values track
+ * the live range each frame (no nice-number rounding), so the label count stays
+ * constant while data streams in.
+ *
+ * `minGap` is a floor: the count drops to what fits when the plot is too short
+ * to space `count` labels at least `minGap` px apart. Clamped to
+ * `[2, MAX_Y_LABELS]`. Every entry is fully opaque — there's no per-line fade
+ * because the count (and thus each line's pixel slot) doesn't change.
+ */
+export function fixedGridEntries(
+  displayMax: number,
+  valRange: number,
+  chartH: number,
+  padTop: number,
+  count: number,
+  minGap: number,
+  formatValue: (v: number) => string,
+): YAxisEntry[] {
+  "worklet";
+  // minGap floor: at most `floor(chartH / minGap)` gaps fit ⇒ that many + 1 labels.
+  const maxFit = Math.floor(chartH / minGap) + 1;
+  let n = Math.min(count, maxFit, MAX_Y_LABELS);
+  if (n < 2) n = 2;
+
+  const stepPx = chartH / (n - 1);
+  const stepVal = valRange / (n - 1);
+  const entries: YAxisEntry[] = [];
+  for (let i = 0; i < n; i++) {
+    const y = padTop + i * stepPx;
+    const val = displayMax - i * stepVal;
+    entries.push({ y, label: formatValue(val), alpha: 1 });
+  }
+  return entries;
 }
 
 /**
@@ -94,6 +131,7 @@ export function computeGridEntries(
   dt: number,
   minGap = 36,
   grid: GridMetrics = GRID_METRICS_DEFAULTS,
+  count = 0,
 ): { entries: YAxisEntry[]; interval: number } {
   "worklet";
   const chartH = canvasHeight - padTop - padBottom;
@@ -101,6 +139,25 @@ export function computeGridEntries(
 
   const valRange = displayMax - displayMin;
   if (valRange <= 0) return { entries: [], interval: prevInterval };
+
+  // Fixed-count mode bypasses nice-interval picking and per-line fading. Leave
+  // `prevInterval`/`labelAlphas` untouched so toggling back to the dynamic grid
+  // resumes cleanly. Needs at least 2 labels (a high/low pair) to be meaningful;
+  // count of 0 or 1 falls through to the dynamic nice-interval grid.
+  if (count >= 2) {
+    return {
+      entries: fixedGridEntries(
+        displayMax,
+        valRange,
+        chartH,
+        padTop,
+        count,
+        minGap,
+        formatValue,
+      ),
+      interval: prevInterval,
+    };
+  }
 
   const pxPerUnit = chartH / valRange;
 

--- a/packages/react-native-livechart/src/hooks/useYAxis.ts
+++ b/packages/react-native-livechart/src/hooks/useYAxis.ts
@@ -19,6 +19,7 @@ export function useYAxis(
   font: SkFont,
   minGap = 36,
   gridMetrics: GridMetrics = GRID_METRICS_DEFAULTS,
+  count = 0,
 ) {
   const prevInterval = useSharedValue(0);
   const labelAlphas = useSharedValue<Record<number, number>>({});
@@ -39,6 +40,7 @@ export function useYAxis(
       dt,
       minGap,
       gridMetrics,
+      count,
     );
 
     prevInterval.set(result.interval);

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -567,6 +567,18 @@ export interface YAxisConfig {
   /** Minimum pixel gap between grid lines. Default `36`. */
   minGap?: number;
   /**
+   * Show a fixed number of price labels instead of the dynamic nice-interval
+   * grid. When set (≥ 2), exactly `count` labels are spaced evenly **in pixels**
+   * across the plot — top label = current high, bottom = current low — so the
+   * count never changes as data streams in. Values are not rounded to "nice"
+   * numbers; they track the live range each frame.
+   *
+   * `minGap` still acts as a floor: if `count` labels won't fit at least
+   * `minGap` px apart, the count is reduced to what fits. Clamped to at most 15
+   * (the label pool size). Omit (or `0`) for the default dynamic grid.
+   */
+  count?: number;
+  /**
    * Float the price axis over a full-width plot instead of reserving a right
    * gutter for it. The line/candles run all the way to the right edge, and the
    * price labels (and the live-value badge) float on top — so the chart isn't

--- a/packages/react-native-livechart/tests/draw/grid.test.ts
+++ b/packages/react-native-livechart/tests/draw/grid.test.ts
@@ -1,4 +1,9 @@
-import { computeGridEntries, fineLineTargetAlpha, pickInterval } from "../../src/draw/grid";
+import {
+  computeGridEntries,
+  fineLineTargetAlpha,
+  fixedGridEntries,
+  pickInterval,
+} from "../../src/draw/grid";
 
 describe("fineLineTargetAlpha", () => {
   it("maps fine pixel spacing to 0, blend, and 1 bands (default minGap)", () => {
@@ -159,6 +164,74 @@ describe("computeGridEntries", () => {
     expect(r.entries.length).toBeGreaterThan(0);
     // Phase-1 stops emitting targets past the cap (would be ~2000 uncapped).
     expect(Object.keys(alphas).length).toBeLessThanOrEqual(1000);
+  });
+});
+
+describe("fixedGridEntries", () => {
+  const fmt = (v: number) => v.toFixed(2);
+
+  it("places exactly `count` evenly-spaced labels spanning high→low", () => {
+    // 400px plot, 36px minGap → maxFit 12, so count of 5 is honored exactly.
+    const entries = fixedGridEntries(100, 100, 400, 12, 5, 36, fmt);
+    expect(entries).toHaveLength(5);
+    // Top label = displayMax at padTop, bottom = displayMin at padTop + chartH.
+    expect(entries[0]).toEqual({ y: 12, label: "100.00", alpha: 1 });
+    expect(entries[4]).toEqual({ y: 412, label: "0.00", alpha: 1 });
+    // Even pixel + value steps between adjacent labels.
+    expect(entries[1].y - entries[0].y).toBeCloseTo(100);
+    expect(entries[2].label).toBe("50.00");
+  });
+
+  it("reduces the count when minGap won't fit all labels (floor)", () => {
+    // 100px plot, 50px minGap → at most 2 gaps... floor(100/50)+1 = 3 labels.
+    const entries = fixedGridEntries(100, 100, 100, 0, 10, 50, fmt);
+    expect(entries).toHaveLength(3);
+  });
+
+  it("never drops below 2 labels even on a tiny plot", () => {
+    const entries = fixedGridEntries(100, 100, 10, 0, 8, 36, fmt);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("caps the count at the label pool size (15)", () => {
+    const entries = fixedGridEntries(100, 100, 100000, 0, 50, 1, fmt);
+    expect(entries).toHaveLength(15);
+  });
+});
+
+describe("computeGridEntries fixed-count mode", () => {
+  const fmt = (v: number) => v.toFixed(0);
+
+  it("returns fixed equidistant entries and leaves interval untouched", () => {
+    const alphas: Record<number, number> = {};
+    const r = computeGridEntries(
+      0,
+      100,
+      400,
+      12,
+      28,
+      7, // prevInterval — must survive untouched in fixed mode
+      alphas,
+      fmt,
+      16.67,
+      36,
+      undefined,
+      4,
+    );
+    expect(r.entries).toHaveLength(4);
+    expect(r.entries.every((e) => e.alpha === 1)).toBe(true);
+    expect(r.interval).toBe(7);
+    // Fixed mode must not seed the value-keyed fade map.
+    expect(Object.keys(alphas)).toHaveLength(0);
+  });
+
+  it("falls through to the dynamic grid for count < 2", () => {
+    // count of 1 isn't a meaningful fixed axis (needs a high/low pair), so it
+    // must take the dynamic nice-interval path — which seeds the fade map —
+    // rather than the fixed path (which leaves it empty).
+    const alphas: Record<number, number> = {};
+    computeGridEntries(0, 100, 400, 12, 28, 0, alphas, fmt, 16.67, 36, undefined, 1);
+    expect(Object.keys(alphas).length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -192,15 +192,36 @@ describe("resolveYAxis", () => {
   });
 
   it("returns defaults for true", () => {
-    expect(resolveYAxis(true)).toEqual({ minGap: 36, float: false });
+    expect(resolveYAxis(true)).toEqual({ minGap: 36, count: 0, float: false });
   });
 
   it("merges partial config with defaults", () => {
-    expect(resolveYAxis({ minGap: 48 })).toEqual({ minGap: 48, float: false });
+    expect(resolveYAxis({ minGap: 48 })).toEqual({
+      minGap: 48,
+      count: 0,
+      float: false,
+    });
   });
 
   it("carries through the float flag", () => {
-    expect(resolveYAxis({ float: true })).toEqual({ minGap: 36, float: true });
+    expect(resolveYAxis({ float: true })).toEqual({
+      minGap: 36,
+      count: 0,
+      float: true,
+    });
+  });
+
+  it("carries through a fixed count", () => {
+    expect(resolveYAxis({ count: 5 })).toEqual({
+      minGap: 36,
+      count: 5,
+      float: false,
+    });
+  });
+
+  it("normalizes count to a non-negative integer", () => {
+    expect(resolveYAxis({ count: 4.8 })?.count).toBe(4);
+    expect(resolveYAxis({ count: -3 })?.count).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a **fixed Y-axis price count** to the chart. By default the Y axis picks a dynamic number of "nice"-value grid lines from `minGap`; this PR lets you ask for an **exact number** of price labels instead, spaced evenly down the plot.

```tsx
<LiveChart data={data} value={value} yAxis={{ count: 5 }} />
```

Works the same on `LiveChartSeries`.

## Behaviour

- **Exactly N equidistant prices in pixels** — top label = current high, bottom = current low. The count stays constant as data streams in; the values track the live range each frame (they are *not* rounded to nice numbers).
- **`minGap` stays a floor** — if `count` labels won't fit at least `minGap` px apart (short plot), the count drops to what fits. Clamped to `[2, 15]` (the label pool size).
- **`count` of `0` or `1` keeps the dynamic grid** — fixed mode needs a high/low pair to be meaningful, so it only activates at `count >= 2`.

## Changes

**Library**
- `types.ts` — `count?: number` on `YAxisConfig`.
- `core/resolveConfig.ts` — `count` on the resolved config (default `0`), normalized to a non-negative integer.
- `constants.ts` — centralized `MAX_Y_LABELS` (was a local literal in `YAxisOverlay`).
- `draw/grid.ts` — new pure `fixedGridEntries` helper + `count` branch in `computeGridEntries` (leaves dynamic-mode hysteresis / fade state untouched).
- `hooks/useYAxis.ts`, `components/LiveChart.tsx`, `components/LiveChartSeries.tsx`, `components/YAxisOverlay.tsx` — thread `count` through.

**Tests** — `fixedGridEntries` (exact count, `minGap` floor, min 2, cap 15), the `count` branch + `count < 2` fall-through in `computeGridEntries`, and `resolveYAxis` normalization.

**Demo + docs** — "Fixed Y price count" control (Auto / 3 / 5 / 7) in `app/demo/axes-and-grid.tsx`; guide + API reference updated.

## Testing

- `npm run verify` green: typecheck ✓, lint ✓, **1208 tests pass** (coverage thresholds held).
- Verified on the iOS simulator (iPhone 16 Pro, dev build). The Y axis rendered exactly N evenly-spaced prices in each mode:

  | Mode | Y-axis prices |
  |------|---------------|
  | **Auto** (dynamic) | 6 nice-value labels (100.0 / 99.60 / 99.10 / …) |
  | **3** | 103.5 · 101.0 · 98.52 |
  | **5** | 102.7 · 100.2 · 97.73 · 95.23 · 92.73 (step ~2.5) |
  | **7** | 99.17 · 97.93 · 96.70 · 95.47 · 94.24 · … (step ~1.23) |

## 🎥 Demo

https://github.com/user-attachments/assets/ea118da9-208b-4555-be77-ea624163ec53


