### PR TITLE
fix: hide LiveChartSeries selection dot by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`LiveChartSeries` hides the scrub selection dot by default** (`selectionDot`
+  now defaults to `false` on the multi-series chart; `LiveChart` is unchanged).
+  With multiple lines the dot could only track the leading series, which read as
+  a stray dot following one line while scrubbing — the crosshair + per-series
+  tooltip stack already mark the scrub point. Pass `selectionDot` (or a
+  `SelectionDotConfig`) explicitly to opt back in.
+
 ### Fixed
 
 - **Y-axis now adapts to the visible window while time-scrolled.** While panned

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -64,11 +64,13 @@ default off.
   defaulted to `false`); pass `scrub={false}` to disable.
 </ParamField>
 
-<ParamField body="selectionDot" type="boolean | SelectionDotConfig" default="true">
-  Dot drawn at the scrub intersection (anchored to the leading series) while
-  scrubbing. `false` hides it; pass a config to set `size` / `color` / `ring`, or
-  `{ component }` for a fully custom Skia dot. See
-  [Scrubbing](/guides/scrubbing#selection-dot).
+<ParamField body="selectionDot" type="boolean | SelectionDotConfig" default="false">
+  Dot drawn at the scrub intersection while scrubbing. **Hidden by default on
+  `LiveChartSeries`** (unlike `LiveChart`): with multiple lines the dot can only
+  track the leading series, so the crosshair + per-series tooltips mark the
+  scrub point instead. Pass `true` to opt in (it anchors to the leading series),
+  a config to set `size` / `color` / `ring`, or `{ component }` for a fully
+  custom Skia dot. See [Scrubbing](/guides/scrubbing#selection-dot).
 </ParamField>
 
 <ParamField body="onScrub" type="(point: ScrubPointMulti | null) => void">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -359,7 +359,8 @@ interface SelectionDotRingConfig {
   color?: string; // ring color, defaults to the dot color
   width?: number; // ring thickness past the dot, default 2
 }
-// The scrub-intersection dot (selectionDot). Default ON.
+// The scrub-intersection dot (selectionDot). Default ON for LiveChart,
+// OFF for LiveChartSeries (the crosshair + tooltips mark the scrub point there).
 interface SelectionDotConfig {
   size?: number; // dot radius, default 4
   color?: string; // dot color, defaults to the line / leading-series color

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -235,8 +235,10 @@ through to the parent gesture, while a deliberate hold begins scrubbing.
 
 ## Selection dot
 
-A dot is drawn at the scrub intersection — where the crosshair meets the line (or the leading
-series, on `LiveChartSeries`). It's **on by default**, so you get it for free with `scrub`.
+A dot is drawn at the scrub intersection — where the crosshair meets the line. On `LiveChart` it's
+**on by default**, so you get it for free with `scrub`. On `LiveChartSeries` it's **off by
+default** — with multiple lines the dot can only track the leading series, so the crosshair +
+per-series tooltips mark the scrub point instead; pass `selectionDot` explicitly to opt in.
 
 Turn it off, or tweak its look, with the `boolean | SelectionDotConfig` `selectionDot` prop:
 
@@ -275,7 +277,8 @@ function RingDot({ x, y, opacity, color, size }: SelectionDotProps) {
 <LiveChart data={data} value={value} selectionDot={{ component: RingDot }} />;
 ```
 
-The same `selectionDot` prop works on `LiveChartSeries`.
+The same `selectionDot` prop works on `LiveChartSeries` — there it defaults to hidden, so pass
+`true` (or a config) to show the dot anchored to the leading series.
 
 ## Reading the scrub position (single series)
 

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -208,7 +208,11 @@ function useLiveChartSeriesController({
       ? (timeScrollHoldMs ?? (scrubCfg?.panGestureDelay || HOLD_TO_SCRUB_MS))
       : (scrubCfg?.panGestureDelay ?? 0);
 
-  const selectionDotCfg = resolveSelectionDot(selectionDot);
+  // Multi-series defaults the scrub selection dot OFF: it can only track one
+  // line (the leading series), which reads as a bug next to the other series.
+  // The crosshair line + per-series tooltip stack already mark the scrub point.
+  // Passing `selectionDot` explicitly (true / config) still opts it in.
+  const selectionDotCfg = resolveSelectionDot(selectionDot ?? false);
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
   // Outer footprint of a dot (the color-filled radius plus the halo ring).

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1979,9 +1979,14 @@ export interface LiveChartCoreProps {
   /** Crosshair scrubbing on hover/drag. `true` = defaults, `false` = disabled, or pass `ScrubConfig`. Default `true`. */
   scrub?: boolean | ScrubConfig;
   /**
-   * Selection dot drawn at the scrub intersection while scrubbing. `true`/omitted
-   * = built-in dot, `false` = hidden, or pass `SelectionDotConfig` (`size`,
-   * `color`, `ring`, or a custom `component`). Default `true`.
+   * Selection dot drawn at the scrub intersection while scrubbing. `true` =
+   * built-in dot, `false` = hidden, or pass `SelectionDotConfig` (`size`,
+   * `color`, `ring`, or a custom `component`).
+   *
+   * Defaults differ per chart: `LiveChart` shows it (`true`); `LiveChartSeries`
+   * hides it (`false`) — with multiple lines the dot can only track the leading
+   * series, so the crosshair + per-series tooltips mark the scrub point instead.
+   * Pass `true` / a config to opt a multi-series chart in.
    */
   selectionDot?: boolean | SelectionDotConfig;
   /** Called once when the user starts scrubbing/panning the chart. */

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -5,6 +5,7 @@ import { useSharedValue } from "react-native-reanimated";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
+import { DefaultSelectionDot } from "../src/components/SelectionDot";
 import type { SeriesConfig } from "../src/types";
 
 describe("LiveChartSeries", () => {
@@ -118,6 +119,65 @@ describe("LiveChartSeries", () => {
     fireEvent(layoutView, "layout", {
       nativeEvent: { layout: { width: 400, height: 300 } },
     });
+  });
+
+  it("hides the scrub selection dot by default (multi-series)", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return <LiveChartSeries series={series} />;
+    }
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    const views = screen.UNSAFE_getAllByType(View);
+    const layoutView =
+      views.find((v) => typeof v.props.onLayout === "function") ?? views[0];
+    fireEvent(layoutView, "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+    // The dot can only follow one line, so multi-series defaults it off.
+    expect(screen.UNSAFE_queryAllByType(DefaultSelectionDot)).toHaveLength(0);
+  });
+
+  it("shows the scrub selection dot when opted in via selectionDot", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return <LiveChartSeries series={series} selectionDot />;
+    }
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    const views = screen.UNSAFE_getAllByType(View);
+    const layoutView =
+      views.find((v) => typeof v.props.onLayout === "function") ?? views[0];
+    fireEvent(layoutView, "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+    expect(
+      screen.UNSAFE_queryAllByType(DefaultSelectionDot).length,
+    ).toBeGreaterThan(0);
   });
 
   it("renders with explicit non-default props", async () => {


### PR DESCRIPTION
On LiveChartSeries the scrub selection dot could only track the leading series, so with multiple lines it read as a stray dot trailing one line. selectionDot now defaults to false for LiveChartSeries (single-series LiveChart is unchanged); the crosshair plus per-series tooltips already mark the scrub point. Pass selectionDot (true or a config) to opt a multi-series chart back in.

Docs and the selectionDot ParamField / type default note are updated to match; tests cover the new hidden default and the explicit opt-in.