### PR TITLE
feat(scrub): add `hideOverlaysOnScrub` to fade markers + reference lines while scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`scrub.hideOverlaysOnScrub`** (`boolean`, default `false`) on `LiveChart` and
+  `LiveChartSeries`. Fades the annotation overlays — buy/sell **markers** and
+  **reference lines** (both the built-in Skia tags/lines and any custom
+  `renderMarker` / `renderReferenceLine` RN views) — out while scrubbing so they
+  don't clutter the crosshair read-out, easing back in on release. Driven by the
+  scrub-active state (not the crosshair's edge-proximity fade, which would
+  resurface the overlays near the live dot) and eased on the UI thread. Animates
+  only a group opacity — the marker atlas and reference-line geometry are left
+  intact (still one batched draw each), so there's no per-scrub data rebuild.
+
 ## [4.4.0] - 2026-06-26
 
 ### Added

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -1,10 +1,12 @@
 import { StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Circle, Group } from "@shopify/react-native-skia";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   formatTime,
   LiveChart,
+  type Marker,
+  type ReferenceLine,
   type ScrubConfig,
   type SelectionDotProps,
   type TooltipRenderProps,
@@ -24,6 +26,9 @@ import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 export const options = { title: "Scrubbing" };
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+// Seed price for the line so the reference lines below land in-range.
+const START = 100;
 
 type ScrubMode = "off" | "on" | "noTooltip";
 
