### PR TITLE
perf: add live renderer experiment matrix

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,8 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.brandtnewlabs.react-native-livechart",
-      "appleTeamId": "MCL33ZBD7G"
+      "appleTeamId": "MCL33ZBD7G",
+      "deploymentTarget": "16.4"
     },
     "android": {
       "adaptiveIcon": {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -223,7 +223,10 @@ const Footer = () => (
 
 export default function Index() {
   const insets = useSafeAreaInsets();
-  if (process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE) {
+  if (
+    process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ||
+    process.env.EXPO_PUBLIC_MEMORY_PROFILE_RUN
+  ) {
     return <Redirect href={"/memory-profile" as Href} />;
   }
   return (

--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -3,21 +3,24 @@
  *
  * Keep the synthetic feed mounted through every phase so static/live trace
  * differences measure chart rendering rather than the JS data producer.
- * Select the variant at bundle time with:
+ * Select the matrix run at bundle time with:
  *
- *   EXPO_PUBLIC_MEMORY_PROFILE_MODE=static|live
+ *   EXPO_PUBLIC_MEMORY_PROFILE_RUN=live-monotone-round
  */
 import { useEffect, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { LiveChart } from "react-native-livechart";
+import { resolveLiveRendererProfile } from "../profiling/liveRendererProfile";
 import { useSimulatedChartData } from "../sim/useSimulatedChartData";
 
-const PROFILE_MODE =
-  process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE === "static" ? "static" : "live";
+const PROFILE = resolveLiveRendererProfile(
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_RUN,
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE,
+);
 
 const PHASES = [
   { name: "baseline", chartMounted: false, seconds: 15 },
-  { name: `${PROFILE_MODE}-chart`, chartMounted: true, seconds: 30 },
+  { name: PROFILE.id, chartMounted: true, seconds: 30 },
   { name: "unmounted", chartMounted: false, seconds: 15 },
 ] as const;
 
@@ -29,9 +32,9 @@ export default function MemoryProfileScreen() {
     multiSeries: false,
     candleAggregation: false,
     tradeStream: false,
-    tradesPerSecond: 10,
-    maxPoints: 2000,
-    historySpanSeconds: 40,
+    tradesPerSecond: PROFILE.tradesPerSecond,
+    maxPoints: PROFILE.maxPoints,
+    historySpanSeconds: PROFILE.historySpanSeconds,
   });
 
   useEffect(() => {
@@ -54,14 +57,25 @@ export default function MemoryProfileScreen() {
         MEMORY PROFILE {phaseIndex}: {phase.name}
       </Text>
       <Text style={styles.detail}>
-        Feed: 10 updates/s · chart: {PROFILE_MODE}
+        {PROFILE.mode} · {PROFILE.curve} · {PROFILE.join}/{PROFILE.cap}
+      </Text>
+      <Text style={styles.detail}>
+        {PROFILE.tradesPerSecond} updates/s · {PROFILE.timeWindowSeconds}s window
+        · {PROFILE.chartHeight}px high
       </Text>
       {phase.chartMounted ? (
-        <View style={styles.chartBox}>
+        <View style={[styles.chartBox, { height: PROFILE.chartHeight }]}>
           <LiveChart
             data={data}
             value={value}
-            static={PROFILE_MODE === "static"}
+            static={PROFILE.mode === "static"}
+            timeWindow={PROFILE.timeWindowSeconds}
+            line={{
+              curve: PROFILE.curve,
+              join: PROFILE.join,
+              cap: PROFILE.cap,
+              width: PROFILE.lineWidth,
+            }}
             gradient={false}
             badge={false}
             pulse={false}
@@ -96,6 +110,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   chartBox: {
-    height: 150,
+    width: "100%",
   },
 });

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -67,6 +67,8 @@ python3 scripts/run_ios_renderer_matrix.py \
 The runner builds a Release bundle for each selection, records the same 65-second
 timeline, exports Activity Monitor XML, and writes one Markdown phase summary
 beside each trace. It refuses to overwrite traces unless `--force` is supplied.
+Metro's transform cache is keyed by the selected run, mode, and cadence so a
+sequential matrix cannot silently reuse the previous run's inlined environment.
 
 ## Physical footprint
 

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -22,9 +22,51 @@ chart is absent, mounted in static mode, or mounted in live mode:
 | 15–45 s | Chart mounted                            |
 | 45–60 s | Chart unmounted; producer remains active |
 
-Setting `EXPO_PUBLIC_MEMORY_PROFILE_MODE` to `static` or `live` selects the
-variant at bundle time and redirects the demo app to the profiling route. The
-ordinary demo index is unchanged when the variable is absent.
+Setting `EXPO_PUBLIC_MEMORY_PROFILE_RUN` selects a checked-in renderer-matrix
+run at bundle time and redirects the demo app to the profiling route. The
+original `EXPO_PUBLIC_MEMORY_PROFILE_MODE=static|live` switch remains available
+as a compatibility override. The ordinary demo index is unchanged when neither
+variable is present.
+
+## Renderer experiment matrix
+
+`profiling/live-renderer-matrix.json` is the source of truth for controlled
+renderer comparisons. Every live variant keeps the feed, window, line width,
+feature flags, and fixed phases identical unless its description names that
+dimension:
+
+| Run | Isolated question |
+| --- | --- |
+| `static-control` | How much cost remains without the continuous chart loop? |
+| `live-monotone-round` | What is the current production live baseline? |
+| `live-monotone-sharp` | Do round caps and joins drive mask churn? |
+| `live-linear-round` | Do cubic path verbs drive mask churn? |
+| `live-linear-sharp` | What does the simplest built-in stroke cost? |
+| `live-monotone-round-dense` | Does allocation volume scale with point density? |
+| `live-monotone-round-tall` | Does allocation volume scale with mask area? |
+
+List or dry-run the matrix without a connected phone:
+
+```sh
+python3 scripts/run_ios_renderer_matrix.py --list
+python3 scripts/run_ios_renderer_matrix.py \
+  --udid DEVICE_UDID --run live-monotone-round --dry-run
+```
+
+Run selected physical-device captures (omit `--run` to execute the full matrix):
+
+```sh
+python3 scripts/run_ios_renderer_matrix.py \
+  --device Trooper --udid DEVICE_UDID \
+  --capture both \
+  --run static-control \
+  --run live-monotone-round \
+  --run live-linear-sharp
+```
+
+The runner builds a Release bundle for each selection, records the same 65-second
+timeline, exports Activity Monitor XML, and writes one Markdown phase summary
+beside each trace. It refuses to overwrite traces unless `--force` is supplied.
 
 ## Physical footprint
 
@@ -91,10 +133,7 @@ volume from 81.14 MiB (577 allocations) to 1.83 MiB (13 allocations).
 Build and install each Release variant:
 
 ```sh
-EXPO_PUBLIC_MEMORY_PROFILE_MODE=static npx expo run:ios \
-  --device Trooper --configuration Release --no-bundler
-
-EXPO_PUBLIC_MEMORY_PROFILE_MODE=live npx expo run:ios \
+EXPO_PUBLIC_MEMORY_PROFILE_RUN=live-monotone-round npx expo run:ios \
   --device Trooper --configuration Release --no-bundler
 ```
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -13,9 +13,19 @@ const livechartRoot = path.resolve(
 );
 
 const config = getDefaultConfig(projectRoot);
+// Expo inlines EXPO_PUBLIC_* values during transformation, but Metro's default
+// cache key does not include those values. Profiling builds run sequentially with
+// different matrix selections, so give each selection its own transform cache;
+// otherwise a later trace can silently reuse the first run's bundle.
+const rendererProfileCacheKey = [
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_RUN ?? "default",
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ?? "default",
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE ?? "default",
+].join(":");
 
 // Metro types mark `watchFolders` readonly — merge a new object instead of mutating.
 module.exports = {
   ...config,
+  cacheVersion: `${config.cacheVersion ?? "1"}:renderer-profile:${rendererProfileCacheKey}`,
   watchFolders: [...(config.watchFolders ?? []), livechartRoot],
 };

--- a/profiling/live-renderer-matrix.json
+++ b/profiling/live-renderer-matrix.json
@@ -1,0 +1,53 @@
+{
+  "defaults": {
+    "mode": "live",
+    "curve": "monotone",
+    "join": "round",
+    "cap": "round",
+    "lineWidth": 2,
+    "tradesPerSecond": 10,
+    "historySpanSeconds": 40,
+    "timeWindowSeconds": 30,
+    "maxPoints": 2000,
+    "chartHeight": 150
+  },
+  "runs": [
+    {
+      "id": "static-control",
+      "description": "No continuous chart loop; isolates mount and worklet cost.",
+      "mode": "static"
+    },
+    {
+      "id": "live-monotone-round",
+      "description": "Current production line renderer and canonical live baseline."
+    },
+    {
+      "id": "live-monotone-sharp",
+      "description": "Keeps cubic geometry but removes round stroke caps and joins.",
+      "join": "miter",
+      "cap": "butt"
+    },
+    {
+      "id": "live-linear-round",
+      "description": "Removes cubic geometry while retaining round stroke edges.",
+      "curve": "linear"
+    },
+    {
+      "id": "live-linear-sharp",
+      "description": "Straight segments with the simplest built-in stroke edges.",
+      "curve": "linear",
+      "join": "miter",
+      "cap": "butt"
+    },
+    {
+      "id": "live-monotone-round-dense",
+      "description": "Triples incoming point density while preserving the baseline renderer.",
+      "tradesPerSecond": 30
+    },
+    {
+      "id": "live-monotone-round-tall",
+      "description": "Doubles the raster mask height while preserving path complexity.",
+      "chartHeight": 300
+    }
+  ]
+}

--- a/profiling/liveRendererProfile.test.ts
+++ b/profiling/liveRendererProfile.test.ts
@@ -1,0 +1,41 @@
+import {
+  DEFAULT_RENDERER_PROFILE_ID,
+  LIVE_RENDERER_PROFILES,
+  resolveLiveRendererProfile,
+} from "./liveRendererProfile";
+
+describe("live renderer profile matrix", () => {
+  it("has unique ids and a resolvable default", () => {
+    const ids = LIVE_RENDERER_PROFILES.map((profile) => profile.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain(DEFAULT_RENDERER_PROFILE_ID);
+  });
+
+  it("merges each run with the canonical defaults", () => {
+    for (const profile of LIVE_RENDERER_PROFILES) {
+      expect(profile.chartHeight).toBeGreaterThan(0);
+      expect(profile.historySpanSeconds).toBeGreaterThan(0);
+      expect(profile.lineWidth).toBeGreaterThan(0);
+      expect(profile.maxPoints).toBeGreaterThan(0);
+      expect(profile.timeWindowSeconds).toBeGreaterThan(0);
+      expect(profile.tradesPerSecond).toBeGreaterThan(0);
+    }
+  });
+
+  it("selects a named run and falls back for an unknown id", () => {
+    expect(resolveLiveRendererProfile("live-linear-sharp")).toMatchObject({
+      curve: "linear",
+      join: "miter",
+      cap: "butt",
+    });
+    expect(resolveLiveRendererProfile("not-a-run").id).toBe(
+      DEFAULT_RENDERER_PROFILE_ID,
+    );
+  });
+
+  it("keeps the original static/live environment variable as an override", () => {
+    expect(
+      resolveLiveRendererProfile("live-linear-sharp", "static"),
+    ).toMatchObject({ id: "live-linear-sharp", mode: "static" });
+  });
+});

--- a/profiling/liveRendererProfile.ts
+++ b/profiling/liveRendererProfile.ts
@@ -1,0 +1,58 @@
+import matrix from "./live-renderer-matrix.json";
+
+export type RendererProfileMode = "static" | "live";
+export type RendererProfileCurve = "monotone" | "linear";
+export type RendererProfileJoin = "round" | "miter" | "bevel";
+export type RendererProfileCap = "round" | "butt" | "square";
+
+export interface RendererProfile {
+  id: string;
+  description: string;
+  mode: RendererProfileMode;
+  curve: RendererProfileCurve;
+  join: RendererProfileJoin;
+  cap: RendererProfileCap;
+  lineWidth: number;
+  tradesPerSecond: number;
+  historySpanSeconds: number;
+  timeWindowSeconds: number;
+  maxPoints: number;
+  chartHeight: number;
+}
+
+type RendererProfileOverrides = Partial<
+  Omit<RendererProfile, "id" | "description">
+> & {
+  id: string;
+  description: string;
+};
+
+const defaults = matrix.defaults as Omit<
+  RendererProfile,
+  "id" | "description"
+>;
+const runs = matrix.runs as RendererProfileOverrides[];
+
+export const DEFAULT_RENDERER_PROFILE_ID = "live-monotone-round";
+
+export const LIVE_RENDERER_PROFILES: readonly RendererProfile[] = runs.map(
+  (run) => ({ ...defaults, ...run }),
+);
+
+/**
+ * Resolve the bundle-time profiling selection. `EXPO_PUBLIC_MEMORY_PROFILE_MODE`
+ * remains as a compatibility override for the original static/live harness.
+ */
+export function resolveLiveRendererProfile(
+  profileId: string | undefined,
+  legacyMode?: string,
+): RendererProfile {
+  const selected =
+    LIVE_RENDERER_PROFILES.find((profile) => profile.id === profileId) ??
+    LIVE_RENDERER_PROFILES.find(
+      (profile) => profile.id === DEFAULT_RENDERER_PROFILE_ID,
+    )!;
+
+  if (legacyMode !== "static" && legacyMode !== "live") return selected;
+  return { ...selected, mode: legacyMode };
+}

--- a/profiling/metroConfig.test.ts
+++ b/profiling/metroConfig.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const projectRoot = path.resolve(__dirname, "..");
+
+function loadCacheVersion(
+  run: string,
+  mode: string,
+  cadence: string,
+): string {
+  return execFileSync(
+    process.execPath,
+    [
+      "-e",
+      "process.stdout.write(String(require('./metro.config').cacheVersion))",
+    ],
+    {
+      cwd: projectRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        EXPO_PUBLIC_MEMORY_PROFILE_RUN: run,
+        EXPO_PUBLIC_MEMORY_PROFILE_MODE: mode,
+        EXPO_PUBLIC_MEMORY_PROFILE_CADENCE: cadence,
+      },
+    },
+  ).trim();
+}
+
+describe("renderer profiling Metro cache", () => {
+  it("uses a separate transform cache for every profiling selector", () => {
+    const baseline = loadCacheVersion("static-control", "static", "display");
+
+    expect(baseline).toContain(
+      "renderer-profile:static-control:static:display",
+    );
+    expect(loadCacheVersion("live-control", "static", "display")).not.toBe(
+      baseline,
+    );
+    expect(loadCacheVersion("static-control", "live", "display")).not.toBe(
+      baseline,
+    );
+    expect(loadCacheVersion("static-control", "static", "adaptive")).not.toBe(
+      baseline,
+    );
+  });
+});

--- a/scripts/run_ios_renderer_matrix.py
+++ b/scripts/run_ios_renderer_matrix.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Build and capture the fixed-phase iOS live-renderer experiment matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "profiling" / "live-renderer-matrix.json"
+BUNDLE_ID = "com.brandtnewlabs.react-native-livechart"
+ACTIVITY_XPATH = (
+    "/trace-toc/run[@number=\"1\"]/data/"
+    "table[@schema=\"activity-monitor-process-live\"]"
+)
+
+
+def command_text(command: list[str], env: dict[str, str] | None = None) -> str:
+    prefix = ""
+    if env:
+        prefix = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items())
+        prefix += " "
+    return prefix + shlex.join(command)
+
+
+def run_command(
+    command: list[str],
+    *,
+    extra_env: dict[str, str] | None = None,
+    dry_run: bool,
+    capture_output: bool = False,
+) -> str:
+    print(f"$ {command_text(command, extra_env)}", flush=True)
+    if dry_run:
+        return ""
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+    return result.stdout if capture_output else ""
+
+
+def load_runs() -> list[dict[str, Any]]:
+    matrix = json.loads(MATRIX_PATH.read_text())
+    defaults = matrix["defaults"]
+    return [{**defaults, **run} for run in matrix["runs"]]
+
+
+def select_runs(
+    runs: list[dict[str, Any]], selected_ids: list[str]
+) -> list[dict[str, Any]]:
+    if not selected_ids:
+        return runs
+    by_id = {run["id"]: run for run in runs}
+    missing = [run_id for run_id in selected_ids if run_id not in by_id]
+    if missing:
+        raise ValueError(f"unknown matrix run(s): {', '.join(missing)}")
+    return [by_id[run_id] for run_id in selected_ids]
+
+
+def trace_path(output_dir: Path, run_id: str, template: str) -> Path:
+    suffix = "activity" if template == "Activity Monitor" else "allocations"
+    return output_dir / f"{run_id}.{suffix}.trace"
+
+
+def remove_output(path: Path) -> None:
+    if not path.exists():
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def capture_run(
+    run: dict[str, Any],
+    *,
+    args: argparse.Namespace,
+) -> None:
+    run_id = run["id"]
+    profile_env = {"EXPO_PUBLIC_MEMORY_PROFILE_RUN": run_id}
+    print(f"\n## {run_id}: {run['description']}", flush=True)
+
+    if not args.skip_build:
+        run_command(
+            [
+                "npx",
+                "expo",
+                "run:ios",
+                "--device",
+                args.device,
+                "--configuration",
+                "Release",
+                "--no-bundler",
+            ],
+            extra_env=profile_env,
+            dry_run=args.dry_run,
+        )
+
+    templates = []
+    if args.capture in ("activity", "both"):
+        templates.append("Activity Monitor")
+    if args.capture in ("allocations", "both"):
+        templates.append("Allocations")
+
+    for template in templates:
+        trace = trace_path(args.output_dir, run_id, template)
+        if trace.exists() and not args.force and not args.dry_run:
+            raise FileExistsError(f"refusing to overwrite existing trace: {trace}")
+        if trace.exists() and args.force and not args.dry_run:
+            remove_output(trace)
+        run_command(
+            [
+                "xcrun",
+                "xctrace",
+                "record",
+                "--template",
+                template,
+                "--device",
+                args.udid,
+                "--time-limit",
+                "65s",
+                "--output",
+                str(trace),
+                "--launch",
+                BUNDLE_ID,
+            ],
+            dry_run=args.dry_run,
+        )
+
+        if template != "Activity Monitor":
+            continue
+        xml = args.output_dir / f"{run_id}.activity.xml"
+        summary = args.output_dir / f"{run_id}.activity.md"
+        if args.force and not args.dry_run:
+            remove_output(xml)
+            remove_output(summary)
+        run_command(
+            [
+                "xcrun",
+                "xctrace",
+                "export",
+                "--input",
+                str(trace),
+                "--xpath",
+                ACTIVITY_XPATH,
+                "--output",
+                str(xml),
+            ],
+            dry_run=args.dry_run,
+        )
+        markdown = run_command(
+            [
+                sys.executable,
+                "scripts/summarize_activity_monitor.py",
+                str(xml),
+            ],
+            dry_run=args.dry_run,
+            capture_output=True,
+        )
+        if not args.dry_run:
+            summary.write_text(markdown)
+            print(markdown, end="")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="Trooper", help="Expo device name")
+    parser.add_argument("--udid", help="xctrace device identifier")
+    parser.add_argument(
+        "--run",
+        action="append",
+        default=[],
+        help="matrix run id; repeat to select multiple (default: all)",
+    )
+    parser.add_argument(
+        "--capture",
+        choices=("activity", "allocations", "both"),
+        default="activity",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("/tmp/livechart-renderer-matrix"),
+    )
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--list", action="store_true")
+    args = parser.parse_args()
+
+    runs = load_runs()
+    if args.list:
+        for run in runs:
+            print(f"{run['id']}: {run['description']}")
+        return
+    if not args.udid:
+        parser.error("--udid is required unless --list is used")
+
+    selected = select_runs(runs, args.run)
+    if args.skip_build and len(selected) != 1:
+        parser.error("--skip-build requires exactly one --run selection")
+    if not args.dry_run:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+    for run in selected:
+        capture_run(run, args=args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- replace the single hard-coded memory probe with a checked-in renderer experiment matrix
- isolate curve geometry, stroke edges, point density, and raster-mask height while keeping fixed profiling phases
- add a runner that builds, records, exports, and summarizes selected Activity Monitor and Allocations captures

## Why

PR #194 identified steady live allocation churn in Skia's software path renderer and mask pixmap allocation. This matrix makes each suspected rendering dimension reproducible before production behavior changes.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand --silent` (91 suites, 1,323 passed, 5 skipped)
- React Doctor against `origin/codex/profile-live-allocation-churn`: 100/100 for changed source
- matrix `--list` and selected-run `--dry-run`
