### PR TITLE
feat(loading): LoadingConfig.axisLabels to toggle the skeleton Y-axis placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`LoadingConfig.axisLabels`** (`boolean`, default `true`). Set `false` to hide the
+  loading shell's skeleton Y-axis label placeholders and show only the breathing
+  squiggle. Resolves through `resolveLoading`, so it works on both `LiveChart` and
+  `LiveChartSeries` (`loading={{ axisLabels: false }}`). Thanks @dszym00.
+
 ### Fixed
 
 - **Crash `[Worklets] Cannot copy value of type PanGesture` on

--- a/app/demo/states-and-formatting.tsx
+++ b/app/demo/states-and-formatting.tsx
@@ -47,9 +47,18 @@ export default function StatesScreen() {
   const [onePoint, setOnePoint] = useState(false);
   const [loading, setLoading] = useState(false);
   const [styledLoading, setStyledLoading] = useState(false);
+  const [axisLabels, setAxisLabels] = useState(true);
   const [formatMode, setFormatMode] = useState<FormatMode>("default");
 
   const customFormat = formatMode === "custom";
+
+  // Resolve the loading prop from the style + axis-label toggles below. `axisLabels`
+  // rides on the LoadingConfig, so `false` drops the skeleton Y-axis placeholders.
+  const loadingCfg: boolean | LoadingConfig = styledLoading
+    ? { ...STYLED_LOADING, axisLabels }
+    : axisLabels
+      ? true
+      : { axisLabels: false };
 
   const emptyData = useSharedValue<LiveChartPoint[]>([]);
   const emptyValue = useSharedValue(100);
@@ -80,7 +89,7 @@ export default function StatesScreen() {
           value={chartValue}
           accentColor={ACCENT}
           theme={APP_THEME}
-          loading={loading && (styledLoading ? STYLED_LOADING : true)}
+          loading={loading && loadingCfg}
           emptyText={showEmptyShell ? "Nothing to see here" : "No data"}
           formatValue={customFormat ? formatValueUsd : undefined}
           formatTime={customFormat ? formatTimeIsoUtcFragment : undefined}
@@ -123,6 +132,11 @@ export default function StatesScreen() {
           label="Styled shell"
           active={styledLoading}
           onPress={() => setStyledLoading((s) => !s)}
+        />
+        <Chip
+          label="Axis labels"
+          active={axisLabels}
+          onPress={() => setAxisLabels((a) => !a)}
         />
       </ControlRow>
 

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -384,8 +384,9 @@ provided; everything else has a default.
 <ParamField body="loading" type="boolean | LoadingConfig">
   Breathing-line loading shell until data is ready. `true` uses the defaults; pass
   a [`LoadingConfig`](/api-reference/types#loadingconfig) to restyle it (`color`,
-  `strokeWidth`, `amplitude`, `speed`). `false` / omitted is "not loading". The
-  loading→live reveal duration is set via the `transitions` prop below — see
+  `strokeWidth`, `amplitude`, `speed`, and `axisLabels` to toggle the skeleton
+  Y-axis placeholders). `false` / omitted is "not loading". The loading→live reveal
+  duration is set via the `transitions` prop below — see
   [Transitions](/guides/transitions).
 </ParamField>
 

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -397,6 +397,7 @@ interface LoadingConfig {
   strokeWidth?: number;    // squiggle stroke width; default the chart line strokeWidth
   amplitude?: number;      // base breathing-wave height (px); default 14
   speed?: number;          // breathing-wave speed multiplier; default 1 (0 freezes)
+  axisLabels?: boolean;    // draw the skeleton Y-axis placeholders; default true (false = squiggle only)
 }
 // Pinch-to-zoom the visible time window (two-finger, focal-anchored). @experimental
 interface ZoomConfig {

--- a/docs/guides/states-and-formatting.mdx
+++ b/docs/guides/states-and-formatting.mdx
@@ -36,17 +36,19 @@ Y-axis placeholders. Every field is optional:
   value={value}
   loading={
     !ready && {
-      color: "#64748b",  // squiggle + skeleton color (default: theme gridLine)
-      strokeWidth: 3,     // squiggle thickness (default: the chart line width)
-      amplitude: 22,      // breathing-wave height in px (default: 14)
-      speed: 1.5,         // wave cadence (default: 1; 0 freezes the wave)
+      color: "#64748b",   // squiggle + skeleton color (default: theme gridLine)
+      strokeWidth: 3,      // squiggle thickness (default: the chart line width)
+      amplitude: 22,       // breathing-wave height in px (default: 14)
+      speed: 1.5,          // wave cadence (default: 1; 0 freezes the wave)
+      axisLabels: false,   // hide the skeleton Y-axis placeholders (default: true)
     }
   }
 />
 ```
 
 Pass `true` for the defaults, the object to restyle, and `false` (or omit) for "not loading" — so
-`loading={!ready && cfg}` toggles the styled shell as data arrives. `color`, `amplitude`, and `speed`
+`loading={!ready && cfg}` toggles the styled shell as data arrives. Set `axisLabels: false` to drop the
+skeleton Y-axis placeholders and show only the breathing squiggle. `color`, `amplitude`, and `speed`
 also flow into the brief reveal morph, so the squiggle keeps its look as it melts into the line. The
 same config works on `LiveChartSeries`. The loading→live reveal duration itself is controlled by the
 [`transitions.reveal`](/guides/transitions) prop.

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1150,6 +1150,7 @@ function useLiveChartController({
     loadingStrokeWidth: loadingCfg?.strokeWidth,
     loadingAmplitude: loadingCfg?.amplitude,
     loadingSpeed: loadingCfg?.speed,
+    loadingAxisLabels: loadingCfg?.axisLabels ?? true,
     // derived render values
     backgroundColor,
     gradientEnd,
@@ -1375,6 +1376,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     overlayScrubFade,
     renderMarker,
     emptyText,
+    loadingAxisLabels,
     metricsCfg,
     layoutWidth,
     yAxisCfg,
@@ -1641,6 +1643,7 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         badgeTail={badgeCfg?.tail ?? true}
         badgeMetrics={metricsCfg.badge}
         emptyMetrics={metricsCfg.emptyState}
+        showAxisLabels={loadingAxisLabels}
         lineColor={loadingLineColor}
         lineStrokeWidth={loadingStrokeWidth}
         waveAmplitude={loadingAmplitude}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -531,6 +531,7 @@ function useLiveChartSeriesController({
     loadingStrokeWidth: loadingCfg?.strokeWidth,
     loadingAmplitude: loadingCfg?.amplitude,
     loadingSpeed: loadingCfg?.speed,
+    loadingAxisLabels: loadingCfg?.axisLabels ?? true,
     effectiveSeries,
     layoutHeight,
     onLayout,
@@ -599,6 +600,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     renderMarker,
     series,
     emptyText,
+    loadingAxisLabels,
     metricsCfg,
     loadingLineColor,
     loadingStrokeWidth,
@@ -738,6 +740,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         strokeWidth={strokeWidth}
         badge={false}
         emptyMetrics={metricsCfg.emptyState}
+        showAxisLabels={loadingAxisLabels}
         lineColor={loadingLineColor}
         lineStrokeWidth={loadingStrokeWidth}
         waveAmplitude={loadingAmplitude}

--- a/packages/react-native-livechart/src/components/LoadingOverlay.tsx
+++ b/packages/react-native-livechart/src/components/LoadingOverlay.tsx
@@ -62,6 +62,7 @@ export function LoadingOverlay({
   badgeTail = true,
   badgeMetrics = BADGE_METRICS_DEFAULTS,
   emptyMetrics = EMPTY_STATE_METRICS_DEFAULTS,
+  showAxisLabels = true,
   lineColor,
   lineStrokeWidth,
   waveAmplitude = 14,
@@ -93,6 +94,8 @@ export function LoadingOverlay({
   badgeMetrics?: BadgeMetrics;
   /** Empty-state layout tokens. */
   emptyMetrics?: EmptyStateMetrics;
+  /** Draw the skeleton Y-axis label placeholders. Default `true`. */
+  showAxisLabels?: boolean;
 }) {
   // Same left-inset formula as GridOverlay (only used when badge=true)
   const leftInset =
@@ -268,38 +271,42 @@ export function LoadingOverlay({
       </Group>
 
       {/* Skeleton Y-axis label placeholders */}
-      <RoundedRect
-        x={lx}
-        y={ly0}
-        width={RECT_W}
-        height={RECT_H}
-        r={RECT_R}
+      {showAxisLabels ? (
+        <>
+          <RoundedRect
+            x={lx}
+            y={ly0}
+            width={RECT_W}
+            height={RECT_H}
+            r={RECT_R}
         color={loadingColor}
-      />
-      <RoundedRect
-        x={lx}
-        y={ly1}
-        width={RECT_W}
-        height={RECT_H}
-        r={RECT_R}
+          />
+          <RoundedRect
+            x={lx}
+            y={ly1}
+            width={RECT_W}
+            height={RECT_H}
+            r={RECT_R}
         color={loadingColor}
-      />
-      <RoundedRect
-        x={lx}
-        y={ly2}
-        width={RECT_W}
-        height={RECT_H}
-        r={RECT_R}
+          />
+          <RoundedRect
+            x={lx}
+            y={ly2}
+            width={RECT_W}
+            height={RECT_H}
+            r={RECT_R}
         color={loadingColor}
-      />
-      <RoundedRect
-        x={lx}
-        y={ly3}
-        width={RECT_W}
-        height={RECT_H}
-        r={RECT_R}
+          />
+          <RoundedRect
+            x={lx}
+            y={ly3}
+            width={RECT_W}
+            height={RECT_H}
+            r={RECT_R}
         color={loadingColor}
-      />
+          />
+        </>
+      ) : null}
 
       {/* Empty state label */}
       <SkiaText

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -644,6 +644,8 @@ export interface ResolvedLoadingConfig {
   amplitude: number;
   /** Breathing-wave speed multiplier. */
   speed: number;
+  /** Draw the skeleton Y-axis label placeholders. */
+  axisLabels: boolean;
 }
 
 const LOADING_DEFAULTS: ResolvedLoadingConfig = {
@@ -651,6 +653,7 @@ const LOADING_DEFAULTS: ResolvedLoadingConfig = {
   strokeWidth: undefined,
   amplitude: LOADING_WAVE_AMPLITUDE,
   speed: LOADING_WAVE_SPEED,
+  axisLabels: true,
 };
 
 /**

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1668,6 +1668,12 @@ export interface LoadingConfig {
    * `<1` slower, `0` freezes it. Default `1`.
    */
   speed?: number;
+  /**
+   * Whether the shell draws the skeleton Y-axis label placeholders (the short
+   * rounded dashes centred in the gutter). Set `false` to show only the breathing
+   * squiggle with no placeholder ticks. Default `true`.
+   */
+  axisLabels?: boolean;
 }
 
 /** Props shared between `LiveChart` and `LiveChartSeries`. */
@@ -1701,10 +1707,11 @@ export interface LiveChartCoreProps {
    *
    * `true` shows the shell with the defaults; pass a {@link LoadingConfig} to
    * restyle it — `color` / `strokeWidth` for the squiggle + skeleton, `amplitude`
-   * / `speed` for the breathing wave. `false` / omitted is "not loading". Toggle
-   * between the config and `false` as data loads (e.g. `loading={isLoading && cfg}`).
-   * The loading→live reveal duration is governed separately by
-   * {@link TransitionConfig.reveal} (the `transitions` prop).
+   * / `speed` for the breathing wave, `axisLabels` to toggle the skeleton
+   * placeholders. `false` / omitted is "not loading". Toggle between the config
+   * and `false` as data loads (e.g. `loading={isLoading && cfg}`). The loading→live
+   * reveal duration is governed separately by {@link TransitionConfig.reveal} (the
+   * `transitions` prop).
    */
   loading?: boolean | LoadingConfig;
   /**

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -320,6 +320,29 @@ describe("LoadingOverlay", () => {
     render(<Fixture />);
   });
 
+  it("renders in loading state without skeleton axis labels (showAxisLabels=false)", () => {
+    function Fixture() {
+      const morphT = useSharedValue(0);
+      const isLoading = useSharedValue(true);
+      const isEmpty = useSharedValue(false);
+      return (
+        <LoadingOverlay
+          engine={makeLoadingEngine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          morphT={morphT}
+          isLoading={isLoading}
+          isEmpty={isEmpty}
+          emptyText="No data"
+          strokeWidth={2}
+          showAxisLabels={false}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
   it("renders with zero canvas size (early return path)", () => {
     function Fixture() {
       const morphT = useSharedValue(0.5);

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -629,6 +629,7 @@ describe("resolveLoading", () => {
     strokeWidth: undefined,
     amplitude: 14,
     speed: 1,
+    axisLabels: true,
   };
 
   it("returns null for undefined / false (not loading)", () => {
@@ -653,6 +654,13 @@ describe("resolveLoading", () => {
       ...DEFAULTS,
       amplitude: 22,
       speed: 1.5,
+    });
+  });
+
+  it("toggles the skeleton axis-label placeholders off", () => {
+    expect(resolveLoading({ axisLabels: false })).toEqual({
+      ...DEFAULTS,
+      axisLabels: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds **`LoadingConfig.axisLabels`** (`boolean`, default `true`). Set it `false` to hide the loading shell's skeleton Y-axis label placeholders (the short rounded dashes in the gutter) and show only the breathing squiggle:

```tsx
<LiveChart data={data} value={value} loading={{ axisLabels: false }} />
```

It rides on the existing `LoadingConfig`, resolves through `resolveLoading` into `LOADING_DEFAULTS`, and threads model → `ChartStack` → `LoadingOverlay.showAxisLabels` — exactly how `color` / `strokeWidth` / `amplitude` / `speed` already flow — so it works on both `LiveChart` and `LiveChartSeries`. Default is unchanged (placeholders still drawn).

## Relationship to #182

This supersedes #182 by @dszym00 (thanks!). That PR shipped the same feature but as a flat top-level `loadingAxisLabels` prop, which bypassed the `LoadingConfig` / `resolveLoading` machinery and added a lone top-level prop next to the config object that already owns every other loading style. This version reshapes it onto `LoadingConfig.axisLabels` to match the established API (and matches #182's own description). @dszym00 is preserved as co-author, and rebased cleanly on top of #181.

The good `LoadingOverlay` leaf change from #182 (the `showAxisLabels` prop + conditional render) is kept as-is.

## Included

- `LoadingConfig.axisLabels` + `ResolvedLoadingConfig` / `LOADING_DEFAULTS` and the threading in both components
- Docs: `types.mdx`, `livechart.mdx`, and the `states-and-formatting` guide
- `CHANGELOG.md` under `[Unreleased] → Added`
- A `resolveLoading` unit test for the toggle (plus the existing `LoadingOverlay` test)
- An **"Axis labels"** toggle on the States & formatting demo (docs↔demo parity)

## Verification

- `npm run verify` (typecheck + lint + test) — 89 suites / 1262 tests pass, on top of latest `main` (#181 merged).
- Manually verified on the **iOS 26.4 simulator**: default draws the 4 skeleton dashes; `loading={{ axisLabels: false }}` drops them and shows the squiggle only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
