### PR TITLE
chore(release): v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.0] - 2026-07-02
+
 ### Added
 
 - **`LoadingConfig.axisLabels`** (`boolean`, default `true`). Set `false` to hide the

--- a/package-lock.json
+++ b/package-lock.json
@@ -17597,7 +17597,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "4.7.0"
+  "version": "4.8.0"
 }


### PR DESCRIPTION
Release **v4.8.0** (minor — one new backward-compatible feature + one fix; no peer-dependency or breaking changes).

Bumps `packages/react-native-livechart` `4.7.0 → 4.8.0` and cuts the `[Unreleased]` notes into a dated `4.8.0` section. Lockfile regenerated with npm 10 (CI-consistent — `@emnapi` intact). `npm run verify` passes (89 suites / 1262 tests).

## [4.8.0]

### Added

- **`LoadingConfig.axisLabels`** (`boolean`, default `true`). Set `false` to hide the loading shell's skeleton Y-axis label placeholders and show only the breathing squiggle. Resolves through `resolveLoading`, so it works on both `LiveChart` and `LiveChartSeries` (`loading={{ axisLabels: false }}`). Thanks @dszym00. ([#183](https://github.com/brandtnewlabs/react-native-livechart/pull/183))

### Fixed

- **Crash `[Worklets] Cannot copy value of type PanGesture` on `react-native-worklets` ≥ 0.10** (Reanimated ≥ 4.5, Expo SDK 57, RN 0.86). Several `"worklet"` closures in `LiveChart` / `LiveChartSeries` referenced `crosshair.scrubActive`, which made the worklets Babel plugin capture the whole `crosshair` object — including the non-serializable `gesture` (`Gesture.Pan()`) it also returns. Worklets 0.10 removed the silent fallback for unknown class instances and now throws on serialization, so scrub + time-scroll/pinch charts crashed on mount. The affected closures now capture only the hoisted `SharedValue`; behavior is unchanged. Latent (non-crashing) on worklets 0.9.x. ([#181](https://github.com/brandtnewlabs/react-native-livechart/pull/181))

---

After merge: publish to npm, then tag `v4.8.0` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
