### PR TITLE
feat(transitions): candleLerpSpeed to control/disable candle-width resize (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`transitions.candleLerpSpeed`** (`number`, default `0.08`) on `LiveChart`.
+  Controls the per-frame speed at which candle bodies resize when `candleWidth`
+  changes (a timeframe / bucket switch). Same units as `smoothing` (`0`–`1`); set
+  it to `1` to resize candles in a single frame instead of the default
+  "fat → thin" slide. `transitions={false}` now also snaps the candle width
+  (every transition instant). Replaces the previously hard-coded candle-width
+  lerp speed, which nothing could tune or disable. Thanks
+  [@dszym00](https://github.com/dszym00).
+  ([#176](https://github.com/brandtnewlabs/react-native-livechart/issues/176))
+
 ## [4.6.0] - 2026-06-29
 
 ### Added

--- a/app/demo/transitions.tsx
+++ b/app/demo/transitions.tsx
@@ -14,12 +14,23 @@ export const options = { title: "Transitions" };
 const WINDOW = 300;
 const CANDLE_WIDTH = 15;
 
-type Example = "mode" | "crossfade" | "snap";
+type Example = "mode" | "crossfade" | "snap" | "candleWidth";
 
 const EXAMPLE_OPTIONS: { value: Example; label: string }[] = [
   { value: "mode", label: "Line ↔ Candle (mode)" },
   { value: "crossfade", label: "Cross-fade (transition)" },
   { value: "snap", label: "Snap on timeframe (snapKey)" },
+  { value: "candleWidth", label: "Candle resize (candleLerpSpeed)" },
+];
+
+// Two candle bucket sizes (seconds) for the candleLerpSpeed example. Switching
+// re-buckets the OHLC (fewer / fatter ⇄ more / thinner bars) — the moment the
+// candle bodies ease (or snap) to their new width.
+type Bucket = 15 | 30;
+
+const BUCKET_OPTIONS: { value: Bucket; label: string }[] = [
+  { value: 15, label: "15s" },
+  { value: 30, label: "30s" },
 ];
 
 // Three timeframes (visible window in seconds) for the snapKey example — all fit
@@ -63,12 +74,18 @@ export default function TransitionsScreen() {
   // snaps the framing (snapKey set) or eases into it (snapKey omitted).
   const [timeframe, setTimeframe] = useState<Timeframe>("5m");
   const [snap, setSnap] = useState(true);
+  // candleLerpSpeed example: a bucket selector + a toggle for whether a width
+  // change snaps in one frame (candleLerpSpeed: 1) or eases (the 0.08 default).
+  const [bucket, setBucket] = useState<Bucket>(15);
+  const [candleSnap, setCandleSnap] = useState(true);
 
   const { data, value, candles, liveCandle } = useSimulatedChartData({
     multiSeries: false,
     candleAggregation: true,
     tradeStream: false,
-    candleWidth: CANDLE_WIDTH,
+    // The candleWidth example drives the live re-bucketing from `bucket`; every
+    // other example uses the fixed CANDLE_WIDTH seed.
+    candleWidth: example === "candleWidth" ? bucket : CANDLE_WIDTH,
     // Dense seed (fine "1m" sampling over the window) so the candle side of the
     // morph shows real bodies + wicks rather than flat one-point dojis.
     historySpanSeconds: WINDOW,
@@ -117,6 +134,25 @@ export default function TransitionsScreen() {
             snapKey={snap ? timeframe : undefined}
             transitions={{ reveal: 0 }}
             accessibilityLabel={`Price chart, ${timeframe} window`}
+            scrub={false}
+          />
+        ) : example === "candleWidth" ? (
+          // Candle-width resize: switching the bucket re-buckets the OHLC (the
+          // candle count + width both change). With Instant on, the bodies snap to
+          // the new width in one frame (candleLerpSpeed: 1); off uses the 0.08
+          // default ease, the "fat → thin" slide from #176.
+          <LiveChart
+            data={data}
+            value={value}
+            mode="candle"
+            candles={candles}
+            liveCandle={liveCandle}
+            candleWidth={bucket}
+            accentColor={ACCENT}
+            theme={APP_THEME}
+            timeWindow={WINDOW}
+            transitions={{ candleLerpSpeed: candleSnap ? 1 : undefined }}
+            accessibilityLabel={`Candle chart, ${bucket}s buckets`}
             scrub={false}
           />
         ) : (
@@ -199,6 +235,28 @@ export default function TransitionsScreen() {
             and y-range jump to the new framing in one frame; live ticks still
             glide ({`smoothing={0.4}`}). Toggle Snap off to feel the same change
             slide in instead — that slide is the easing, not a transition.
+          </Text>
+        </>
+      ) : example === "candleWidth" ? (
+        <>
+          <ChipRow
+            label="Bucket"
+            options={BUCKET_OPTIONS}
+            value={bucket}
+            onChange={setBucket}
+          />
+          <ControlRow label="transitions.candleLerpSpeed">
+            <ToggleChip
+              label="Instant (candleLerpSpeed: 1)"
+              value={candleSnap}
+              onChange={setCandleSnap}
+            />
+          </ControlRow>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            Switch the Bucket to re-aggregate the candles. With Instant on
+            ({`transitions={{ candleLerpSpeed: 1 }}`}) the bodies resize in one
+            frame; toggle it off for the default 0.08 ease — the slow “fat → thin”
+            slide from #176. Independent of {`snapKey`} / {`smoothing`}.
           </Text>
         </>
       ) : (

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -392,10 +392,12 @@ provided; everything else has a default.
 <ParamField body="transitions" type="boolean | TransitionConfig">
   Tune or disable the built-in transition animations. `true` / omitted keeps the
   defaults; `false` makes them instant (no grow-in when data appears or the
-  timeframe changes, no candle↔line crossfade); a
+  timeframe changes, no candle↔line crossfade, candle width snaps); a
   [`TransitionConfig`](/api-reference/types#config-objects) sets per-transition
   durations in ms — `reveal` (default `600`) and `mode` (default `300`), `0` to
-  snap. Live value tracking is governed separately by `smoothing`, and
+  snap — plus `candleLerpSpeed` (default `0.08`, `1` = instant), the per-frame
+  speed at which candle bodies resize when `candleWidth` changes (a timeframe /
+  bucket switch). Live value tracking is governed separately by `smoothing`, and
   static-entry suppression by `static`. See [Transitions](/guides/transitions).
 </ParamField>
 

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -387,8 +387,9 @@ interface ReturnToLiveConfig {
 }
 // Tune/disable the built-in transition animations — the object form of `transitions`.
 interface TransitionConfig {
-  reveal?: number; // grow-in/collapse on data appear, timeframe change, candle→line; default 600 (0 = snap)
-  mode?: number;   // candle↔line crossfade (single-series LiveChart only); default 300 (0 = snap)
+  reveal?: number;          // grow-in/collapse on data appear, timeframe change, candle→line; default 600 (0 = snap)
+  mode?: number;            // candle↔line crossfade (single-series LiveChart only); default 300 (0 = snap)
+  candleLerpSpeed?: number; // candle-width ease speed (0–1, like smoothing); candle mode; default 0.08 (1 = instant resize)
 }
 // Styling for the breathing loading shell — the object form of `loading`.
 interface LoadingConfig {

--- a/docs/guides/transitions.mdx
+++ b/docs/guides/transitions.mdx
@@ -52,6 +52,9 @@ also on a timeframe change, and when a line chart's data appears) and the **mode
   instead of animating it in.
 - **`mode`** (default `300` ms) — the candle↔line crossfade. Single-series `LiveChart` only
   (multi-series is always lines).
+- **`candleLerpSpeed`** (default `0.08`, candle mode only) — the per-frame speed at which candle
+  **bodies resize** when `candleWidth` changes. Same units as `smoothing` (`0`–`1`); `1` snaps in
+  one frame. See [Candle-width resize](#candle-width-resize-on-a-timeframe-change) below.
 
 <Note>
   `transitions` covers the **entry / mode** animations only. The live value's easing toward its
@@ -60,6 +63,30 @@ also on a timeframe change, and when a line chart's data appears) and the **mode
 </Note>
 
 The same `transitions` prop works on `LiveChartSeries` (only `reveal` applies there).
+
+## Candle-width resize on a timeframe change
+
+In candle mode the candle **body width** eases toward `candleWidth` each frame, so when you switch
+the bucket size (e.g. `1m → 1D`) the candles glide from "fat → thin" over ~half a second. That
+ease is independent of the engine framing, so `snapKey`, `smoothing`, and `reveal` / `mode` don't
+touch it. Control it with `transitions.candleLerpSpeed`:
+
+```tsx
+<LiveChart
+  mode="candle"
+  candles={candles}
+  candleWidth={bucketFor(tf)}                 // changes with the timeframe
+  transitions={{ candleLerpSpeed: 1 }}        // resize in one frame — no "fat → thin" slide
+/>;
+```
+
+- **`1`** — instant: the bodies jump to the new width the frame `candleWidth` changes.
+- **`0.08`** (default) — the original gentle resize.
+- **lower** — slower; **`0`** freezes the width (it never tracks `candleWidth`).
+
+Setting `transitions={false}` also snaps the width (it makes every transition instant), so
+`transitions={{ reveal: 0, mode: 0, candleLerpSpeed: 1 }}` and `transitions={false}` resize candles
+the same way.
 
 ## Snap on a timeframe or data change
 

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -723,6 +723,7 @@ function useLiveChartController({
     volumeBandHeight,
     volumeCfg?.radius ?? 0,
     !isStatic, // static: no candle-width lerp loop
+    transitionsCfg.candleLerpSpeed, // `transitions.candleLerpSpeed` (1 = instant)
   );
   const { dotX, dotY } = useLiveDot(
     engine,

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -491,22 +491,34 @@ export function resolveReturnToLiveMs(
 export interface ResolvedTransitionConfig {
   reveal: number | undefined;
   mode: number | undefined;
+  /** Candle-width lerp speed (0–1); `undefined` = use the built-in default. */
+  candleLerpSpeed: number | undefined;
 }
 
 const clampMs = (v: number | undefined): number | undefined =>
   v == null ? undefined : v > 0 ? v : 0;
 
+/** Clamp a per-frame lerp speed to `[0, 1]`; `undefined` → built-in default. */
+const clampSpeed = (v: number | undefined): number | undefined =>
+  v == null ? undefined : v < 0 ? 0 : v > 1 ? 1 : v;
+
 /**
- * Resolves the `transitions` prop. `false` → all transitions instant (`0`);
- * `true` / omitted → defaults (both `undefined` = use the built-in durations);
- * an object → per-transition overrides (an omitted field keeps its default).
+ * Resolves the `transitions` prop. `false` → all transitions instant (durations
+ * `0`, candle width snaps with speed `1`); `true` / omitted → defaults (all
+ * `undefined` = use the built-in durations / speed); an object → per-transition
+ * overrides (an omitted field keeps its default).
  */
 export function resolveTransitions(
   prop: boolean | TransitionConfig | undefined,
 ): ResolvedTransitionConfig {
-  if (prop === false) return { reveal: 0, mode: 0 };
-  if (prop == null || prop === true) return { reveal: undefined, mode: undefined };
-  return { reveal: clampMs(prop.reveal), mode: clampMs(prop.mode) };
+  if (prop === false) return { reveal: 0, mode: 0, candleLerpSpeed: 1 };
+  if (prop == null || prop === true)
+    return { reveal: undefined, mode: undefined, candleLerpSpeed: undefined };
+  return {
+    reveal: clampMs(prop.reveal),
+    mode: clampMs(prop.mode),
+    candleLerpSpeed: clampSpeed(prop.candleLerpSpeed),
+  };
 }
 
 const AXIS_LABEL_DEFAULTS: ResolvedAxisLabelConfig = {

--- a/packages/react-native-livechart/src/hooks/useCandlePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useCandlePaths.ts
@@ -36,9 +36,23 @@ export function useCandlePaths(
   volumeRadius = 0,
   /** Static charts run no loops: register without starting. Default `true`. */
   autostart = true,
+  /**
+   * Per-frame lerp speed (0–1) for the candle-body width as it eases toward
+   * `candleWidthSecs`. `1` snaps in one frame (no "fat → thin" slide on a
+   * timeframe / bucket change); `undefined` uses {@link CANDLE_WIDTH_LERP_SPEED}.
+   * Resolved from `transitions.candleLerpSpeed`. See #176.
+   */
+  candleLerpSpeed?: number,
 ) {
   const targetCandleWidth = useDerivedValue(() => candleWidthSecs);
   const displayCandleWidth = useSharedValue(candleWidthSecs);
+  // `transitions.candleLerpSpeed` overrides the built-in speed (0–1, already
+  // clamped by `resolveTransitions`); fall back to the default when unset.
+  // Bridged through a derived value so the frame-callback worklet always reads
+  // the current speed on the UI thread (mirrors `targetCandleWidth`).
+  const widthLerpSpeed = useDerivedValue(
+    () => candleLerpSpeed ?? CANDLE_WIDTH_LERP_SPEED,
+  );
 
   const upBodiesBuilder = usePathBuilder();
   const downBodiesBuilder = usePathBuilder();
@@ -55,7 +69,7 @@ export function useCandlePaths(
       lerp(
         displayCandleWidth.get(),
         targetCandleWidth.get(),
-        CANDLE_WIDTH_LERP_SPEED,
+        widthLerpSpeed.get(),
         dt,
       ),
     );

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1627,6 +1627,19 @@ export interface TransitionConfig {
    * `LiveChart` only (multi-series is always lines). Default `300`. `0` = instant.
    */
   mode?: number;
+  /**
+   * Per-frame lerp speed for the **candle body width** as it eases from the old
+   * to the new `candleWidth` — candle mode only. Same units as `smoothing`
+   * (`0`–`1`, the fraction approached per 60fps frame): `1` snaps the width in a
+   * single frame, lower is slower, `0` freezes it. Default `0.08`.
+   *
+   * Set this to `1` to make a `candleWidth` change (e.g. a timeframe / bucket
+   * switch like 1m → 1D) resize the candles instantly instead of sliding
+   * "fat → thin". Unlike `reveal` / `mode` this is a speed, not a duration, and
+   * unlike `snapKey` (which settles the engine framing) it controls only the
+   * candle-width animation. See [#176](https://github.com/brandtnewlabs/react-native-livechart/issues/176).
+   */
+  candleLerpSpeed?: number;
 }
 
 /**

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -528,6 +528,16 @@ describe("LiveChart", () => {
     render(<CandleHarness scrub />);
   });
 
+  it("renders candle mode with an instant candleLerpSpeed (transitions)", () => {
+    const screen = render(
+      <CandleHarness transitions={{ candleLerpSpeed: 1 }} />,
+    );
+    const views = screen.UNSAFE_getAllByType(View);
+    fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+  });
+
   it("disables gradient in candle mode", () => {
     render(<CandleHarness gradient />);
   });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -331,21 +331,28 @@ describe("resolveTransitions", () => {
     expect(resolveTransitions(undefined)).toEqual({
       reveal: undefined,
       mode: undefined,
+      candleLerpSpeed: undefined,
     });
     expect(resolveTransitions(true)).toEqual({
       reveal: undefined,
       mode: undefined,
+      candleLerpSpeed: undefined,
     });
   });
 
-  it("returns 0 (instant) for both when false", () => {
-    expect(resolveTransitions(false)).toEqual({ reveal: 0, mode: 0 });
+  it("returns instant for all when false (durations 0, candle width snaps at speed 1)", () => {
+    expect(resolveTransitions(false)).toEqual({
+      reveal: 0,
+      mode: 0,
+      candleLerpSpeed: 1,
+    });
   });
 
   it("carries per-transition overrides", () => {
     expect(resolveTransitions({ reveal: 0, mode: 120 })).toEqual({
       reveal: 0,
       mode: 120,
+      candleLerpSpeed: undefined,
     });
   });
 
@@ -353,6 +360,7 @@ describe("resolveTransitions", () => {
     expect(resolveTransitions({ reveal: 0 })).toEqual({
       reveal: 0,
       mode: undefined,
+      candleLerpSpeed: undefined,
     });
   });
 
@@ -360,7 +368,24 @@ describe("resolveTransitions", () => {
     expect(resolveTransitions({ reveal: -50, mode: -1 })).toEqual({
       reveal: 0,
       mode: 0,
+      candleLerpSpeed: undefined,
     });
+  });
+
+  it("carries candleLerpSpeed (1 = instant candle-width resize)", () => {
+    expect(resolveTransitions({ candleLerpSpeed: 1 })).toEqual({
+      reveal: undefined,
+      mode: undefined,
+      candleLerpSpeed: 1,
+    });
+  });
+
+  it("clamps candleLerpSpeed to [0, 1]", () => {
+    expect(resolveTransitions({ candleLerpSpeed: 5 }).candleLerpSpeed).toBe(1);
+    expect(resolveTransitions({ candleLerpSpeed: -2 }).candleLerpSpeed).toBe(0);
+    expect(resolveTransitions({ candleLerpSpeed: 0.5 }).candleLerpSpeed).toBe(
+      0.5,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #176

## Problem

In candle mode the candle body width eases toward `candleWidth` via a hard-coded per-frame lerp (`CANDLE_WIDTH_LERP_SPEED = 0.08` in `useCandlePaths.ts`) that nothing could tune or disable. So a timeframe / bucket switch (e.g. `1m → 1D`) always slid the candles "fat → thin" over ~0.5s — independent of `snapKey`, `smoothing`, and `transitions`, as @dszym00 found.

## Fix

Expose the speed as **`transitions.candleLerpSpeed`** (the requested API):

- `0`–`1`, same units as `smoothing`; **default `0.08`** (behavior unchanged).
- **`1` = instant** — the bodies jump to the new width in one frame, no slide.
- `transitions={false}` now also snaps the candle width (every transition instant).

```tsx
<LiveChart mode="candle" candles={candles} candleWidth={bucketFor(tf)}
  transitions={{ candleLerpSpeed: 1 }} />   // no "fat → thin" slide
```

Threaded `transitions.candleLerpSpeed` → `resolveTransitions` (clamped to `[0, 1]`) → `useCandlePaths`, replacing the hard-coded constant. Bridged through a derived value so the frame-callback worklet reads the current speed on the UI thread.

## Changed

- `TransitionConfig.candleLerpSpeed` + `ResolvedTransitionConfig` (resolve + clamp).
- `useCandlePaths` uses the resolved speed (falls back to the `0.08` default).
- `LiveChart` passes it through.
- Docs: `api-reference/types.mdx`, `api-reference/livechart.mdx`, the `transitions` guide (+ a "Candle resize" example in the transitions demo). CHANGELOG.

## Test plan

- **Unit:** `resolveTransitions` cases (default / instant / `[0,1]` clamp) + a candle render with `candleLerpSpeed: 1`. Full library suite green (1259 tests), coverage thresholds met.
- **agent-device (iOS 26.4 sim):** Transitions demo → "Candle resize (candleLerpSpeed)" example. Switching the bucket 15s ⇄ 30s re-aggregates the OHLC and the candles render correctly (thin/many ⇄ fat/few) with both **Instant on** (snap) and **off** (0.08 ease) — no crash. The instant-vs-ease *timing* is guaranteed by the unit tests (sub-second easing isn't reliably extractable from the 220×480 sim capture).

---
First of a 2-PR stack (sibling: #179 for #177).
