### PR TITLE
fix: don't capture the whole crosshair object in worklets (Cannot copy value of type PanGesture on worklets ≥0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Crash `[Worklets] Cannot copy value of type PanGesture` on
+  `react-native-worklets` ≥ 0.10** (Reanimated ≥ 4.5, Expo SDK 57, RN 0.86).
+  Several `"worklet"` closures in `LiveChart` / `LiveChartSeries` referenced
+  `crosshair.scrubActive`, which made the worklets Babel plugin capture the whole
+  `crosshair` object — including the non-serializable `gesture` (`Gesture.Pan()`)
+  it also returns. Worklets 0.10 removed the silent fallback for unknown class
+  instances and now throws on serialization, so scrub + time-scroll/pinch charts
+  crashed on mount. The affected closures now capture only the hoisted
+  `SharedValue`; behavior is unchanged. Latent (non-crashing) on worklets 0.9.x.
+
 ## [4.7.0] - 2026-07-01
 
 ### Added

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -912,6 +912,12 @@ function useLiveChartController({
       : 0,
   );
 
+  // Capture only the shared value in the worklets below. Referencing
+  // `crosshair.scrubActive` inside a worklet closes over the whole `crosshair`
+  // object (which holds a non-serializable `gesture`), throwing
+  // "[Worklets] Cannot copy value of type `PanGesture`" on worklets >=0.10.
+  const crosshairScrubActive = crosshair.scrubActive;
+
   // ── Time-scroll (drag back through history) ───────────────────────────────
   // Experimental: a pan freezes the window at an absolute time and resumes
   // following once dragged back to the live edge. Pan is clamped to the earliest
@@ -929,7 +935,7 @@ function useLiveChartController({
     // Clear any live crosshair when a scroll drag takes over.
     onScrollStart: () => {
       "worklet";
-      crosshair.scrubActive.set(false);
+      crosshairScrubActive.set(false);
     },
   });
 
@@ -946,7 +952,7 @@ function useLiveChartController({
     maxTimeWindow: zoomCfg?.maxTimeWindow,
     onZoomStart: () => {
       "worklet";
-      crosshair.scrubActive.set(false);
+      crosshairScrubActive.set(false);
     },
   });
 
@@ -1054,7 +1060,7 @@ function useLiveChartController({
   const liveDotOpacity = useDerivedValue(
     () =>
       reveal.dotOpacity.value *
-      (selectionDotDuringScrub && crosshair.scrubActive.value ? 0 : 1),
+      (selectionDotDuringScrub && crosshairScrubActive.value ? 0 : 1),
   );
 
   // Fade the annotation overlays (markers + reference lines) out while scrubbing
@@ -1066,7 +1072,7 @@ function useLiveChartController({
     !isStatic && scrubCfg !== null && scrubCfg.hideOverlaysOnScrub === true;
   const overlayScrubFade = useDerivedValue(() =>
     fadeOverlaysOnScrub
-      ? withTiming(crosshair.scrubActive.get() ? 0 : 1, {
+      ? withTiming(crosshairScrubActive.get() ? 0 : 1, {
           duration: SCRUB_OVERLAY_FADE_MS,
         })
       : 1,

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -391,6 +391,12 @@ function useLiveChartSeriesController({
     onGestureEnd,
   );
 
+  // Capture only the shared value in the worklets below. Referencing
+  // `crosshair.scrubActive` inside a worklet closes over the whole `crosshair`
+  // object (which holds a non-serializable `gesture`), throwing
+  // "[Worklets] Cannot copy value of type `PanGesture`" on worklets >=0.10.
+  const crosshairScrubActive = crosshair.scrubActive;
+
   // `projected` is used internally by the hit-test gesture; the overlay
   // self-projects, so we only need the gesture here.
   const { tapGesture: markerTapGesture } = useMarkers(
@@ -428,7 +434,7 @@ function useLiveChartSeriesController({
     mode: scrollGestureMode,
     onScrollStart: () => {
       "worklet";
-      crosshair.scrubActive.set(false);
+      crosshairScrubActive.set(false);
     },
   });
 
@@ -442,7 +448,7 @@ function useLiveChartSeriesController({
     maxTimeWindow: zoomCfg?.maxTimeWindow,
     onZoomStart: () => {
       "worklet";
-      crosshair.scrubActive.set(false);
+      crosshairScrubActive.set(false);
     },
   });
 
@@ -480,7 +486,7 @@ function useLiveChartSeriesController({
     scrubCfg !== null && scrubCfg.hideOverlaysOnScrub === true;
   const overlayScrubFade = useDerivedValue(() =>
     fadeOverlaysOnScrub
-      ? withTiming(crosshair.scrubActive.get() ? 0 : 1, {
+      ? withTiming(crosshairScrubActive.get() ? 0 : 1, {
           duration: SCRUB_OVERLAY_FADE_MS,
         })
       : 1,


### PR DESCRIPTION
## Summary

Several `"worklet"` closures in `LiveChart` / `LiveChartSeries` reference `crosshair.scrubActive`. Because the Reanimated/worklets Babel plugin captures the **base identifier** used in a worklet body (`crosshair`), not just the `.scrubActive` shared value, the closure drags in the **entire object** returned by `useCrosshair` / `useCrosshairSeries` — which also holds `gesture` (a `Gesture.Pan()` instance).

On `react-native-worklets` **0.9.x** this was latent: the serializer's fallback for unknown class instances returned an opaque placeholder (`inaccessibleObject`), so nothing crashed. In **0.10.0** that fallback was removed and replaced with a hard throw:

```
throw new Error(`[Worklets] Cannot copy value of type \`${constructorName}\`.`)
```

So the captured `PanGesture` now throws instead of being silently stubbed, and any `LiveChart` / `LiveChartSeries` with scrub + time-scroll/pinch enabled **crashes on mount**:

```
[Worklets] Cannot copy value of type `PanGesture`
```

This is what Expo SDK 57 / Reanimated 4.5 (RN 0.86) pull in.

## Affected versions

- Reproduces on `react-native-livechart` **4.6.0** and **4.7.0** (latest).
- Trigger: `react-native-worklets` **≥ 0.10.0** (Reanimated ≥ 4.5, Expo SDK 57, RN 0.86).

## Affected worklet sites

`src/components/LiveChart.tsx`:
- `onScrollStart` (passed to `usePanScroll`)
- `onZoomStart` (passed to `usePinchZoom`)
- `liveDotOpacity` — `useDerivedValue`
- `overlayScrubFade` — `useDerivedValue`

`src/components/LiveChartSeries.tsx`:
- `onScrollStart`
- `onZoomStart`
- `overlayScrubFade` — `useDerivedValue`

Fixing only the gesture callbacks would be insufficient — the `useDerivedValue` closures throw the same way.

## Fix

Hoist the shared value into a local right after the `useCrosshair(...)` / `useCrosshairSeries(...)` call, and reference that local (not `crosshair.scrubActive`) in every worklet body. The worklet then captures only the `SharedValue`, which serializes fine.

```ts
const crosshair = useCrosshair(/* … */);

// Capture only the shared value in the worklets below. Referencing
// `crosshair.scrubActive` inside a worklet closes over the whole `crosshair`
// object (which holds a non-serializable `gesture`), throwing
// "[Worklets] Cannot copy value of type `PanGesture`" on worklets >=0.10.
const crosshairScrubActive = crosshair.scrubActive;
```

Render-context uses of `crosshair.scrubActive` (JSX props, hook arguments) are unaffected and left as-is — only worklet bodies need the hoisted local.

## Behavior

Unchanged. `crosshairScrubActive` is the exact same `SharedValue<boolean>` instance as `crosshair.scrubActive`; no worklet closes over `crosshair` anymore.

## Reproduction

Render a `LiveChart` (or `LiveChartSeries`) with scrub + time-scroll/pinch enabled under Reanimated 4.5 / worklets 0.10. It throws `[Worklets] Cannot copy value of type \`PanGesture\`` on mount.

## Verification

- `npm run verify` (typecheck + lint + test) passes locally — 89 suites / 1260 tests.
- Manually verified in the app which uses expo 57
- No public API change; `CHANGELOG.md` updated under `## [Unreleased]` → `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
