### PR TITLE
feat(time-scroll): animated, configurable return-to-live + fix freeze on disable (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-06-25
+
+### Added
+
+- **Animated "return to live"** when `timeScroll` is switched off while scrolled
+  back. Instead of snapping, the window now **eases onto the live edge** (a brief
+  ~450 ms decelerate, all on the UI thread). It interpolates toward the *current*
+  live edge each frame, so it lands exactly on live with no end-snap.
+- **`returnToLive` prop** (`boolean | ReturnToLiveConfig`) on `LiveChart` and
+  `LiveChartSeries` to control that glide: `true` (default) glides over `450` ms,
+  `false` snaps instantly (the previous behavior), and `{ duration }` sets a custom
+  length. It's a sibling of `timeScroll` (not nested in `TimeScrollConfig`) so it
+  stays in effect through `timeScroll={false}` — the toggle that triggers it.
+  Exports the new `ReturnToLiveConfig` type.
+  ([#164](https://github.com/brandtnewlabs/react-native-livechart/issues/164))
+
+### Fixed
+
+- **Disabling `timeScroll` (or a mode switch that turns it off) no longer freezes
+  the chart at the scrolled-back position.** Previously, panning back through
+  history and then setting `timeScroll={false}` — or switching `mode` so the
+  consumer stopped passing `timeScroll` — left the window frozen at the scrolled-to
+  position with no way to return to live: the frozen edge survived because nothing
+  reset it once the gesture was disabled. The chart now returns to the live edge
+  (gliding by default — see Added), resets the internal scroll state so re-enabling
+  `timeScroll` resumes from live rather than snapping back, and, as an added guard,
+  follows live instead of stranding the window on an empty plot when a frozen edge
+  falls before the active series' first data point (e.g. line and candle series
+  with different history spans).
+  ([#164](https://github.com/brandtnewlabs/react-native-livechart/issues/164))
+
 ## [4.2.1] - 2026-06-25
 
 ### Fixed

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -43,11 +43,28 @@ const HOLD_OPTIONS: { value: number; label: string }[] = [
   { value: 750, label: "750ms" },
 ];
 
+// `returnToLive` controls how the window goes back to live when timeScroll is
+// switched off mid-scroll: glide (default), instant snap, or a slower glide.
+type ReturnMode = "glide" | "instant" | "slow";
+
+const RETURN_OPTIONS: { value: ReturnMode; label: string }[] = [
+  { value: "glide", label: "Glide" },
+  { value: "instant", label: "Instant" },
+  { value: "slow", label: "Slow" },
+];
+
+const RETURN_TO_LIVE: Record<ReturnMode, boolean | { duration: number }> = {
+  glide: true,
+  instant: false,
+  slow: { duration: 900 },
+};
+
 export default function TimeScrollScreen() {
   const [mode, setMode] = useState<"candle" | "line">("candle");
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [holdMs, setHoldMs] = useState(500);
   const [enabled, setEnabled] = useState(true);
+  const [returnMode, setReturnMode] = useState<ReturnMode>("glide");
   const [zoomOn, setZoomOn] = useState(true);
   const [scrub, setScrub] = useState(true);
   const [orderTicket, setOrderTicket] = useState(true);
@@ -99,6 +116,7 @@ export default function TimeScrollScreen() {
           // Pill tracks the last visible price as you scroll back.
           badge={{ followViewEdge: true }}
           timeScroll={enabled ? { gesture, scrubHoldMs: holdMs } : false}
+          returnToLive={RETURN_TO_LIVE[returnMode]}
           zoom={zoomOn}
           // Paging callbacks (Phase 3): log the visible range (~1 Hz) and show an
           // indicator while the left edge is near the oldest seeded candle. The
@@ -144,6 +162,13 @@ export default function TimeScrollScreen() {
       <ControlRow label="Pan to scroll">
         <ToggleChip label="timeScroll" value={enabled} onChange={setEnabled} />
       </ControlRow>
+
+      <ChipRow
+        label="Return to live (toggle timeScroll off while scrolled back)"
+        options={RETURN_OPTIONS}
+        value={returnMode}
+        onChange={setReturnMode}
+      />
 
       <ControlRow label="Pinch to zoom">
         <ToggleChip label="zoom" value={zoomOn} onChange={setZoomOn} />

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -87,9 +87,19 @@ default off.
 
 <ParamField body="timeScroll" type="boolean | TimeScrollConfig" default="false">
   Pan back through history (same as `LiveChart`). Drag (or fling) to scroll; the
-  chart stops auto-following until you return to the live edge. Per-series dots /
-  value labels track each series' value at the visible right edge while scrolled.
+  chart stops auto-following until you return to the live edge. Setting it back to
+  `false` while scrolled back glides the window back to the live edge (eased, not
+  an instant jump; never frozen at the old position). Per-series dots / value
+  labels track each series' value at the visible right edge while scrolled.
   **@experimental.** See [Time-scroll](/guides/time-scroll).
+</ParamField>
+
+<ParamField body="returnToLive" type="boolean | ReturnToLiveConfig" default="true">
+  Controls the glide back to live when `timeScroll` is switched off while scrolled
+  back (same as `LiveChart`). `true` (default) eases over `450` ms, `false` snaps
+  instantly, `{ duration }` sets a custom length. Sibling of `timeScroll` so it
+  survives `timeScroll={false}`. **@experimental.** See
+  [Time-scroll → Turning it back off](/guides/time-scroll#turning-it-back-off).
 </ParamField>
 
 <ParamField body="zoom" type="boolean | ZoomConfig" default="false">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -287,11 +287,24 @@ provided; everything else has a default.
 
 <ParamField body="timeScroll" type="boolean | TimeScrollConfig" default="false">
   Pan back through history: drag (or fling) to scroll, and the chart stops
-  auto-following until you return to the live edge. `true` uses the default
-  drag-to-scroll gesture (`"holdToScrub"` — drag scrolls, press-and-hold scrubs);
-  pass a [`TimeScrollConfig`](/api-reference/types#config-objects) to pick
-  `"axisDrag"` (drag the x-axis strip) or set `scrubHoldMs`.
+  auto-following until you return to the live edge. Setting it back to `false`
+  while scrolled back — or switching `mode` so it's no longer passed — glides the
+  window back to the live edge (eased, not an instant jump; never frozen at the
+  old position).
+  `true` uses the default drag-to-scroll gesture (`"holdToScrub"` — drag scrolls,
+  press-and-hold scrubs); pass a
+  [`TimeScrollConfig`](/api-reference/types#config-objects) to pick `"axisDrag"`
+  (drag the x-axis strip) or set `scrubHoldMs`.
   **@experimental.** See [Time-scroll](/guides/time-scroll).
+</ParamField>
+
+<ParamField body="returnToLive" type="boolean | ReturnToLiveConfig" default="true">
+  Controls the glide back to the live edge when `timeScroll` is switched off while
+  scrolled back. `true` (default) eases onto live over `450` ms; `false` snaps
+  instantly; `{ duration }` sets a custom glide length (ms). Kept separate from
+  `timeScroll` so it survives `timeScroll={false}` (the toggle that triggers it).
+  **@experimental.** See
+  [Time-scroll → Turning it back off](/guides/time-scroll#turning-it-back-off).
 </ParamField>
 
 <ParamField body="zoom" type="boolean | ZoomConfig" default="false">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -367,6 +367,10 @@ interface TimeScrollConfig {
   gesture?: "holdToScrub" | "axisDrag"; // activation; default "holdToScrub"
   scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
 }
+// Tunes the return-to-live glide (the `returnToLive` prop). @experimental
+interface ReturnToLiveConfig {
+  duration?: number; // glide duration (ms) back to live; default 450 (0 = instant snap)
+}
 // Pinch-to-zoom the visible time window (two-finger, focal-anchored). @experimental
 interface ZoomConfig {
   minTimeWindow?: number; // tightest window in seconds (max zoom-in); default timeWindow / 8

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -26,6 +26,28 @@ return to the live edge, where live-following resumes. One-finger plot scrubbing
 Panning is clamped to the earliest retained point, so keep enough history in `data` (or `candles`)
 to scroll into — seed a few windows' worth and keep your buffer longer than the visible window.
 
+### Turning it back off
+
+Setting `timeScroll` back to `false` while scrolled back — or switching `mode` so your component
+stops passing it — **glides the window back to the live edge**: a brief eased animation (it
+decelerates onto live), not an instant jump. It never stays frozen at the previous scroll position,
+so toggling time-scroll (or changing modes) is always a clean return to live, and re-enabling it
+later starts from the live edge rather than the old frozen spot. This holds even when your line and
+candle series carry different amounts of history: a frozen edge that would land before the active
+series' first point follows live instead of stranding the plot empty.
+
+Tune that glide — or turn it off — with the **`returnToLive`** prop (a sibling of `timeScroll`, so it
+survives `timeScroll={false}`):
+
+```tsx
+<LiveChart data={data} value={value} timeScroll={enabled} returnToLive={false} />        // instant snap
+<LiveChart data={data} value={value} timeScroll={enabled} returnToLive={{ duration: 700 }} /> // slower glide
+```
+
+`true` (the default) eases onto live over 450 ms; `false` snaps instantly (the pre-4.3 behavior);
+`{ duration }` sets a custom length in milliseconds. It only governs this programmatic return —
+flinging back to the live edge with the pan gesture keeps its own inertia.
+
 ## Gestures
 
 `timeScroll: true` uses the default **drag-to-scroll** gesture. Pass a `TimeScrollConfig` to pick the

--- a/package-lock.json
+++ b/package-lock.json
@@ -17597,7 +17597,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "4.2.1",
+      "version": "4.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "4.2.1"
+  "version": "4.3.0"
 }

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -37,6 +37,7 @@ import {
   resolvePulse,
   resolveScrub,
   resolveScrubAction,
+  resolveReturnToLiveMs,
   resolveSelectionDot,
   resolveThreshold,
   resolveTradeStream,
@@ -216,6 +217,7 @@ function useLiveChartController({
   windowBuffer = 0,
   nowOverride,
   timeScroll = false,
+  returnToLive,
   zoom = false,
   accessibilityLabel,
   accessibilityRole = "image",
@@ -494,6 +496,9 @@ function useLiveChartController({
   // onto the JS thread (set by the reaction below, after the engine exists).
   const [scrolledBack, setScrolledBack] = useState(false);
   const timeScrollEnabled = Boolean(timeScroll) && !isStatic;
+  // Glide duration for the return-to-live animation (0 = instant). A sibling of
+  // `timeScroll` so it survives `timeScroll={false}` (the disable that triggers it).
+  const returnToLiveMs = resolveReturnToLiveMs(returnToLive);
   const zoomCfg = resolveZoom(zoom);
   const zoomEnabled = zoomCfg !== null && !isStatic;
 
@@ -552,6 +557,8 @@ function useLiveChartController({
     timeWindow,
     paused,
     static: isStatic,
+    scrollEnabled: timeScrollEnabled,
+    returnToLiveMs,
     smoothing,
     adaptiveSpeedBoost: metricsCfg.motion.adaptiveSpeedBoost,
     exaggerate,
@@ -568,12 +575,16 @@ function useLiveChartController({
 
   // Mirror the UI-thread scroll state to React so the floating y-axis can keep
   // a right gutter at the live edge and collapse it only while scrolled back.
-  // Fires once per null↔frozen transition, and only matters for float+timeScroll.
+  // Fires once per null↔frozen transition. `viewEnd` is only non-null while
+  // time-scroll is enabled and actively scrolled (the engine resets it to null
+  // when time-scroll is disabled — see #164), so we don't gate on
+  // `timeScrollEnabled` here: that would strand `scrolledBack` at `true` after a
+  // disable-while-scrolled, wrongly floating the y-axis on a later re-enable.
   useAnimatedReaction(
     () => engine.viewEnd.value != null,
     /* istanbul ignore next -- Reanimated reaction; state mirrored on the JS thread, not exercised under Jest */
     (isScrolled, prev) => {
-      if (isScrolled !== prev && yAxisFloat && timeScrollEnabled) {
+      if (isScrolled !== prev && yAxisFloat) {
         scheduleOnRN(setScrolledBack, isScrolled);
       }
     },

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -36,6 +36,7 @@ import {
   resolveMarkerCluster,
   resolveMetrics,
   resolveMultiSeriesDot,
+  resolveReturnToLiveMs,
   resolveScrub,
   resolveSelectionDot,
   resolveXAxis,
@@ -147,6 +148,7 @@ function useLiveChartSeriesController({
   scrub = true,
   selectionDot,
   timeScroll = false,
+  returnToLive,
   zoom = false,
   onScrub,
   onGestureStart,
@@ -181,6 +183,9 @@ function useLiveChartSeriesController({
   // gesture to wait for a press-and-hold so a quick drag scrolls instead — the
   // hold delay is threaded into `useCrosshairSeries` below.
   const timeScrollEnabled = Boolean(timeScroll);
+  // Return-to-live glide duration (0 = instant); sibling of `timeScroll` so it
+  // survives `timeScroll={false}` (the disable that triggers it). See #164.
+  const returnToLiveMs = resolveReturnToLiveMs(returnToLive);
   const zoomCfg = resolveZoom(zoom);
   const zoomEnabled = zoomCfg !== null;
   const scrollGestureMode =
@@ -296,6 +301,8 @@ function useLiveChartSeriesController({
     series: effectiveSeries,
     timeWindow,
     paused,
+    scrollEnabled: timeScrollEnabled,
+    returnToLiveMs,
     smoothing,
     adaptiveSpeedBoost: metricsCfg.motion.adaptiveSpeedBoost,
     exaggerate,

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -24,6 +24,13 @@ export const MAX_Y_LABELS = 15;
  */
 export const HOLD_TO_SCRUB_MS = 500;
 
+/**
+ * Duration (ms) of the "return to live" glide — how long the window takes to ease
+ * from a scrolled-back position to the live edge when `timeScroll` is disabled
+ * (or a mode switch turns it off). Eased out so it decelerates onto live. See #164.
+ */
+export const RETURN_TO_LIVE_MS = 450;
+
 // ─── Metric default tokens (single source of truth for LiveChartMetrics) ─────
 // The resolved `metrics` config (see resolveMetrics) is assembled from these
 // objects. Draw/worklet helpers default their metric params to the matching

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -70,6 +70,17 @@ export interface EngineTickInput {
    */
   viewEnd?: number | null;
   /**
+   * "Return to live" glide (see #164). When time-scroll is disabled while scrolled
+   * back, the engine hook clears {@link viewEnd} and animates {@link returnT} from
+   * `0`→`1`; each frame the right edge interpolates from {@link returnFrom} (the
+   * frozen edge captured at that moment) to the *current* live edge by `returnT`,
+   * so the window glides forward and lands exactly on live (no end-snap). At
+   * `1`/`undefined` it pins to the live edge — the normal follow behavior.
+   */
+  returnT?: number;
+  /** Frozen right-edge time the {@link returnT} glide starts from. See {@link returnT}. */
+  returnFrom?: number;
+  /**
    * Absolute visible-window width (seconds) to freeze at, or `null`/`undefined`
    * to follow the configured {@link timeWindow}. Set by the pinch-zoom gesture
    * (see `usePinchZoom` / the `zoom` prop). The symmetric counterpart of
@@ -98,13 +109,38 @@ export function tickLiveChartEngineFrame(
   const liveEdge = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
   state.liveEdge = liveEdge;
   const viewEnd = input.viewEnd;
-  if (viewEnd != null && viewEnd < liveEdge) {
-    // Scrolled back in time: freeze the right edge at an absolute timestamp so
-    // the window stops tracking "now" (see usePanScroll / the `timeScroll` prop).
+  // First time of the visible series' data — the floor a frozen edge must stay
+  // at or above. `-Infinity` when there's no data to bound against, so the freeze
+  // still works (we can't strand a plot we have no time bounds for).
+  let firstDataTime = -Infinity;
+  if (input.mode === "candle") {
+    const cs = input.candles;
+    if (cs && cs.length > 0) firstDataTime = cs[0].time;
+  } else if (input.points.length > 0) {
+    firstDataTime = input.points[0].time;
+  }
+  // Freeze the right edge while the pan gesture has parked `viewEnd` behind the
+  // live edge AND that edge still sits within the data. A frozen edge stranded
+  // before the active series' first point falls through to following live (so a
+  // line/candle span mismatch never strands the window on an empty plot). When
+  // time-scroll is disabled the hook clears `viewEnd` (and kicks off the glide
+  // below), so a stale edge can't keep the window frozen. See #164.
+  const scrolledBack =
+    viewEnd != null && viewEnd < liveEdge && viewEnd >= firstDataTime;
+  if (scrolledBack) {
     state.timestamp = viewEnd;
   } else if (!input.paused) {
-    // Following the live edge — viewEnd is null/undefined or has caught back up.
-    state.timestamp = liveEdge;
+    // Following live. While a "return to live" glide is in flight (returnT < 1)
+    // ease the right edge from the frozen `returnFrom` to the *current* live edge
+    // by returnT — converges exactly on live with no end-snap. Otherwise pin to
+    // the live edge (the steady-state follow).
+    const returnT = input.returnT;
+    if (returnT != null && returnT < 1 && input.returnFrom != null) {
+      state.timestamp =
+        input.returnFrom + (liveEdge - input.returnFrom) * returnT;
+    } else {
+      state.timestamp = liveEdge;
+    }
   }
   // else: paused with no active pan → leave the frozen timestamp untouched.
 
@@ -272,8 +308,7 @@ export function tickLiveChartEngineFrame(
   // Edge value: the price at the visible window's right edge. Following live →
   // track the live value (badge unchanged). Scrolled back → track the last
   // visible point/candle close, lerped so a `followViewEdge` badge glides to the
-  // last price as you pan.
-  const scrolledBack = viewEnd != null && viewEnd < liveEdge;
+  // last price as you pan. Reuses the gated `scrolledBack` computed above.
   if (!scrolledBack) {
     state.edgeValue = state.displayValue;
   } else {

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -57,6 +57,16 @@ export interface MultiEngineTickInput {
    */
   viewEnd?: number | null;
   /**
+   * "Return to live" glide (see #164). When time-scroll is disabled while scrolled
+   * back, the hook clears {@link viewEnd} and animates {@link returnT} `0`→`1`;
+   * each frame the right edge interpolates from {@link returnFrom} to the *current*
+   * live edge by `returnT`, gliding onto live with no end-snap. `1`/`undefined`
+   * pins to the live edge.
+   */
+  returnT?: number;
+  /** Frozen right-edge time the {@link returnT} glide starts from. */
+  returnFrom?: number;
+  /**
    * Absolute visible-window width (seconds) to freeze at, or `null`/`undefined`
    * to follow {@link timeWindow}. Drives pinch-zoom (see `usePinchZoom`); the
    * symmetric counterpart of {@link viewEnd}.
@@ -78,12 +88,34 @@ export function tickLiveChartSeriesEngineFrame(
   const liveEdge = baseNow + (input.windowBuffer ?? 0) * input.timeWindow;
   state.liveEdge = liveEdge;
   const viewEnd = input.viewEnd;
-  if (viewEnd != null && viewEnd < liveEdge) {
-    // Scrolled back in time: freeze the right edge (see usePanScroll).
+  // Earliest first-point time across visible series — the floor a frozen edge
+  // must stay at or above. `-Infinity` when no visible series has data, so the
+  // freeze still works (nothing to bound the window against).
+  let firstDataTime = Infinity;
+  for (let i = 0; i < input.series.length; i++) {
+    if (input.series[i].visible === false) continue;
+    const d = input.series[i].data;
+    if (d.length > 0 && d[0].time < firstDataTime) firstDataTime = d[0].time;
+  }
+  if (firstDataTime === Infinity) firstDataTime = -Infinity;
+  // Freeze the right edge while the gesture has parked `viewEnd` behind the live
+  // edge AND that edge still sits within the data; a stranded edge falls through
+  // to following live. When time-scroll is disabled the hook clears `viewEnd` and
+  // kicks off the glide below, so a stale edge can't keep the window frozen. #164.
+  const scrolledBack =
+    viewEnd != null && viewEnd < liveEdge && viewEnd >= firstDataTime;
+  if (scrolledBack) {
     state.timestamp = viewEnd;
   } else if (!input.paused) {
-    // Following the live edge — viewEnd is null/undefined or has caught back up.
-    state.timestamp = liveEdge;
+    // Following live; ease from the frozen `returnFrom` to the current live edge
+    // while a "return to live" glide is in flight (returnT < 1), else pin to live.
+    const returnT = input.returnT;
+    if (returnT != null && returnT < 1 && input.returnFrom != null) {
+      state.timestamp =
+        input.returnFrom + (liveEdge - input.returnFrom) * returnT;
+    } else {
+      state.timestamp = liveEdge;
+    }
   }
   // else: paused with no active pan → leave the frozen timestamp untouched.
 
@@ -115,7 +147,7 @@ export function tickLiveChartSeriesEngineFrame(
   // window's right edge, so they must track each series' value AT that edge
   // (`timestamp`), not the live value — otherwise the dot floats at the current
   // price while the line ends in the past. Mirrors single-series `edgeValue`.
-  const scrolledBack = viewEnd != null && viewEnd < liveEdge;
+  // Reuses the gated `scrolledBack` computed above.
 
   for (let i = 0; i < n; i++) {
     let target = series[i].value;

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -25,6 +25,7 @@ import type {
   SelectionDotConfig,
   SelectionDotProps,
   SelectionDotRingConfig,
+  ReturnToLiveConfig,
   ThresholdConfig,
   ThresholdLineConfig,
   TradeEvent,
@@ -45,6 +46,7 @@ import {
   FADE_EDGE_WIDTH,
   GRID_METRICS_DEFAULTS,
   MOTION_METRICS_DEFAULTS,
+  RETURN_TO_LIVE_MS,
 } from "../constants";
 
 // ─── Resolved types (all fields required, no optionals) ──────────────────────
@@ -454,6 +456,25 @@ export function resolveZoom(
   prop: boolean | ZoomConfig | undefined,
 ): ResolvedZoomConfig | null {
   return resolveToggle(prop, ZOOM_DEFAULTS, false);
+}
+
+/**
+ * Resolves `timeScroll.returnToLive` to the "return to live" glide duration in ms,
+ * where `0` means an instant snap (no animation):
+ *  - `undefined` / `true` → default {@link RETURN_TO_LIVE_MS}
+ *  - `false` → `0` (instant)
+ *  - `{ duration }` → that duration (a non-positive value collapses to `0`)
+ *
+ * See {@link ReturnToLiveConfig} / #164.
+ */
+export function resolveReturnToLiveMs(
+  prop: boolean | ReturnToLiveConfig | undefined,
+): number {
+  if (prop === false) return 0;
+  if (prop == null || prop === true) return RETURN_TO_LIVE_MS;
+  const d = prop.duration;
+  if (d == null) return RETURN_TO_LIVE_MS;
+  return d > 0 ? d : 0;
 }
 
 const AXIS_LABEL_DEFAULTS: ResolvedAxisLabelConfig = {

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -7,13 +7,16 @@
  */
 import { useEffect, useState } from "react";
 import {
+  cancelAnimation,
+  Easing,
   useAnimatedReaction,
   useDerivedValue,
   useFrameCallback,
   useSharedValue,
+  withTiming,
   type SharedValue,
 } from "react-native-reanimated";
-import { MS_PER_FRAME_60FPS } from "../constants";
+import { MS_PER_FRAME_60FPS, RETURN_TO_LIVE_MS } from "../constants";
 import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
 import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
 
@@ -39,6 +42,20 @@ export interface EngineConfig {
   nowOverride?: number;
   windowBuffer?: number;
   paused?: boolean;
+  /**
+   * Whether the `timeScroll` gesture is active. Flipping this to `false` while
+   * scrolled back clears {@link ChartEngineScroll.viewEnd} and **glides** the
+   * window back to the live edge (a brief eased animation, not an instant jump),
+   * so disabling time-scroll — or a mode switch that turns it off — never strands
+   * the chart at a past position. See #164.
+   */
+  scrollEnabled?: boolean;
+  /**
+   * Duration (ms) of the return-to-live glide when {@link scrollEnabled} flips to
+   * `false` while scrolled back. `0` snaps instantly (no animation). Defaults to
+   * {@link RETURN_TO_LIVE_MS}. Resolved from `timeScroll.returnToLive`. See #164.
+   */
+  returnToLiveMs?: number;
   /**
    * Loop-free render: settle the display state once (smoothing forced to 1, no
    * per-frame frame callback) for many small charts in a list. See
@@ -166,6 +183,10 @@ export interface EngineFrameRefs {
   pausedSV: SharedValue<boolean>;
   /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
   viewEndSV?: SharedValue<number | null>;
+  /** "Return to live" glide progress (0→1); the right edge eases to live. Optional. */
+  returnTSV?: SharedValue<number>;
+  /** Frozen right-edge time the return glide starts from. Optional. */
+  returnFromSV?: SharedValue<number>;
   /** Pinch-zoom window-width override (null = follow timeWindow). Optional for callers/tests. */
   viewWindowSV?: SharedValue<number | null>;
   /** Receives the computed live edge each frame. Optional for callers/tests. */
@@ -223,6 +244,8 @@ export function applyLiveChartEngineFrame(
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
     viewEnd: sv.viewEndSV?.value,
+    returnT: sv.returnTSV?.value,
+    returnFrom: sv.returnFromSV?.value,
     viewWindow: sv.viewWindowSV?.value,
     mode: sv.modeSV.value,
     candles: sv.candles?.value,
@@ -283,6 +306,14 @@ export function useLiveChartEngine(
   const nowOverrideSV = useDerivedValue(() => config.nowOverride);
   const windowBufferSV = useDerivedValue(() => config.windowBuffer ?? 0);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
+  // Whether time-scroll is active. Drives the return-to-live reaction below
+  // (the tick no longer reads it — clearing `viewEnd` is what makes it follow).
+  // Defaults to enabled so a caller that omits it behaves as before.
+  const scrollEnabledSV = useDerivedValue(() => config.scrollEnabled ?? true);
+  // Return-to-live glide duration (ms); 0 = instant snap. Read by the reaction.
+  const returnToLiveMsSV = useDerivedValue(
+    () => config.returnToLiveMs ?? RETURN_TO_LIVE_MS,
+  );
   const modeSV = useDerivedValue(() => config.mode ?? "line");
 
   // Animation state (mutated on UI thread each frame)
@@ -303,6 +334,12 @@ export function useLiveChartEngine(
   const viewEnd = useSharedValue<number | null>(null);
   const liveEdge = useSharedValue(initialTimestamp);
   const edgeValue = useSharedValue(0);
+  // "Return to live" glide (see #164). When time-scroll is disabled while scrolled
+  // back, the reaction below clears `viewEnd`, snapshots the frozen edge into
+  // `returnFrom`, and animates `returnT` 0→1; the tick eases the right edge onto
+  // the live edge over that progress. `returnT` rests at 1 (no glide in flight).
+  const returnT = useSharedValue(1);
+  const returnFrom = useSharedValue(0);
 
   // Live data extrema (value + time of the visible high / low). NaN until the
   // first tick finds data — the extrema label stays hidden until then.
@@ -343,6 +380,8 @@ export function useLiveChartEngine(
     windowBufferSV,
     pausedSV,
     viewEndSV: viewEnd,
+    returnTSV: returnT,
+    returnFromSV: returnFrom,
     viewWindowSV: viewWindow,
     liveEdgeSV: liveEdge,
     edgeValueSV: edgeValue,
@@ -361,6 +400,37 @@ export function useLiveChartEngine(
     "worklet";
     applyLiveChartEngineFrame(frameInfo, frameRefs);
   }, !config.static);
+
+  // When time-scroll is disabled while scrolled back, return the window to the
+  // live edge. With a positive duration this glides: snapshot the frozen edge into
+  // `returnFrom`, clear `viewEnd` (so the tick stops freezing and follows), and
+  // animate `returnT` 0→1 — the tick interpolates `returnFrom`→live by that
+  // progress, landing exactly on live. Duration 0 (`returnToLive: false`) just
+  // clears `viewEnd` for an instant snap. Clearing `viewEnd` also means a later
+  // re-enable resumes from live, not the stale frozen position. All on the UI
+  // thread, no JS round-trip. See #164.
+  useAnimatedReaction(
+    () => scrollEnabledSV.value,
+    /* istanbul ignore next -- Reanimated reaction driven by a prop→derived change; not exercised under the SharedValue mock (see the viewWindow-reset test note), verified in-app */
+    (enabled, prev) => {
+      if (prev === true && !enabled && viewEnd.value != null) {
+        const ms = returnToLiveMsSV.value;
+        if (ms > 0) {
+          returnFrom.value = viewEnd.value;
+          cancelAnimation(viewEnd);
+          viewEnd.value = null;
+          returnT.value = 0;
+          returnT.value = withTiming(1, {
+            duration: ms,
+            easing: Easing.out(Easing.cubic),
+          });
+        } else {
+          cancelAnimation(viewEnd);
+          viewEnd.value = null; // returnT stays 1 → tick pins to live (instant)
+        }
+      }
+    },
+  );
 
   // One-shot settle for static charts: the fingerprint changes when the canvas
   // lays out (width 0→real) or the framing inputs change, and the handler runs a

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -1,11 +1,15 @@
 import { useRef, useState } from "react";
 import {
+  cancelAnimation,
+  Easing,
+  useAnimatedReaction,
   useDerivedValue,
   useFrameCallback,
   useSharedValue,
+  withTiming,
   type SharedValue,
 } from "react-native-reanimated";
-import { MS_PER_FRAME_60FPS } from "../constants";
+import { MS_PER_FRAME_60FPS, RETURN_TO_LIVE_MS } from "../constants";
 import type { LiveChartPoint, SeriesConfig } from "../types";
 import { tickLiveChartSeriesEngineFrame } from "./liveChartSeriesEngineTick";
 import type { ChartEngineScroll, MultiEngineState } from "./useLiveChartEngine";
@@ -24,6 +28,19 @@ export interface MultiSeriesEngineConfig {
   nowOverride?: number;
   windowBuffer?: number;
   paused?: boolean;
+  /**
+   * Whether the `timeScroll` gesture is active. Flipping to `false` while scrolled
+   * back clears {@link ChartEngineScroll.viewEnd} and **glides** the window back to
+   * the live edge (eased, not an instant jump), so disabling time-scroll never
+   * strands the chart at a past position. See #164.
+   */
+  scrollEnabled?: boolean;
+  /**
+   * Duration (ms) of the return-to-live glide when {@link scrollEnabled} flips to
+   * `false` while scrolled back. `0` snaps instantly. Defaults to
+   * {@link RETURN_TO_LIVE_MS}. Resolved from `timeScroll.returnToLive`. See #164.
+   */
+  returnToLiveMs?: number;
 }
 
 export interface MultiEngineFrameRefs {
@@ -49,6 +66,10 @@ export interface MultiEngineFrameRefs {
   pausedSV: SharedValue<boolean>;
   /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
   viewEndSV?: SharedValue<number | null>;
+  /** "Return to live" glide progress (0→1); the right edge eases to live. Optional. */
+  returnTSV?: SharedValue<number>;
+  /** Frozen right-edge time the return glide starts from. Optional. */
+  returnFromSV?: SharedValue<number>;
   /** Pinch-zoom window-width override (null = follow timeWindow). Optional for callers/tests. */
   viewWindowSV?: SharedValue<number | null>;
   /** Receives the computed live edge each frame. Optional for callers/tests. */
@@ -137,6 +158,8 @@ export function applyLiveChartSeriesEngineFrame(
     nowSeconds: Date.now() / 1000,
     paused: sv.pausedSV.value,
     viewEnd: sv.viewEndSV?.value,
+    returnT: sv.returnTSV?.value,
+    returnFrom: sv.returnFromSV?.value,
     viewWindow: sv.viewWindowSV?.value,
   });
   sv.displayMin.value = state.displayMin;
@@ -173,6 +196,13 @@ export function useLiveChartSeriesEngine(
   const nowOverrideSV = useDerivedValue(() => config.nowOverride);
   const windowBufferSV = useDerivedValue(() => config.windowBuffer ?? 0);
   const pausedSV = useDerivedValue(() => config.paused ?? false);
+  // Whether time-scroll is active — drives the return-to-live reaction below.
+  // Defaults to enabled (legacy behavior).
+  const scrollEnabledSV = useDerivedValue(() => config.scrollEnabled ?? true);
+  // Return-to-live glide duration (ms); 0 = instant snap. Read by the reaction.
+  const returnToLiveMsSV = useDerivedValue(
+    () => config.returnToLiveMs ?? RETURN_TO_LIVE_MS,
+  );
 
   const displayMin = useSharedValue(0);
   const displayMax = useSharedValue(1);
@@ -186,6 +216,10 @@ export function useLiveChartSeriesEngine(
   // Pan-scroll state (see useLiveChartEngine). Defaults to following live.
   const viewEnd = useSharedValue<number | null>(null);
   const liveEdge = useSharedValue(initialTimestamp);
+  // "Return to live" glide (see #164) — `returnT` rests at 1; the reaction below
+  // animates it 0→1 from `returnFrom` when time-scroll is disabled while scrolled.
+  const returnT = useSharedValue(1);
+  const returnFrom = useSharedValue(0);
 
   const displaySeriesValues = useSharedValue<number[]>([]);
   const seriesOpacities = useSharedValue<number[]>([]);
@@ -235,6 +269,8 @@ export function useLiveChartSeriesEngine(
         windowBufferSV,
         pausedSV,
         viewEndSV: viewEnd,
+        returnTSV: returnT,
+        returnFromSV: returnFrom,
         viewWindowSV: viewWindow,
         liveEdgeSV: liveEdge,
         extremaMinValue,
@@ -245,6 +281,34 @@ export function useLiveChartSeriesEngine(
       scratch,
     );
   });
+
+  // Return the window to live when time-scroll is disabled while scrolled back
+  // (mirrors useLiveChartEngine): with a positive duration, glide — snapshot the
+  // frozen edge, clear `viewEnd`, and animate `returnT` 0→1 so the tick eases
+  // `returnFrom`→live; duration 0 just clears `viewEnd` for an instant snap.
+  // Clearing `viewEnd` also means a later re-enable resumes from live. See #164.
+  useAnimatedReaction(
+    () => scrollEnabledSV.value,
+    /* istanbul ignore next -- Reanimated reaction driven by a prop→derived change; not exercised under the SharedValue mock, verified in-app */
+    (enabled, prev) => {
+      if (prev === true && !enabled && viewEnd.value != null) {
+        const ms = returnToLiveMsSV.value;
+        if (ms > 0) {
+          returnFrom.value = viewEnd.value;
+          cancelAnimation(viewEnd);
+          viewEnd.value = null;
+          returnT.value = 0;
+          returnT.value = withTiming(1, {
+            duration: ms,
+            easing: Easing.out(Easing.cubic),
+          });
+        } else {
+          cancelAnimation(viewEnd);
+          viewEnd.value = null;
+        }
+      }
+    },
+  );
 
   return {
     data,

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -79,6 +79,7 @@ export type {
   ReferenceLineBadgeConfig,
   ReferenceLineGroupingConfig,
   ReferenceLineRenderProps,
+  ReturnToLiveConfig,
   ScrubActionConfig,
   ScrubActionPoint,
   ScrubConfig,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1493,6 +1493,22 @@ export interface TimeScrollConfig {
 }
 
 /**
+ * Tunes the "return to live" glide — the eased animation that carries the window
+ * back to the live edge when `timeScroll` is switched off while scrolled back. See
+ * {@link TimeScrollConfig.returnToLive}.
+ *
+ * @experimental
+ */
+export interface ReturnToLiveConfig {
+  /**
+   * Glide duration in milliseconds. Default `450`. The window decelerates onto the
+   * live edge (ease-out cubic). Lower = snappier; `0` is treated as no animation
+   * (an instant snap).
+   */
+  duration?: number;
+}
+
+/**
  * Pinch-to-zoom the visible time window (see {@link LiveChartCoreProps.zoom}).
  *
  * @experimental Prototype — gesture model and API may change.
@@ -1683,6 +1699,11 @@ export interface LiveChartCoreProps {
    * live edge again. One-finger plot-area scrub is unchanged. Requires retained
    * history in `data` / `candles` to scroll into.
    *
+   * Setting this back to `false` while scrolled back — or switching `mode` so it's
+   * no longer passed — **glides** the window back to the live edge (a brief eased
+   * animation, not an instant jump); it never stays frozen at the previous scroll
+   * position. Tune or disable that glide with {@link returnToLive}.
+   *
    * `true` uses the default drag-to-scroll gesture (`"holdToScrub"`); pass a
    * {@link TimeScrollConfig} to pick the activation (`"holdToScrub"` or
    * `"axisDrag"`). Default `false`.
@@ -1690,6 +1711,22 @@ export interface LiveChartCoreProps {
    * @experimental Prototype — gesture model and API may change.
    */
   timeScroll?: boolean | TimeScrollConfig;
+  /**
+   * Controls the **return-to-live glide** — the animation that carries the window
+   * back to the live edge when {@link timeScroll} is switched off (set to `false`,
+   * or a `mode` switch stops passing it) while scrolled back into history:
+   *  - `true` (default) — glide back, easing onto the live edge over `450` ms.
+   *  - `false` — snap instantly, no animation.
+   *  - {@link ReturnToLiveConfig} — glide with a custom `{ duration }` (ms).
+   *
+   * Kept separate from {@link timeScroll} on purpose: the common way to leave
+   * time-scroll (`timeScroll={false}`) discards any `TimeScrollConfig`, so this
+   * lives alongside it to stay in effect through the toggle. Only governs that
+   * programmatic return; a finger fling back to live keeps its own inertia.
+   *
+   * @experimental
+   */
+  returnToLive?: boolean | ReturnToLiveConfig;
   /**
    * Pinch-to-zoom the visible time window. Two-finger pinch in/out narrows or
    * widens the window, anchored at the focal point between your fingers. Composes

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -611,6 +611,70 @@ describe("tickLiveChartEngineFrame", () => {
       expect(s.timestamp).toBe(950);
     });
 
+    // #164: the "return to live" glide. With viewEnd cleared, the right edge
+    // interpolates from returnFrom to the live edge by returnT (0→1).
+    it("starts the return glide at the frozen edge (returnT=0)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ returnFrom: 950, returnT: 0 }));
+      expect(s.timestamp).toBe(950); // lerp(950, 1000, 0)
+    });
+
+    it("eases the right edge toward live mid-glide (returnT=0.5)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ returnFrom: 950, returnT: 0.5 }));
+      expect(s.timestamp).toBe(975); // lerp(950, 1000, 0.5)
+    });
+
+    it("lands exactly on the live edge when the glide completes (returnT=1)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(s, input({ returnFrom: 950, returnT: 1 }));
+      expect(s.timestamp).toBe(1000); // pinned to live, no end-snap
+    });
+
+    it("a frozen viewEnd still wins over an in-flight glide", () => {
+      // While actually scrolled back, viewEnd takes precedence over returnT.
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({ viewEnd: 950, returnFrom: 900, returnT: 0.5 }),
+      );
+      expect(s.timestamp).toBe(950);
+    });
+
+    // #164: a frozen edge stranded before the first data point follows live
+    // instead of rendering an empty plot (the differing-span repro).
+    it("follows live when the frozen edge precedes the first line point", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({ viewEnd: 950, points: [{ time: 980, value: 1 }] }),
+      );
+      expect(s.timestamp).toBe(1000); // 950 < firstTime 980 ⇒ follow live
+    });
+
+    it("freezes when the edge sits at or after the first line point", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({ viewEnd: 950, points: [{ time: 940, value: 1 }] }),
+      );
+      expect(s.timestamp).toBe(950); // 950 >= firstTime 940 ⇒ frozen
+    });
+
+    it("follows live when the frozen edge precedes the first candle", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          mode: "candle",
+          candles: [{ time: 980, open: 1, high: 2, low: 0.5, close: 1.5 }],
+          liveCandle: null,
+        }),
+      );
+      expect(s.timestamp).toBe(1000); // 950 < firstCandle 980 ⇒ follow live
+    });
+
     // edgeValue — the price at the window's right edge (for a followViewEdge badge).
     it("edgeValue tracks the live value while following", () => {
       const s = baseState();

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -682,6 +682,61 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       expect(s.timestamp).toBe(950);
     });
 
+    // #164: the "return to live" glide. With viewEnd cleared, the right edge
+    // interpolates from returnFrom to the live edge by returnT (0→1).
+    it("eases the right edge from returnFrom toward live by returnT", () => {
+      const start = baseMulti();
+      tickLiveChartSeriesEngineFrame(start, input({ returnFrom: 950, returnT: 0 }));
+      expect(start.timestamp).toBe(950);
+
+      const mid = baseMulti();
+      tickLiveChartSeriesEngineFrame(mid, input({ returnFrom: 950, returnT: 0.5 }));
+      expect(mid.timestamp).toBe(975);
+
+      const done = baseMulti();
+      tickLiveChartSeriesEngineFrame(done, input({ returnFrom: 950, returnT: 1 }));
+      expect(done.timestamp).toBe(1000);
+    });
+
+    // #164: a frozen edge before any visible series' first point follows live.
+    it("follows live when the frozen edge precedes the first visible point", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          series: [
+            {
+              id: "a",
+              color: "#00f",
+              value: 5,
+              data: [{ time: 980, value: 5 }],
+            },
+          ],
+        }),
+      );
+      expect(s.timestamp).toBe(1000); // 950 < firstTime 980 ⇒ follow live
+    });
+
+    it("freezes when the edge sits at or after the first visible point", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          series: [
+            {
+              id: "a",
+              color: "#00f",
+              value: 5,
+              data: [{ time: 940, value: 5 }],
+            },
+          ],
+        }),
+      );
+      expect(s.timestamp).toBe(950); // 950 >= firstTime 940 ⇒ frozen
+    });
+
     // Regression: while scrolled back, each series' tip/dot must track its value
     // AT the visible right edge, not the live value — otherwise the dot floats at
     // the current price while the line ends in the past.

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -14,6 +14,7 @@ import {
   resolveMultiSeriesDot,
   resolvePulse,
   resolveReferenceLineConfig,
+  resolveReturnToLiveMs,
   resolveScrub,
   resolveScrubAction,
   resolveSelectionDot,
@@ -35,6 +36,7 @@ import {
   FADE_EDGE_WIDTH,
   GRID_METRICS_DEFAULTS,
   MOTION_METRICS_DEFAULTS,
+  RETURN_TO_LIVE_MS,
 } from "../src/constants";
 import { leftEdgeFadeColorsFromBgRgb } from "../src/theme";
 
@@ -291,6 +293,32 @@ describe("resolveZoom", () => {
       minTimeWindow: 5,
       maxTimeWindow: 600,
     });
+  });
+});
+
+// ─── resolveReturnToLiveMs ───────────────────────────────────────────────────
+
+describe("resolveReturnToLiveMs", () => {
+  it("defaults to the glide duration for undefined and true", () => {
+    expect(resolveReturnToLiveMs(undefined)).toBe(RETURN_TO_LIVE_MS);
+    expect(resolveReturnToLiveMs(true)).toBe(RETURN_TO_LIVE_MS);
+  });
+
+  it("returns 0 (instant) for false", () => {
+    expect(resolveReturnToLiveMs(false)).toBe(0);
+  });
+
+  it("uses a custom duration from the config object", () => {
+    expect(resolveReturnToLiveMs({ duration: 700 })).toBe(700);
+  });
+
+  it("falls back to the default when duration is omitted", () => {
+    expect(resolveReturnToLiveMs({})).toBe(RETURN_TO_LIVE_MS);
+  });
+
+  it("collapses a non-positive duration to an instant snap", () => {
+    expect(resolveReturnToLiveMs({ duration: 0 })).toBe(0);
+    expect(resolveReturnToLiveMs({ duration: -100 })).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #164. Cuts **v4.3.0** (minor — adds the `returnToLive` prop).

## Problem

With `timeScroll` enabled, panning back through history freezes the window at the scrolled-to time. Setting `timeScroll={false}` — or switching `mode` so the consumer stops passing it — left the window **frozen at that past position** with no way back to live (nothing reset the frozen edge once the gesture was disabled). With differing line/candle history spans, the frozen edge could land before the active series' first point and render an **empty plot**.

## What changed

**Returns to live instead of freezing — and glides there.** When time-scroll is disabled while scrolled back, the engine snapshots the frozen edge, clears it, and animates a 0→1 progress (`withTiming`, ease-out cubic). Each frame the right edge interpolates from the frozen edge to the *current* live edge by that progress, so it lands exactly on live with **no end-snap**. All on the UI thread.

**New `returnToLive` prop** (`boolean | ReturnToLiveConfig`) on `LiveChart` + `LiveChartSeries`:
- `true` (default) — glide over 450 ms
- `false` — snap instantly (the pre-4.3 behavior)
- `{ duration }` — custom glide length

It's a **sibling** of `timeScroll` (not nested in `TimeScrollConfig`) on purpose: the usual way to leave time-scroll is `timeScroll={false}`, which would discard a nested config exactly when the return fires. Resolved via `resolveReturnToLiveMs`; exports `ReturnToLiveConfig`.

**Robustness:** a frozen edge before the active series' first data point follows live instead of stranding an empty plot; clearing the edge means re-enabling `timeScroll` resumes from live, not the stale position.

## API / docs

- New `returnToLive` prop + `ReturnToLiveConfig` type — documented in `types`, `livechart`, `livechart-series` api-reference, the time-scroll guide, and a "Return to live" control in the time-scroll demo.
- CHANGELOG under **4.3.0** (Added: glide + prop; Fixed: #164 freeze).

## Tests

- Tick unit tests for the return interpolation (returnT 0→0.5→1 maps frozen→live) and the data-range clamp (line / candle / multi-series).
- `resolveReturnToLiveMs` resolver tests (true/false/`{duration}`/non-positive).
- `npm run verify` green: typecheck + lint + 89 suites / 1236 tests, coverage thresholds met.

## Manual QA (iOS 26.4 sim, Time-scroll demo, candle mode)

Pan back → window freezes; toggle `timeScroll` off → window **glides** back to the live edge and resumes following; re-enabling resumes from live (no jump back). The new "Return to live" demo control switches between Glide / Instant / Slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