@@ -156,6 +161,8 @@ export default function ScrubbingScreen() {
   const [dimOpacity, setDimOpacity] = useState(0.3);
   const [dotMode, setDotMode] = useState<DotMode>("default");
   const [holdToScrub, setHoldToScrub] = useState(false);
+  // Fade markers + reference lines out while scrubbing (scrub.hideOverlaysOnScrub).
+  const [hideOverlays, setHideOverlays] = useState(true);
   // onGestureStart/onGestureEnd are JS-thread callbacks, so plain React state
   // is fine here (they fire once per gesture, not once per pointer move).
   const [gestureState, setGestureState] = useState<"idle" | "scrubbing…">(
@@ -181,6 +188,7 @@ export default function ScrubbingScreen() {
     multiSeries: false,
     candleAggregation: displayMode === "candle",
     tradeStream: false,
+    startValue: START,
     candleWidth: candleWidthSecs,
     // Dense seed (fine "1m" sampling over the window) so candle buckets get many
     // ticks each — real bodies + wicks instead of flat one-point dojis.
@@ -193,6 +201,32 @@ export default function ScrubbingScreen() {
     maxPoints: 6000,
   });
 
+  // Static reference lines (avg-entry / limit-style) so there's something for
+  // `hideOverlaysOnScrub` to fade. In-range because the line starts at START.
+  const referenceLines: ReferenceLine[] = [
+    { value: START * 1.04, label: "Limit Sell", color: "#f87171" },
+    { value: START * 0.96, label: "Avg Buy", color: "#34d399" },
+  ];
+
+  // A few buy/sell markers anchored to the line (value omitted), seeded once at
+  // recent times so they sit in the window. Live position tracked on the UI
+  // thread; here they're just present for the fade to act on.
+  const markers = useSharedValue<Marker[]>([]);
+  useEffect(() => {
+    const now = Date.now() / 1000;
+    markers.set(
+      [30, 80, 150, 220].map((ago, i) => ({
+        id: `m${i}`,
+        time: now - ago,
+        kind: "trade" as const,
+        color: i % 2 === 0 ? "#34d399" : "#f87171",
+        icon: i % 2 === 0 ? "+" : "−",
+        pill: true,
+        side: i % 2 === 0 ? ("below" as const) : ("above" as const),
+      })),
+    );
+  }, [markers]);
+
   const scrub: ScrubConfig | boolean =
     scrubMode === "off"
       ? false
@@ -200,6 +234,7 @@ export default function ScrubbingScreen() {
           tooltip: scrubMode !== "noTooltip",
           dimOpacity,
           panGestureDelay,
+          hideOverlaysOnScrub: hideOverlays,
           // Tooltip layout knobs — apply to the built-in pill and the custom
           // render alike (placement + margin position either one).
           tooltipPlacement,
@@ -249,6 +284,8 @@ export default function ScrubbingScreen() {
           accentColor={ACCENT}
           theme={APP_THEME}
           timeWindow={windowSecs}
+          referenceLines={referenceLines}
+          markers={markers}
           scrub={scrub}
           // A custom tooltip works in both modes: the blue date pill in line
           // mode, a bespoke OHLC pill (reading `ctx.candle`) in candle mode.
@@ -358,6 +395,15 @@ export default function ScrubbingScreen() {
           label="Hold to scrub (250ms)"
           value={holdToScrub}
           onChange={setHoldToScrub}
+        />
+      </ControlRow>
+      <ControlRow label="Overlays">
+        {/* scrub.hideOverlaysOnScrub — fade markers + reference lines while
+            scrubbing. Toggle off to see them stay put under the crosshair. */}
+        <ToggleChip
+          label="Hide on scrub"
+          value={hideOverlays}
+          onChange={setHideOverlays}
         />
       </ControlRow>
 

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -329,6 +329,7 @@ interface ScrubConfig {
   tooltipMargin?: number; // gap (px) to the pinned plot edge (top for side/top, bottom for bottom); default 8
   tooltipShowValue?: boolean; tooltipShowTime?: boolean; // default both true; drop a row (e.g. date-only)
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0
+  hideOverlaysOnScrub?: boolean; // fade markers + reference lines out while scrubbing; default false
 }
 // Order-ticket mode (scrubAction). Opt-in — default off.
 interface ScrubActionConfig {

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -178,6 +178,30 @@ Default `0.3`.
 
 The same `dimOpacity` option works on `LiveChartSeries`.
 
+## Hide overlays while scrubbing (`hideOverlaysOnScrub`)
+
+`dimOpacity` fades the line/candles, but annotation overlays — buy/sell **markers** and
+**reference lines** — stay at full strength and can clutter the crosshair read-out. Set
+`hideOverlaysOnScrub` to fade them out for the duration of the scrub and back in on release.
+
+```tsx
+<LiveChart data={data} value={value} scrub={{ hideOverlaysOnScrub: true }} />
+```
+
+It covers both the built-in Skia tags/lines **and** any custom `renderMarker` /
+`renderReferenceLine` views. The fade is driven by the scrub-active state (not the crosshair's
+edge-proximity fade, so the overlays don't resurface as the crosshair nears the live dot) and eased
+on the UI thread.
+
+<Note>
+  Cheap by construction: only a **group opacity** animates — the marker atlas and reference-line
+  geometry are untouched (still one batched draw each). It does **not** rebuild or empty the overlay
+  data per scrub, so there's no per-scrub layout/recompute cost.
+</Note>
+
+The leading live dot is governed separately — see [Selection dot](#selection-dot). Works the same on
+`LiveChartSeries`.
+
 ## Dashed crosshair (`crosshairDash`)
 
 The vertical crosshair line is solid by default. Set `crosshairDash` to draw it dashed — `true`

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
-import {
+import Animated, {
   useAnimatedReaction,
+  useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
+  withTiming,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 
@@ -22,7 +24,11 @@ import {
   vec,
 } from "@shopify/react-native-skia";
 
-import { DEFAULT_ACCENT_COLOR, HOLD_TO_SCRUB_MS } from "../constants";
+import {
+  DEFAULT_ACCENT_COLOR,
+  HOLD_TO_SCRUB_MS,
+  SCRUB_OVERLAY_FADE_MS,
+} from "../constants";
 import {
   resolveAreaDots,
   resolveAxisLabel,
@@ -1027,6 +1033,25 @@ function useLiveChartController({
       (selectionDotDuringScrub && crosshair.scrubActive.value ? 0 : 1),
   );
 
+  // Fade the annotation overlays (markers + reference lines) out while scrubbing
+  // when `scrub.hideOverlays` is set. Eased off the scrub-ACTIVE flag — not the
+  // crosshair's edge-proximity fade, which drops to 0 near the live dot and would
+  // resurface the overlays mid-scrub. Only this group opacity animates; the
+  // marker atlas / reference-line draws stay intact (one batched draw each).
+  const fadeOverlaysOnScrub =
+    !isStatic && scrubCfg !== null && scrubCfg.hideOverlaysOnScrub === true;
+  const overlayScrubFade = useDerivedValue(() =>
+    fadeOverlaysOnScrub
+      ? withTiming(crosshair.scrubActive.get() ? 0 : 1, {
+          duration: SCRUB_OVERLAY_FADE_MS,
+        })
+      : 1,
+  );
+  // Markers already fade with the dot reveal; fold the scrub-hide fade in too.
+  const markerGroupOpacity = useDerivedValue(
+    () => reveal.dotOpacity.get() * overlayScrubFade.get(),
+  );
+
   return {
     // passthrough props the render needs
     style,
@@ -1121,6 +1146,8 @@ function useLiveChartController({
     dotX,
     dotY,
     liveDotOpacity,
+    overlayScrubFade,
+    markerGroupOpacity,
     momentumSV,
     tradeMarkers,
     degenPack,
@@ -1309,6 +1336,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     markersActive,
     markersSV,
     markerClusterCfg,
+    markerGroupOpacity,
+    overlayScrubFade,
     renderMarker,
     emptyText,
     metricsCfg,
@@ -1350,21 +1379,24 @@ function ChartStack({ model }: { model: LiveChartModel }) {
 
       {/* Index keys: reference lines are a positional array and two may share
           value + label (e.g. duplicate working orders at the same price), which a
-          content-derived key would collapse to one. */}
-      {allRefLines.map((rl, i) => (
-        <ReferenceLineOverlay
-          key={i}
-          engine={engine}
-          padding={effectivePadding}
-          line={rl}
-          palette={palette}
-          formatValue={formatValue}
-          font={skiaFont}
-          fontProp={fontProp}
-          dragValues={dragValues}
-          index={i}
-        />
-      ))}
+          content-derived key would collapse to one. Wrapped in a fade group so
+          `scrub.hideOverlaysOnScrub` can ease the lines out while scrubbing. */}
+      <Group opacity={overlayScrubFade}>
+        {allRefLines.map((rl, i) => (
+          <ReferenceLineOverlay
+            key={i}
+            engine={engine}
+            padding={effectivePadding}
+            line={rl}
+            palette={palette}
+            formatValue={formatValue}
+            font={skiaFont}
+            fontProp={fontProp}
+            dragValues={dragValues}
+            index={i}
+          />
+        ))}
+      </Group>
 
       {/* Threshold marker line + label (behind the chart line). */}
       {thresholdCfg?.line && (
@@ -1523,7 +1555,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
       )}
 
       {markersActive && (
-        <Group opacity={reveal.dotOpacity}>
+        <Group opacity={markerGroupOpacity}>
           <MarkerOverlay
             markers={markersSV}
             engine={engine}
@@ -1747,10 +1779,11 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
     skiaFont,
     fontProp,
     degenShakeTransform,
+    overlayScrubFade,
   } = model;
   if (allRefLines.length === 0) return null;
   return (
-    <Group transform={degenShakeTransform}>
+    <Group transform={degenShakeTransform} opacity={overlayScrubFade}>
       {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
           key={i}
@@ -1853,7 +1886,14 @@ export function LiveChart(props: LiveChartProps) {
     topConnector,
     bottomConnector,
     lineIsLinear,
+    overlayScrubFade,
   } = model;
+
+  // Mirror the Skia overlay fade onto the RN custom-overlay siblings (custom
+  // markers / reference-line tags) so `scrub.hideOverlaysOnScrub` hides them too.
+  const overlayFadeStyle = useAnimatedStyle(() => ({
+    opacity: overlayScrubFade.get(),
+  }));
 
   return (
     <GestureDetector gesture={rootGesture}>
@@ -1921,33 +1961,47 @@ export function LiveChart(props: LiveChartProps) {
         />
 
         {/* Custom-rendered markers — RN views floated over the canvas (non-Skia),
-            pinned to each marker's live position. Sibling of <Canvas>. */}
+            pinned to each marker's live position. Sibling of <Canvas>. Wrapped in
+            a box-none fade layer so `scrub.hideOverlaysOnScrub` hides them with the
+            Skia markers (the wrapper is full-bleed; children keep their own
+            absolute positions). */}
         {markersActive && renderMarker && (
-          <CustomMarkerOverlay
-            markers={markersSV}
-            renderMarker={renderMarker}
-            engine={engine}
-            padding={effectivePadding}
-            lineData={engine.data}
-            lineLinear={lineIsLinear}
-            cluster={markerClusterCfg}
-          />
+          <Animated.View
+            pointerEvents="box-none"
+            style={[StyleSheet.absoluteFill, overlayFadeStyle]}
+          >
+            <CustomMarkerOverlay
+              markers={markersSV}
+              renderMarker={renderMarker}
+              engine={engine}
+              padding={effectivePadding}
+              lineData={engine.data}
+              lineLinear={lineIsLinear}
+              cluster={markerClusterCfg}
+            />
+          </Animated.View>
         )}
 
         {/* Custom-rendered reference-line tags — RN views floated over the canvas
             (non-Skia), pinned to each Form-A line's value. Sibling of <Canvas>.
-            Built-in Skia tags for these lines are suppressed (no double-draw). */}
+            Built-in Skia tags for these lines are suppressed (no double-draw).
+            Same box-none fade wrapper as the custom markers above. */}
         {renderReferenceLine && allRefLines.length > 0 && (
-          <CustomReferenceLineOverlay
-            lines={allRefLines}
-            renderReferenceLine={renderReferenceLine}
-            custom={refLineCustom}
-            engine={engine}
-            padding={effectivePadding}
-            formatValue={formatValue}
-            dragValues={dragValues}
-            dragActive={dragActive}
-          />
+          <Animated.View
+            pointerEvents="box-none"
+            style={[StyleSheet.absoluteFill, overlayFadeStyle]}
+          >
+            <CustomReferenceLineOverlay
+              lines={allRefLines}
+              renderReferenceLine={renderReferenceLine}
+              custom={refLineCustom}
+              engine={engine}
+              padding={effectivePadding}
+              formatValue={formatValue}
+              dragValues={dragValues}
+              dragActive={dragActive}
+            />
+          </Animated.View>
         )}
 
         {/* Custom scrub tooltip — an RN view floated over the canvas (non-Skia),

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -6,12 +6,14 @@
  */
 import { Canvas, Group } from "@shopify/react-native-skia";
 import { useLayoutEffect, useState } from "react";
-import { View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
-import {
+import Animated, {
   useAnimatedReaction,
+  useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
+  withTiming,
   type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
@@ -19,6 +21,7 @@ import {
   DEFAULT_ACCENT_COLOR,
   HOLD_TO_SCRUB_MS,
   MAX_MULTI_SERIES,
+  SCRUB_OVERLAY_FADE_MS,
 } from "../constants";
 import {
   lineColorsSignatureFromArray,
@@ -453,6 +456,23 @@ function useLiveChartSeriesController({
 
   const backgroundColor = `rgb(${palette.bgRgb[0]}, ${palette.bgRgb[1]}, ${palette.bgRgb[2]})`;
 
+  // Fade markers + reference lines out while scrubbing when
+  // `scrub.hideOverlaysOnScrub` is set. Eased off the scrub-ACTIVE flag (not the
+  // crosshair edge fade, which would resurface them near the live dot); only a
+  // group opacity animates — the overlay draws stay intact. See `LiveChart`.
+  const fadeOverlaysOnScrub =
+    scrubCfg !== null && scrubCfg.hideOverlaysOnScrub === true;
+  const overlayScrubFade = useDerivedValue(() =>
+    fadeOverlaysOnScrub
+      ? withTiming(crosshair.scrubActive.get() ? 0 : 1, {
+          duration: SCRUB_OVERLAY_FADE_MS,
+        })
+      : 1,
+  );
+  const markerGroupOpacity = useDerivedValue(
+    () => reveal.dotOpacity.get() * overlayScrubFade.get(),
+  );
+
   return {
     // passthrough props the render needs
     series,
@@ -500,6 +520,8 @@ function useLiveChartSeriesController({
     markersActive,
     markersSV,
     markerClusterCfg,
+    markerGroupOpacity,
+    overlayScrubFade,
     renderMarker,
     // selection dot: resolved config + fallback color (the leading series' color)
     selectionDot: selectionDotCfg,
@@ -545,6 +567,8 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     markersActive,
     markersSV,
     markerClusterCfg,
+    markerGroupOpacity,
+    overlayScrubFade,
     renderMarker,
     series,
     emptyText,
@@ -570,18 +594,21 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
 
       {/* Index keys: reference lines are a positional array and two may share
           value + label (e.g. duplicate working orders at the same price), which a
-          content-derived key would collapse to one. */}
-      {allRefLines.map((rl, i) => (
-        <ReferenceLineOverlay
-          key={i}
-          engine={engine}
-          padding={effectivePadding}
-          line={rl}
-          palette={palette}
-          formatValue={formatValue}
-          font={skiaFont}
-        />
-      ))}
+          content-derived key would collapse to one. Fade group lets
+          `scrub.hideOverlaysOnScrub` ease the lines out while scrubbing. */}
+      <Group opacity={overlayScrubFade}>
+        {allRefLines.map((rl, i) => (
+          <ReferenceLineOverlay
+            key={i}
+            engine={engine}
+            padding={effectivePadding}
+            line={rl}
+            palette={palette}
+            formatValue={formatValue}
+            font={skiaFont}
+          />
+        ))}
+      </Group>
 
       {dotCfg.valueLine && (
         <Group opacity={reveal.lineOpacity}>
@@ -654,7 +681,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
       )}
 
       {markersActive && (
-        <Group opacity={reveal.dotOpacity}>
+        <Group opacity={markerGroupOpacity}>
           <MarkerOverlay
             markers={markersSV}
             engine={engine}
@@ -726,10 +753,11 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
     formatValue,
     skiaFont,
     degenShakeTransform,
+    overlayScrubFade,
   } = model;
   if (allRefLines.length === 0) return null;
   return (
-    <Group transform={degenShakeTransform}>
+    <Group transform={degenShakeTransform} opacity={overlayScrubFade}>
       {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
           key={i}
@@ -778,7 +806,14 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     markersSV,
     markerClusterCfg,
     renderMarker,
+    overlayScrubFade,
   } = model;
+
+  // Mirror the Skia overlay fade onto the RN custom-marker sibling so
+  // `scrub.hideOverlaysOnScrub` hides it with the Skia markers.
+  const overlayFadeStyle = useAnimatedStyle(() => ({
+    opacity: overlayScrubFade.get(),
+  }));
 
   // Extend the scrub dim past the plot's right edge to fully cover the series
   // dots (with their halo) and pulse rings, all centered on that edge. The
@@ -876,16 +911,23 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
           />
 
           {/* Custom-rendered markers — RN views floated over the canvas
-              (non-Skia), pinned to each marker's live position. */}
+              (non-Skia), pinned to each marker's live position. Box-none fade
+              wrapper so `scrub.hideOverlaysOnScrub` hides them with the Skia
+              markers (full-bleed; children keep their own absolute positions). */}
           {markersActive && renderMarker && (
-            <CustomMarkerOverlay
-              markers={markersSV}
-              renderMarker={renderMarker}
-              engine={engine}
-              padding={effectivePadding}
-              series={series}
-              cluster={markerClusterCfg}
-            />
+            <Animated.View
+              pointerEvents="box-none"
+              style={[StyleSheet.absoluteFill, overlayFadeStyle]}
+            >
+              <CustomMarkerOverlay
+                markers={markersSV}
+                renderMarker={renderMarker}
+                engine={engine}
+                padding={effectivePadding}
+                series={series}
+                cluster={markerClusterCfg}
+              />
+            </Animated.View>
           )}
         </View>
       </GestureDetector>

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -31,6 +31,14 @@ export const HOLD_TO_SCRUB_MS = 500;
  */
 export const RETURN_TO_LIVE_MS = 450;
 
+/**
+ * Duration (ms) of the fade applied to annotation overlays (markers + reference
+ * lines) when `scrub.hideOverlaysOnScrub` is on — how long they take to ease out as a
+ * scrub starts and back in on release. Driven by the scrub-active flag, eased on
+ * the UI thread. Shared by `LiveChart` and `LiveChartSeries`.
+ */
+export const SCRUB_OVERLAY_FADE_MS = 150;
+
 // ─── Metric default tokens (single source of truth for LiveChartMetrics) ─────
 // The resolved `metrics` config (see resolveMetrics) is assembled from these
 // objects. Draw/worklet helpers default their metric params to the matching

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -165,6 +165,8 @@ export interface ResolvedScrubConfig {
   tooltipShowTime: boolean;
   /** Press-and-hold delay (ms) before scrubbing activates. 0 = immediate. */
   panGestureDelay: number;
+  /** Fade markers + reference lines out while scrubbing. */
+  hideOverlaysOnScrub: boolean;
 }
 
 export interface ResolvedScrubActionConfig {
@@ -571,6 +573,7 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltipShowValue: true,
   tooltipShowTime: true,
   panGestureDelay: 0,
+  hideOverlaysOnScrub: false,
 };
 
 /**

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -720,6 +720,23 @@ export interface ScrubConfig {
    * Default `0`.
    */
   panGestureDelay?: number;
+  /**
+   * Fade the annotation overlays — buy/sell **markers** and **reference lines**
+   * (both the built-in Skia tags/lines and any custom `renderMarker` /
+   * `renderReferenceLine` RN views) — out while scrubbing, so they don't clutter
+   * the crosshair read-out. Reverses on release.
+   *
+   * The fade is driven by the **scrub-active** state (not the crosshair's
+   * edge-proximity fade, which would resurface the overlays as the crosshair
+   * nears the live dot) and eased on the UI thread over `SCRUB_OVERLAY_FADE_MS`.
+   * It animates only a **group opacity** — the marker atlas and reference-line
+   * geometry are left intact (still one batched draw each), so it's far cheaper
+   * than emptying / rebuilding overlay data per scrub. The leading dot is
+   * governed separately by `selectionDot`.
+   *
+   * `false` / omitted keeps the overlays visible while scrubbing (default).
+   */
+  hideOverlaysOnScrub?: boolean;
 }
 
 /**

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -462,6 +462,7 @@ describe("resolveScrub", () => {
       tooltipShowValue: true,
       tooltipShowTime: true,
       panGestureDelay: 0,
+      hideOverlaysOnScrub: false,
     });
   });
 
@@ -475,6 +476,7 @@ describe("resolveScrub", () => {
       tooltipShowValue: true,
       tooltipShowTime: true,
       panGestureDelay: 0,
+      hideOverlaysOnScrub: false,
     });
   });
 
@@ -488,6 +490,7 @@ describe("resolveScrub", () => {
       tooltipShowValue: true,
       tooltipShowTime: true,
       panGestureDelay: 0,
+      hideOverlaysOnScrub: false,
     });
   });
 
@@ -511,7 +514,15 @@ describe("resolveScrub", () => {
       tooltipShowValue: true,
       tooltipShowTime: true,
       panGestureDelay: 300,
+      hideOverlaysOnScrub: false,
     });
+  });
+
+  it("defaults hideOverlaysOnScrub to false and carries it when set", () => {
+    expect(resolveScrub(true)?.hideOverlaysOnScrub).toBe(false);
+    expect(
+      resolveScrub({ hideOverlaysOnScrub: true })?.hideOverlaysOnScrub,
+    ).toBe(true);
   });
 
   it("carries a custom tooltipBorderRadius", () => {


### PR DESCRIPTION
## What

Add an opt-in `scrub.hideOverlaysOnScrub` (boolean, default `false`) on both `LiveChart` and `LiveChartSeries`. While scrubbing, the annotation overlays — buy/sell **markers** and **reference lines** — fade out so they don't clutter the crosshair read-out, easing back in on release.

## Why

`dimOpacity` already fades the line/candles, but markers and reference lines stay at full strength and clutter the crosshair read-out during a scrub. This gives a one-flag way to clear them.

## How

- Driven by the **scrub-active** state, not the crosshair's edge-proximity fade (which drops to 0 near the live dot and would resurface the overlays mid-scrub). Eased on the UI thread over a new `SCRUB_OVERLAY_FADE_MS` (150 ms).
- Cheap by construction: only a **group opacity** animates — the marker atlas and reference-line geometry are left intact (still one batched draw each). No per-scrub data rebuild.
- Covers built-in Skia tags/lines **and** the custom `renderMarker` / `renderReferenceLine` RN siblings (same fade via a `box-none` `Animated.View` wrapper).

## Docs / tests

- `docs/api-reference/types.mdx` + `docs/guides/scrubbing.mdx` + `CHANGELOG.md` updated.
- `resolveScrub` tests updated (default + carries the flag).
- `npm run verify` green: typecheck, lint, 89 suites / 1232 tests, coverage thresholds held.

