### PR TITLE
chore(release): v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.0] - 2026-07-01
+
 ### Added
 
 - **`transitions.candleLerpSpeed`** (`number`, default `0.08`) on `LiveChart`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17597,7 +17597,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "4.6.0"
+  "version": "4.7.0"
 }


### PR DESCRIPTION
Release **v4.7.0** — minor (two backward-compatible additions, no peer-dep changes).

Bumps `react-native-livechart` `4.6.0 → 4.7.0`, dates the CHANGELOG section, and regenerates `package-lock.json` with npm 10 (only the version line changes; `@emnapi/*` entries preserved for CI's `npm ci`).

## [4.7.0]

### Added

- **`transitions.candleLerpSpeed`** (`number`, default `0.08`) on `LiveChart` — tune or disable the candle-width resize animation on a `candleWidth` change; `1` = instant. ([#176](https://github.com/brandtnewlabs/react-native-livechart/issues/176), PR #178)

### Changed

- **`static` charts are now scrubbable** — `scrub` / `scrubAction` stay live on a `static` `LiveChart` (on-demand gestures, no per-frame loop), so a still chart stays zero-idle-cost yet reveals its crosshair on touch. ([#177](https://github.com/brandtnewlabs/react-native-livechart/issues/177), PR #179)

Both from @dszym00.

## After merge

`npm publish` (from `packages/react-native-livechart/`, your security key) → then tag `v4.7.0`, cut the GitHub Release, and reply on #176 / #177 that it shipped.
