### PR TITLE
perf: mount optional chart worklets conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Disabled `LiveChart` subsystems no longer register their UI-thread worklets.**
+  Axis, badge, trade-tape, custom-overlay, degen, and line-vs-candle rendering
+  hooks now live in conditionally mounted child components. Minimal line charts
+  avoid compiling and retaining worklets for features they do not use.
+
 ## [4.9.1] - 2026-07-06
 
 ### Changed

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,7 +1,4 @@
 import {
-  createContext,
-  type ReactNode,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -1344,17 +1341,15 @@ function useLiveChartController({
 type LiveChartModel = ReturnType<typeof useLiveChartController>;
 
 type YAxisEntries = ReturnType<typeof useYAxis>["yAxisEntries"];
-const YAxisEntriesContext = createContext<YAxisEntries | null>(null);
 type DegenState = ReturnType<typeof useDegen>;
-const DegenContext = createContext<DegenState | null>(null);
 
 /** Owns the particle/shake state only while the degen effect is enabled. */
-function ChartDegenProvider({
+function ChartWithDegen({
   model,
-  children,
+  yAxisEntries,
 }: {
   model: LiveChartModel;
-  children: ReactNode;
+  yAxisEntries: YAxisEntries | null;
 }) {
   const { engine, dotX, dotY, momentumSV, degenCfg, onDegenShake, isStatic } =
     model;
@@ -1368,23 +1363,17 @@ function ChartDegenProvider({
     isStatic,
   );
   return (
-    <DegenContext.Provider value={state}>{children}</DegenContext.Provider>
+    <ChartView model={model} yAxisEntries={yAxisEntries} degen={state} />
   );
 }
 
 /**
  * Owns the Y-axis worklets. The provider itself is mounted only while the axis
  * is enabled, so `yAxis={false}` never registers its shared values or mapper.
- * Context lets the grid (below the plot) and floating labels (above it) share a
- * single mapper despite living at different paint-order positions.
+ * The entries are passed through ordinary props so both paint-order positions
+ * receive the same mapper across the React Native → Skia renderer boundary.
  */
-function ChartYAxisProvider({
-  model,
-  children,
-}: {
-  model: LiveChartModel;
-  children: ReactNode;
-}) {
+function ChartWithYAxis({ model }: { model: LiveChartModel }) {
   const {
     engine,
     effectivePadding,
@@ -1402,29 +1391,20 @@ function ChartYAxisProvider({
     metricsCfg.grid,
     yAxisCfg?.count ?? 0,
   );
-  return (
-    <YAxisEntriesContext.Provider value={yAxisEntries}>
-      {children}
-    </YAxisEntriesContext.Provider>
-  );
-}
-
-function useChartYAxisEntries(): YAxisEntries {
-  const entries = useContext(YAxisEntriesContext);
-  if (entries === null) {
-    throw new Error(
-      "Chart Y-axis layers must be wrapped in ChartYAxisProvider",
-    );
+  if (model.degenCfg) {
+    return <ChartWithDegen model={model} yAxisEntries={yAxisEntries} />;
   }
-  return entries;
+  return <ChartView model={model} yAxisEntries={yAxisEntries} degen={null} />;
 }
 
 function ChartYAxisLayer({
   model,
   variant,
+  entries,
 }: {
   model: LiveChartModel;
   variant: "all" | "grid" | "labels";
+  entries: YAxisEntries;
 }) {
   const {
     reveal,
@@ -1438,7 +1418,6 @@ function ChartYAxisLayer({
     gridStyleCfg,
     yAxisFloat,
   } = model;
-  const entries = useChartYAxisEntries();
   return (
     <Group opacity={reveal.yAxisOpacity}>
       <YAxisOverlay
@@ -1492,7 +1471,15 @@ function ChartXAxisLayer({ model }: { model: LiveChartModel }) {
  * the fade's `dstOut` only softens the fills — the line and everything above it
  * (drawn in `ChartStack`, after the fade) stay crisp at the left edge.
  */
-function ChartFillLayer({ model }: { model: LiveChartModel }) {
+function ChartFillLayer({
+  model,
+  yAxisEntries,
+  degen,
+}: {
+  model: LiveChartModel;
+  yAxisEntries: YAxisEntries | null;
+  degen: DegenState | null;
+}) {
   const {
     yAxisCfg,
     yAxisFloat,
@@ -1513,15 +1500,17 @@ function ChartFillLayer({ model }: { model: LiveChartModel }) {
     thresholdSeriesHasPoints,
     thresholdFillUniforms,
   } = model;
-  const degen = useContext(DegenContext);
-
   return (
     <Group transform={degen?.shakeTransform}>
       {/* Y-axis. Default: grid + labels here (in a reserved gutter). Floating
           mode: grid only — the labels + a soft edge fade draw above the candles
           in ChartStack so the plot runs full-width and candles dim under them. */}
       {yAxisCfg && (
-        <ChartYAxisLayer model={model} variant={yAxisFloat ? "grid" : "all"} />
+        <ChartYAxisLayer
+          model={model}
+          variant={yAxisFloat ? "grid" : "all"}
+          entries={yAxisEntries!}
+        />
       )}
 
       {/* Dot-lattice area fill (the under-line `fillPath` painted with a dot
@@ -1663,7 +1652,15 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
  *  segment dividers, value/reference lines, the line/candles, axes, dot, degen,
  *  markers, and the loading/empty art. Background fills are in `ChartFillLayer`
  *  (below the fade); the live value text is `ChartValueOverlay` (above the fade). */
-function ChartStack({ model }: { model: LiveChartModel }) {
+function ChartStack({
+  model,
+  yAxisEntries,
+  degen,
+}: {
+  model: LiveChartModel;
+  yAxisEntries: YAxisEntries | null;
+  degen: DegenState | null;
+}) {
   const {
     reveal,
     engine,
@@ -1720,8 +1717,6 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     loadingAmplitude,
     loadingSpeed,
   } = model;
-  const degen = useContext(DegenContext);
-
   return (
     <Group transform={degen?.shakeTransform}>
       {/* Segment dividers + labels (behind the line). The scrub-focus emphasis is
@@ -1841,7 +1836,11 @@ function ChartStack({ model }: { model: LiveChartModel }) {
           edge) so the plot runs full-width and candles stay fully visible behind
           them. (Default non-floating axis draws grid + labels in ChartFillLayer.) */}
       {yAxisCfg && yAxisFloat && (
-        <ChartYAxisLayer model={model} variant="labels" />
+        <ChartYAxisLayer
+          model={model}
+          variant="labels"
+          entries={yAxisEntries!}
+        />
       )}
 
       {/* X-axis time labels. With a volume band the bottom padding is inflated by
@@ -1941,7 +1940,13 @@ function ChartStack({ model }: { model: LiveChartModel }) {
 }
 
 /** Owns the trade-tape frame callback and only mounts with a trade stream. */
-function ChartTradeStreamLayer({ model }: { model: LiveChartModel }) {
+function ChartTradeStreamLayer({
+  model,
+  degen,
+}: {
+  model: LiveChartModel;
+  degen: DegenState | null;
+}) {
   const {
     engine,
     tradeStream,
@@ -1952,7 +1957,6 @@ function ChartTradeStreamLayer({ model }: { model: LiveChartModel }) {
     reveal,
     isStatic,
   } = model;
-  const degen = useContext(DegenContext);
   const tradeMarkers = useTradeStream(
     engine,
     tradeStream!,
@@ -1975,7 +1979,13 @@ function ChartTradeStreamLayer({ model }: { model: LiveChartModel }) {
 }
 
 /** Scrub crosshair/tooltip drawn in canvas space on top of the shaken stack. */
-function ChartScrubLayer({ model }: { model: LiveChartModel }) {
+function ChartScrubLayer({
+  model,
+  degen,
+}: {
+  model: LiveChartModel;
+  degen: DegenState | null;
+}) {
   const {
     scrubCfg,
     palette,
@@ -1989,8 +1999,6 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
     selectionColor,
     renderTooltip,
   } = model;
-  const degen = useContext(DegenContext);
-
   // A custom tooltip is an RN overlay (sibling of <Canvas>), so the built-in
   // Skia tooltip is suppressed here while it's active — the line pill in line
   // mode, and the OHLC stack in candle mode (see the stack gate below).
@@ -2055,7 +2063,13 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
 /** Live-value text drawn as its own canvas layer, above both the area gradient
  *  and the left-edge fade, so the large number stays crisp at the left edge
  *  instead of being washed out by the fade's `dstOut` blend. */
-function ChartValueOverlay({ model }: { model: LiveChartModel }) {
+function ChartValueOverlay({
+  model,
+  degen,
+}: {
+  model: LiveChartModel;
+  degen: DegenState | null;
+}) {
   const {
     showValue,
     engine,
@@ -2067,8 +2081,6 @@ function ChartValueOverlay({ model }: { model: LiveChartModel }) {
     valueMomentumColor,
     reveal,
   } = model;
-  const degen = useContext(DegenContext);
-
   if (!showValue) return null;
 
   return (
@@ -2090,7 +2102,13 @@ function ChartValueOverlay({ model }: { model: LiveChartModel }) {
 
 /** Live-price badge, drawn above the scrub dim so the dim never clips its left
  *  edge. Shares the degen shake transform so it tracks the shaken stack. */
-function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
+function ChartBadgeLayer({
+  model,
+  degen,
+}: {
+  model: LiveChartModel;
+  degen: DegenState | null;
+}) {
   const {
     badgeFont,
     reveal,
@@ -2102,7 +2120,6 @@ function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
     metricsCfg,
     yAxisFloat,
   } = model;
-  const degen = useContext(DegenContext);
   const badgeCfg = model.badgeCfg!;
   const badgeData = useBadge(
     engine,
@@ -2143,7 +2160,13 @@ function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
  *  left-pinned badge (off-axis / `labelBadge`) and any label stay crisp instead
  *  of being erased by the fade's dstOut. The lines/bands themselves render in the
  *  base pass inside ChartStack (behind the chart content). */
-function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
+function ChartRefBadgeLayer({
+  model,
+  degen,
+}: {
+  model: LiveChartModel;
+  degen: DegenState | null;
+}) {
   const {
     allRefLines,
     refLineCustom,
@@ -2162,7 +2185,6 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
     fontProp,
     overlayScrubFade,
   } = model;
-  const degen = useContext(DegenContext);
   if (allRefLines.length === 0) return null;
   return (
     <Group transform={degen?.shakeTransform} opacity={overlayScrubFade}>
@@ -2303,8 +2325,15 @@ function ChartCustomConsumerOverlay({ model }: { model: LiveChartModel }) {
   return <ChartOverlayLayer render={renderOverlay!} context={overlayContext} />;
 }
 
-export function LiveChart(props: LiveChartProps) {
-  const model = useLiveChartController(props);
+function ChartView({
+  model,
+  yAxisEntries,
+  degen,
+}: {
+  model: LiveChartModel;
+  yAxisEntries: YAxisEntries | null;
+  degen: DegenState | null;
+}) {
   const {
     rootGesture,
     backgroundColor,
@@ -2332,7 +2361,7 @@ export function LiveChart(props: LiveChartProps) {
     bottomConnector,
   } = model;
 
-  const chart = (
+  return (
     <GestureDetector gesture={rootGesture}>
       <View
         style={[{ flex: 1, backgroundColor }, style]}
@@ -2345,7 +2374,11 @@ export function LiveChart(props: LiveChartProps) {
           {/* Background fills first, then the left-edge fade (a canvas-space sibling
               so dstOut blends correctly), then the line stack on top — so the fade
               softens only the fills and the line stays crisp at the left edge. */}
-          <ChartFillLayer model={model} />
+          <ChartFillLayer
+            model={model}
+            yAxisEntries={yAxisEntries}
+            degen={degen}
+          />
 
           {leftEdgeFadeCfg && (
             <LeftEdgeFade
@@ -2358,7 +2391,11 @@ export function LiveChart(props: LiveChartProps) {
           )}
 
           {/* Line stack above the fade so the line stays crisp at the left edge. */}
-          <ChartStack model={model} />
+          <ChartStack
+            model={model}
+            yAxisEntries={yAxisEntries}
+            degen={degen}
+          />
 
           {/* "extrema-edge" connector lines (dot → edge readout), above the chart
               content so the dashed guide reads over the line / candles. */}
@@ -2373,19 +2410,19 @@ export function LiveChart(props: LiveChartProps) {
           )}
 
           {/* Reference-line badges + labels above the fade so they stay crisp. */}
-          <ChartRefBadgeLayer model={model} />
+          <ChartRefBadgeLayer model={model} degen={degen} />
 
-          <ChartValueOverlay model={model} />
+          <ChartValueOverlay model={model} degen={degen} />
 
           {model.tradeStreamResolved && model.tradeStream && (
-            <ChartTradeStreamLayer model={model} />
+            <ChartTradeStreamLayer model={model} degen={degen} />
           )}
 
-          <ChartScrubLayer model={model} />
+          <ChartScrubLayer model={model} degen={degen} />
 
           {/* Live-price badge on top of the scrub dim so the dim never clips
               its left edge (the badge tracks the live value, not the scrub). */}
-          {model.badgeCfg && <ChartBadgeLayer model={model} />}
+          {model.badgeCfg && <ChartBadgeLayer model={model} degen={degen} />}
 
           {/* Scrub-action reticle + action badge — top-most, no shake transform. */}
           <ChartScrubActionLayer model={model} />
@@ -2444,17 +2481,15 @@ export function LiveChart(props: LiveChartProps) {
       </View>
     </GestureDetector>
   );
+}
 
-  let wrappedChart: ReactNode = chart;
+export function LiveChart(props: LiveChartProps) {
+  const model = useLiveChartController(props);
   if (model.yAxisCfg) {
-    wrappedChart = (
-      <ChartYAxisProvider model={model}>{wrappedChart}</ChartYAxisProvider>
-    );
+    return <ChartWithYAxis model={model} />;
   }
   if (model.degenCfg) {
-    wrappedChart = (
-      <ChartDegenProvider model={model}>{wrappedChart}</ChartDegenProvider>
-    );
+    return <ChartWithDegen model={model} yAxisEntries={null} />;
   }
-  return wrappedChart;
+  return <ChartView model={model} yAxisEntries={null} degen={null} />;
 }

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -118,7 +127,6 @@ import type {
   LiveChartPoint,
   LiveChartProps,
   Marker,
-  TradeEvent,
 } from "../types";
 import {
   ThresholdBadgeOverlay,
@@ -158,7 +166,6 @@ import { TradeStreamOverlay } from "./TradeStreamOverlay";
 import { ValueLineOverlay } from "./ValueLineOverlay";
 import { XAxisOverlay } from "./XAxisOverlay";
 import { YAxisOverlay } from "./YAxisOverlay";
-
 
 /** Stable empty grouping result (identity-stable so downstream worklets don't
  *  re-run) used when reference-line grouping is off. */
@@ -324,8 +331,6 @@ function useLiveChartController({
   onReachStart,
   onDegenShake,
 }: LiveChartProps) {
-  const emptyTradeStream = useSharedValue<TradeEvent[]>([]);
-  const tradeStreamSV = tradeStream ?? emptyTradeStream;
   const emptyMarkers = useSharedValue<Marker[]>([]);
   const markersSV = markers ?? emptyMarkers;
   // Stand-in threshold value so `useThreshold` can be called unconditionally
@@ -408,7 +413,10 @@ function useLiveChartController({
 
   // Form-A lines a custom `renderReferenceLine` owns → suppress their built-in tag
   // (no double-draw). Probed on the JS thread, index-aligned with `allRefLines`.
-  const refLineCustom = customReferenceLineFlags(allRefLines, renderReferenceLine);
+  const refLineCustom = customReferenceLineFlags(
+    allRefLines,
+    renderReferenceLine,
+  );
 
   // Live Y values of the *draggable* Form-A lines, folded into the engine's
   // axis-range fit so dragging a line toward / past the visible edge expands the
@@ -726,7 +734,14 @@ function useLiveChartController({
         continue;
       }
       const v = dragValues.get()[i] ?? l.value;
-      const y = computeScrubDotY(v, dMin, dMax, ch, top, effectivePadding.bottom);
+      const y = computeScrubDotY(
+        v,
+        dMin,
+        dMax,
+        ch,
+        top,
+        effectivePadding.bottom,
+      );
       ys.push(y < 0 ? -1 : Math.min(bottom, Math.max(top, y)));
     }
     return groupReferenceLines(ys, refGroupingRadius);
@@ -890,27 +905,6 @@ function useLiveChartController({
     adA * (areaDotsCfg?.opacity ?? 1),
   ];
 
-  const {
-    upBodiesPath,
-    downBodiesPath,
-    upWicksPath,
-    downWicksPath,
-    upBarsPath,
-    downBarsPath,
-  } = useCandlePaths(
-    engine,
-    effectivePadding,
-    // Match engine: stashed candles while reverse-morphing in candle mode.
-    isCandle ? candlesEngine : candles,
-    isCandle ? liveEngine : liveCandle,
-    candleWidth,
-    isCandle,
-    metricsCfg.candle,
-    volumeBandHeight,
-    volumeCfg?.radius ?? 0,
-    !isStatic, // static: no candle-width lerp loop
-    transitionsCfg.candleLerpSpeed, // `transitions.candleLerpSpeed` (1 = instant)
-  );
   const { dotX, dotY } = useLiveDot(
     engine,
     effectivePadding,
@@ -918,64 +912,9 @@ function useLiveChartController({
     badgeCfg?.followViewEdge ?? false,
   );
 
-  // Price↔pixel / time↔pixel bridge for a custom `renderOverlay`. Built
-  // unconditionally (hooks rule); only mounted when `renderOverlay` is provided.
-  const overlayContext = useChartOverlayContext(engine, effectivePadding);
-
   const momentumSV = useMomentum(engine, momentum);
 
-  const tradeMarkers = useTradeStream(
-    engine,
-    tradeStreamSV,
-    effectivePadding,
-    !isStatic && tradeStreamResolved !== null,
-    !isStatic, // static: no trade-tape loop
-  );
-
-  const {
-    pack: degenPack,
-    packRevision: degenPackRevision,
-    shakeTransform: degenShakeTransform,
-  } = useDegen(engine, dotX, dotY, momentumSV, degenCfg, onDegenShake, isStatic);
-
   // ── Overlay hooks ─────────────────────────────────────────────────────
-  const { yAxisEntries } = useYAxis(
-    engine,
-    effectivePadding,
-    formatValue,
-    skiaFont,
-    yAxisCfg?.minGap ?? 36,
-    metricsCfg.grid,
-    yAxisCfg?.count ?? 0,
-  );
-
-  const { xAxisEntries } = useXAxis(
-    engine,
-    effectivePadding,
-    formatTime,
-    skiaFont,
-  );
-
-  const badgeData = useBadge(
-    engine,
-    effectivePadding,
-    palette,
-    formatValue,
-    badgeFont,
-    badgeCfg?.variant ?? "default",
-    badgeCfg?.tail ?? true,
-    momentumSV,
-    badgeCfg?.position ?? "right",
-    badgeCfg?.background,
-    metricsCfg.badge,
-    metricsCfg.motion.badgeColorSpeed,
-    effectiveYAxisFloat,
-    engine.edgeValue,
-    badgeCfg?.followViewEdge ?? false,
-    badgeCfg?.radius,
-    badgeCfg?.textColor,
-  );
-
   // Scrub/crosshair must see the same stash-backed candles as the engine.
   const candleOpts = isCandle
     ? {
@@ -1239,8 +1178,7 @@ function useLiveChartController({
   // Hide the live dot while scrubbing when a selection dot is marking the scrub
   // point instead — otherwise both dots show at once. Applies on static charts
   // too, now that they're scrubbable.
-  const selectionDotDuringScrub =
-    scrubCfg !== null && selectionDotCfg !== null;
+  const selectionDotDuringScrub = scrubCfg !== null && selectionDotCfg !== null;
   const liveDotOpacity = useDerivedValue(
     () =>
       reveal.dotOpacity.value *
@@ -1276,7 +1214,9 @@ function useLiveChartController({
     valueMomentumColor,
     lineProp,
     formatValue,
+    formatTime,
     isCandle,
+    isStatic,
     // Half a candle width (seconds) so an "extrema" axis label's dot lands on the
     // candle's drawn center, not its bucket-start (left) edge. 0 in line mode.
     extremaTimeOffset: isCandle ? candleWidth / 2 : 0,
@@ -1297,6 +1237,7 @@ function useLiveChartController({
     gridStyleCfg,
     degenCfg,
     tradeStreamResolved,
+    tradeStream,
     leftEdgeFadeCfg,
     metricsCfg,
     allRefLines,
@@ -1355,18 +1296,17 @@ function useLiveChartController({
     gradientPositions,
     lineGroupOpacity,
     candleGroupOpacity,
+    candlesEngine,
+    liveEngine,
+    candleWidth,
+    transitionsCfg,
     layoutWidth,
     onLayout,
     linePath,
     fillPath,
     thresholdFillPath,
     lineIsLinear,
-    upBodiesPath,
-    downBodiesPath,
-    upWicksPath,
-    downWicksPath,
-    upBarsPath,
-    downBarsPath,
+    volumeCfg,
     // Volume bars: active flag, fade-in opacity, and resolved colors (default to
     // the candle palette). The reserved band height is read by the x-axis.
     volumeActive: volumeCfg !== null,
@@ -1380,13 +1320,7 @@ function useLiveChartController({
     overlayScrubFade,
     markerGroupOpacity,
     momentumSV,
-    tradeMarkers,
-    degenPack,
-    degenPackRevision,
-    degenShakeTransform,
-    yAxisEntries,
-    xAxisEntries,
-    badgeData,
+    onDegenShake,
     crosshair,
     rootGesture,
     markersActive,
@@ -1395,7 +1329,6 @@ function useLiveChartController({
     renderMarker,
     renderTooltip,
     renderOverlay,
-    overlayContext,
     // selection dot: resolved config + fallback color (the chart line/accent color)
     selectionDot: selectionDotCfg,
     selectionColor: lineProp?.color ?? palette.line,
@@ -1410,6 +1343,149 @@ function useLiveChartController({
 
 type LiveChartModel = ReturnType<typeof useLiveChartController>;
 
+type YAxisEntries = ReturnType<typeof useYAxis>["yAxisEntries"];
+const YAxisEntriesContext = createContext<YAxisEntries | null>(null);
+type DegenState = ReturnType<typeof useDegen>;
+const DegenContext = createContext<DegenState | null>(null);
+
+/** Owns the particle/shake state only while the degen effect is enabled. */
+function ChartDegenProvider({
+  model,
+  children,
+}: {
+  model: LiveChartModel;
+  children: ReactNode;
+}) {
+  const { engine, dotX, dotY, momentumSV, degenCfg, onDegenShake, isStatic } =
+    model;
+  const state = useDegen(
+    engine,
+    dotX,
+    dotY,
+    momentumSV,
+    degenCfg,
+    onDegenShake,
+    isStatic,
+  );
+  return (
+    <DegenContext.Provider value={state}>{children}</DegenContext.Provider>
+  );
+}
+
+/**
+ * Owns the Y-axis worklets. The provider itself is mounted only while the axis
+ * is enabled, so `yAxis={false}` never registers its shared values or mapper.
+ * Context lets the grid (below the plot) and floating labels (above it) share a
+ * single mapper despite living at different paint-order positions.
+ */
+function ChartYAxisProvider({
+  model,
+  children,
+}: {
+  model: LiveChartModel;
+  children: ReactNode;
+}) {
+  const {
+    engine,
+    effectivePadding,
+    formatValue,
+    skiaFont,
+    yAxisCfg,
+    metricsCfg,
+  } = model;
+  const { yAxisEntries } = useYAxis(
+    engine,
+    effectivePadding,
+    formatValue,
+    skiaFont,
+    yAxisCfg?.minGap ?? 36,
+    metricsCfg.grid,
+    yAxisCfg?.count ?? 0,
+  );
+  return (
+    <YAxisEntriesContext.Provider value={yAxisEntries}>
+      {children}
+    </YAxisEntriesContext.Provider>
+  );
+}
+
+function useChartYAxisEntries(): YAxisEntries {
+  const entries = useContext(YAxisEntriesContext);
+  if (entries === null) {
+    throw new Error(
+      "Chart Y-axis layers must be wrapped in ChartYAxisProvider",
+    );
+  }
+  return entries;
+}
+
+function ChartYAxisLayer({
+  model,
+  variant,
+}: {
+  model: LiveChartModel;
+  variant: "all" | "grid" | "labels";
+}) {
+  const {
+    reveal,
+    engine,
+    effectivePadding,
+    palette,
+    skiaFont,
+    badgeUsesRightGutter,
+    badgeCfg,
+    metricsCfg,
+    gridStyleCfg,
+    yAxisFloat,
+  } = model;
+  const entries = useChartYAxisEntries();
+  return (
+    <Group opacity={reveal.yAxisOpacity}>
+      <YAxisOverlay
+        variant={variant}
+        float={variant === "labels" && yAxisFloat}
+        entries={entries}
+        engine={engine}
+        padding={effectivePadding}
+        palette={palette}
+        font={skiaFont}
+        badge={badgeUsesRightGutter}
+        badgeTail={badgeCfg?.tail ?? true}
+        badgeMetrics={metricsCfg.badge}
+        gridStyle={gridStyleCfg}
+      />
+    </Group>
+  );
+}
+
+/** Owns the X-axis worklet and only mounts when `xAxis` is enabled. */
+function ChartXAxisLayer({ model }: { model: LiveChartModel }) {
+  const {
+    engine,
+    effectivePadding,
+    formatTime,
+    skiaFont,
+    palette,
+    volumeBandHeight,
+  } = model;
+  const { xAxisEntries } = useXAxis(
+    engine,
+    effectivePadding,
+    formatTime,
+    skiaFont,
+  );
+  return (
+    <XAxisOverlay
+      entries={xAxisEntries}
+      engine={engine}
+      padding={effectivePadding}
+      palette={palette}
+      font={skiaFont}
+      volumeBandHeight={volumeBandHeight}
+    />
+  );
+}
+
 /**
  * Background fills drawn BENEATH the left-edge fade: the y-axis grid, the area
  * gradient, and the threshold profit/loss band. Split out from `ChartStack` so
@@ -1418,19 +1494,10 @@ type LiveChartModel = ReturnType<typeof useLiveChartController>;
  */
 function ChartFillLayer({ model }: { model: LiveChartModel }) {
   const {
-    degenShakeTransform,
     yAxisCfg,
     yAxisFloat,
     reveal,
-    yAxisEntries,
-    engine,
     effectivePadding,
-    palette,
-    skiaFont,
-    badgeUsesRightGutter,
-    badgeCfg,
-    gridStyleCfg,
-    metricsCfg,
     gradientCfg,
     areaDotsCfg,
     areaDotColorVec,
@@ -1446,27 +1513,15 @@ function ChartFillLayer({ model }: { model: LiveChartModel }) {
     thresholdSeriesHasPoints,
     thresholdFillUniforms,
   } = model;
+  const degen = useContext(DegenContext);
 
   return (
-    <Group transform={degenShakeTransform}>
+    <Group transform={degen?.shakeTransform}>
       {/* Y-axis. Default: grid + labels here (in a reserved gutter). Floating
           mode: grid only — the labels + a soft edge fade draw above the candles
           in ChartStack so the plot runs full-width and candles dim under them. */}
       {yAxisCfg && (
-        <Group opacity={reveal.yAxisOpacity}>
-          <YAxisOverlay
-            variant={yAxisFloat ? "grid" : "all"}
-            entries={yAxisEntries}
-            engine={engine}
-            padding={effectivePadding}
-            palette={palette}
-            font={skiaFont}
-            badge={badgeUsesRightGutter}
-            badgeTail={badgeCfg?.tail ?? true}
-            badgeMetrics={metricsCfg.badge}
-            gridStyle={gridStyleCfg}
-          />
-        </Group>
+        <ChartYAxisLayer model={model} variant={yAxisFloat ? "grid" : "all"} />
       )}
 
       {/* Dot-lattice area fill (the under-line `fillPath` painted with a dot
@@ -1529,13 +1584,87 @@ function ChartFillLayer({ model }: { model: LiveChartModel }) {
   );
 }
 
+/**
+ * Candle/volume paths are a mode-specific subsystem. Keeping their hooks in a
+ * child means a line chart never registers the candle-width frame callback or
+ * the six derived path worklets.
+ */
+function ChartCandleLayer({ model }: { model: LiveChartModel }) {
+  const {
+    engine,
+    effectivePadding,
+    candlesEngine,
+    liveEngine,
+    candleWidth,
+    metricsCfg,
+    volumeBandHeight,
+    volumeCfg,
+    isStatic,
+    transitionsCfg,
+    candleGroupOpacity,
+    palette,
+    volumeOpacity,
+    volumeUpColor,
+    volumeDownColor,
+  } = model;
+  const {
+    upBodiesPath,
+    downBodiesPath,
+    upWicksPath,
+    downWicksPath,
+    upBarsPath,
+    downBarsPath,
+  } = useCandlePaths(
+    engine,
+    effectivePadding,
+    candlesEngine,
+    liveEngine,
+    candleWidth,
+    true,
+    metricsCfg.candle,
+    volumeBandHeight,
+    volumeCfg?.radius ?? 0,
+    !isStatic,
+    transitionsCfg.candleLerpSpeed,
+  );
+
+  return (
+    <>
+      <Group opacity={candleGroupOpacity}>
+        <Path
+          path={upWicksPath}
+          style="stroke"
+          strokeWidth={metricsCfg.candle.wickWidth}
+          color={palette.wickUp}
+        />
+        <Path
+          path={downWicksPath}
+          style="stroke"
+          strokeWidth={metricsCfg.candle.wickWidth}
+          color={palette.wickDown}
+        />
+        <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
+        <Path path={downBodiesPath} style="fill" color={palette.candleDown} />
+      </Group>
+
+      {volumeCfg && (
+        <Group opacity={candleGroupOpacity}>
+          <Group opacity={volumeOpacity}>
+            <Path path={upBarsPath} style="fill" color={volumeUpColor} />
+            <Path path={downBarsPath} style="fill" color={volumeDownColor} />
+          </Group>
+        </Group>
+      )}
+    </>
+  );
+}
+
 /** Main shaken chart stack drawn ABOVE the left-edge fade so the line stays crisp:
  *  segment dividers, value/reference lines, the line/candles, axes, dot, degen,
  *  markers, and the loading/empty art. Background fills are in `ChartFillLayer`
  *  (below the fade); the live value text is `ChartValueOverlay` (above the fade). */
 function ChartStack({ model }: { model: LiveChartModel }) {
   const {
-    degenShakeTransform,
     reveal,
     engine,
     effectivePadding,
@@ -1567,27 +1696,13 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     lineIsLinear,
     strokeWidth,
     lineProp,
-    candleGroupOpacity,
-    upWicksPath,
-    downWicksPath,
-    upBodiesPath,
-    downBodiesPath,
-    upBarsPath,
-    downBarsPath,
-    volumeActive,
-    volumeBandHeight,
-    volumeOpacity,
-    volumeUpColor,
-    volumeDownColor,
+    isCandle,
     xAxisCfg,
-    xAxisEntries,
     dotX,
     liveDotOpacity,
     pulseCfg,
     dotCfg,
     degenCfg,
-    degenPack,
-    degenPackRevision,
     markersActive,
     markersSV,
     markerClusterCfg,
@@ -1600,17 +1715,15 @@ function ChartStack({ model }: { model: LiveChartModel }) {
     layoutWidth,
     yAxisCfg,
     yAxisFloat,
-    yAxisEntries,
-    badgeUsesRightGutter,
-    gridStyleCfg,
     loadingLineColor,
     loadingStrokeWidth,
     loadingAmplitude,
     loadingSpeed,
   } = model;
+  const degen = useContext(DegenContext);
 
   return (
-    <Group transform={degenShakeTransform}>
+    <Group transform={degen?.shakeTransform}>
       {/* Segment dividers + labels (behind the line). The scrub-focus emphasis is
           painted on the line stroke itself, below — this overlay draws no fill. */}
       {resolvedSegments.map((seg, i) => (
@@ -1722,73 +1835,18 @@ function ChartStack({ model }: { model: LiveChartModel }) {
         </Path>
       </Group>
 
-      {/* Candle bodies/wicks (fades in in candle mode) */}
-      <Group opacity={candleGroupOpacity}>
-        <Path
-          path={upWicksPath}
-          style="stroke"
-          strokeWidth={metricsCfg.candle.wickWidth}
-          color={palette.wickUp}
-        />
-        <Path
-          path={downWicksPath}
-          style="stroke"
-          strokeWidth={metricsCfg.candle.wickWidth}
-          color={palette.wickDown}
-        />
-        <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
-        <Path
-          path={downBodiesPath}
-          style="fill"
-          color={palette.candleDown}
-        />
-      </Group>
-
-      {/* Volume bars in the reserved band below the candles. Fades in with the
-          candle group (outer opacity); the config opacity dims the whole band
-          (inner). Up/down bars carry their own colors (default candle palette). */}
-      {volumeActive && (
-        <Group opacity={candleGroupOpacity}>
-          <Group opacity={volumeOpacity}>
-            <Path path={upBarsPath} style="fill" color={volumeUpColor} />
-            <Path path={downBarsPath} style="fill" color={volumeDownColor} />
-          </Group>
-        </Group>
-      )}
+      {isCandle && <ChartCandleLayer model={model} />}
 
       {/* Floating axis: the labels float ABOVE the candles (right-aligned at the
           edge) so the plot runs full-width and candles stay fully visible behind
           them. (Default non-floating axis draws grid + labels in ChartFillLayer.) */}
       {yAxisCfg && yAxisFloat && (
-        <Group opacity={reveal.yAxisOpacity}>
-          <YAxisOverlay
-            variant="labels"
-            float
-            entries={yAxisEntries}
-            engine={engine}
-            padding={effectivePadding}
-            palette={palette}
-            font={skiaFont}
-            badge={badgeUsesRightGutter}
-            badgeTail={badgeCfg?.tail ?? true}
-            badgeMetrics={metricsCfg.badge}
-            gridStyle={gridStyleCfg}
-          />
-        </Group>
+        <ChartYAxisLayer model={model} variant="labels" />
       )}
 
       {/* X-axis time labels. With a volume band the bottom padding is inflated by
           the band height; pass it so the axis shifts back to the very bottom. */}
-      {xAxisCfg && (
-        <XAxisOverlay
-          entries={xAxisEntries}
-          engine={engine}
-          padding={effectivePadding}
-          palette={palette}
-          font={skiaFont}
-          volumeBandHeight={volumeBandHeight}
-        />
-      )}
+      {xAxisCfg && <ChartXAxisLayer model={model} />}
 
       {/* Live dot — the badge is drawn later (after the scrub layer) so the
           scrub dim never clips the live-price badge's left edge. Hidden while
@@ -1812,8 +1870,8 @@ function ChartStack({ model }: { model: LiveChartModel }) {
       {degenCfg && (
         <Group opacity={reveal.dotOpacity}>
           <DegenParticlesOverlay
-            pack={degenPack}
-            packRevision={degenPackRevision}
+            pack={degen!.pack}
+            packRevision={degen!.packRevision}
             engine={engine}
             palette={palette}
             particleSlotCount={degenCfg.particleSlotCount}
@@ -1882,18 +1940,47 @@ function ChartStack({ model }: { model: LiveChartModel }) {
   );
 }
 
-/** Trade-tape labels and the scrub crosshair/tooltip (drawn in canvas space, on
- *  top of the shaken stack). */
+/** Owns the trade-tape frame callback and only mounts with a trade stream. */
+function ChartTradeStreamLayer({ model }: { model: LiveChartModel }) {
+  const {
+    engine,
+    tradeStream,
+    tradeStreamResolved,
+    effectivePadding,
+    palette,
+    skiaFont,
+    reveal,
+    isStatic,
+  } = model;
+  const degen = useContext(DegenContext);
+  const tradeMarkers = useTradeStream(
+    engine,
+    tradeStream!,
+    effectivePadding,
+    !isStatic,
+    !isStatic,
+  );
+  return (
+    <Group transform={degen?.shakeTransform}>
+      <TradeStreamOverlay
+        markers={tradeMarkers}
+        palette={palette}
+        padding={effectivePadding}
+        font={skiaFont}
+        opacity={reveal.dotOpacity}
+        labelOffsetX={tradeStreamResolved!.labelOffsetX}
+      />
+    </Group>
+  );
+}
+
+/** Scrub crosshair/tooltip drawn in canvas space on top of the shaken stack. */
 function ChartScrubLayer({ model }: { model: LiveChartModel }) {
   const {
-    tradeStreamResolved,
     scrubCfg,
-    degenShakeTransform,
-    tradeMarkers,
     palette,
     effectivePadding,
     skiaFont,
-    reveal,
     crosshair,
     isCandle,
     pulseCfg,
@@ -1902,13 +1989,14 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
     selectionColor,
     renderTooltip,
   } = model;
+  const degen = useContext(DegenContext);
 
   // A custom tooltip is an RN overlay (sibling of <Canvas>), so the built-in
   // Skia tooltip is suppressed here while it's active — the line pill in line
   // mode, and the OHLC stack in candle mode (see the stack gate below).
   const customTooltipActive = renderTooltip != null;
 
-  if (!tradeStreamResolved && !scrubCfg) return null;
+  if (!scrubCfg) return null;
 
   // Extend the scrub dim past the plot's right edge to fully cover the live dot
   // (with its halo) and pulse ring, all centered on that edge. The gutter
@@ -1919,18 +2007,7 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
   );
 
   return (
-    <Group transform={degenShakeTransform}>
-      {tradeStreamResolved && (
-        <TradeStreamOverlay
-          markers={tradeMarkers}
-          palette={palette}
-          padding={effectivePadding}
-          font={skiaFont}
-          opacity={reveal.dotOpacity}
-          labelOffsetX={tradeStreamResolved.labelOffsetX}
-        />
-      )}
-
+    <Group transform={degen?.shakeTransform}>
       {scrubCfg && (
         <CrosshairOverlay
           scrubX={crosshair.scrubX}
@@ -1981,7 +2058,6 @@ function ChartScrubLayer({ model }: { model: LiveChartModel }) {
 function ChartValueOverlay({ model }: { model: LiveChartModel }) {
   const {
     showValue,
-    degenShakeTransform,
     engine,
     effectivePadding,
     palette,
@@ -1991,11 +2067,12 @@ function ChartValueOverlay({ model }: { model: LiveChartModel }) {
     valueMomentumColor,
     reveal,
   } = model;
+  const degen = useContext(DegenContext);
 
   if (!showValue) return null;
 
   return (
-    <Group transform={degenShakeTransform}>
+    <Group transform={degen?.shakeTransform}>
       <Group opacity={reveal.lineOpacity}>
         <ValueTextOverlay
           engine={engine}
@@ -2014,10 +2091,40 @@ function ChartValueOverlay({ model }: { model: LiveChartModel }) {
 /** Live-price badge, drawn above the scrub dim so the dim never clips its left
  *  edge. Shares the degen shake transform so it tracks the shaken stack. */
 function ChartBadgeLayer({ model }: { model: LiveChartModel }) {
-  const { badgeCfg, badgeData, badgeFont, reveal, degenShakeTransform } = model;
-  if (!badgeCfg) return null;
+  const {
+    badgeFont,
+    reveal,
+    engine,
+    effectivePadding,
+    palette,
+    formatValue,
+    momentumSV,
+    metricsCfg,
+    yAxisFloat,
+  } = model;
+  const degen = useContext(DegenContext);
+  const badgeCfg = model.badgeCfg!;
+  const badgeData = useBadge(
+    engine,
+    effectivePadding,
+    palette,
+    formatValue,
+    badgeFont,
+    badgeCfg.variant,
+    badgeCfg.tail,
+    momentumSV,
+    badgeCfg.position,
+    badgeCfg.background,
+    metricsCfg.badge,
+    metricsCfg.motion.badgeColorSpeed,
+    yAxisFloat,
+    engine.edgeValue,
+    badgeCfg.followViewEdge,
+    badgeCfg.radius,
+    badgeCfg.textColor,
+  );
   return (
-    <Group transform={degenShakeTransform}>
+    <Group transform={degen?.shakeTransform}>
       <Group opacity={reveal.badgeOpacity}>
         <BadgeOverlay
           badge={badgeData}
@@ -2053,12 +2160,12 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
     formatValue,
     skiaFont,
     fontProp,
-    degenShakeTransform,
     overlayScrubFade,
   } = model;
+  const degen = useContext(DegenContext);
   if (allRefLines.length === 0) return null;
   return (
-    <Group transform={degenShakeTransform} opacity={overlayScrubFade}>
+    <Group transform={degen?.shakeTransform} opacity={overlayScrubFade}>
       {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
           key={i}
@@ -2096,8 +2203,14 @@ function ChartRefBadgeLayer({ model }: { model: LiveChartModel }) {
  *  shake group so the rendered badge stays aligned with the untransformed tap
  *  hit-test; it tracks the locked reticle, not the shaken stack. */
 function ChartScrubActionLayer({ model }: { model: LiveChartModel }) {
-  const { scrubActionCfg, crosshair, engine, effectivePadding, palette, skiaFont } =
-    model;
+  const {
+    scrubActionCfg,
+    crosshair,
+    engine,
+    effectivePadding,
+    palette,
+    skiaFont,
+  } = model;
   if (
     !scrubActionCfg ||
     !crosshair.lockActive ||
@@ -2126,6 +2239,70 @@ function ChartScrubActionLayer({ model }: { model: LiveChartModel }) {
   );
 }
 
+/**
+ * RN-backed marker and reference-line slots. Their animated fade mapper is
+ * registered only when at least one custom annotation renderer is present.
+ */
+function ChartCustomAnnotations({ model }: { model: LiveChartModel }) {
+  const {
+    markersActive,
+    markersSV,
+    markerClusterCfg,
+    renderMarker,
+    renderReferenceLine,
+    allRefLines,
+    refLineCustom,
+    dragValues,
+    dragActive,
+    engine,
+    effectivePadding,
+    formatValue,
+    lineIsLinear,
+    overlayScrubFade,
+  } = model;
+  const overlayFadeStyle = useAnimatedStyle(() => ({
+    opacity: overlayScrubFade.get(),
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      style={[StyleSheet.absoluteFill, overlayFadeStyle]}
+    >
+      {markersActive && renderMarker && (
+        <CustomMarkerOverlay
+          markers={markersSV}
+          renderMarker={renderMarker}
+          engine={engine}
+          padding={effectivePadding}
+          lineData={engine.data}
+          lineLinear={lineIsLinear}
+          cluster={markerClusterCfg}
+        />
+      )}
+      {renderReferenceLine && allRefLines.length > 0 && (
+        <CustomReferenceLineOverlay
+          lines={allRefLines}
+          renderReferenceLine={renderReferenceLine}
+          custom={refLineCustom}
+          engine={engine}
+          padding={effectivePadding}
+          formatValue={formatValue}
+          dragValues={dragValues}
+          dragActive={dragActive}
+        />
+      )}
+    </Animated.View>
+  );
+}
+
+/** Owns the price/time projection worklets for the custom overlay slot. */
+function ChartCustomConsumerOverlay({ model }: { model: LiveChartModel }) {
+  const { engine, effectivePadding, renderOverlay } = model;
+  const overlayContext = useChartOverlayContext(engine, effectivePadding);
+  return <ChartOverlayLayer render={renderOverlay!} context={overlayContext} />;
+}
+
 export function LiveChart(props: LiveChartProps) {
   const model = useLiveChartController(props);
   const {
@@ -2143,34 +2320,19 @@ export function LiveChart(props: LiveChartProps) {
     topLabelCfg,
     bottomLabelCfg,
     markersActive,
-    markersSV,
-    markerClusterCfg,
     renderMarker,
     renderTooltip,
     renderOverlay,
     renderReferenceLine,
     allRefLines,
-    refLineCustom,
-    dragValues,
-    dragActive,
-    overlayContext,
     scrubCfg,
     crosshair,
-    isCandle,
     extremaTimeOffset,
     topConnector,
     bottomConnector,
-    lineIsLinear,
-    overlayScrubFade,
   } = model;
 
-  // Mirror the Skia overlay fade onto the RN custom-overlay siblings (custom
-  // markers / reference-line tags) so `scrub.hideOverlaysOnScrub` hides them too.
-  const overlayFadeStyle = useAnimatedStyle(() => ({
-    opacity: overlayScrubFade.get(),
-  }));
-
-  return (
+  const chart = (
     <GestureDetector gesture={rootGesture}>
       <View
         style={[{ flex: 1, backgroundColor }, style]}
@@ -2200,24 +2362,30 @@ export function LiveChart(props: LiveChartProps) {
 
           {/* "extrema-edge" connector lines (dot → edge readout), above the chart
               content so the dashed guide reads over the line / candles. */}
-          <ExtremaConnectorOverlay
-            engine={engine}
-            padding={effectivePadding}
-            extremaTimeOffset={extremaTimeOffset}
-            top={topConnector}
-            bottom={bottomConnector}
-          />
+          {(topConnector || bottomConnector) && (
+            <ExtremaConnectorOverlay
+              engine={engine}
+              padding={effectivePadding}
+              extremaTimeOffset={extremaTimeOffset}
+              top={topConnector}
+              bottom={bottomConnector}
+            />
+          )}
 
           {/* Reference-line badges + labels above the fade so they stay crisp. */}
           <ChartRefBadgeLayer model={model} />
 
           <ChartValueOverlay model={model} />
 
+          {model.tradeStreamResolved && model.tradeStream && (
+            <ChartTradeStreamLayer model={model} />
+          )}
+
           <ChartScrubLayer model={model} />
 
           {/* Live-price badge on top of the scrub dim so the dim never clips
               its left edge (the badge tracks the live value, not the scrub). */}
-          <ChartBadgeLayer model={model} />
+          {model.badgeCfg && <ChartBadgeLayer model={model} />}
 
           {/* Scrub-action reticle + action badge — top-most, no shake transform. */}
           <ChartScrubActionLayer model={model} />
@@ -2225,58 +2393,26 @@ export function LiveChart(props: LiveChartProps) {
 
         {/* RN labels floated over the canvas (sibling of <Canvas>, an RN view).
             Pinned to the plot's top/bottom edges via the resolved padding. */}
-        <AxisLabelOverlay
-          topLabel={topLabelCfg}
-          bottomLabel={bottomLabelCfg}
-          engine={engine}
-          formatValue={formatValue}
-          defaultColor={palette.gridLabel}
-          padding={effectivePadding}
-          extremaTimeOffset={extremaTimeOffset}
-        />
+        {(topLabelCfg || bottomLabelCfg) && (
+          <AxisLabelOverlay
+            topLabel={topLabelCfg}
+            bottomLabel={bottomLabelCfg}
+            engine={engine}
+            formatValue={formatValue}
+            defaultColor={palette.gridLabel}
+            padding={effectivePadding}
+            extremaTimeOffset={extremaTimeOffset}
+          />
+        )}
 
         {/* Custom-rendered markers — RN views floated over the canvas (non-Skia),
             pinned to each marker's live position. Sibling of <Canvas>. Wrapped in
             a box-none fade layer so `scrub.hideOverlaysOnScrub` hides them with the
             Skia markers (the wrapper is full-bleed; children keep their own
             absolute positions). */}
-        {markersActive && renderMarker && (
-          <Animated.View
-            pointerEvents="box-none"
-            style={[StyleSheet.absoluteFill, overlayFadeStyle]}
-          >
-            <CustomMarkerOverlay
-              markers={markersSV}
-              renderMarker={renderMarker}
-              engine={engine}
-              padding={effectivePadding}
-              lineData={engine.data}
-              lineLinear={lineIsLinear}
-              cluster={markerClusterCfg}
-            />
-          </Animated.View>
-        )}
-
-        {/* Custom-rendered reference-line tags — RN views floated over the canvas
-            (non-Skia), pinned to each Form-A line's value. Sibling of <Canvas>.
-            Built-in Skia tags for these lines are suppressed (no double-draw).
-            Same box-none fade wrapper as the custom markers above. */}
-        {renderReferenceLine && allRefLines.length > 0 && (
-          <Animated.View
-            pointerEvents="box-none"
-            style={[StyleSheet.absoluteFill, overlayFadeStyle]}
-          >
-            <CustomReferenceLineOverlay
-              lines={allRefLines}
-              renderReferenceLine={renderReferenceLine}
-              custom={refLineCustom}
-              engine={engine}
-              padding={effectivePadding}
-              formatValue={formatValue}
-              dragValues={dragValues}
-              dragActive={dragActive}
-            />
-          </Animated.View>
+        {((markersActive && renderMarker) ||
+          (renderReferenceLine && allRefLines.length > 0)) && (
+          <ChartCustomAnnotations model={model} />
         )}
 
         {/* Custom scrub tooltip — an RN view floated over the canvas (non-Skia),
@@ -2304,10 +2440,21 @@ export function LiveChart(props: LiveChartProps) {
         {/* Custom consumer overlay — an RN view tree floated over the canvas with
             the price↔pixel / time↔pixel bridge, for order / avg-entry / liquidation
             tags etc. Topmost RN sibling; `box-none` so empty areas still scrub. */}
-        {renderOverlay && (
-          <ChartOverlayLayer render={renderOverlay} context={overlayContext} />
-        )}
+        {renderOverlay && <ChartCustomConsumerOverlay model={model} />}
       </View>
     </GestureDetector>
   );
+
+  let wrappedChart: ReactNode = chart;
+  if (model.yAxisCfg) {
+    wrappedChart = (
+      <ChartYAxisProvider model={model}>{wrappedChart}</ChartYAxisProvider>
+    );
+  }
+  if (model.degenCfg) {
+    wrappedChart = (
+      <ChartDegenProvider model={model}>{wrappedChart}</ChartDegenProvider>
+    );
+  }
+  return wrappedChart;
 }

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -4,6 +4,13 @@ import React from "react";
 import { View } from "react-native";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import { LiveChart } from "../src/components/LiveChart";
+import * as badgeHooks from "../src/hooks/useBadge";
+import * as candlePathHooks from "../src/hooks/useCandlePaths";
+import * as chartOverlayHooks from "../src/hooks/useChartOverlayContext";
+import * as degenHooks from "../src/hooks/useDegen";
+import * as tradeStreamHooks from "../src/hooks/useTradeStream";
+import * as xAxisHooks from "../src/hooks/useXAxis";
+import * as yAxisHooks from "../src/hooks/useYAxis";
 import type {
   CandlePoint,
   LiveChartPoint,
@@ -164,6 +171,37 @@ describe("LiveChart", () => {
 
   it("supports gradient off and overlays off", () => {
     render(<Harness gradient={false} yAxis={false} badge={false} />);
+  });
+
+  it("does not register disabled optional subsystem worklets", () => {
+    const badgeSpy = jest.spyOn(badgeHooks, "useBadge");
+    const candlePathSpy = jest.spyOn(candlePathHooks, "useCandlePaths");
+    const degenSpy = jest.spyOn(degenHooks, "useDegen");
+    const overlaySpy = jest.spyOn(chartOverlayHooks, "useChartOverlayContext");
+    const tradeSpy = jest.spyOn(tradeStreamHooks, "useTradeStream");
+    const xAxisSpy = jest.spyOn(xAxisHooks, "useXAxis");
+    const yAxisSpy = jest.spyOn(yAxisHooks, "useYAxis");
+
+    render(
+      <Harness
+        badge={false}
+        degen={false}
+        xAxis={false}
+        yAxis={false}
+        renderOverlay={undefined}
+        tradeStream={undefined}
+      />,
+    );
+
+    expect(badgeSpy).not.toHaveBeenCalled();
+    expect(candlePathSpy).not.toHaveBeenCalled();
+    expect(degenSpy).not.toHaveBeenCalled();
+    expect(overlaySpy).not.toHaveBeenCalled();
+    expect(tradeSpy).not.toHaveBeenCalled();
+    expect(xAxisSpy).not.toHaveBeenCalled();
+    expect(yAxisSpy).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
   });
 
   it("renders areaDots (dot-lattice area fill) with default palette tint", () => {


### PR DESCRIPTION
## Summary

- mount Y-axis, X-axis, badge, trade stream, custom overlay, degen, and candle-path hook owners only when their feature is enabled
- keep shared Y-axis state in a provider so floating labels and grid still use one mapper
- add regression coverage proving disabled subsystems never invoke their hooks

## Physical-device result

Release/Hermes on Trooper (iPhone 17 Pro Max), static minimal line chart:

| Phase | Before | This PR | Delta |
| --- | ---: | ---: | ---: |
| Baseline | 120.3 MiB | 121.2 MiB | +0.9 MiB |
| Mounted, settled | 311.3 MiB | 253.8 MiB | -57.5 MiB |
| After unmount | 308.4 MiB | 247.4 MiB | -61.0 MiB |

Trace: /tmp/livechart-pr1-static.trace

## Verification

- npm run verify (90 suites, 1319 passing, 5 skipped)
- React Doctor changed-file scan: no new diagnostics; library score 80
- physical Release build installed and measured on Trooper