### PR TITLE
feat(static): keep scrub + scrubAction live on static charts (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@dszym00](https://github.com/dszym00).
   ([#176](https://github.com/brandtnewlabs/react-native-livechart/issues/176))
 
+### Changed
+
+- **`static` charts are now scrubbable.** `scrub` and `scrubAction` stay live on a
+  `static` `LiveChart` — they're on-demand touch gestures with no per-frame loop,
+  so a still chart stays at zero idle cost yet reveals its crosshair / value
+  read-out on touch. Previously `static` forced both off, so the only way to stop
+  the render loop (e.g. for many sparklines in a list) also removed scrubbing. The
+  continuous animations (`pulse`, `degen`, the entry reveal) remain disabled under
+  `static`. Thanks [@dszym00](https://github.com/dszym00).
+  ([#177](https://github.com/brandtnewlabs/react-native-livechart/issues/177))
+
 ## [4.6.0] - 2026-06-29
 
 ### Added

--- a/app/demo/sparklines.tsx
+++ b/app/demo/sparklines.tsx
@@ -4,6 +4,7 @@ import { LiveChart, type LiveChartPoint } from "react-native-livechart";
 import { useSharedValue } from "react-native-reanimated";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { ACCENT, ACCENT_PRESETS } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { demoStyles } from "../../demo-lib/styles";
@@ -107,12 +108,15 @@ export default function SparklinesScreen() {
   // Featured larger sparkline shown in the fixed chart slot above the grid.
   const featuredData = useSharedValue<LiveChartPoint[]>(seeds[0].points);
   const featuredValue = useSharedValue(seeds[0].last);
+  // A static chart is still scrubbable — the gesture is event-driven, so the
+  // render loop stays off until you touch. Toggle it on the featured chart.
+  const [scrubFeatured, setScrubFeatured] = useState(true);
 
   return (
     <DemoScreen
       title="Sparklines"
       docs="guides/sparklines"
-      description="static — many mini-charts in a list with zero per-chart animation loops"
+      description="static — many mini-charts in a list with zero per-chart animation loops (still scrubbable on touch)"
       chart={
         <LiveChart
           static
@@ -123,15 +127,28 @@ export default function SparklinesScreen() {
           timeWindow={CELL_SPAN}
           nowOverride={seeds[0].endTime}
           windowBuffer={0}
-          scrub={false}
+          scrub={scrubFeatured}
           pulse={false}
         />
       }
     >
+      <ControlRow label="Featured chart (static)">
+        <ToggleChip
+          label="Scrub on touch"
+          value={scrubFeatured}
+          onChange={setScrubFeatured}
+        />
+      </ControlRow>
+      <Text style={[demoStyles.chipText, { opacity: 0.6, marginBottom: 12 }]}>
+        The featured chart above is {`static`} — no render loop — yet stays
+        scrubbable: drag across it to reveal the crosshair. {`scrub`} is an
+        on-demand gesture, so the loop stays off until you touch.
+      </Text>
       <Text style={demoStyles.sectionLabel}>{CELL_COUNT} static sparklines</Text>
       <Text style={[demoStyles.chipText, { opacity: 0.6, marginBottom: 12 }]}>
         Each cell renders once from a fixed seeded walk. No frame callback, no
-        pulse, no scrub, no entry animation — so a long list of them stays cheap.
+        pulse, no entry animation — so a long list of them stays cheap. (These
+        leave {`scrub`} off too; a thumbnail rarely needs it.)
       </Text>
       <View style={styles.grid}>
         {seeds.map((seed) => (

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -403,9 +403,11 @@ provided; everything else has a default.
 
 <ParamField body="static" type="boolean" default="false">
   Render once with no per-frame animation loops — engine, degen, trades, candles,
-  markers, pulse, and entry reveal are all disabled, and scrubbing is off. Keeps
-  many small charts cheap when you render a list or grid of sparklines. Frame the
-  data edge-to-edge with `timeWindow` + `nowOverride`. See the
+  markers, pulse, and entry reveal are all disabled. `scrub` / `scrubAction` stay
+  available, though: they're on-demand touch gestures with no per-frame cost, so a
+  still chart costs nothing at rest yet is still scrubbable on touch. Keeps many
+  small charts cheap when you render a list or grid of sparklines. Frame the data
+  edge-to-edge with `timeWindow` + `nowOverride`. See the
   [Sparklines guide](/guides/sparklines).
 </ParamField>
 

--- a/docs/guides/sparklines.mdx
+++ b/docs/guides/sparklines.mdx
@@ -6,8 +6,12 @@ description: "Render many cheap, non-animated mini-charts in a list or grid with
 
 `static` renders a `LiveChart` **once** with zero per-frame animation loops. The engine tick
 loop, the degen/trade/candle/marker callbacks, the pulse, and the entry reveal are all
-disabled, and scrubbing is off. That makes each instance cheap enough to put dozens of them in a
-scrolling list — a watchlist row, a token grid, a portfolio of sparklines.
+disabled. That makes each instance cheap enough to put dozens of them in a scrolling list — a
+watchlist row, a token grid, a portfolio of sparklines.
+
+Touch interaction still works: `scrub` and `scrubAction` are on-demand gestures with no
+per-frame loop, so a static chart costs nothing at rest yet becomes scrubbable the moment a
+finger lands on it — see [Scrubbing a static chart](#scrubbing-a-static-chart) below.
 
 It mirrors `react-native-graph`'s `animated={false}`.
 
@@ -17,9 +21,10 @@ It mirrors `react-native-graph`'s `animated={false}`.
 
 ## When to use it
 
-Reach for `static` when you're rendering **many** mini-charts at once and don't need them to
-animate or respond to touch. A single hero chart should stay live; a `FlatList` of forty
-thumbnails should be `static`.
+Reach for `static` when you're rendering **many** mini-charts at once and don't need each one
+to animate continuously. A single hero chart should stay live; a `FlatList` of forty thumbnails
+should be `static`. They can still be scrubbed on touch (see below) — `static` only turns off
+the continuous loop, not interaction.
 
 ## A sparkline cell
 
@@ -69,6 +74,38 @@ span you want to show and `nowOverride` to your dataset's last timestamp (unix s
 window ends right at the latest point. This is the same approach as the
 [historical data fill](/guides/historical-data) pattern.
 
+## Scrubbing a static chart
+
+`static` turns off the continuous render loop, not interaction — so a still sparkline is still
+scrubbable. `scrub` (and `scrubAction`) are event-driven gestures: they cost nothing while the
+finger is off the chart, and on touch they read the already-settled geometry. So you get a
+zero-idle-cost cell that reveals its crosshair / value read-out the moment it's pressed:
+
+```tsx
+<LiveChart
+  static
+  data={history}
+  value={lastValue}
+  timeWindow={span}
+  nowOverride={lastTime}
+  scrub          // ← works on a static chart; the loop stays off until you touch it
+/>;
+```
+
+This is the right tool for a list of cells you want **inert until touched**. Before, the only
+way to stop the loop was `static`, which also took scrubbing with it; now you can have both.
+
+<Note>
+  Continuous animations — `pulse`, `degen`, the entry reveal — stay off in `static` mode (they're
+  loops, not gestures). Only the on-demand touch gestures (`scrub`, `scrubAction`) remain live.
+</Note>
+
+### Pausing off-screen charts in a long list
+
+Because `static` is a prop, you can flip it from a list's viewability callback: render off-screen
+rows `static` (loop fully off, still scrubbable if they peek on screen) and the visible hero row
+live. Toggling `static` → live resumes the loop and catches up.
+
 ## `static` vs `paused`
 
 They sound similar but do opposite things:
@@ -76,6 +113,6 @@ They sound similar but do opposite things:
 - **`paused`** freezes a **live** chart — the tick loop keeps running, the value keeps buffering,
   and resuming catches the window back up to real time. Use it for one interactive chart.
 - **`static`** removes the loops **entirely** — nothing animates and nothing recovers, because
-  there's nothing to recover. Use it for many instances at once.
+  there's nothing to recover. Use it for many instances at once. Scrubbing still works (above).
 
 See the full prop list in the [`LiveChart` reference](/api-reference/livechart).

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -295,8 +295,10 @@ function useLiveChartController({
   const bottomLabelCfg = resolveAxisLabel(bottomLabel);
   const badgeCfg = resolveBadge(badge);
   const scrubCfg = resolveScrub(scrub);
-  // Static charts run no gestures, so scrub-action (tap/drag to lock a price) is off.
-  const scrubActionCfg = isStatic ? null : resolveScrubAction(scrubAction);
+  // Scrub + scrub-action are on-demand touch gestures (event-driven, no per-frame
+  // loop), so they stay live on static charts — `static` suppresses the continuous
+  // render loop, not interaction. A still sparkline in a list can still be scrubbed.
+  const scrubActionCfg = resolveScrubAction(scrubAction);
   // Volume bars sit below the candles — a candle-mode-only feature (inert in
   // line mode, like the candle paths themselves).
   const volumeCfg = isCandle ? resolveVolume(volume) : null;
@@ -886,9 +888,10 @@ function useLiveChartController({
     formatValue,
     formatTime,
     skiaFont,
-    // Static charts have an inert pan gesture — no scrub work on the UI thread.
-    // Scrub-action also needs the gesture live even when plain scrub is off.
-    !isStatic && (scrubCfg !== null || scrubActionCfg !== null),
+    // Scrub / scrub-action stay live even on static charts: the gesture is
+    // event-driven (no per-frame loop), so a settled chart costs nothing at rest
+    // yet becomes scrubbable on touch. `static` only kills the continuous loop.
+    scrubCfg !== null || scrubActionCfg !== null,
     onScrub,
     candleOpts,
     scrubHoldMs,
@@ -1044,9 +1047,10 @@ function useLiveChartController({
   );
 
   // Hide the live dot while scrubbing when a selection dot is marking the scrub
-  // point instead — otherwise both dots show at once.
+  // point instead — otherwise both dots show at once. Applies on static charts
+  // too, now that they're scrubbable.
   const selectionDotDuringScrub =
-    !isStatic && scrubCfg !== null && selectionDotCfg !== null;
+    scrubCfg !== null && selectionDotCfg !== null;
   const liveDotOpacity = useDerivedValue(
     () =>
       reveal.dotOpacity.value *

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -2021,8 +2021,10 @@ export interface LiveChartProps extends LiveChartCoreProps {
   /** Latest live value for smooth interpolation between data updates. */
   value: SharedValue<number>;
   /** Render once with no per-frame animation loop — for many small charts (sparklines)
-   *  in a list. Pulse/scrub/degen and the entry animation are disabled. Frame the data
-   *  with `timeWindow` + `nowOverride` (see the historical-data-fill pattern). */
+   *  in a list. The continuous animations (pulse, degen, the entry reveal) are disabled,
+   *  but `scrub` / `scrubAction` stay available — they're on-demand touch gestures with
+   *  no per-frame cost, so a still chart is still scrubbable. Frame the data with
+   *  `timeWindow` + `nowOverride` (see the historical-data-fill pattern). */
   static?: boolean;
   /**
    * Render a custom overlay floated over the chart canvas, handed a price↔pixel /

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -569,11 +569,19 @@ describe("LiveChart", () => {
     });
   });
 
-  it("static gates off pulse, scrub, and degen even when requested", () => {
-    // The controller forces these features off in static; exercising the gating
-    // branches with all three explicitly enabled must still render cleanly.
+  it("static gates off pulse + degen but keeps scrub/scrubAction live", () => {
+    // The controller forces the continuous animations (pulse, degen) off in
+    // static, but scrub / scrubAction stay live (on-demand, no per-frame loop).
+    // Exercising every gating branch with all of them enabled must render cleanly.
     const screen = render(
-      <Harness static pulse scrub degen nowOverride={1700000030} />,
+      <Harness
+        static
+        pulse
+        scrub
+        scrubAction
+        degen
+        nowOverride={1700000030}
+      />,
     );
     const views = screen.UNSAFE_getAllByType(View);
     fireEvent(views[0], "layout", {

--- a/packages/react-native-livechart/tests/staticMode.test.tsx
+++ b/packages/react-native-livechart/tests/staticMode.test.tsx
@@ -85,6 +85,36 @@ describe("static mode — no per-frame loops", () => {
     );
   });
 
+  it("keeps every loop inert when a static chart enables scrub + scrubAction", () => {
+    // #177: scrub / scrubAction are on-demand touch gestures (event-driven, no
+    // per-frame loop), so enabling them on a static chart must NOT reactivate any
+    // frame callback — a still sparkline stays scrubbable at zero idle cost.
+    function Harness() {
+      const data = useSharedValue<LiveChartPoint[]>([
+        { time: 1700000000, value: 10 },
+        { time: 1700000030, value: 30 },
+      ]);
+      const value = useSharedValue(30);
+      return (
+        <LiveChart
+          static
+          scrub
+          scrubAction
+          data={data}
+          value={value}
+          timeWindow={30}
+          nowOverride={1700000030}
+        />
+      );
+    }
+    const screen = render(<Harness />);
+    screen.rerender(<Harness />);
+    expect(frameCallbackCalls.length).toBeGreaterThanOrEqual(2);
+    expect(frameCallbackCalls.every((autostart) => autostart === false)).toBe(
+      true,
+    );
+  });
+
   it("autostarts LiveChart frame-callback loops when not static", () => {
     function Harness() {
       const data = useSharedValue<LiveChartPoint[]>([


### PR DESCRIPTION
Closes #177

## Problem

`static` turned off the per-frame render loop **and** every gesture, so the only way to stop the loop (e.g. dozens of sparklines in a list) also took scrubbing with it. As @dszym00 put it: there was no *"still chart that becomes scrubbable when the user touches it."*

## Fix

Scrub / scrubAction are **on-demand, event-driven gestures with no per-frame loop** — `useCrosshair` is built from `useDerivedValue` / `useAnimatedReaction` only, no `useFrameCallback`, so its derived values only recompute while a finger is down. They cost nothing at rest. So stop forcing them off under `static`:

- A settled `static` chart stays **zero-idle-cost** yet reveals its crosshair on touch.
- The continuous animations (`pulse`, `degen`, the entry reveal) stay disabled — `static` kills the loop, not interaction.
- Also dropped the `!isStatic` guard on the live-dot ↔ selection-dot swap so the dot doesn't double up while scrubbing a static chart.

```tsx
<LiveChart static data={d} value={v} timeWindow={span} nowOverride={t} scrub />
// the loop stays off until you touch; scrub works on touch
```

For a long list you can flip `static` from a viewability callback to pause off-screen rows (still scrubbable if they peek on screen) — documented in the Sparklines guide.

## Changed

- `LiveChart`: removed the `!isStatic` gate on the crosshair `active` flag, on `scrubActionCfg`, and on the live-dot / selection-dot swap.
- `static` JSDoc + docs (`api-reference/livechart.mdx`, Sparklines guide) + CHANGELOG.
- Demo: a "Scrub on touch" toggle on the Sparklines featured (static) chart.
- Test: a `staticMode` test proving scrub + scrubAction add **no** active frame callback on a static chart (the zero-idle-cost invariant).

## Test plan

- **Unit:** a static chart with `scrub` + `scrubAction` registers every frame callback inert (`autostart === false`). Full library suite green (1260 tests), coverage thresholds met.
- **agent-device (iOS 26.4 sim):** Sparklines demo, the featured **static** chart. A press-and-hold engages the full scrub crosshair — tooltip (value **46.81** + time **20:46:54**), the selection dot on the line, and the dim on the segment right of the crosshair — confirming scrub now works on a `static` chart. (On `main` the gesture is `enabled(false)` for static, so nothing appears.)

---
Stacked on #178 (#176). Its base retargets to `main` when #178 merges.
