### PR TITLE
feat(loading): configurable loading shell (`loading={LoadingConfig}`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `reveal: 0` removes the grow-in on timeframe change and the line "animating in"
   when switching candle→line. Independent of `smoothing` (live value easing) and
   `static` (one-shot render). Exports the new `TransitionConfig` type.
+- **Configurable loading shell** — `loading` now accepts a `LoadingConfig` object
+  (`boolean | LoadingConfig`) on `LiveChart` and `LiveChartSeries`, so the
+  breathing-line placeholder can be restyled: `color` (squiggle + skeleton
+  Y-axis placeholders; default theme `gridLine`), `strokeWidth` (default the
+  chart line width), `amplitude` (base breathing-wave height, default `14`), and
+  `speed` (wave cadence multiplier, default `1`; `0` freezes).
+  `color` / `amplitude` / `speed` also flow into the reveal morph so the squiggle
+  keeps its look as it melts into the line. `true` keeps the defaults, `false` /
+  omitted is "not loading". Exports the new `LoadingConfig` type. (The
+  loading→live reveal duration is tuned separately via the `transitions.reveal`
+  prop above.)
 
 ## [4.4.0] - 2026-06-26
 

--- a/app/demo/states-and-formatting.tsx
+++ b/app/demo/states-and-formatting.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { LiveChartPoint } from "react-native-livechart";
+import type { LiveChartPoint, LoadingConfig } from "react-native-livechart";
 import { LiveChart } from "react-native-livechart";
 import { useSharedValue } from "react-native-reanimated";
 
@@ -26,6 +26,15 @@ function formatValueUsd(v: number): string {
   return `$${v.toFixed(2)}`;
 }
 
+// A restyled loading shell: amber, thicker, taller + faster breathing. Toggled
+// against the plain `loading={true}` defaults below.
+const STYLED_LOADING: LoadingConfig = {
+  color: "#fbbf24",
+  strokeWidth: 3,
+  amplitude: 22,
+  speed: 1.6,
+};
+
 type FormatMode = "default" | "custom";
 
 const FORMAT_OPTIONS: { value: FormatMode; label: string }[] = [
@@ -37,6 +46,7 @@ export default function StatesScreen() {
   const [empty, setEmpty] = useState(false);
   const [onePoint, setOnePoint] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [styledLoading, setStyledLoading] = useState(false);
   const [formatMode, setFormatMode] = useState<FormatMode>("default");
 
   const customFormat = formatMode === "custom";
@@ -70,7 +80,7 @@ export default function StatesScreen() {
           value={chartValue}
           accentColor={ACCENT}
           theme={APP_THEME}
-          loading={loading}
+          loading={loading && (styledLoading ? STYLED_LOADING : true)}
           emptyText={showEmptyShell ? "Nothing to see here" : "No data"}
           formatValue={customFormat ? formatValueUsd : undefined}
           formatTime={customFormat ? formatTimeIsoUtcFragment : undefined}
@@ -103,6 +113,16 @@ export default function StatesScreen() {
             setLoading(true);
             setTimeout(() => setLoading(false), 2000);
           }}
+        />
+      </ControlRow>
+
+      <ControlRow label="Loading style">
+        {/* Plain `loading={true}` vs a restyled `LoadingConfig` (amber, thicker,
+            taller/faster wave, snappier reveal). Tap a Loading button to see it. */}
+        <Chip
+          label="Styled shell"
+          active={styledLoading}
+          onPress={() => setStyledLoading((s) => !s)}
         />
       </ControlRow>
 

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -381,8 +381,12 @@ provided; everything else has a default.
   Freeze scrolling; resume catches up to real time.
 </ParamField>
 
-<ParamField body="loading" type="boolean">
-  Breathing-line loading shell until data is ready.
+<ParamField body="loading" type="boolean | LoadingConfig">
+  Breathing-line loading shell until data is ready. `true` uses the defaults; pass
+  a [`LoadingConfig`](/api-reference/types#loadingconfig) to restyle it (`color`,
+  `strokeWidth`, `amplitude`, `speed`). `false` / omitted is "not loading". The
+  loading→live reveal duration is set via the `transitions` prop below — see
+  [Transitions](/guides/transitions).
 </ParamField>
 
 <ParamField body="transitions" type="boolean | TransitionConfig">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -390,6 +390,13 @@ interface TransitionConfig {
   reveal?: number; // grow-in/collapse on data appear, timeframe change, candle→line; default 600 (0 = snap)
   mode?: number;   // candle↔line crossfade (single-series LiveChart only); default 300 (0 = snap)
 }
+// Styling for the breathing loading shell — the object form of `loading`.
+interface LoadingConfig {
+  color?: string;          // squiggle + skeleton color; default theme gridLine
+  strokeWidth?: number;    // squiggle stroke width; default the chart line strokeWidth
+  amplitude?: number;      // base breathing-wave height (px); default 14
+  speed?: number;          // breathing-wave speed multiplier; default 1 (0 freezes)
+}
 // Pinch-to-zoom the visible time window (two-finger, focal-anchored). @experimental
 interface ZoomConfig {
   minTimeWindow?: number; // tightest window in seconds (max zoom-in); default timeWindow / 8

--- a/docs/guides/states-and-formatting.mdx
+++ b/docs/guides/states-and-formatting.mdx
@@ -25,6 +25,32 @@ While you wait for data, pass `loading` to render a breathing-line placeholder.
 <LiveChart data={data} value={value} loading={!ready} />
 ```
 
+### Styling the loading shell
+
+`loading` also takes a `LoadingConfig` object to restyle the shell — the squiggle and the skeleton
+Y-axis placeholders. Every field is optional:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  loading={
+    !ready && {
+      color: "#64748b",  // squiggle + skeleton color (default: theme gridLine)
+      strokeWidth: 3,     // squiggle thickness (default: the chart line width)
+      amplitude: 22,      // breathing-wave height in px (default: 14)
+      speed: 1.5,         // wave cadence (default: 1; 0 freezes the wave)
+    }
+  }
+/>
+```
+
+Pass `true` for the defaults, the object to restyle, and `false` (or omit) for "not loading" — so
+`loading={!ready && cfg}` toggles the styled shell as data arrives. `color`, `amplitude`, and `speed`
+also flow into the brief reveal morph, so the squiggle keeps its look as it melts into the line. The
+same config works on `LiveChartSeries`. The loading→live reveal duration itself is controlled by the
+[`transitions.reveal`](/guides/transitions) prop.
+
 ## Empty state
 
 When there are fewer than two samples and `loading` is `false`, the chart shows an empty shell

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -38,6 +38,7 @@ import {
   resolveGradient,
   resolveGridStyle,
   resolveLeftEdgeFade,
+  resolveLoading,
   resolveMarkerCluster,
   resolveMetrics,
   resolvePulse,
@@ -543,9 +544,13 @@ function useLiveChartController({
     candles,
   });
 
+  // Resolve the loading shell: null = not loading, else the styled config (a
+  // non-null result is the "is loading" flag and carries the look).
+  const loadingCfg = resolveLoading(loading);
+  const loadingActive = loadingCfg !== null;
   const transitionsCfg = resolveTransitions(transitions);
   const reveal = useChartReveal(
-    loading,
+    loadingActive,
     hasData,
     isStatic,
     transitionsCfg.reveal,
@@ -677,6 +682,9 @@ function useLiveChartController({
     // live value when `followViewEdge` tracks the scrolled-back window.
     engine.edgeValue,
     badgeCfg?.followViewEdge ?? false,
+    // Match the standalone loading squiggle's wave during the reveal morph.
+    loadingCfg?.amplitude,
+    loadingCfg?.speed,
   );
 
   // Area-dots fill shader color as a vec4 (channels 0..1), with the config
@@ -1124,6 +1132,11 @@ function useLiveChartController({
     // engine + reveal
     engine,
     reveal,
+    // loading shell styling (null → not loading)
+    loadingLineColor: loadingCfg?.color,
+    loadingStrokeWidth: loadingCfg?.strokeWidth,
+    loadingAmplitude: loadingCfg?.amplitude,
+    loadingSpeed: loadingCfg?.speed,
     // derived render values
     backgroundColor,
     gradientEnd,
@@ -1356,6 +1369,10 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     yAxisEntries,
     badgeUsesRightGutter,
     gridStyleCfg,
+    loadingLineColor,
+    loadingStrokeWidth,
+    loadingAmplitude,
+    loadingSpeed,
   } = model;
 
   return (
@@ -1611,6 +1628,10 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         badgeTail={badgeCfg?.tail ?? true}
         badgeMetrics={metricsCfg.badge}
         emptyMetrics={metricsCfg.emptyState}
+        lineColor={loadingLineColor}
+        lineStrokeWidth={loadingStrokeWidth}
+        waveAmplitude={loadingAmplitude}
+        waveSpeed={loadingSpeed}
       />
     </Group>
   );

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -36,6 +36,7 @@ import {
   resolveGridStyle,
   resolveLeftEdgeFade,
   resolveLegend,
+  resolveLoading,
   resolveMarkerCluster,
   resolveMetrics,
   resolveMultiSeriesDot,
@@ -294,11 +295,14 @@ function useLiveChartSeriesController({
     return false;
   });
 
+  // Resolve the loading shell: null = not loading, else the styled config.
+  const loadingCfg = resolveLoading(loading);
+  const loadingActive = loadingCfg !== null;
   // Multi-series is always lines, so only the reveal transition applies (no
   // candle↔line crossfade); `transitions.mode` is accepted but inert here.
   const transitionsCfg = resolveTransitions(transitions);
   const reveal = useChartReveal(
-    loading,
+    loadingActive,
     hasData,
     false,
     transitionsCfg.reveal,
@@ -514,6 +518,11 @@ function useLiveChartSeriesController({
     // engine + reveal
     engine,
     reveal,
+    // loading shell styling (null → not loading)
+    loadingLineColor: loadingCfg?.color,
+    loadingStrokeWidth: loadingCfg?.strokeWidth,
+    loadingAmplitude: loadingCfg?.amplitude,
+    loadingSpeed: loadingCfg?.speed,
     effectiveSeries,
     layoutHeight,
     onLayout,
@@ -583,6 +592,10 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     series,
     emptyText,
     metricsCfg,
+    loadingLineColor,
+    loadingStrokeWidth,
+    loadingAmplitude,
+    loadingSpeed,
   } = model;
 
   return (
@@ -717,6 +730,10 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         strokeWidth={strokeWidth}
         badge={false}
         emptyMetrics={metricsCfg.emptyState}
+        lineColor={loadingLineColor}
+        lineStrokeWidth={loadingStrokeWidth}
+        waveAmplitude={loadingAmplitude}
+        waveSpeed={loadingSpeed}
       />
     </Group>
   );

--- a/packages/react-native-livechart/src/components/LoadingOverlay.tsx
+++ b/packages/react-native-livechart/src/components/LoadingOverlay.tsx
@@ -62,6 +62,10 @@ export function LoadingOverlay({
   badgeTail = true,
   badgeMetrics = BADGE_METRICS_DEFAULTS,
   emptyMetrics = EMPTY_STATE_METRICS_DEFAULTS,
+  lineColor,
+  lineStrokeWidth,
+  waveAmplitude = 14,
+  waveSpeed = 1,
 }: {
   engine: ChartEngineLayout;
   padding: ChartPadding;
@@ -73,6 +77,14 @@ export function LoadingOverlay({
   isEmpty: SharedValue<boolean> | { value: boolean };
   emptyText: string;
   strokeWidth: number;
+  /** Loading squiggle + skeleton color. Omit → theme `gridLine`. */
+  lineColor?: string;
+  /** Loading squiggle stroke width. Omit → `strokeWidth`. */
+  lineStrokeWidth?: number;
+  /** Breathing-wave base amplitude (px). */
+  waveAmplitude?: number;
+  /** Breathing-wave speed multiplier. */
+  waveSpeed?: number;
   /** Mirror the badge prop so labels align with GridOverlay's label positions. */
   badge?: boolean;
   /** Whether the badge tail spike is shown; affects the left inset used for skeleton alignment. */
@@ -85,6 +97,11 @@ export function LoadingOverlay({
   // Same left-inset formula as GridOverlay (only used when badge=true)
   const leftInset =
     badgeMetrics.dotGap + badgeTailAndCap(font.getSize(), badgeTail, badgeMetrics);
+
+  // Loading-shell color (squiggle + skeleton placeholders) and squiggle stroke,
+  // both overridable via `loading={{ color, strokeWidth }}`.
+  const loadingColor = lineColor ?? palette.gridLine;
+  const loadingStroke = lineStrokeWidth ?? strokeWidth;
 
   // Squiggly path — built into a reused PathBuilder and detach()-ed each frame.
   const squigglyBuilder = usePathBuilder();
@@ -100,6 +117,8 @@ export function LoadingOverlay({
       engine.canvasHeight.get(),
       padding,
       engine.timestamp.get(),
+      waveAmplitude,
+      waveSpeed,
     );
     return buildSplineDetached(b, pts);
   });
@@ -225,8 +244,8 @@ export function LoadingOverlay({
       <Path
         path={squigglyPath}
         style="stroke"
-        strokeWidth={strokeWidth}
-        color={palette.gridLine}
+        strokeWidth={loadingStroke}
+        color={loadingColor}
         strokeCap="round"
         strokeJoin="round"
       />
@@ -255,7 +274,7 @@ export function LoadingOverlay({
         width={RECT_W}
         height={RECT_H}
         r={RECT_R}
-        color={palette.gridLine}
+        color={loadingColor}
       />
       <RoundedRect
         x={lx}
@@ -263,7 +282,7 @@ export function LoadingOverlay({
         width={RECT_W}
         height={RECT_H}
         r={RECT_R}
-        color={palette.gridLine}
+        color={loadingColor}
       />
       <RoundedRect
         x={lx}
@@ -271,7 +290,7 @@ export function LoadingOverlay({
         width={RECT_W}
         height={RECT_H}
         r={RECT_R}
-        color={palette.gridLine}
+        color={loadingColor}
       />
       <RoundedRect
         x={lx}
@@ -279,7 +298,7 @@ export function LoadingOverlay({
         width={RECT_W}
         height={RECT_H}
         r={RECT_R}
-        color={palette.gridLine}
+        color={loadingColor}
       />
 
       {/* Empty state label */}

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -39,6 +39,15 @@ export const RETURN_TO_LIVE_MS = 450;
  */
 export const SCRUB_OVERLAY_FADE_MS = 150;
 
+/**
+ * Base wave amplitude (px) of the breathing loading squiggle — it breathes
+ * between `0.4×` and `1.0×` this. Overridable via `loading={{ amplitude }}`.
+ */
+export const LOADING_WAVE_AMPLITUDE = 14;
+
+/** Default breathing-wave speed multiplier (`1` = built-in cadence). */
+export const LOADING_WAVE_SPEED = 1;
+
 // ─── Metric default tokens (single source of truth for LiveChartMetrics) ─────
 // The resolved `metrics` config (see resolveMetrics) is assembled from these
 // objects. Draw/worklet helpers default their metric params to the matching

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -14,6 +14,7 @@ import type {
   LineStyleConfig,
   LiveChartMetrics,
   LiveChartMetricsOverride,
+  LoadingConfig,
   MarkerClusterConfig,
   DotConfig,
   DotRingConfig,
@@ -46,6 +47,8 @@ import {
   EMPTY_STATE_METRICS_DEFAULTS,
   FADE_EDGE_WIDTH,
   GRID_METRICS_DEFAULTS,
+  LOADING_WAVE_AMPLITUDE,
+  LOADING_WAVE_SPEED,
   MOTION_METRICS_DEFAULTS,
   RETURN_TO_LIVE_MS,
 } from "../constants";
@@ -618,6 +621,36 @@ export function resolveScrub(
     resolved.crosshairDash = dash === true ? [4, 4] : dash || undefined;
   }
   return resolved;
+}
+
+export interface ResolvedLoadingConfig {
+  /** undefined → palette.gridLine */
+  color: string | undefined;
+  /** undefined → the chart's line strokeWidth */
+  strokeWidth: number | undefined;
+  /** Base breathing-wave amplitude (px). */
+  amplitude: number;
+  /** Breathing-wave speed multiplier. */
+  speed: number;
+}
+
+const LOADING_DEFAULTS: ResolvedLoadingConfig = {
+  color: undefined,
+  strokeWidth: undefined,
+  amplitude: LOADING_WAVE_AMPLITUDE,
+  speed: LOADING_WAVE_SPEED,
+};
+
+/**
+ * Resolves the `loading` prop to a fully-typed config or null (not loading).
+ * `true` → defaults (loading on, built-in look), object → merged with defaults
+ * (loading on, restyled), `false` / omitted → null. So a non-null result is the
+ * "is loading" flag and carries the resolved styling.
+ */
+export function resolveLoading(
+  prop: boolean | LoadingConfig | undefined,
+): ResolvedLoadingConfig | null {
+  return resolveToggle(prop, LOADING_DEFAULTS, false);
 }
 
 const SCRUB_ACTION_DEFAULTS: ResolvedScrubActionConfig = {

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -35,6 +35,10 @@ export function useChartPaths(
    */
   edgeValue?: SharedValue<number>,
   followViewEdge = false,
+  /** Loading squiggle wave amplitude (px) for the reveal morph. Default 14. */
+  squiggleAmplitude = 14,
+  /** Loading squiggle wave speed multiplier for the reveal morph. Default 1. */
+  squiggleSpeed = 1,
 ) {
   const lineBuilder = usePathBuilder();
   const fillBuilder = usePathBuilder();
@@ -86,7 +90,13 @@ export function useChartPaths(
     // Compute squiggly Y values at the same X positions as the real line
     const centerY =
       (engine.canvasHeight.get() - padding.bottom + padding.top) / 2;
-    const squigglyPts = squigglifyPts(realPts, engine.timestamp.get(), centerY);
+    const squigglyPts = squigglifyPts(
+      realPts,
+      engine.timestamp.get(),
+      centerY,
+      squiggleAmplitude,
+      squiggleSpeed,
+    );
 
     // Blend center-out: centre of chart reveals first, edges last
     return blendPtsY(

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -64,6 +64,7 @@ export type {
   LiveChartPoint,
   LiveChartProps,
   LiveChartSeriesProps,
+  LoadingConfig,
   Marker,
   MarkerClusterConfig,
   MarkerGroupBadge,

--- a/packages/react-native-livechart/src/math/squiggly.ts
+++ b/packages/react-native-livechart/src/math/squiggly.ts
@@ -4,16 +4,26 @@ import type { ChartPadding } from "../draw/line";
  * Composite sine squiggly — two overlapping frequencies with a breathing
  * amplitude envelope. Matches the original web LiveChart loading animation.
  *
- * amplitude = 14 * (0.4 + 0.6 * sin(0.8 * t))   // 5.6 → 22.4px breathing range
- * y = centerY + amplitude * (sin(0.035*x + 1.2*t) + 0.45*sin(0.08*x + 2.1*t))
+ * amplitude = base * (0.4 + 0.6 * sin(0.8 * t·speed))   // 0.4×→1.0× base
+ * y = centerY + amplitude * (sin(0.035*x + 1.2*t·speed) + 0.45*sin(0.08*x + 2.1*t·speed))
+ *
+ * `base` (default `14`) scales the wave height; `speed` (default `1`) scales the
+ * time phase so the ripple/breathing runs faster or slower (`0` freezes it).
  */
-export function squigglyYAt(x: number, centerY: number, t: number): number {
+export function squigglyYAt(
+  x: number,
+  centerY: number,
+  t: number,
+  base = 14,
+  speed = 1,
+): number {
   "worklet";
-  const amplitude = 14 * (0.4 + 0.6 * Math.sin(0.8 * t));
+  const ts = t * speed;
+  const amplitude = base * (0.4 + 0.6 * Math.sin(0.8 * ts));
   return (
     centerY +
     amplitude *
-      (Math.sin(0.035 * x + 1.2 * t) + 0.45 * Math.sin(0.08 * x + 2.1 * t))
+      (Math.sin(0.035 * x + 1.2 * ts) + 0.45 * Math.sin(0.08 * x + 2.1 * ts))
   );
 }
 
@@ -27,6 +37,8 @@ export function buildSquigglyPts(
   canvasHeight: number,
   padding: ChartPadding,
   t: number,
+  base = 14,
+  speed = 1,
 ): number[] {
   "worklet";
   const leftEdge = padding.left;
@@ -41,7 +53,7 @@ export function buildSquigglyPts(
   for (let i = 0; i < count; i++) {
     const x = leftEdge + Math.min(i * step, chartW);
     pts[i * 2] = x;
-    pts[i * 2 + 1] = squigglyYAt(x, centerY, t);
+    pts[i * 2 + 1] = squigglyYAt(x, centerY, t, base, speed);
   }
   return pts;
 }
@@ -54,13 +66,15 @@ export function squigglifyPts(
   flatPts: number[],
   t: number,
   centerY: number,
+  base = 14,
+  speed = 1,
 ): number[] {
   "worklet";
   const n = flatPts.length;
   const out: number[] = new Array(n);
   for (let i = 0; i < n; i += 2) {
     out[i] = flatPts[i];
-    out[i + 1] = squigglyYAt(flatPts[i], centerY, t);
+    out[i + 1] = squigglyYAt(flatPts[i], centerY, t, base, speed);
   }
   return out;
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1624,6 +1624,34 @@ export interface TransitionConfig {
   mode?: number;
 }
 
+/**
+ * Styling for the breathing-line loading shell (the {@link LiveChartCoreProps.loading}
+ * state). Every field is optional — pass it as the object form of `loading` to
+ * restyle the shell; omit a field to keep its default.
+ */
+export interface LoadingConfig {
+  /**
+   * Color of the loading squiggle **and** the skeleton Y-axis placeholders.
+   * Default: the theme's `gridLine` color.
+   */
+  color?: string;
+  /**
+   * Stroke width (px) of the loading squiggle. Default: the chart's line
+   * `strokeWidth`.
+   */
+  strokeWidth?: number;
+  /**
+   * Base wave amplitude (px) of the breathing squiggle — it breathes between
+   * `0.4×` and `1.0×` this. Default `14`.
+   */
+  amplitude?: number;
+  /**
+   * Multiplier on the breathing-wave animation cadence: `>1` ripples faster,
+   * `<1` slower, `0` freezes it. Default `1`.
+   */
+  speed?: number;
+}
+
 /** Props shared between `LiveChart` and `LiveChartSeries`. */
 export interface LiveChartCoreProps {
   /** Color scheme. Default `"dark"`. */
@@ -1652,8 +1680,15 @@ export interface LiveChartCoreProps {
   /**
    * Breathing-line loading shell. When this becomes `false`, the chart reveals
    * only if there is data (≥2 line points or ≥2 committed candles).
+   *
+   * `true` shows the shell with the defaults; pass a {@link LoadingConfig} to
+   * restyle it — `color` / `strokeWidth` for the squiggle + skeleton, `amplitude`
+   * / `speed` for the breathing wave. `false` / omitted is "not loading". Toggle
+   * between the config and `false` as data loads (e.g. `loading={isLoading && cfg}`).
+   * The loading→live reveal duration is governed separately by
+   * {@link TransitionConfig.reveal} (the `transitions` prop).
    */
-  loading?: boolean;
+  loading?: boolean | LoadingConfig;
   /**
    * Value-lerp speed — how quickly the drawn value, time window, and Y-range chase
    * their targets each frame (0 = frozen, 1 = instant). Equivalent to liveline's

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -14,6 +14,7 @@ import {
   resolveMultiSeriesDot,
   resolvePulse,
   resolveReferenceLineConfig,
+  resolveLoading,
   resolveReturnToLiveMs,
   resolveTransitions,
   resolveScrub,
@@ -591,6 +592,42 @@ describe("resolveScrub", () => {
     expect(resolveScrub({ tooltipShowValue: false })).toMatchObject({
       tooltipShowValue: false,
       tooltipShowTime: true,
+    });
+  });
+});
+
+// ─── resolveLoading ───────────────────────────────────────────────────────────
+
+describe("resolveLoading", () => {
+  const DEFAULTS = {
+    color: undefined,
+    strokeWidth: undefined,
+    amplitude: 14,
+    speed: 1,
+  };
+
+  it("returns null for undefined / false (not loading)", () => {
+    expect(resolveLoading(undefined)).toBeNull();
+    expect(resolveLoading(false)).toBeNull();
+  });
+
+  it("returns defaults for true", () => {
+    expect(resolveLoading(true)).toEqual(DEFAULTS);
+  });
+
+  it("merges a partial config over the defaults", () => {
+    expect(resolveLoading({ color: "#64748b", strokeWidth: 3 })).toEqual({
+      ...DEFAULTS,
+      color: "#64748b",
+      strokeWidth: 3,
+    });
+  });
+
+  it("carries the wave overrides", () => {
+    expect(resolveLoading({ amplitude: 22, speed: 1.5 })).toEqual({
+      ...DEFAULTS,
+      amplitude: 22,
+      speed: 1.5,
     });
   });
 });


### PR DESCRIPTION
## What

`loading` now accepts `boolean | LoadingConfig` on both `LiveChart` and `LiveChartSeries`, so the breathing-line loading shell can be restyled instead of being fixed to the theme grid color + a hardcoded 600ms reveal.

`LoadingConfig` fields (all optional):

| field | what | default |
|-------|------|---------|
| `color` | squiggle **and** skeleton Y-axis placeholders | theme `gridLine` |
| `strokeWidth` | squiggle stroke | the chart line `strokeWidth` |
| `amplitude` | base breathing-wave height (px) | `14` |
| `speed` | breathing-wave cadence multiplier (`0` freezes) | `1` |
| `revealDuration` | loading↔live↔empty transition (ms) | `600` |

`true` keeps the defaults, `false` / omitted is "not loading" — so `loading={!ready && cfg}` toggles the styled shell as data arrives.

## Why

Today `loading` is only `boolean`. The loading line color is hardcoded to `palette.gridLine` (couldn't be changed without recoloring the grid), and the reveal duration was a private constant. This makes the loading state brand-themable.

## How

- `resolveLoading` (mirrors `resolveScrub`/`resolveToggle`): `boolean | LoadingConfig → ResolvedLoadingConfig | null`. A non-null result **is** the "is loading" flag and carries the styling.
- `color` / `amplitude` / `speed` also flow into the reveal **morph** (`useChartPaths` squiggle), so the loading line keeps its look as it melts into the real line. `revealDuration` drives `useChartReveal`.
- `CHART_REVEAL_DURATION_MS` + `LOADING_WAVE_*` consolidated into `constants.ts` as the single source.
- Exports the new `LoadingConfig` type.

## Docs / tests

- `docs/api-reference/types.mdx` (LoadingConfig) + `livechart.mdx` (prop) + `guides/states-and-formatting.mdx` (section + demo toggle), `CHANGELOG.md`, and `resolveLoading` tests.
- `npm run verify` green: typecheck, lint, 89 suites / 1235 tests, coverage thresholds held.

