### PR TITLE
fix: Y-axis re-fits to the visible window while time-scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Y-axis now adapts to the visible window while time-scrolled.** While panned
+  back through history (`timeScroll`), the engine's Y-range folded in data
+  *newer* than the frozen window edge, the in-progress live candle, and the live
+  price — so the axis stayed pinned to the live range instead of re-fitting the
+  history on screen. All three are now excluded from the range while scrolled
+  back (line + candle, single- and multi-series); live-following behavior is
+  unchanged.
+
 ## [4.9.0] - 2026-07-06
 
 ### Added

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -30,6 +30,11 @@ return to the live edge, where live-following resumes. One-finger plot scrubbing
 Panning is clamped to the earliest retained point, so keep enough history in `data` (or `candles`)
 to scroll into — seed a few windows' worth and keep your buffer longer than the visible window.
 
+While scrolled back, the **Y-range fits the visible window**: only the points (or candles) inside
+the frozen window shape the axis — newer data and the live price sit beyond the right edge and
+don't stretch it — so the axis re-fits the history you're looking at as you pan. Back at the live
+edge, the range folds the live value back in as usual.
+
 ### Turning it back off
 
 Setting `timeScroll` back to `false` while scrolled back — or switching `mode` so your component

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -235,7 +235,9 @@ export function tickLiveChartEngineFrame(
       }
     }
     const lc = input.liveCandle;
-    if (lc) {
+    // Fold the in-progress candle in only while its bucket is visible — when
+    // scrolled back past it, the live candle must not stretch the Y range.
+    if (lc && (!scrolledBack || lc.time <= state.timestamp)) {
       /* istanbul ignore next -- trivial min/max */
       if (lc.low < tMin) {
         tMin = lc.low;
@@ -257,6 +259,11 @@ export function tickLiveChartEngineFrame(
       else hi = mid;
     }
     for (let i = lo; i < points.length; i++) {
+      // While scrolled back, stop at the frozen right edge (mirrors the candle
+      // scan) so newer points don't inflate the visible Y range. Following
+      // live, keep the tail inclusive — feed timestamps can run slightly ahead
+      // of the local clock and must not flicker out of the range.
+      if (scrolledBack && points[i].time > state.timestamp) break;
       const v = points[i].value;
       if (v < tMin) {
         tMin = v;
@@ -279,9 +286,15 @@ export function tickLiveChartEngineFrame(
   state.extremaMinTime = hasMin ? minTime : NaN;
   state.extremaMaxTime = hasMax ? maxTime : NaN;
 
-  const cv = state.displayValue;
-  if (cv < tMin) tMin = cv;
-  if (cv > tMax) tMax = cv;
+  // Keep the animated live tip inside the range — but only while it's actually
+  // in the window. Scrolled back, the live value sits beyond the frozen right
+  // edge; folding it in would pin the Y range to the live price and stop the
+  // axis from adapting to the visible history.
+  if (!scrolledBack) {
+    const cv = state.displayValue;
+    if (cv < tMin) tMin = cv;
+    if (cv > tMax) tMax = cv;
+  }
 
   const ref = input.referenceValue;
   if (ref !== undefined) {

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -215,6 +215,12 @@ export function tickLiveChartSeriesEngineFrame(
       else hi = mid;
     }
     for (let j = lo; j < points.length; j++) {
+      // While scrolled back, stop at the frozen right edge so newer points
+      // don't inflate the visible Y range (the per-series tips folded below
+      // already track the edge value, so they stay in-range). Following live,
+      // keep the tail inclusive — feed timestamps can run slightly ahead of
+      // the local clock and must not flicker out of the range.
+      if (scrolledBack && points[j].time > state.timestamp) break;
       const v = points[j].value;
       /* istanbul ignore next -- trivial min/max */
       if (v < tMin) tMin = v;

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -796,6 +796,77 @@ describe("tickLiveChartEngineFrame", () => {
       expect(s.edgeValue).toBeGreaterThan(0);
       expect(s.edgeValue).toBeLessThanOrEqual(42);
     });
+
+    // Y-range while scrolled back: only the data inside the frozen window may
+    // shape displayMin/Max — newer points, the live candle, and the live value
+    // all sit past the frozen right edge and must not stretch the axis.
+    it("excludes points after the frozen edge from the Y range (line)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          snap: true,
+          points: [
+            { time: 940, value: 10 },
+            { time: 945, value: 12 }, // in-window extrema: 10..12
+            { time: 990, value: 1000 }, // after the frozen edge — excluded
+          ],
+        }),
+      );
+      expect(s.displayMax).toBeLessThan(100); // ≈12 + margin, not ≈1000
+      expect(s.extremaMaxValue).toBe(12);
+      expect(s.extremaMinValue).toBe(10);
+    });
+
+    it("excludes the live value from the Y range while scrolled back", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          snap: true,
+          targetValue: 500, // live price far above the visible history
+          points: [
+            { time: 940, value: 10 },
+            { time: 945, value: 12 },
+          ],
+        }),
+      );
+      expect(s.displayValue).toBe(500); // still tracks live…
+      expect(s.displayMax).toBeLessThan(100); // …but doesn't stretch the range
+    });
+
+    it("excludes a live candle past the frozen edge from the Y range", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          snap: true,
+          targetValue: 12,
+          mode: "candle",
+          candles: [{ time: 940, open: 10, high: 12, low: 9, close: 11 }],
+          liveCandle: { time: 990, open: 900, high: 1000, low: 800, close: 950 },
+        }),
+      );
+      expect(s.displayMax).toBeLessThan(100); // ≈12 + margin, not ≈1000
+    });
+
+    it("still includes the live candle in the Y range while following", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({
+          snap: true,
+          targetValue: 950,
+          mode: "candle",
+          candles: [{ time: 940, open: 10, high: 12, low: 9, close: 11 }],
+          liveCandle: { time: 990, open: 900, high: 1000, low: 800, close: 950 },
+        }),
+      );
+      expect(s.displayMax).toBeGreaterThanOrEqual(1000);
+    });
   });
 
   // ── Extrema tracking (for "extrema"-positioned axis labels) ──────────────

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -769,6 +769,34 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       );
       expect(live.displayValues[0]).toBe(99);
     });
+
+    // Y-range while scrolled back: points after the frozen right edge must not
+    // stretch displayMin/Max — the axis adapts to the visible history instead.
+    it("excludes points after the frozen edge from the Y range", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          snap: true,
+          series: [
+            {
+              id: "a",
+              color: "#00f",
+              value: 1000,
+              data: [
+                { time: 940, value: 10 },
+                { time: 945, value: 12 }, // in-window extrema: 10..12
+                { time: 990, value: 1000 }, // after the frozen edge — excluded
+              ],
+            },
+          ],
+        }),
+      );
+      expect(s.displayMax).toBeLessThan(100); // ≈12 + margin, not ≈1000
+      expect(s.extremaMaxValue).toBe(12);
+      expect(s.extremaMinValue).toBe(10);
+    });
   });
 
   describe("snap (one-shot settle)", () => {


### PR DESCRIPTION
While time-scrolled back through history, the engine's Y-range folded in three values that sit past the frozen right edge: points newer than the window edge, the in-progress live candle, and the animated live price. The axis stayed pinned to the live range instead of re-fitting the visible history.

Guards all three behind the scrolled-back state, in liveChartEngineTick.ts (line, candle, live tip) and liveChartSeriesEngineTick.ts (multi-series). Live-following is unchanged; the added tests cover the scrolled-back Y-range.