### PR TITLE
feat(markers): vertical column stacking via markerCluster direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Vertical marker stacking** — `MarkerClusterConfig.direction`. The
+  `markerCluster` object form gains `direction?: "horizontal" | "vertical"`.
+  `"horizontal"` (default, unchanged) fans co-located markers into an overlapping
+  row; `"vertical"` piles them into a **column** that grows away from the line in
+  each glyph's `side` direction (`"above"` climbs up, `"below"` descends,
+  `"center"` climbs up from the line) — the transactions-stacked-on-the-candle
+  look. Collapse-to-count, grouping, and hit-testing all carry over; raise
+  `maxBeforeGroup` for taller columns before they collapse to a count badge.
+
 ## [4.1.0] - 2026-06-23
 
 ### Added

--- a/app/demo/markers-and-trades.tsx
+++ b/app/demo/markers-and-trades.tsx
@@ -113,6 +113,7 @@ export default function MarkersScreen() {
   const [streamOn, setStreamOn] = useState(false);
   const [custom, setCustom] = useState(false);
   const [stacked, setStacked] = useState(false);
+  const [vertical, setVertical] = useState(false);
   const [overlap, setOverlap] = useState(0.75);
   const [hitRadius, setHitRadius] = useState(22);
   const [vol, setVol] = useState<(typeof VOLATILITY_MODES)[number]>("normal");
@@ -209,7 +210,16 @@ export default function MarkersScreen() {
           timeWindow={WINDOW}
           markers={markers}
           markerHitRadius={hitRadius}
-          markerCluster={stacked ? { mode: "stacked", overlap } : "anchored"}
+          markerCluster={
+            stacked
+              ? {
+                  mode: "stacked",
+                  direction: vertical ? "vertical" : "horizontal",
+                  overlap,
+                  maxBeforeGroup: vertical ? 20 : 5,
+                }
+              : "anchored"
+          }
           renderMarker={
             custom
               ? (m) => (
@@ -280,11 +290,15 @@ export default function MarkersScreen() {
 
       <ControlRow label="Collision">
         <ToggleChip label="markerCluster: stacked" value={stacked} onChange={setStacked} />
+        {stacked ? (
+          <ToggleChip label="vertical column" value={vertical} onChange={setVertical} />
+        ) : null}
       </ControlRow>
       <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
         With stacking on, co-located markers fan apart horizontally (overlapping,
         left-over-right); a dense burst collapses to a count badge (tap it for the
-        member list).
+        member list). Switch on the vertical column to pile them up the value axis
+        instead (buys down, sells up) — the transactions-on-the-candle look.
       </Text>
       {stacked ? (
         <ChipRow

--- a/app/showcase/fomo-perps.tsx
+++ b/app/showcase/fomo-perps.tsx
@@ -16,6 +16,7 @@ import {
 import {
   LiveChart,
   type CandlePoint,
+  type Marker,
   type ReferenceLine,
   type ScrubActionPoint,
   type ScrubPoint,
@@ -98,7 +99,10 @@ const CHART_HEIGHT = 286;
 // never reseeds to a fresh random walk. Display candles are merged up from the base
 // width to the chosen interval. The fixed span must cover the widest visible window.
 const BASE_CANDLE_SECS = 6;
-const FIXED_HISTORY_SECS = 9000;
+// Capped so the chart processes few enough candles per frame to hold a solid 60fps.
+// The per-frame candle work scales with this span ÷ BASE_CANDLE_SECS; the original
+// 9000 (~1500 base candles) periodically stalled the UI thread to ~56.
+const FIXED_HISTORY_SECS = 1200;
 // Roughly how many candles a timeframe shows at the 1× ("1D") range.
 const VISIBLE_CANDLES = 24;
 
@@ -509,6 +513,63 @@ export default function FomoPerpsShowcase() {
     },
   );
 
+  // ── Trade-tape markers (the "trenches" transaction stacks) ──────────────────
+  // Co-located buy/sell bursts that pile into vertical COLUMNS on the candles via
+  // `markerCluster={{ direction: "vertical" }}`. Every burst stacks UP off the
+  // candle (green + buys, red − sells) — `side: "above"` for both, color tells
+  // them apart. Anchored by `time` only (no `value`), so each column roots on the
+  // line at its candle. Seeded across the loaded history so columns show
+  // immediately, then ONE small burst drops per new candle (~4.5s), capped to keep
+  // the count low — both so a co-located bucket stays under `maxBeforeGroup` (no
+  // count-badge summaries) and so the per-frame cluster pass stays light.
+  const markers = useSharedValue<Marker[]>([]);
+  useEffect(() => {
+    const CAP = 40; // total glyphs kept; fewer = lighter per-frame clustering
+    let counter = 0;
+    let seeded = false;
+    let lastEdge = -1; // skip repeat bursts on the same candle (no mega-piles)
+    const makeBurst = (time: number): Marker[] => {
+      const buy = Math.random() < 0.5;
+      const n = 2 + Math.floor(Math.random() * 3); // 2–4 coins per column
+      return Array.from({ length: n }, () => {
+        counter += 1;
+        return {
+          id: `tx${counter}`,
+          time,
+          kind: "trade" as const,
+          color: buy ? C.green : C.red,
+          icon: buy ? "+" : "−",
+          pill: true,
+          // All trades stack UP off the candle (color = buy/sell), matching the
+          // trenches reference where every coin column rises from the price.
+          side: "above" as const,
+        };
+      });
+    };
+    const tick = () => {
+      const cur = data.get();
+      if (cur.length < 10) return; // wait for the feed to warm up
+      if (!seeded) {
+        seeded = true;
+        const out: Marker[] = [];
+        const step = Math.max(1, Math.floor(cur.length / 5));
+        for (let i = 6; i < cur.length - 2; i += step) {
+          out.push(...makeBurst(cur[i].time));
+        }
+        lastEdge = cur[cur.length - 1].time;
+        markers.set(out.slice(-CAP));
+        return;
+      }
+      const edge = cur[cur.length - 1].time;
+      if (edge === lastEdge) return; // one burst per candle, never pile a time
+      lastEdge = edge;
+      markers.set([...markers.get(), ...makeBurst(edge)].slice(-CAP));
+    };
+    tick(); // seed now if the feed is ready, else the interval picks it up
+    const id = setInterval(tick, 4500);
+    return () => clearInterval(id);
+  }, [data, markers]);
+
   // Trend tint vs the 24h open: green above, red below. Recolors the line, dot,
   // and badge together; flips only on a crossing (rare), so it's cheap.
   const [trendDown, setTrendDown] = useState(false);
@@ -638,6 +699,11 @@ export default function FomoPerpsShowcase() {
           liveCandle={candleMode ? displayLive : undefined}
           candleWidth={interval.candleWidthSecs}
           timeWindow={visibleWindow}
+          // Trade tape: co-located buy/sell bursts piled into vertical COLUMNS that
+          // stack UP off the candles (color = buy/sell) — see the Markers guide's
+          // vertical-stacking direction.
+          markers={markers}
+          markerCluster={{ direction: "vertical", overlap: 0.6, maxBeforeGroup: 12 }}
           // Stable green accent in candle mode (bodies carry the up/down color);
           // trend-flipping green/red for the line + its badge/dot.
           accentColor={candleMode ? C.green : trendColor}

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -99,6 +99,7 @@ interface MarkerRenderContext {
 // implies mode: "stacked" unless you set mode explicitly.
 interface MarkerClusterConfig {
   mode?: "anchored" | "stacked";
+  direction?: "horizontal" | "vertical"; // fan sideways (default) or pile into a column
   overlap?: number;        // 0 (touching) – 1 (stacked); default 0.75
   maxBeforeGroup?: number; // collapse a run past this many; default 5
 }

--- a/docs/guides/markers-and-trades.mdx
+++ b/docs/guides/markers-and-trades.mdx
@@ -63,6 +63,16 @@ Pass the object form to tune the fan — `overlap` (0–1, default `0.75`) and t
 markerCluster={{ overlap: 0.75, maxBeforeGroup: 8 }}
 ```
 
+By default the stack fans **horizontally**. Pass `direction: "vertical"` to pile co-located markers
+into a **column** instead — each glyph keeps its time (x) and stacks along the value axis, growing
+away from the line in its `side` direction (`"above"` climbs up, `"below"` descends, `"center"` climbs
+up from the line). This is the "transactions piled on the candle" look; raise `maxBeforeGroup` so a
+tall column doesn't collapse to a count badge early.
+
+```tsx
+markerCluster={{ direction: "vertical", overlap: 0.6, maxBeforeGroup: 20 }}
+```
+
 Built-in `kind` glyphs are `"trade" | "boost" | "graduation" | "winner" | "clawback"`. Override
 the glyph with `icon` (text/emoji) or `image` (a Skia `SkImage`). Set `pill` to wrap the `icon` in a
 filled circular badge in the marker `color` (icon rendered white) — e.g. a green `+` buy / red `−`

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -609,6 +609,7 @@ export function resolveMarkerCluster(
   if (typeof prop === "object") {
     return {
       mode: prop.mode ?? "stacked",
+      direction: prop.direction ?? "horizontal",
       overlap: clamp01(prop.overlap ?? MARKER_CLUSTER_OVERLAP),
       gap: MARKER_CLUSTER_GAP,
       maxBeforeGroup: prop.maxBeforeGroup ?? MARKER_CLUSTER_MAX_BEFORE_GROUP,
@@ -616,6 +617,7 @@ export function resolveMarkerCluster(
   }
   return {
     mode: prop === "stacked" ? "stacked" : "anchored",
+    direction: "horizontal",
     overlap: MARKER_CLUSTER_OVERLAP,
     gap: MARKER_CLUSTER_GAP,
     maxBeforeGroup: MARKER_CLUSTER_MAX_BEFORE_GROUP,

--- a/packages/react-native-livechart/src/hooks/useMarkers.ts
+++ b/packages/react-native-livechart/src/hooks/useMarkers.ts
@@ -24,6 +24,7 @@ import type {
 
 const ANCHORED_CLUSTER: ResolvedMarkerCluster = {
   mode: "anchored",
+  direction: "horizontal",
   overlap: 0.75,
   gap: 2,
   maxBeforeGroup: 5,

--- a/packages/react-native-livechart/src/math/markerCluster.ts
+++ b/packages/react-native-livechart/src/math/markerCluster.ts
@@ -8,6 +8,10 @@ export interface ResolvedMarkerCluster {
   /** `"anchored"` = no collision handling (glyphs overlap). `"stacked"` = fan +
    *  collapse co-located markers. */
   mode: "anchored" | "stacked";
+  /** `"horizontal"` fans co-located glyphs sideways into an overlapping row;
+   *  `"vertical"` piles them into a column growing away from the line in each
+   *  glyph's `side` direction. */
+  direction: "horizontal" | "vertical";
   /** Fraction (0–1) that adjacent co-located glyphs overlap when fanned. The fan
    *  step is `glyphHeight * (1 - overlap)`; `glyphHeight` is a slightly generous
    *  primitive estimate, so the *visible* overlap runs a touch lower. */
@@ -113,11 +117,30 @@ function layoutBucket(
     return;
   }
 
+  const step = h * (1 - opts.config.overlap);
+
+  if (opts.config.direction === "vertical") {
+    // Vertical column: every glyph keeps the anchor x and stacks along y, growing
+    // AWAY from the line in the side direction (above → up, below → down,
+    // center → up from the line). `j` runs in time order, so the newest sits
+    // furthest out — and, drawn last in array order, paints over the one below it.
+    const dir = side === "below" ? 1 : -1;
+    for (let j = 0; j < count; j++) {
+      const p = proj[idx[s + j]];
+      p.x = anchorX;
+      p.y = anchorY + sideDy + dir * j * step;
+      p.hidden = false;
+      p.isGrouped = false;
+      p.groupCount = 0;
+      p.groupRep = -1;
+    }
+    return;
+  }
+
   // Horizontal overlapping fan, centered on the anchor x. Glyphs share the side
   // height. Positions run right→left as the bucket order advances, so the newest
   // (last, highest array index) sits LEFTMOST — and since the overlay draws in
   // array order, it paints on top: a left-over-right cascade ("(" over ")" over ")").
-  const step = h * (1 - opts.config.overlap);
   for (let j = 0; j < count; j++) {
     const p = proj[idx[s + j]];
     p.x = anchorX + ((count - 1) / 2 - j) * step;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1115,6 +1115,16 @@ export interface MarkerClusterConfig {
   /** Defaults to `"stacked"` when this object form is used. */
   mode?: "anchored" | "stacked";
   /**
+   * Stack direction when `mode: "stacked"`. `"horizontal"` (default) fans
+   * co-located glyphs sideways into an overlapping row (the "( ) ) )"
+   * stacked-coins look). `"vertical"` piles them into a **column** that grows
+   * away from the line in each glyph's `side` direction — `side: "above"` climbs
+   * up, `"below"` descends, `"center"` climbs up from the line. This is the
+   * transactions-stacked-on-the-candle look; raise `maxBeforeGroup` for taller
+   * columns before they collapse to a count badge. Default `"horizontal"`.
+   */
+  direction?: "horizontal" | "vertical";
+  /**
    * How much adjacent co-located glyphs overlap when fanned, `0` (just touching)
    * to `1` (fully stacked). Default `0.75`. The on-screen overlap is approximate
    * (the fan step is estimated from the glyph size, not its exact pixels).
@@ -1600,7 +1610,9 @@ export interface LiveChartCoreProps {
    * their {@link Marker.side}, collapsing a cluster into a single count-badge
    * marker once it exceeds {@link MarkerClusterConfig.maxBeforeGroup}. Grouping is
    * recomputed per frame, so a cluster fans back out as you zoom/scroll in. Pass a
-   * {@link MarkerClusterConfig} object to tune the `overlap` and group threshold.
+   * {@link MarkerClusterConfig} object to tune the `overlap` and group threshold,
+   * or set `direction: "vertical"` to pile co-located markers into a column
+   * (growing away from the line in their `side` direction) instead of a row.
    */
   markerCluster?: "anchored" | "stacked" | MarkerClusterConfig;
   /**

--- a/packages/react-native-livechart/tests/hooks/useMarkers.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useMarkers.test.tsx
@@ -51,7 +51,7 @@ describe("useMarkers", () => {
         undefined,
         true,
         false,
-        { mode: "stacked", overlap: 0.6, gap: 2, maxBeforeGroup: 5 },
+        { mode: "stacked", direction: "horizontal", overlap: 0.6, gap: 2, maxBeforeGroup: 5 },
       );
     });
     expect(typeof result.current.hitTest).toBe("function");

--- a/packages/react-native-livechart/tests/math/markerCluster.test.ts
+++ b/packages/react-native-livechart/tests/math/markerCluster.test.ts
@@ -9,12 +9,21 @@ import type { Marker } from "../../src/types";
 
 const ANCHORED: ClusterMarkersOpts["config"] = {
   mode: "anchored",
+  direction: "horizontal",
   overlap: 0.6,
   gap: 2,
   maxBeforeGroup: 5,
 };
 const STACKED: ClusterMarkersOpts["config"] = {
   mode: "stacked",
+  direction: "horizontal",
+  overlap: 0.6,
+  gap: 2,
+  maxBeforeGroup: 5,
+};
+const STACKED_VERTICAL: ClusterMarkersOpts["config"] = {
+  mode: "stacked",
+  direction: "vertical",
   overlap: 0.6,
   gap: 2,
   maxBeforeGroup: 5,
@@ -141,5 +150,57 @@ describe("clusterMarkers — stacked", () => {
     clusterMarkers(markers, proj, { config: STACKED });
     expect(proj[0].y).toBe(150); // connector untouched
     expect(proj[0].hidden).toBe(false);
+  });
+});
+
+describe("clusterMarkers — stacked vertical", () => {
+  const STEP = 16 * (1 - 0.6); // glyphHeight(trade) * (1 - overlap) = 6.4
+
+  it("piles co-located same-side markers into a vertical column at the anchor x", () => {
+    const markers = [trade("a", 1, "above"), trade("b", 2, "above"), trade("c", 3, "above")];
+    const proj = [pm(100, 150), pm(100, 150), pm(100, 150)];
+    clusterMarkers(markers, proj, { config: STACKED_VERTICAL });
+    // All keep the anchor x; the column climbs UP from the "above" base (140).
+    expect(proj.every((p) => p.x === 100 && !p.hidden && !p.isGrouped)).toBe(true);
+    expect(proj[0].y).toBeCloseTo(140); // base = 150 - (16/2 + 2)
+    expect(proj[1].y).toBeCloseTo(140 - STEP);
+    expect(proj[2].y).toBeCloseTo(140 - 2 * STEP);
+  });
+
+  it("grows down for `below` and up for `above` — opposite stacks at one anchor", () => {
+    const markers = [
+      trade("d1", 1, "below"),
+      trade("d2", 2, "below"),
+      trade("u1", 3, "above"),
+      trade("u2", 4, "above"),
+    ];
+    const proj = [pm(100, 150), pm(100, 150), pm(100, 150), pm(100, 150)];
+    clusterMarkers(markers, proj, { config: STACKED_VERTICAL });
+    expect(proj[0].y).toBeCloseTo(160); // below base, descending
+    expect(proj[1].y).toBeCloseTo(160 + STEP);
+    expect(proj[2].y).toBeCloseTo(140); // above base, ascending
+    expect(proj[3].y).toBeCloseTo(140 - STEP);
+    expect(proj.every((p) => p.x === 100)).toBe(true);
+  });
+
+  it("climbs up from the line for a `center` column", () => {
+    const markers = [trade("a", 1, "center"), trade("b", 2, "center")];
+    const proj = [pm(100, 150), pm(100, 150)];
+    clusterMarkers(markers, proj, { config: STACKED_VERTICAL });
+    expect(proj[0].y).toBeCloseTo(150); // first sits on the line
+    expect(proj[1].y).toBeCloseTo(150 - STEP);
+    expect(proj.every((p) => p.x === 100)).toBe(true);
+  });
+
+  it("still collapses a column past maxBeforeGroup to a count badge at the base", () => {
+    const markers = Array.from({ length: 6 }, (_, i) => trade(`m${i}`, i + 1, "above"));
+    const proj = markers.map(() => pm(100, 150));
+    clusterMarkers(markers, proj, { config: STACKED_VERTICAL });
+    const rep = proj[5]; // newest by time
+    expect(rep.isGrouped).toBe(true);
+    expect(rep.groupCount).toBe(6);
+    expect(rep.x).toBe(100);
+    expect(rep.y).toBe(140); // collapses at the side base, not up the column
+    expect(proj.slice(0, 5).every((p) => p.hidden && p.groupRep === 5)).toBe(true);
   });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1458,11 +1458,13 @@ describe("resolveMarkerCluster", () => {
   it("defaults to anchored with stacking defaults", () => {
     expect(resolveMarkerCluster(undefined)).toEqual({
       mode: "anchored",
+      direction: "horizontal",
       overlap: 0.75,
       gap: 2,
       maxBeforeGroup: 5,
     });
     expect(resolveMarkerCluster("anchored").mode).toBe("anchored");
+    expect(resolveMarkerCluster("stacked").direction).toBe("horizontal");
   });
 
   it("enables stacking when requested", () => {
@@ -1472,12 +1474,15 @@ describe("resolveMarkerCluster", () => {
   it("accepts the object form, implying stacked, with tunable overlap/threshold", () => {
     expect(resolveMarkerCluster({ overlap: 0.8, maxBeforeGroup: 3 })).toEqual({
       mode: "stacked",
+      direction: "horizontal",
       overlap: 0.8,
       gap: 2,
       maxBeforeGroup: 3,
     });
     // Explicit mode honored; overlap clamped to [0, 0.95].
     expect(resolveMarkerCluster({ mode: "anchored" }).mode).toBe("anchored");
+    // Vertical stacking is opt-in via the object form.
+    expect(resolveMarkerCluster({ direction: "vertical" }).direction).toBe("vertical");
     expect(resolveMarkerCluster({ overlap: 5 }).overlap).toBe(0.95);
     expect(resolveMarkerCluster({ overlap: -1 }).overlap).toBe(0);
   });


### PR DESCRIPTION
## Summary

Adds **vertical marker stacking** to the library, demos it with a buy/sell **trade tape** in the Fomo Perps showcase, and includes a candle-count perf fix that keeps that screen at a solid 60fps.

## Library — `MarkerClusterConfig.direction`

`markerCluster` gains `direction?: "horizontal" | "vertical"` (default `"horizontal"`, unchanged).

- `"horizontal"` — the existing sideways overlapping fan.
- `"vertical"` — piles co-located markers into a **column** growing away from the line in each glyph's `side` direction (`"above"` climbs up, `"below"` descends) — the transactions-stacked-on-the-candle look.

`maxBeforeGroup` collapse, grouping, and hit-testing all carry over. It's a localized branch in `layoutBucket` (offset `y` instead of `x`). Adds unit tests, type-reference + guide docs, and a "vertical column" toggle in the Markers & trades demo.

## Showcase — Fomo Perps trade tape

The Fomo Perps example gains a live buy/sell trade tape: co-located bursts that pile into vertical green/red coin columns rising off the candles.

## Perf — cap Fomo candle history (60fps)

Profiling showed the Fomo UI thread dipping to ~56fps every few seconds. Isolated empirically on-device:

| Condition | UI thread |
|---|---|
| ~560 coarse candles (`FIXED_HISTORY_SECS=9000`) | dips to 56 |
| ~75 coarse candles (`FIXED_HISTORY_SECS=1200`) | flat 60 |

The cost scales with the **number of candles the chart processes per frame** — **not** the markers (CPU identical on/off; dips persisted with markers fully removed) and not the price readout (JS-thread). Capped `FIXED_HISTORY_SECS` 9000 → 1200 to hold 60. The deeper library-level fix (process only visible candles per frame) is a noted follow-up, not in this PR.

## Testing

- `npm run verify` green — typecheck + lint + **1213 tests**.
- iOS 26.4 simulator: vertical columns render correctly in both the showcase and the demo; the capped 1200s history measured a flat **60** on the UI thread (markers-off sample — markers add ~0, CPU identical on/off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
