### PR TITLE
fix(reference-lines): draggable line wins the scrub gesture race (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Draggable reference lines now win the gesture race against scrubbing.**
+  Previously, grabbing a `draggable` reference line while `scrub` was enabled
+  would drop a scrub crosshair instead of moving the line — the drag fell through
+  to scrub the moment the touch drifted even slightly sideways (which a real
+  finger drag almost always does at the start). A grabbed line now **owns** the
+  touch: once you press within reach of the line, any drag past the activation
+  threshold drags it, in any direction. Scrubbing still works everywhere outside
+  a draggable line's grab band, so the two features can finally be used together.
+  ([#163](https://github.com/brandtnewlabs/react-native-livechart/issues/163))
+
 ## [4.2.0] - 2026-06-23
 
 ### Added

--- a/app/demo/working-orders.tsx
+++ b/app/demo/working-orders.tsx
@@ -151,7 +151,7 @@ export default function WorkingOrdersScreen() {
     <DemoScreen
       title="Working orders"
       docs="guides/reference-lines-and-bands"
-      description="Drag BUY / SELL to set a price (snap 0.05, clamped to bounds). Watch the live value, committed value, and the drag-callback log. Toggle custom RN tags and near-value grouping."
+      description="Drag BUY / SELL to set a price (snap 0.05, clamped to bounds) — scrub anywhere off the lines. Watch the live value, committed value, and the drag-callback log. Toggle custom RN tags and near-value grouping."
       chart={
         <LiveChart
           data={data}
@@ -178,7 +178,6 @@ export default function WorkingOrdersScreen() {
               : false
           }
           renderReferenceLine={custom ? renderReferenceLine : undefined}
-          scrub={false}
         />
       }
     >

--- a/docs/guides/reference-lines-and-bands.mdx
+++ b/docs/guides/reference-lines-and-bands.mdx
@@ -103,6 +103,11 @@ the value back into `value` to make it controlled. `onDragIn` / `onDragOut` are 
 also fire when the axis rescales under a fixed value (e.g. an order scrolling off the top), so
 they're a clean "is my order still on screen" signal even without dragging.
 
+Dragging coexists with [scrubbing](/guides/scrubbing): a press that lands within reach of a
+draggable line grabs the line and any drag moves it (in any direction), while a press anywhere else
+scrubs as usual. So you can keep `scrub` enabled alongside draggable orders — only the thin grab
+band around each draggable line is reserved for the drag.
+
 ## Custom tags (`renderReferenceLine`)
 
 Replace a line's built-in pill / gutter label with any **React Native** view — the same model as

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -798,13 +798,30 @@ function useLiveChartController({
       dragValues,
     );
 
-  // Combined "defer" hit-test for the scrub-action place-tap: yield to a marker or
-  // a pressable badge under the finger so the tap is routed there instead of
-  // dropping a reticle. (Both hit-tests return false when their feature is off.)
+  // Draggable reference lines: a per-line vertical pan that grabs a line near its
+  // value and drags it along the Y-axis (with snap / bounds / callbacks). Built
+  // unconditionally for stable hook order (and before `useCrosshair` so the scrub
+  // can defer to a line under the finger); the gesture self-disables when no line
+  // opts in, and it's only composed into the root when `refDragEnabled`.
+  const refDragEnabled =
+    !isStatic && allRefLines.some((l) => l.draggable === true);
+  const { gesture: refDragGesture, hitTest: refDragHitTest } = useReferenceDrag(
+    engine,
+    effectivePadding,
+    allRefLines,
+    dragValues,
+    dragActive,
+    !isStatic,
+  );
+
+  // Combined "defer" hit-test: the scrub-action place-tap and the live scrub both
+  // yield to a marker, a pressable badge, or a draggable line under the finger — so
+  // a press there is routed to that overlay / drag instead of dropping a reticle or
+  // crosshair. (Each hit-test returns false when its feature is off.)
   /* istanbul ignore next -- worklet runs on the UI thread, not in Jest */
   const deferTapHit = (x: number, y: number): boolean => {
     "worklet";
-    return markerHitTest(x, y) || refLineHitTest(x, y);
+    return markerHitTest(x, y) || refLineHitTest(x, y) || refDragHitTest(x, y);
   };
 
   // Time-scroll activation. `holdToScrub`: a quick one-finger drag scrolls while
@@ -843,7 +860,7 @@ function useLiveChartController({
     scrubActionCfg,
     onScrubAction,
     metricsCfg.badge,
-    markersActive || refPressActive ? deferTapHit : undefined,
+    markersActive || refPressActive || refDragEnabled ? deferTapHit : undefined,
     scrubCfg?.tooltipPlacement ?? "side",
     scrubCfg?.tooltipShowValue ?? true,
     scrubCfg?.tooltipShowTime ?? true,
@@ -875,21 +892,6 @@ function useLiveChartController({
       crosshair.scrubActive.set(false);
     },
   });
-
-  // Draggable reference lines: a per-line vertical pan that grabs a line near its
-  // value and drags it along the Y-axis (with snap / bounds / callbacks). Built
-  // unconditionally for stable hook order; the gesture self-disables when no line
-  // opts in, and it's only composed into the root when `refDragEnabled`.
-  const refDragEnabled =
-    !isStatic && allRefLines.some((l) => l.draggable === true);
-  const refDragGesture = useReferenceDrag(
-    engine,
-    effectivePadding,
-    allRefLines,
-    dragValues,
-    dragActive,
-    !isStatic,
-  );
 
   // Pinch-to-zoom the visible window (two-finger). Anchors at the focal point and
   // writes viewWindow + viewEnd; composes via Simultaneous (it's two-finger, so

--- a/packages/react-native-livechart/src/hooks/useReferenceDrag.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceDrag.ts
@@ -13,6 +13,7 @@ import {
   clampToBounds,
   nearestDraggableIndex,
   referenceValueOut,
+  resolveDragIntent,
 } from "../math/referenceDrag";
 import { referenceLineForm } from "../math/referenceLines";
 import type { ReferenceLine } from "../types";
@@ -24,7 +25,7 @@ import {
 
 /** Vertical reach (px) around a line within which a touch grabs it. */
 const GRAB_SLOP = 14;
-/** Travel (px) that resolves drag (vertical) vs. fall-through (horizontal) intent. */
+/** Travel (px) past which a grabbed line starts dragging (in either axis). */
 const DRAG_ACTIVATE_PX = 4;
 
 /** Stable empty array so the handle / out-state worklets stay referentially stable
@@ -40,9 +41,12 @@ const EMPTY: never[] = [];
  * and overlays read.
  *
  * The pan uses `manualActivation`: it grabs only when a touch starts within
- * {@link GRAB_SLOP} of a draggable line **and** the motion is vertical — a
- * horizontal drag (scrub) or a touch off every line fails fast so the chart's other
- * gestures run (compose this ahead of them via `Gesture.Exclusive`).
+ * {@link GRAB_SLOP} of a draggable line, then **owns** that touch — any drag past
+ * {@link DRAG_ACTIVATE_PX} (in either axis) drags the line. A touch off every line
+ * fails fast so the chart's other gestures (scrub / scroll) run everywhere else
+ * (compose this ahead of them via `Gesture.Exclusive`). Crucially it no longer
+ * falls through to scrub on a horizontal start, so a drag begun on a line always
+ * wins the race rather than dropping a scrub crosshair (#163).
  *
  * Also fires the per-line drag callbacks: `onChange` (de-duped during drag),
  * `onCommit` (on release), and `onDragIn` / `onDragOut` (value crossing the visible
@@ -55,7 +59,12 @@ export function useReferenceDrag(
   dragValues: SharedValue<number[]>,
   dragActive: SharedValue<boolean[]>,
   enabled: boolean,
-): ReturnType<typeof Gesture.Pan> {
+): {
+  gesture: ReturnType<typeof Gesture.Pan>;
+  /** True when a touch at (x,y) would grab a draggable line — lets the scrub
+   *  gesture decline that press so it never drops a crosshair on a line (#163). */
+  hitTest: (x: number, y: number) => boolean;
+} {
   const anyDraggable =
     enabled &&
     lines.some((l) => l.draggable && referenceLineForm(l) === "line");
@@ -178,16 +187,22 @@ export function useReferenceDrag(
   /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
   const onTouchesMove = (
     e: { allTouches: { x: number; y: number }[] },
-    manager: { activate: () => void; fail: () => void },
+    manager: { activate: () => void },
   ) => {
     "worklet";
     if (dragIndex.get() < 0) return;
     const t = e.allTouches[0];
     if (!t) return;
-    const dx = Math.abs(t.x - startX.get());
-    const dy = Math.abs(t.y - startY.get());
-    if (dy > DRAG_ACTIVATE_PX && dy >= dx) manager.activate();
-    else if (dx > DRAG_ACTIVATE_PX) manager.fail();
+    // A line is grabbed → it owns the touch: any drag past the threshold drags it.
+    // We don't fail on horizontal intent (which used to hand the touch to scrub) —
+    // that let the scrub crosshair win the race even on a vertical drag started on
+    // the line (#163). Scrub / scroll still run off a line's grab band.
+    const intent = resolveDragIntent(
+      t.x - startX.get(),
+      t.y - startY.get(),
+      DRAG_ACTIVATE_PX,
+    );
+    if (intent === "activate") manager.activate();
   };
 
   /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
@@ -242,7 +257,20 @@ export function useReferenceDrag(
     activated.set(false);
   };
 
-  return Gesture.Pan()
+  // Geometric hit-test shared with the scrub gesture: is (x,y) within reach of a
+  // draggable line's handle? The scrub's `onStart` consults this to bail on a
+  // press over a line, so it never drops a crosshair there even though it activates
+  // independently of this manual-activation pan (the `Exclusive` priority alone
+  // doesn't hold scrub back while this gesture is merely pressed). x is unused —
+  // a Form-A line spans the full width, so only the y-reach matters.
+  /* istanbul ignore next -- worklet, runs on the UI thread */
+  const hitTest = (_x: number, y: number): boolean => {
+    "worklet";
+    if (!anyDraggable) return false;
+    return nearestDraggableIndex(handleYs.get(), y, GRAB_SLOP) >= 0;
+  };
+
+  const gesture = Gesture.Pan()
     .enabled(anyDraggable)
     .maxPointers(1)
     .manualActivation(true)
@@ -251,4 +279,6 @@ export function useReferenceDrag(
     .onStart(onStart)
     .onUpdate(onUpdate)
     .onFinalize(onFinalize);
+
+  return { gesture, hitTest };
 }

--- a/packages/react-native-livechart/src/math/referenceDrag.ts
+++ b/packages/react-native-livechart/src/math/referenceDrag.ts
@@ -44,6 +44,25 @@ export function nearestDraggableIndex(
 }
 
 /**
+ * Resolve a grabbed line's drag intent from the touch travel (px) since the grab.
+ * Once a line is grabbed it **owns** the touch: any drag past `threshold` px in
+ * either axis activates the drag. We deliberately don't fall through to scrub on
+ * horizontal / diagonal intent — that let the scrub crosshair win the race even
+ * on a vertical drag started on the line (#163). Returns `"activate"` past the
+ * threshold, else `"wait"` (keep the gesture armed for more travel).
+ */
+export function resolveDragIntent(
+  dx: number,
+  dy: number,
+  threshold: number,
+): "activate" | "wait" {
+  "worklet";
+  return Math.abs(dx) > threshold || Math.abs(dy) > threshold
+    ? "activate"
+    : "wait";
+}
+
+/**
  * Whether a line's value sits **outside** its watched interval — the trigger for
  * `onDragOut` / `onDragIn` (edge-detected by the caller). When `bounds` is set the
  * watched interval is `bounds` (at-or-past a bound counts as out, since the drag

--- a/packages/react-native-livechart/tests/math/referenceDrag.test.ts
+++ b/packages/react-native-livechart/tests/math/referenceDrag.test.ts
@@ -2,6 +2,7 @@ import {
   clampToBounds,
   nearestDraggableIndex,
   referenceValueOut,
+  resolveDragIntent,
 } from "../../src/math/referenceDrag";
 
 describe("clampToBounds", () => {
@@ -43,6 +44,26 @@ describe("nearestDraggableIndex", () => {
 
   it("favors the later (topmost-drawn) index on a tie", () => {
     expect(nearestDraggableIndex([50, 50], 50, 14)).toBe(1);
+  });
+});
+
+describe("resolveDragIntent", () => {
+  it("waits until the travel passes the threshold", () => {
+    expect(resolveDragIntent(0, 0, 4)).toBe("wait");
+    expect(resolveDragIntent(4, 4, 4)).toBe("wait"); // exactly at threshold (not past)
+    expect(resolveDragIntent(-4, -4, 4)).toBe("wait");
+  });
+
+  it("activates on vertical travel past the threshold", () => {
+    expect(resolveDragIntent(0, 5, 4)).toBe("activate");
+    expect(resolveDragIntent(1, -6, 4)).toBe("activate");
+  });
+
+  it("activates on horizontal / diagonal travel too (drag owns the touch, #163)", () => {
+    expect(resolveDragIntent(5, 0, 4)).toBe("activate");
+    // Horizontal-dominant start that previously fell through to scrub now drags.
+    expect(resolveDragIntent(8, 2, 4)).toBe("activate");
+    expect(resolveDragIntent(-9, 1, 4)).toBe("activate");
   });
 });
 


### PR DESCRIPTION
A press on a `draggable` reference line dropped a scrub crosshair instead of
moving the line. Two causes: the manual-activation drag fell through to scrub on
any horizontal/diagonal start (a real finger drag almost always drifts sideways
at the start), and `Gesture.Exclusive` priority didn't actually hold the scrub
pan (`minDistance(0)`) back while the drag was merely pressed.

Now a grabbed line owns the touch — any drag past the activation threshold moves
it, in any direction — and the scrub defers to a press landing on a draggable
line via the existing `deferTapHit` hit-test (the same mechanism that yields to
markers / pressable badges). Scrubbing still works everywhere outside a line's
grab band, so it can be used alongside draggable orders. The Working orders demo
re-enables `scrub` to show the two coexisting.

Verified on the iOS 26.4 simulator: dragging BUY/SELL moves the line (live
onChange + commit, no crosshair); scrubbing off the lines still shows the
crosshair.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>