### PR TITLE
feat(transitions): `transitions` prop to tune/disable reveal + mode animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resurface the overlays near the live dot) and eased on the UI thread. Animates
   only a group opacity — the marker atlas and reference-line geometry are left
   intact (still one batched draw each), so there's no per-scrub data rebuild.
+- **`transitions` prop** (`boolean | TransitionConfig`) on `LiveChart` and
+  `LiveChartSeries` to tune or disable the built-in transition animations.
+  `false` makes them instant; an object sets per-transition durations in ms —
+  `reveal` (the grow-in when data appears / on a timeframe change / when a line
+  chart's data appears; default `600`) and `mode` (the candle↔line crossfade,
+  single-series only; default `300`), with `0` snapping that transition.
+  `reveal: 0` removes the grow-in on timeframe change and the line "animating in"
+  when switching candle→line. Independent of `smoothing` (live value easing) and
+  `static` (one-shot render). Exports the new `TransitionConfig` type.
 
 ## [4.4.0] - 2026-06-26
 

--- a/app/demo/transitions.tsx
+++ b/app/demo/transitions.tsx
@@ -40,6 +40,8 @@ export default function TransitionsScreen() {
   const [mode, setMode] = useState<Mode>("line");
   const [accent, setAccent] = useState<Accent>("blue");
   const [keepMounted, setKeepMounted] = useState(true);
+  // `transitions={false}` → instant reveal + instant line↔candle crossfade.
+  const [instant, setInstant] = useState(false);
 
   const { data, value, candles, liveCandle } = useSimulatedChartData({
     multiSeries: false,
@@ -76,6 +78,7 @@ export default function TransitionsScreen() {
             accentColor={ACCENT}
             theme={APP_THEME}
             timeWindow={WINDOW}
+            transitions={instant ? false : undefined}
             accessibilityLabel={`Price ${mode} chart`}
             scrub={false}
           />
@@ -125,9 +128,18 @@ export default function TransitionsScreen() {
             value={mode}
             onChange={setMode}
           />
+          <ControlRow label="transitions">
+            {/* transitions={false} → instant reveal + instant line↔candle switch. */}
+            <ToggleChip
+              label="Instant (no animation)"
+              value={instant}
+              onChange={setInstant}
+            />
+          </ControlRow>
           <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
             One LiveChart with a toggled mode — the engine morphs line↔candle and
-            the y-axis eases between the two ranges (no re-reveal).
+            the y-axis eases between the two ranges (no re-reveal). Flip Instant
+            ({`transitions={false}`}) to switch with no animation.
           </Text>
         </>
       ) : (

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -385,6 +385,16 @@ provided; everything else has a default.
   Breathing-line loading shell until data is ready.
 </ParamField>
 
+<ParamField body="transitions" type="boolean | TransitionConfig">
+  Tune or disable the built-in transition animations. `true` / omitted keeps the
+  defaults; `false` makes them instant (no grow-in when data appears or the
+  timeframe changes, no candle↔line crossfade); a
+  [`TransitionConfig`](/api-reference/types#config-objects) sets per-transition
+  durations in ms — `reveal` (default `600`) and `mode` (default `300`), `0` to
+  snap. Live value tracking is governed separately by `smoothing`, and
+  static-entry suppression by `static`. See [Transitions](/guides/transitions).
+</ParamField>
+
 <ParamField body="static" type="boolean" default="false">
   Render once with no per-frame animation loops — engine, degen, trades, candles,
   markers, pulse, and entry reveal are all disabled, and scrubbing is off. Keeps

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -385,6 +385,11 @@ interface TimeScrollConfig {
 interface ReturnToLiveConfig {
   duration?: number; // glide duration (ms) back to live; default 450 (0 = instant snap)
 }
+// Tune/disable the built-in transition animations — the object form of `transitions`.
+interface TransitionConfig {
+  reveal?: number; // grow-in/collapse on data appear, timeframe change, candle→line; default 600 (0 = snap)
+  mode?: number;   // candle↔line crossfade (single-series LiveChart only); default 300 (0 = snap)
+}
 // Pinch-to-zoom the visible time window (two-finger, focal-anchored). @experimental
 interface ZoomConfig {
   minTimeWindow?: number; // tightest window in seconds (max zoom-in); default timeWindow / 8

--- a/docs/guides/transitions.mdx
+++ b/docs/guides/transitions.mdx
@@ -34,6 +34,33 @@ const [mode, setMode] = useState<"line" | "candle">("line");
 />;
 ```
 
+## Tuning or disabling the animations (`transitions`)
+
+Two built-in animations play automatically: the **reveal** (the grow-in when data first appears —
+also on a timeframe change, and when a line chart's data appears) and the **mode** crossfade
+(candle↔line). The `transitions` prop tunes or turns them off:
+
+```tsx
+<LiveChart … transitions={false} />                 // both instant — no grow-in, no crossfade
+<LiveChart … transitions={{ reveal: 0 }} />         // snap the grow-in, keep the 300ms crossfade
+<LiveChart … transitions={{ reveal: 0, mode: 0 }} /> // same as transitions={false}
+<LiveChart … transitions={{ mode: 500 }} />         // slower crossfade, default grow-in
+```
+
+- **`reveal`** (default `600` ms) — the most common one to disable. With `reveal: 0` the chart no
+  longer "grows in" on a timeframe change, and switching **candle → line** shows the line at once
+  instead of animating it in.
+- **`mode`** (default `300` ms) — the candle↔line crossfade. Single-series `LiveChart` only
+  (multi-series is always lines).
+
+<Note>
+  `transitions` covers the **entry / mode** animations only. The live value's easing toward its
+  target is the separate `smoothing` prop (`1` = instant), and `static` suppresses all per-frame
+  loops for a one-shot render.
+</Note>
+
+The same `transitions` prop works on `LiveChartSeries` (only `reveal` applies there).
+
 ## Cross-fading instances
 
 To switch between *separate* charts — different symbols, timeframes, or accent treatments — wrap

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -43,6 +43,7 @@ import {
   resolvePulse,
   resolveScrub,
   resolveScrubAction,
+  resolveTransitions,
   resolveReturnToLiveMs,
   resolveSelectionDot,
   resolveThreshold,
@@ -214,6 +215,7 @@ function useLiveChartController({
   timeWindow = 30,
   paused = false,
   loading = false,
+  transitions,
   // `static` is a reserved word — alias it so the destructure parses.
   static: isStatic = false,
   smoothing = 0.08,
@@ -541,7 +543,13 @@ function useLiveChartController({
     candles,
   });
 
-  const reveal = useChartReveal(loading, hasData, isStatic);
+  const transitionsCfg = resolveTransitions(transitions);
+  const reveal = useChartReveal(
+    loading,
+    hasData,
+    isStatic,
+    transitionsCfg.reveal,
+  );
 
   // After data clears, keep last snapshot until morphT finishes dropping (web parity).
   const { lineEngineData, candlesEngine, liveEngine } =
@@ -600,6 +608,7 @@ function useLiveChartController({
   const { lineGroupOpacity, candleGroupOpacity } = useModeBlend(
     isCandle,
     reveal.lineOpacity,
+    transitionsCfg.mode,
   );
 
   // ── Per-frame derived values ───────────────────────────────────────────

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -42,6 +42,7 @@ import {
   resolveReturnToLiveMs,
   resolveScrub,
   resolveSelectionDot,
+  resolveTransitions,
   resolveXAxis,
   resolveYAxis,
   resolveZoom,
@@ -129,6 +130,7 @@ function useLiveChartSeriesController({
   timeWindow = 30,
   paused = false,
   loading = false,
+  transitions,
   smoothing = 0.08,
   exaggerate = false,
   nonNegative = false,
@@ -292,7 +294,15 @@ function useLiveChartSeriesController({
     return false;
   });
 
-  const reveal = useChartReveal(loading, hasData);
+  // Multi-series is always lines, so only the reveal transition applies (no
+  // candle↔line crossfade); `transitions.mode` is accepted but inert here.
+  const transitionsCfg = resolveTransitions(transitions);
+  const reveal = useChartReveal(
+    loading,
+    hasData,
+    false,
+    transitionsCfg.reveal,
+  );
 
   const effectiveSeries = useMultiSeriesReverseMorphInputs({
     series,

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -29,6 +29,7 @@ import type {
   ThresholdConfig,
   ThresholdLineConfig,
   TradeEvent,
+  TransitionConfig,
   ValueLineConfig,
   VolumeConfig,
   XAxisConfig,
@@ -477,6 +478,32 @@ export function resolveReturnToLiveMs(
   const d = prop.duration;
   if (d == null) return RETURN_TO_LIVE_MS;
   return d > 0 ? d : 0;
+}
+
+/**
+ * Resolved transition durations. `undefined` for a field means "use the
+ * component's built-in default" (so we don't duplicate the default constants
+ * here); a number is an explicit duration in ms (clamped to ≥ 0).
+ */
+export interface ResolvedTransitionConfig {
+  reveal: number | undefined;
+  mode: number | undefined;
+}
+
+const clampMs = (v: number | undefined): number | undefined =>
+  v == null ? undefined : v > 0 ? v : 0;
+
+/**
+ * Resolves the `transitions` prop. `false` → all transitions instant (`0`);
+ * `true` / omitted → defaults (both `undefined` = use the built-in durations);
+ * an object → per-transition overrides (an omitted field keeps its default).
+ */
+export function resolveTransitions(
+  prop: boolean | TransitionConfig | undefined,
+): ResolvedTransitionConfig {
+  if (prop === false) return { reveal: 0, mode: 0 };
+  if (prop == null || prop === true) return { reveal: undefined, mode: undefined };
+  return { reveal: clampMs(prop.reveal), mode: clampMs(prop.mode) };
 }
 
 const AXIS_LABEL_DEFAULTS: ResolvedAxisLabelConfig = {

--- a/packages/react-native-livechart/src/hooks/useChartReveal.ts
+++ b/packages/react-native-livechart/src/hooks/useChartReveal.ts
@@ -60,6 +60,8 @@ export function useChartReveal(
   hasData: SharedValue<boolean>,
   /** Static charts skip the entry ramp: morphT snaps to its target, no `withTiming`. */
   isStatic = false,
+  /** Reveal/collapse duration (ms). Default {@link CHART_REVEAL_DURATION_MS}; `0` snaps. */
+  revealDuration: number = CHART_REVEAL_DURATION_MS,
 ): ChartRevealState {
   // Best-guess initial so the common case — a live chart that already has data
   // and isn't loading — paints fully revealed with no flash. The reaction below
@@ -85,15 +87,18 @@ export function useChartReveal(
         return;
       }
       if (prev !== chartVisible) {
+        // 0ms → withTiming resolves on the next frame (effectively a snap), so an
+        // explicit `transitions={{ reveal: 0 }}` / `transitions={false}` removes
+        // the grow-in without a special-case branch.
         morphT.set(
           withTiming(chartVisible ? 1 : 0, {
-            duration: CHART_REVEAL_DURATION_MS,
+            duration: revealDuration,
             easing: Easing.out(Easing.cubic),
           }),
         );
       }
     },
-    [hasData, isStatic],
+    [hasData, isStatic, revealDuration],
   );
 
   const isEmpty = useDerivedValue(() => !isLoading.get() && !hasData.get());

--- a/packages/react-native-livechart/src/hooks/useModeBlend.ts
+++ b/packages/react-native-livechart/src/hooks/useModeBlend.ts
@@ -7,7 +7,7 @@ import {
   type SharedValue,
 } from "react-native-reanimated";
 
-const MODE_BLEND_DURATION_MS = 300;
+export const MODE_BLEND_DURATION_MS = 300;
 
 export interface ModeBlendState {
   /** 0 = fully line, 1 = fully candle */
@@ -28,17 +28,19 @@ export interface ModeBlendState {
 export function useModeBlend(
   isCandle: boolean,
   lineOpacity: SharedValue<number>,
+  /** Crossfade duration (ms). Default {@link MODE_BLEND_DURATION_MS}; `0` snaps. */
+  duration: number = MODE_BLEND_DURATION_MS,
 ): ModeBlendState {
   const modeBlend = useSharedValue(isCandle ? 1 : 0);
 
   useEffect(() => {
     modeBlend.set(
       withTiming(isCandle ? 1 : 0, {
-        duration: MODE_BLEND_DURATION_MS,
+        duration,
         easing: Easing.inOut(Easing.ease),
       }),
     );
-  }, [isCandle, modeBlend]);
+  }, [isCandle, modeBlend, duration]);
 
   const lineGroupOpacity = useDerivedValue(
     () => lineOpacity.get() * (1 - modeBlend.get()),

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -97,6 +97,7 @@ export type {
   ThresholdLineConfig,
   TooltipRenderProps,
   TradeEvent,
+  TransitionConfig,
   ValueLineConfig,
   VisibleRange,
   VolumeConfig,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1603,6 +1603,27 @@ export interface VisibleRange {
   following: boolean;
 }
 
+/**
+ * Per-transition animation durations (ms). Passed as the object form of
+ * {@link LiveChartCoreProps.transitions} to tune or disable the built-in
+ * animations. Omit a field to keep its default; `0` makes that transition
+ * instant (snap). Setting `transitions={false}` is shorthand for all `0`.
+ */
+export interface TransitionConfig {
+  /**
+   * Reveal / collapse transition — the grow-in when data first appears (and the
+   * fade-out when it goes away or `loading` toggles). This is what plays on a
+   * timeframe change and when a `line` chart's data appears (e.g. switching from
+   * candle to line). Default `600`. `0` = instant.
+   */
+  reveal?: number;
+  /**
+   * Candle ↔ line crossfade duration when `mode` changes. Single-series
+   * `LiveChart` only (multi-series is always lines). Default `300`. `0` = instant.
+   */
+  mode?: number;
+}
+
 /** Props shared between `LiveChart` and `LiveChartSeries`. */
 export interface LiveChartCoreProps {
   /** Color scheme. Default `"dark"`. */
@@ -1619,6 +1640,15 @@ export interface LiveChartCoreProps {
   timeWindow?: number;
   /** Freeze chart scrolling. Resume catches up to real time. Default `false`. */
   paused?: boolean;
+  /**
+   * Tune or disable the built-in transition animations. `true` / omitted keeps
+   * the defaults; `false` makes them all instant (no grow-in on data
+   * appear/timeframe change, no candle↔line crossfade); a {@link TransitionConfig}
+   * sets per-transition durations in ms (`reveal`, `mode`), where `0` snaps that
+   * one. Live value tracking is governed separately by `smoothing`; static-entry
+   * suppression by `static`.
+   */
+  transitions?: boolean | TransitionConfig;
   /**
    * Breathing-line loading shell. When this becomes `false`, the chart reveals
    * only if there is data (≥2 line points or ≥2 committed candles).

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -15,6 +15,7 @@ import {
   resolvePulse,
   resolveReferenceLineConfig,
   resolveReturnToLiveMs,
+  resolveTransitions,
   resolveScrub,
   resolveScrubAction,
   resolveSelectionDot,
@@ -319,6 +320,46 @@ describe("resolveReturnToLiveMs", () => {
   it("collapses a non-positive duration to an instant snap", () => {
     expect(resolveReturnToLiveMs({ duration: 0 })).toBe(0);
     expect(resolveReturnToLiveMs({ duration: -100 })).toBe(0);
+  });
+});
+
+// ─── resolveTransitions ────────────────────────────────────────────────────────
+
+describe("resolveTransitions", () => {
+  it("returns undefined durations (use built-in defaults) for undefined and true", () => {
+    expect(resolveTransitions(undefined)).toEqual({
+      reveal: undefined,
+      mode: undefined,
+    });
+    expect(resolveTransitions(true)).toEqual({
+      reveal: undefined,
+      mode: undefined,
+    });
+  });
+
+  it("returns 0 (instant) for both when false", () => {
+    expect(resolveTransitions(false)).toEqual({ reveal: 0, mode: 0 });
+  });
+
+  it("carries per-transition overrides", () => {
+    expect(resolveTransitions({ reveal: 0, mode: 120 })).toEqual({
+      reveal: 0,
+      mode: 120,
+    });
+  });
+
+  it("leaves an omitted field undefined (keeps that default)", () => {
+    expect(resolveTransitions({ reveal: 0 })).toEqual({
+      reveal: 0,
+      mode: undefined,
+    });
+  });
+
+  it("clamps negative durations to an instant snap", () => {
+    expect(resolveTransitions({ reveal: -50, mode: -1 })).toEqual({
+      reveal: 0,
+      mode: 0,
+    });
   });
 });
 


### PR DESCRIPTION
## What

A `transitions?: boolean | TransitionConfig` prop on `LiveChart` and `LiveChartSeries` to tune or disable the two built-in entry/mode animations.

```tsx
<LiveChart … transitions={false} />                  // no animation
<LiveChart … transitions={{ reveal: 0 }} />          // snap the grow-in, keep the 300ms crossfade
<LiveChart … transitions={{ reveal: 0, mode: 0 }} /> // both instant
<LiveChart … transitions={{ mode: 500 }} />          // slower crossfade
```

`TransitionConfig` (ms each, `0` = snap, omit = keep default):

| field | what | default |
|-------|------|---------|
| `reveal` | grow-in when data appears / on a timeframe change / when a line chart's data appears (candle→line) | `600` |
| `mode` | candle↔line crossfade (single-series `LiveChart` only) | `300` |

## Why

The reveal duration (`600`) and the mode crossfade (`300`) were private constants. There was no way to disable the grow-in — it replays on every timeframe change, and switching candle→line makes the line "animate in" (its data goes empty→full → reveal fires). The only existing escape was `static`, which also disables gestures. `transitions={{ reveal: 0 }}` (or `transitions={false}`) fixes both while keeping scrub/zoom.

## How

- `resolveTransitions` → `{ reveal, mode }` where `undefined` means "use the built-in default" (so the defaults aren't duplicated), a number is an explicit ms (clamped ≥ 0), and `false` → `{ 0, 0 }`.
- Plumbed into `useChartReveal(…, revealDuration)` and `useModeBlend(…, duration)`, both defaulting to the existing constants. `0ms` `withTiming` resolves next frame ≈ a snap, so no special-case branch.
- Independent of `smoothing` (live value easing) and `static` (one-shot render).
- Exports `TransitionConfig`.

## Docs / tests

- `docs/api-reference/types.mdx` (TransitionConfig) + `livechart.mdx` (prop) + `guides/transitions.mdx` (section + demo "Instant" toggle), `CHANGELOG.md`, and `resolveTransitions` tests.
- `npm run verify` green: typecheck, lint, 89 suites / 1236 tests, coverage thresholds held.

## Note — overlaps with #170

PR #170 (configurable loading) adds `loading.revealDuration`, which also controls the reveal duration but only while `loading` is truthy. This PR's `transitions.reveal` is the always-applies home for it. If both land, I'd suggest dropping `revealDuration` from #170 and keeping it here. Happy to reconcile in whichever merges second.

