### PR TITLE
perf: profile live iOS allocation churn

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { Link, type Href } from "expo-router";
+import { Link, Redirect, type Href } from "expo-router";
 import {
   Linking,
   Pressable,
@@ -223,6 +223,9 @@ const Footer = () => (
 
 export default function Index() {
   const insets = useSafeAreaInsets();
+  if (process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE) {
+    return <Redirect href={"/memory-profile" as Href} />;
+  }
   return (
     <View style={[styles.root, { paddingTop: insets.top + 12 }]}>
       <Text style={styles.title}>LiveChart demos</Text>

--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -1,0 +1,101 @@
+/**
+ * Fixed-phase iOS memory profiling screen.
+ *
+ * Keep the synthetic feed mounted through every phase so static/live trace
+ * differences measure chart rendering rather than the JS data producer.
+ * Select the variant at bundle time with:
+ *
+ *   EXPO_PUBLIC_MEMORY_PROFILE_MODE=static|live
+ */
+import { useEffect, useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { LiveChart } from "react-native-livechart";
+import { useSimulatedChartData } from "../sim/useSimulatedChartData";
+
+const PROFILE_MODE =
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE === "static" ? "static" : "live";
+
+const PHASES = [
+  { name: "baseline", chartMounted: false, seconds: 15 },
+  { name: `${PROFILE_MODE}-chart`, chartMounted: true, seconds: 30 },
+  { name: "unmounted", chartMounted: false, seconds: 15 },
+] as const;
+
+export default function MemoryProfileScreen() {
+  const [phaseIndex, setPhaseIndex] = useState(0);
+
+  const { data, value } = useSimulatedChartData({
+    paused: false,
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    tradesPerSecond: 10,
+    maxPoints: 2000,
+    historySpanSeconds: 40,
+  });
+
+  useEffect(() => {
+    let nextPhase = 1;
+    let timer = setTimeout(function advancePhase() {
+      setPhaseIndex(nextPhase);
+      nextPhase += 1;
+      if (nextPhase < PHASES.length) {
+        timer = setTimeout(advancePhase, PHASES[nextPhase - 1].seconds * 1000);
+      }
+    }, PHASES[0].seconds * 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const phase = PHASES[phaseIndex];
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.label}>
+        MEMORY PROFILE {phaseIndex}: {phase.name}
+      </Text>
+      <Text style={styles.detail}>
+        Feed: 10 updates/s · chart: {PROFILE_MODE}
+      </Text>
+      {phase.chartMounted ? (
+        <View style={styles.chartBox}>
+          <LiveChart
+            data={data}
+            value={value}
+            static={PROFILE_MODE === "static"}
+            gradient={false}
+            badge={false}
+            pulse={false}
+            dot={false}
+            valueLine={false}
+            xAxis={false}
+            yAxis={false}
+            scrub={false}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    gap: 8,
+    paddingTop: 80,
+    paddingHorizontal: 12,
+    backgroundColor: "#0b0b12",
+  },
+  label: {
+    marginBottom: 4,
+    color: "#ffffff",
+    fontSize: 20,
+    fontWeight: "700",
+  },
+  detail: {
+    color: "#aab2c8",
+    fontSize: 14,
+  },
+  chartBox: {
+    height: 150,
+  },
+});

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -1,0 +1,128 @@
+# iOS memory profiling
+
+This note records the physical-device measurements used to separate LiveChart's
+one-time worklet compilation footprint from allocations caused by continuous
+rendering.
+
+## Environment
+
+- iPhone 17 Pro Max (Trooper), iOS 26.6
+- Release build, Hermes enabled, no Metro connection
+- Expo 57 / React Native 0.86
+- Xcode 26.6 Instruments, Activity Monitor and Allocations templates
+- One line series, no candles or trades, at 10 updates per second
+
+The profiling route is `app/memory-profile.tsx`. It keeps the synthetic producer
+alive throughout a fixed 60-second run so that the only variable is whether the
+chart is absent, mounted in static mode, or mounted in live mode:
+
+| Time    | Phase                                    |
+| ------- | ---------------------------------------- |
+| 0–15 s  | Producer only (baseline)                 |
+| 15–45 s | Chart mounted                            |
+| 45–60 s | Chart unmounted; producer remains active |
+
+Setting `EXPO_PUBLIC_MEMORY_PROFILE_MODE` to `static` or `live` selects the
+variant at bundle time and redirects the demo app to the profiling route. The
+ordinary demo index is unchanged when the variable is absent.
+
+## Physical footprint
+
+The table uses samples from 5–15 seconds for baseline, 20–44 seconds for the
+mounted phase, and 50–64 seconds for the unmounted phase. Values are the process
+physical footprint reported by Activity Monitor.
+
+| Variant | Baseline mean | Mounted mean |    Mounted max/last | Unmounted mean | Unmounted last |
+| ------- | ------------: | -----------: | ------------------: | -------------: | -------------: |
+| Static  |    123.55 MiB |   344.11 MiB | 355.08 / 355.08 MiB |     304.25 MiB |     303.77 MiB |
+| Live    |    123.65 MiB |   497.55 MiB | 555.64 / 555.64 MiB |     502.52 MiB |     501.99 MiB |
+
+Continuous rendering therefore added about 153 MiB to the mounted-phase mean
+and about 200 MiB to the observed peak. After unmount, the live run remained
+about 198 MiB above the static control. Allocations shows that most rendering
+allocations were destroyed, so the post-unmount physical footprint should be
+treated as an allocator/VM high-water observation rather than 198 MiB of proven
+live objects.
+
+## Allocation volume and lifetime
+
+Whole-run Allocations statistics make the static/live distinction clear:
+
+| Allocation class        |         Static total |           Live total |      Live persistent |
+| ----------------------- | -------------------: | -------------------: | -------------------: |
+| All heap + anonymous VM | 554.99 MiB / 706,388 | 3.36 GiB / 1,770,074 | 228.78 MiB / 177,780 |
+| Malloc 256 KiB          |     176.00 MiB / 704 |     212.75 MiB / 851 |     173.00 MiB / 692 |
+| Malloc 48 KiB           |      25.22 MiB / 538 |   329.48 MiB / 7,029 |          144 KiB / 3 |
+| Malloc 20 KiB           |      15.51 MiB / 794 |   181.48 MiB / 9,292 |       2.11 MiB / 108 |
+| Malloc 7 KiB            |    11.72 MiB / 1,714 |  158.94 MiB / 23,251 |        714 KiB / 102 |
+| Malloc 144 KiB          |          288 KiB / 2 |        1.83 MiB / 13 |           negligible |
+
+The 256 KiB class is different from the high-frequency rendering classes. Its
+retained call path is:
+
+`evalInEnvironment -> createBCProviderFromSrc -> hermes::Context -> BacktrackingBumpPtrAllocator`
+
+That is Hermes bytecode-module storage created while installing worklets. It is
+mostly persistent and remains after the chart unmounts. The upstream reproduction
+under `reproductions/worklets-hermes-module-retention` isolates this behavior
+without LiveChart or Skia.
+
+By contrast, the 48 KiB, 20 KiB, and 7 KiB classes increase by an order of
+magnitude only in live mode and nearly all instances are destroyed. In a steady
+live interval after worklet installation, the dominant cumulative allocation
+stack was:
+
+`RNSkView::requestRedraw -> RNSkPictureRenderer::renderImmediate -> SkCanvas::drawPicture -> SkRecordDraw -> Device::drawPath -> SoftwarePathRenderer::onDrawPath -> GrSWMaskHelper::init -> SkAutoPixmapStorage::tryAlloc`
+
+About 2.03 GiB flowed through the redraw/render stack in that selected interval;
+about 1.61 GiB passed through Skia's software path renderer and about 816.75 MiB
+through mask pixmap allocation. Only about 4.9 MiB created during the interval
+was still persistent at its end. The remaining live-only cost is therefore
+predominantly transient native Skia/Ganesh path rasterization and mask scratch
+allocation, not growth of the JavaScript point array.
+
+For context, reducing optional and duplicate chart worklets lowered the retained
+256 KiB compilation bucket from 238.75 MiB (955 regions) in the original chart
+to 173.00 MiB (692 regions). It also reduced the original 144 KiB allocation
+volume from 81.14 MiB (577 allocations) to 1.83 MiB (13 allocations).
+
+## Reproduce
+
+Build and install each Release variant:
+
+```sh
+EXPO_PUBLIC_MEMORY_PROFILE_MODE=static npx expo run:ios \
+  --device Trooper --configuration Release --no-bundler
+
+EXPO_PUBLIC_MEMORY_PROFILE_MODE=live npx expo run:ios \
+  --device Trooper --configuration Release --no-bundler
+```
+
+Capture the 60-second route with Activity Monitor or Allocations:
+
+```sh
+xcrun xctrace record --template 'Activity Monitor' \
+  --device DEVICE_UDID --time-limit 65s --output /tmp/livechart.trace \
+  --launch com.brandtnewlabs.react-native-livechart
+
+xcrun xctrace record --template 'Allocations' \
+  --device DEVICE_UDID --time-limit 60s --output /tmp/livechart-alloc.trace \
+  --launch com.brandtnewlabs.react-native-livechart
+```
+
+Export and summarize the Activity Monitor samples:
+
+```sh
+xcrun xctrace export --input /tmp/livechart.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="activity-monitor-process-live"]' \
+  --output /tmp/livechart.xml
+python3 scripts/summarize_activity_monitor.py /tmp/livechart.xml
+```
+
+## Follow-up targets
+
+The next useful experiments are rendering-specific: avoid redraws when geometry
+has not changed, cap the redraw rate below the display refresh rate, reduce path
+or antialiasing complexity, and determine why this workload selects Ganesh's
+software path renderer. Pooling JavaScript or SkPath wrappers is unlikely to
+address the measured mask-pixmap churn.

--- a/scripts/summarize_activity_monitor.py
+++ b/scripts/summarize_activity_monitor.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Summarize physical-footprint phases from an xctrace Activity Monitor export."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+MIB = 1024 * 1024
+
+
+def parse_phase(value: str) -> tuple[str, float, float]:
+    try:
+        name, start, end = value.split(":", 2)
+        return name, float(start), float(end)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "phase must be NAME:START_SECONDS:END_SECONDS"
+        ) from error
+
+
+def load_samples(path: Path) -> list[tuple[float, float]]:
+    root = ET.parse(path).getroot()
+    referenced_values: dict[str, str | None] = {}
+    samples: list[tuple[float, float]] = []
+
+    for row in root.findall(".//row"):
+        values: list[str | None] = []
+        for element in list(row):
+            if reference := element.get("ref"):
+                value = referenced_values.get(reference)
+            else:
+                value = element.text
+                if identifier := element.get("id"):
+                    referenced_values[identifier] = value
+            values.append(value)
+
+        # activity-monitor-process-live column 0 is start time and column 10 is
+        # physical footprint. Values are nanoseconds and bytes respectively.
+        if len(values) > 10 and values[0] is not None and values[10] is not None:
+            samples.append((int(values[0]) / 1_000_000_000, int(values[10]) / MIB))
+
+    if not samples:
+        raise ValueError(f"no Activity Monitor samples found in {path}")
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("xml", type=Path, help="XML produced by xctrace export")
+    parser.add_argument(
+        "--phase",
+        action="append",
+        type=parse_phase,
+        default=[],
+        help="NAME:START_SECONDS:END_SECONDS (repeat for each phase)",
+    )
+    args = parser.parse_args()
+    phases = args.phase or [
+        ("baseline", 5.0, 15.0),
+        ("mounted", 20.0, 44.0),
+        ("unmounted", 50.0, 64.0),
+    ]
+    samples = load_samples(args.xml)
+
+    print("| Phase | Samples | Mean | Min | Max | Last |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: |")
+    for name, start, end in phases:
+        footprints = [value for time, value in samples if start <= time <= end]
+        if not footprints:
+            raise ValueError(f"phase {name!r} has no samples between {start}s and {end}s")
+        print(
+            f"| {name} | {len(footprints)} | {statistics.fmean(footprints):.2f} MiB "
+            f"| {min(footprints):.2f} MiB | {max(footprints):.2f} MiB "
+            f"| {footprints[-1]:.2f} MiB |"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a fixed-phase Release profiling route for static and live chart modes
- add an xctrace Activity Monitor XML summarizer
- document physical-device footprint, allocation classes, and native allocation stacks

## Trooper results

- static: 123.55 MiB baseline, 344.11 MiB mounted mean, 303.77 MiB after unmount
- live: 123.65 MiB baseline, 497.55 MiB mounted mean, 501.99 MiB after unmount
- live Allocations recorded 3.36 GiB total versus 554.99 MiB static
- steady live churn resolves to RNSkView redraws through Skia software path rendering and mask pixmap allocation
- the retained 256 KiB Hermes compilation bucket is 173 MiB after the two preceding optimization PRs, down from 238.75 MiB originally

Most live-only allocation volume is destroyed; the elevated post-unmount physical footprint is therefore reported as allocator/VM high-water rather than proven live objects.

## Verification

- npm run verify: 90 suites, 1,319 passed, 5 skipped
- React Doctor: no diagnostics
- physical Release captures on iPhone 17 Pro Max, iOS 26.6
- static and live Activity Monitor and Allocations traces, 60-second fixed-phase harness