### PR TITLE
perf: evaluate adaptive chart redraw cadence

### DIFF
--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -18,6 +18,15 @@ const PROFILE = resolveLiveRendererProfile(
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE,
 );
 
+// Keep Expo's bundle-time environment access in the example app. The library
+// reads this only when the profiling screen mounts, preserving its Node-free
+// declaration build and avoiding a public profiling prop.
+(
+  globalThis as typeof globalThis & {
+    __reactNativeLiveChartProfileCadence?: string;
+  }
+).__reactNativeLiveChartProfileCadence = PROFILE.cadence;
+
 const PHASES = [
   { name: "baseline", chartMounted: false, seconds: 15 },
   { name: PROFILE.id, chartMounted: true, seconds: 30 },

--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -9,6 +9,7 @@
  */
 import { useEffect, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import { LiveChart } from "react-native-livechart";
 import { resolveLiveRendererProfile } from "../profiling/liveRendererProfile";
 import { useSimulatedChartData } from "../sim/useSimulatedChartData";
@@ -18,14 +19,10 @@ const PROFILE = resolveLiveRendererProfile(
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE,
 );
 
-// Keep Expo's bundle-time environment access in the example app. The library
-// reads this only when the profiling screen mounts, preserving its Node-free
-// declaration build and avoiding a public profiling prop.
-(
-  globalThis as typeof globalThis & {
-    __reactNativeLiveChartProfileCadence?: string;
-  }
-).__reactNativeLiveChartProfileCadence = PROFILE.cadence;
+type LiveChartProfileGlobal = typeof globalThis & {
+  __reactNativeLiveChartProfileCadence?: string;
+  __reactNativeLiveChartProfilePublicationCount?: SharedValue<number>;
+};
 
 const PHASES = [
   { name: "baseline", chartMounted: false, seconds: 15 },
@@ -35,6 +32,10 @@ const PHASES = [
 
 export default function MemoryProfileScreen() {
   const [phaseIndex, setPhaseIndex] = useState(0);
+  const [completedPublicationCount, setCompletedPublicationCount] = useState<
+    number | null
+  >(null);
+  const publicationCount = useSharedValue(0);
 
   const { data, value } = useSimulatedChartData({
     paused: false,
@@ -47,8 +48,22 @@ export default function MemoryProfileScreen() {
   });
 
   useEffect(() => {
+    // Keep profiling controls in the example app and remove them when the route
+    // unmounts, so ordinary library charts retain the production display path.
+    const profileGlobal = globalThis as LiveChartProfileGlobal;
+    profileGlobal.__reactNativeLiveChartProfileCadence = PROFILE.cadence;
+    profileGlobal.__reactNativeLiveChartProfilePublicationCount =
+      publicationCount;
+    return () => {
+      delete profileGlobal.__reactNativeLiveChartProfileCadence;
+      delete profileGlobal.__reactNativeLiveChartProfilePublicationCount;
+    };
+  }, [publicationCount]);
+
+  useEffect(() => {
     let nextPhase = 1;
     let timer = setTimeout(function advancePhase() {
+      if (nextPhase === 1) publicationCount.set(0);
       setPhaseIndex(nextPhase);
       nextPhase += 1;
       if (nextPhase < PHASES.length) {
@@ -56,7 +71,16 @@ export default function MemoryProfileScreen() {
       }
     }, PHASES[0].seconds * 1000);
     return () => clearTimeout(timer);
-  }, []);
+  }, [publicationCount]);
+
+  useEffect(() => {
+    if (phaseIndex !== 2) return;
+    const count = publicationCount.get();
+    setCompletedPublicationCount(count);
+    console.info(
+      `[livechart-profile] ${PROFILE.id}: ${count} engine publications`,
+    );
+  }, [phaseIndex, publicationCount]);
 
   const phase = PHASES[phaseIndex];
 
@@ -72,6 +96,9 @@ export default function MemoryProfileScreen() {
       <Text style={styles.detail}>
         {PROFILE.tradesPerSecond} updates/s · {PROFILE.timeWindowSeconds}s window
         · {PROFILE.chartHeight}px high
+      </Text>
+      <Text style={styles.detail}>
+        publications: {completedPublicationCount ?? "counting during mount"}
       </Text>
       {phase.chartMounted ? (
         <View style={[styles.chartBox, { height: PROFILE.chartHeight }]}>

--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -57,7 +57,8 @@ export default function MemoryProfileScreen() {
         MEMORY PROFILE {phaseIndex}: {phase.name}
       </Text>
       <Text style={styles.detail}>
-        {PROFILE.mode} · {PROFILE.curve} · {PROFILE.join}/{PROFILE.cap}
+        {PROFILE.mode} · {PROFILE.cadence} · {PROFILE.curve} · {PROFILE.join}/
+        {PROFILE.cap}
       </Text>
       <Text style={styles.detail}>
         {PROFILE.tradesPerSecond} updates/s · {PROFILE.timeWindowSeconds}s window

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -46,6 +46,8 @@ dimension:
 | --- | --- |
 | `static-control` | How much cost remains without the continuous chart loop? |
 | `live-monotone-round` | What is the current production live baseline? |
+| `live-monotone-round-30fps` | How much churn disappears at a fixed 30 fps? |
+| `live-monotone-round-adaptive` | Can visible pixel velocity retain 60 fps only where it matters? |
 | `live-monotone-sharp` | Do round caps and joins drive mask churn? |
 | `live-linear-round` | Do cubic path verbs drive mask churn? |
 | `live-linear-sharp` | What does the simplest built-in stroke cost? |
@@ -92,6 +94,18 @@ timeline, exports Activity Monitor XML, and writes one Markdown phase summary
 beside each trace. It refuses to overwrite traces unless `--force` is supplied.
 Metro's transform cache is keyed by the selected run, mode, and cadence so a
 sequential matrix cannot silently reuse the previous run's inlined environment.
+
+Use a physical iOS device: simulator Activity Monitor recordings do not produce
+a valid Instruments trace for this workflow.
+
+The cadence variants are profiling-only bundle switches. `display` preserves the
+existing frame callback. `fixed30` accumulates adjacent display-frame deltas and
+publishes the engine at 30 fps. `adaptive` waits for one half-pixel of horizontal
+movement, clamped between 30 and 60 fps. The accumulated elapsed time is passed
+to the next tick, so easing duration is unchanged; only expensive publication
+and redraw frequency differs. With the canonical 400-point-wide, 30-second
+window, adaptive cadence resolves to 33.3 ms: one publication for every two
+60 Hz display callbacks, or about half as many steady-state redraw requests.
 
 ## Bundle Mode simulator screen
 

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -47,7 +47,9 @@ dimension:
 | `static-control` | How much cost remains without the continuous chart loop? |
 | `live-monotone-round` | What is the current production live baseline? |
 | `live-monotone-round-30fps` | How much churn disappears at a fixed 30 fps? |
-| `live-monotone-round-adaptive` | Can visible pixel velocity retain 60 fps only where it matters? |
+| `live-monotone-round-adaptive-10s` | Does adaptive retain 60 fps for fast 10-second windows? |
+| `live-monotone-round-adaptive-20s` | Does adaptive choose an intermediate 40 fps for 20-second windows? |
+| `live-monotone-round-adaptive` | Does adaptive settle at 30 fps for slow 30-second windows? |
 | `live-monotone-sharp` | Do round caps and joins drive mask churn? |
 | `live-linear-round` | Do cubic path verbs drive mask churn? |
 | `live-linear-sharp` | What does the simplest built-in stroke cost? |
@@ -103,9 +105,16 @@ existing frame callback. `fixed30` accumulates adjacent display-frame deltas and
 publishes the engine at 30 fps. `adaptive` waits for one half-pixel of horizontal
 movement, clamped between 30 and 60 fps. The accumulated elapsed time is passed
 to the next tick, so easing duration is unchanged; only expensive publication
-and redraw frequency differs. With the canonical 400-point-wide, 30-second
-window, adaptive cadence resolves to 33.3 ms: one publication for every two
-60 Hz display callbacks, or about half as many steady-state redraw requests.
+and redraw frequency differs. Cadence phase remainder is retained separately so
+the 25 ms intermediate target alternates one- and two-frame gaps on a 60 Hz
+display instead of quantizing down to 30 fps. The profiling route counts actual
+engine publications during the mounted phase, logs the result, and shows it in
+the unmounted phase. At 400 points wide, the 10-, 20-, and 30-second adaptive
+runs target 60, 40, and 30 publications per second respectively.
+
+This remains a single-series `LiveChart` experiment, not a supported public API
+or a shipped optimization. Productionizing it would require an explicit API,
+multi-series behavior, public docs, and a changelog entry in a separate change.
 
 ## Bundle Mode simulator screen
 

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -47,7 +47,9 @@ dimension:
 | `static-control` | How much cost remains without the continuous chart loop? |
 | `live-monotone-round` | What is the current production live baseline? |
 | `live-monotone-round-30fps` | How much churn disappears at a fixed 30 fps? |
+| `live-monotone-round-10s` | Display-cadence control for the 10-second adaptive run. |
 | `live-monotone-round-adaptive-10s` | Does adaptive retain 60 fps for fast 10-second windows? |
+| `live-monotone-round-20s` | Display-cadence control for the 20-second adaptive run. |
 | `live-monotone-round-adaptive-20s` | Does adaptive choose an intermediate 40 fps for 20-second windows? |
 | `live-monotone-round-adaptive` | Does adaptive settle at 30 fps for slow 30-second windows? |
 | `live-monotone-sharp` | Do round caps and joins drive mask churn? |
@@ -110,11 +112,65 @@ the 25 ms intermediate target alternates one- and two-frame gaps on a 60 Hz
 display instead of quantizing down to 30 fps. The profiling route counts actual
 engine publications during the mounted phase, logs the result, and shows it in
 the unmounted phase. At 400 points wide, the 10-, 20-, and 30-second adaptive
-runs target 60, 40, and 30 publications per second respectively.
+runs target 60, 40, and 30 publications per second respectively. Each adaptive
+window has a matched display-cadence control so window size and visible path
+complexity are held constant within the comparison.
 
 This remains a single-series `LiveChart` experiment, not a supported public API
 or a shipped optimization. Productionizing it would require an explicit API,
 multi-series behavior, public docs, and a changelog entry in a separate change.
+
+## Adaptive cadence physical-device screen
+
+The cadence experiment was screened in Release Bundle Mode on the physical
+iPhone described above. Activity Monitor used the same fixed phases and sample
+windows as the other physical-device runs. Display-cadence 30-second runs were
+recorded A/B/A around the fixed-30 run; the 10- and 20-second adaptive runs use
+the matched display controls from the renderer matrix.
+
+| Run | Mounted footprint mean | Mounted CPU mean | Unmounted footprint last |
+| --- | ---: | ---: | ---: |
+| Display 30 s, A1 | 323.42 MiB | 50.74% | 353.63 MiB |
+| Fixed 30 fps, 30 s | 241.31 MiB | 19.35% | 232.55 MiB |
+| Display 30 s, A2 | 317.25 MiB | 39.61% | 317.14 MiB |
+| Display 10 s | 292.80 MiB | 39.17% | 306.34 MiB |
+| Adaptive 10 s | 247.85 MiB | 18.26% | 235.75 MiB |
+| Display 20 s | 280.01 MiB | 32.18% | 267.00 MiB |
+| Adaptive 20 s | 232.73 MiB | 24.59% | 194.99 MiB |
+| Adaptive 30 s | 237.79 MiB | 19.32% | 224.31 MiB |
+
+Against its matched display control, adaptive cadence reduced mounted physical
+footprint by 15.4% at 10 seconds and 16.9% at 20 seconds, while mounted CPU fell
+by 53.4% and 23.6% respectively. Adaptive 30 seconds reduced footprint by 25.8%
+and CPU by 57.2% against the mean of the two display A passes. It closely matched
+the fixed-30 run, as expected because the adaptive formula reaches its 30 fps
+floor at that window. The display A CPU passes differ materially, so these are
+directional screening results rather than benchmark-precision estimates.
+
+The on-screen publication counter independently confirmed that the scheduler
+selected distinct tiers on the phone's 120 Hz display:
+
+| Run | Publications in mounted 30 s | Observed rate |
+| --- | ---: | ---: |
+| Display 10 s | 3,592 | 119.7/s |
+| Adaptive 10 s | 1,797 | 59.9/s |
+| Adaptive 20 s | 1,246 | 41.5/s |
+| Adaptive 30 s | 898 | 29.9/s |
+
+The intermediate rate is slightly above the 40/s example because the physical
+canvas was about 416 points wide. This counter evidence fixes the original
+30-second-only matrix flaw: the adaptive experiment now demonstrates 60, about
+40, and 30 publications per second rather than comparing two equivalent 30 fps
+runs.
+
+Allocations traces completed for both display A passes, fixed 30 fps, adaptive
+20 seconds, and adaptive 30 seconds. Each saved trace package passes TOC
+validation with `xctrace export`; allocation-volume and lifetime comparison
+still requires manual inspection in Instruments. Animation Hitches produced an
+incomplete trace with a dylib-overlap finalization warning, and two Game
+Performance retries timed out while attaching to the connected phone. Frame
+pacing and hitch evidence is therefore still open, and this experiment should
+remain a draft rather than be treated as a merge-ready production optimization.
 
 ## Bundle Mode simulator screen
 
@@ -177,9 +233,9 @@ trace also completed and saved successfully over USB.
 
 ## Physical footprint
 
-The table uses samples from 5–15 seconds for baseline, 20–44 seconds for the
-mounted phase, and 50–64 seconds for the unmounted phase. Values are the process
-physical footprint reported by Activity Monitor.
+The summary uses samples from 5–15 seconds for baseline, 20–44 seconds for the
+mounted phase, and 50–64 seconds for the unmounted phase. It reports both the
+process physical footprint and CPU percentage from Activity Monitor.
 
 | Variant | Baseline mean | Mounted mean |    Mounted max/last | Unmounted mean | Unmounted last |
 | ------- | ------------: | -----------: | ------------------: | -------------: | -------------: |

--- a/packages/react-native-livechart/src/core/renderCadence.ts
+++ b/packages/react-native-livechart/src/core/renderCadence.ts
@@ -1,0 +1,39 @@
+import { MS_PER_FRAME_60FPS } from "../constants";
+
+export type RenderCadenceMode = "display" | "fixed30" | "adaptive";
+
+export const FIXED_30FPS_INTERVAL_MS = 1000 / 30;
+export const ADAPTIVE_PIXEL_STEP = 0.5;
+
+/** Bundle-time profiling mode. Unknown/absent values preserve display cadence. */
+export function resolveRenderCadenceMode(
+  value: string | undefined,
+): RenderCadenceMode {
+  return value === "fixed30" || value === "adaptive" ? value : "display";
+}
+
+/**
+ * Minimum time between expensive chart-state publications for a profiling mode.
+ *
+ * Adaptive cadence waits until steady horizontal scrolling would move by half a
+ * pixel, clamped to 30–60 fps. Short windows therefore retain display cadence;
+ * longer, slower windows coalesce adjacent display frames.
+ */
+export function renderCadenceIntervalMs(
+  mode: RenderCadenceMode,
+  canvasWidth: number,
+  displayWindowSeconds: number,
+): number {
+  "worklet";
+  if (mode === "display" || canvasWidth <= 0 || displayWindowSeconds <= 0) {
+    return 0;
+  }
+  if (mode === "fixed30") return FIXED_30FPS_INTERVAL_MS;
+
+  const pixelsPerSecond = canvasWidth / displayWindowSeconds;
+  const halfPixelInterval = (ADAPTIVE_PIXEL_STEP / pixelsPerSecond) * 1000;
+  return Math.max(
+    MS_PER_FRAME_60FPS,
+    Math.min(FIXED_30FPS_INTERVAL_MS, halfPixelInterval),
+  );
+}

--- a/packages/react-native-livechart/src/core/renderCadence.ts
+++ b/packages/react-native-livechart/src/core/renderCadence.ts
@@ -1,13 +1,33 @@
 import { MS_PER_FRAME_60FPS } from "../constants";
+import type { SharedValue } from "react-native-reanimated";
 
 export type RenderCadenceMode = "display" | "fixed30" | "adaptive";
 
 type RenderCadenceProfileGlobal = typeof globalThis & {
   __reactNativeLiveChartProfileCadence?: string;
+  __reactNativeLiveChartProfilePublicationCount?: SharedValue<number>;
 };
+
+export interface RenderCadenceSchedulerState {
+  /** Wall-clock time that the next engine publication must consume. */
+  elapsedSincePublicationMs: number;
+  /** Cadence phase, retained across publications to avoid display-rate quantization. */
+  cadenceElapsedMs: number;
+  /** Number of engine publications selected by this scheduler. */
+  publicationCount: number;
+}
 
 export const FIXED_30FPS_INTERVAL_MS = 1000 / 30;
 export const ADAPTIVE_PIXEL_STEP = 0.5;
+const CADENCE_TOLERANCE_MS = 0.01;
+
+export function makeRenderCadenceSchedulerState(): RenderCadenceSchedulerState {
+  return {
+    elapsedSincePublicationMs: 0,
+    cadenceElapsedMs: 0,
+    publicationCount: 0,
+  };
+}
 
 /** Bundle-time profiling mode. Unknown/absent values preserve display cadence. */
 export function resolveRenderCadenceMode(
@@ -26,6 +46,14 @@ export function resolveRenderCadenceProfileOverride(
   const value = (globalThis as RenderCadenceProfileGlobal)
     .__reactNativeLiveChartProfileCadence;
   return resolveRenderCadenceMode(value, fallback);
+}
+
+/** Read the profiling screen's counter without exposing a production prop. */
+export function resolveRenderCadencePublicationCounter():
+  | SharedValue<number>
+  | undefined {
+  return (globalThis as RenderCadenceProfileGlobal)
+    .__reactNativeLiveChartProfilePublicationCount;
 }
 
 /**
@@ -52,4 +80,51 @@ export function renderCadenceIntervalMs(
     MS_PER_FRAME_60FPS,
     Math.min(FIXED_30FPS_INTERVAL_MS, halfPixelInterval),
   );
+}
+
+/**
+ * Accumulate display callbacks and return the elapsed time for the next engine
+ * publication, or `null` when this frame should be coalesced.
+ *
+ * Cadence phase is separate from elapsed engine time. Retaining phase remainder
+ * lets a 25 ms target alternate across 60 Hz frames and average 40 publications
+ * per second, while the returned elapsed time still covers every display delta.
+ */
+export function scheduleRenderCadenceFrame(
+  state: RenderCadenceSchedulerState,
+  mode: RenderCadenceMode,
+  frameMs: number,
+  canvasWidth: number,
+  displayWindowSeconds: number,
+): number | null {
+  "worklet";
+  const intervalMs = renderCadenceIntervalMs(
+    mode,
+    canvasWidth,
+    displayWindowSeconds,
+  );
+  if (intervalMs === 0) {
+    state.elapsedSincePublicationMs = 0;
+    state.cadenceElapsedMs = 0;
+    state.publicationCount += 1;
+    return frameMs;
+  }
+
+  const elapsedMs = state.elapsedSincePublicationMs + frameMs;
+  const cadenceElapsedMs = state.cadenceElapsedMs + frameMs;
+  state.elapsedSincePublicationMs = elapsedMs;
+  state.cadenceElapsedMs = cadenceElapsedMs;
+  if (cadenceElapsedMs + CADENCE_TOLERANCE_MS < intervalMs) return null;
+
+  const elapsedIntervals = Math.max(
+    1,
+    Math.floor((cadenceElapsedMs + CADENCE_TOLERANCE_MS) / intervalMs),
+  );
+  state.cadenceElapsedMs = Math.max(
+    0,
+    cadenceElapsedMs - elapsedIntervals * intervalMs,
+  );
+  state.elapsedSincePublicationMs = 0;
+  state.publicationCount += 1;
+  return elapsedMs;
 }

--- a/packages/react-native-livechart/src/core/renderCadence.ts
+++ b/packages/react-native-livechart/src/core/renderCadence.ts
@@ -2,14 +2,30 @@ import { MS_PER_FRAME_60FPS } from "../constants";
 
 export type RenderCadenceMode = "display" | "fixed30" | "adaptive";
 
+type RenderCadenceProfileGlobal = typeof globalThis & {
+  __reactNativeLiveChartProfileCadence?: string;
+};
+
 export const FIXED_30FPS_INTERVAL_MS = 1000 / 30;
 export const ADAPTIVE_PIXEL_STEP = 0.5;
 
 /** Bundle-time profiling mode. Unknown/absent values preserve display cadence. */
 export function resolveRenderCadenceMode(
   value: string | undefined,
+  fallback: RenderCadenceMode = "display",
 ): RenderCadenceMode {
-  return value === "fixed30" || value === "adaptive" ? value : "display";
+  return value === "display" || value === "fixed30" || value === "adaptive"
+    ? value
+    : fallback;
+}
+
+/** Read the example app's bundle-time profiling override without Node globals. */
+export function resolveRenderCadenceProfileOverride(
+  fallback: RenderCadenceMode = "display",
+): RenderCadenceMode {
+  const value = (globalThis as RenderCadenceProfileGlobal)
+    .__reactNativeLiveChartProfileCadence;
+  return resolveRenderCadenceMode(value, fallback);
 }
 
 /**

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -24,8 +24,11 @@ import {
   type EngineTickMutable,
 } from "./liveChartEngineTick";
 import {
-  renderCadenceIntervalMs,
+  makeRenderCadenceSchedulerState,
+  resolveRenderCadencePublicationCounter,
   resolveRenderCadenceProfileOverride,
+  scheduleRenderCadenceFrame,
+  type RenderCadenceSchedulerState,
 } from "./renderCadence";
 
 export interface EngineConfig {
@@ -241,6 +244,7 @@ export interface EngineFrameRefs {
 export interface EngineFrameScratch {
   state: EngineTickMutable;
   input: EngineTickInput;
+  cadence: RenderCadenceSchedulerState;
 }
 
 /** Allocate one single-series frame scratch. Call once per engine instance. */
@@ -270,6 +274,7 @@ export function makeEngineFrameScratch(): EngineFrameScratch {
       targetValue: 0,
       points: [],
     },
+    cadence: makeRenderCadenceSchedulerState(),
   };
 }
 
@@ -377,6 +382,8 @@ export function useLiveChartEngine(
   // The example app can select a bundle-time experiment without making Node's
   // `process` global part of the publishable library's declaration build.
   const profileRenderCadence = resolveRenderCadenceProfileOverride();
+  const profilePublicationCounter =
+    resolveRenderCadencePublicationCounter();
   // Pinch-zoom window-width override (null = follow the configured window).
   // Declared first so `timeWindow` below can fold it in. Defaults to null so
   // charts without `zoom` behave exactly as before.
@@ -467,11 +474,6 @@ export function useLiveChartEngine(
   // the live edge over that progress. `returnT` rests at 1 (no glide in flight).
   const returnT = useSharedValue(1);
   const returnFrom = useSharedValue(0);
-  // Time accumulated while an experiment coalesces adjacent display frames.
-  // This SharedValue has no renderer subscriber, so updating it does not request
-  // a Skia redraw. The full elapsed time is passed to the next engine tick.
-  const cadenceElapsedMs = useSharedValue(0);
-
   // Live data extrema (value + time of the visible high / low). NaN until the
   // first tick finds data — the extrema label stays hidden until then.
   const extremaMinValue = useSharedValue(NaN);
@@ -545,35 +547,38 @@ export function useLiveChartEngine(
   if (frameScratchRef.current === null) {
     frameScratchRef.current = makeEngineFrameScratch();
   }
-
   // `autostart=false` registers the frame callback without running it — the live
   // loop is fully inert in static mode (the invariant that makes this worth it).
   useFrameCallback((frameInfo) => {
     "worklet";
+    // Production charts take this branch: no profiling SharedValue reads and no
+    // cadence calculation are added to the normal display-rate callback.
+    if (profileRenderCadence === "display") {
+      applyLiveChartEngineFrame(frameInfo, frameRefs, frameScratchRef.current!);
+      if (profilePublicationCounter) {
+        profilePublicationCounter.set(profilePublicationCounter.get() + 1);
+      }
+      return;
+    }
+
     const frameMs =
       frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
-    const intervalMs = renderCadenceIntervalMs(
+    const elapsedMs = scheduleRenderCadenceFrame(
+      frameScratchRef.current!.cadence,
       profileRenderCadence,
+      frameMs,
       canvasWidth.get(),
       displayWindow.get(),
     );
-    if (intervalMs > 0) {
-      const elapsedMs = cadenceElapsedMs.get() + frameMs;
-      // Small tolerance avoids a 120 Hz device needing a fifth frame because
-      // four reported deltas sum a few floating-point microseconds below 1/30s.
-      if (elapsedMs + 0.01 < intervalMs) {
-        cadenceElapsedMs.set(elapsedMs);
-        return;
-      }
-      cadenceElapsedMs.set(0);
-      applyLiveChartEngineFrame(
-        { timeSincePreviousFrame: elapsedMs },
-        frameRefs,
-        frameScratchRef.current!,
-      );
-      return;
+    if (elapsedMs === null) return;
+    applyLiveChartEngineFrame(
+      { timeSincePreviousFrame: elapsedMs },
+      frameRefs,
+      frameScratchRef.current!,
+    );
+    if (profilePublicationCounter) {
+      profilePublicationCounter.set(profilePublicationCounter.get() + 1);
     }
-    applyLiveChartEngineFrame(frameInfo, frameRefs, frameScratchRef.current!);
   }, !config.static);
 
   // When time-scroll is disabled while scrolled back, return the window to the

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -25,14 +25,8 @@ import {
 } from "./liveChartEngineTick";
 import {
   renderCadenceIntervalMs,
-  resolveRenderCadenceMode,
+  resolveRenderCadenceProfileOverride,
 } from "./renderCadence";
-
-// Profiling-only bundle switch. The production default remains `display` until
-// physical-device measurements justify a lower adaptive publication cadence.
-const PROFILE_RENDER_CADENCE = resolveRenderCadenceMode(
-  process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE,
-);
 
 export interface EngineConfig {
   data: SharedValue<LiveChartPoint[]>;
@@ -380,6 +374,9 @@ export function applyLiveChartEngineFrame(
 export function useLiveChartEngine(
   config: EngineConfig,
 ): SingleEngineState & ChartEngineScroll & ChartEngineEdge {
+  // The example app can select a bundle-time experiment without making Node's
+  // `process` global part of the publishable library's declaration build.
+  const profileRenderCadence = resolveRenderCadenceProfileOverride();
   // Pinch-zoom window-width override (null = follow the configured window).
   // Declared first so `timeWindow` below can fold it in. Defaults to null so
   // charts without `zoom` behave exactly as before.
@@ -556,7 +553,7 @@ export function useLiveChartEngine(
     const frameMs =
       frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
     const intervalMs = renderCadenceIntervalMs(
-      PROFILE_RENDER_CADENCE,
+      profileRenderCadence,
       canvasWidth.get(),
       displayWindow.get(),
     );

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -23,6 +23,16 @@ import {
   type EngineTickInput,
   type EngineTickMutable,
 } from "./liveChartEngineTick";
+import {
+  renderCadenceIntervalMs,
+  resolveRenderCadenceMode,
+} from "./renderCadence";
+
+// Profiling-only bundle switch. The production default remains `display` until
+// physical-device measurements justify a lower adaptive publication cadence.
+const PROFILE_RENDER_CADENCE = resolveRenderCadenceMode(
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE,
+);
 
 export interface EngineConfig {
   data: SharedValue<LiveChartPoint[]>;
@@ -460,6 +470,10 @@ export function useLiveChartEngine(
   // the live edge over that progress. `returnT` rests at 1 (no glide in flight).
   const returnT = useSharedValue(1);
   const returnFrom = useSharedValue(0);
+  // Time accumulated while an experiment coalesces adjacent display frames.
+  // This SharedValue has no renderer subscriber, so updating it does not request
+  // a Skia redraw. The full elapsed time is passed to the next engine tick.
+  const cadenceElapsedMs = useSharedValue(0);
 
   // Live data extrema (value + time of the visible high / low). NaN until the
   // first tick finds data — the extrema label stays hidden until then.
@@ -539,6 +553,29 @@ export function useLiveChartEngine(
   // loop is fully inert in static mode (the invariant that makes this worth it).
   useFrameCallback((frameInfo) => {
     "worklet";
+    const frameMs =
+      frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
+    const intervalMs = renderCadenceIntervalMs(
+      PROFILE_RENDER_CADENCE,
+      canvasWidth.get(),
+      displayWindow.get(),
+    );
+    if (intervalMs > 0) {
+      const elapsedMs = cadenceElapsedMs.get() + frameMs;
+      // Small tolerance avoids a 120 Hz device needing a fifth frame because
+      // four reported deltas sum a few floating-point microseconds below 1/30s.
+      if (elapsedMs + 0.01 < intervalMs) {
+        cadenceElapsedMs.set(elapsedMs);
+        return;
+      }
+      cadenceElapsedMs.set(0);
+      applyLiveChartEngineFrame(
+        { timeSincePreviousFrame: elapsedMs },
+        frameRefs,
+        frameScratchRef.current!,
+      );
+      return;
+    }
     applyLiveChartEngineFrame(frameInfo, frameRefs, frameScratchRef.current!);
   }, !config.static);
 

--- a/packages/react-native-livechart/tests/renderCadence.test.ts
+++ b/packages/react-native-livechart/tests/renderCadence.test.ts
@@ -1,9 +1,33 @@
 import { MS_PER_FRAME_60FPS } from "../src/constants";
 import {
   FIXED_30FPS_INTERVAL_MS,
+  makeRenderCadenceSchedulerState,
   renderCadenceIntervalMs,
   resolveRenderCadenceMode,
+  scheduleRenderCadenceFrame,
+  type RenderCadenceMode,
 } from "../src/core/renderCadence";
+
+function simulateSecond(
+  mode: RenderCadenceMode,
+  refreshRate: 60 | 120,
+  displayWindowSeconds: number,
+) {
+  const state = makeRenderCadenceSchedulerState();
+  const frameMs = 1000 / refreshRate;
+  const publishedElapsed: number[] = [];
+  for (let frame = 0; frame < refreshRate; frame += 1) {
+    const elapsed = scheduleRenderCadenceFrame(
+      state,
+      mode,
+      frameMs,
+      400,
+      displayWindowSeconds,
+    );
+    if (elapsed !== null) publishedElapsed.push(elapsed);
+  }
+  return { state, publishedElapsed };
+}
 
 describe("render cadence profiling", () => {
   it("preserves display cadence by default", () => {
@@ -38,5 +62,72 @@ describe("render cadence profiling", () => {
 
   it("does not delay pre-layout engine settlement", () => {
     expect(renderCadenceIntervalMs("adaptive", 0, 30)).toBe(0);
+  });
+
+  it.each([60, 120] as const)(
+    "publishes fixed30 exactly 30 times from %d Hz callbacks",
+    (refreshRate) => {
+      const { state, publishedElapsed } = simulateSecond(
+        "fixed30",
+        refreshRate,
+        30,
+      );
+
+      expect(state.publicationCount).toBe(30);
+      expect(publishedElapsed).toHaveLength(30);
+      expect(
+        publishedElapsed.reduce((total, elapsed) => total + elapsed, 0),
+      ).toBeCloseTo(1000);
+    },
+  );
+
+  it.each([60, 120] as const)(
+    "preserves distinct adaptive rates from %d Hz callbacks",
+    (refreshRate) => {
+      expect(simulateSecond("adaptive", refreshRate, 10).state.publicationCount).toBe(
+        60,
+      );
+      expect(simulateSecond("adaptive", refreshRate, 20).state.publicationCount).toBe(
+        40,
+      );
+      expect(simulateSecond("adaptive", refreshRate, 30).state.publicationCount).toBe(
+        30,
+      );
+    },
+  );
+
+  it("passes all accumulated engine time through after a dropped frame", () => {
+    const state = makeRenderCadenceSchedulerState();
+    expect(scheduleRenderCadenceFrame(state, "fixed30", 1000 / 60, 400, 30)).toBeNull();
+
+    const publishedElapsed = scheduleRenderCadenceFrame(
+      state,
+      "fixed30",
+      50,
+      400,
+      30,
+    );
+
+    expect(publishedElapsed).toBeCloseTo(1000 / 60 + 50);
+    expect(state.publicationCount).toBe(1);
+    expect(state.elapsedSincePublicationMs).toBe(0);
+  });
+
+  it("retains elapsed time across cadence changes and resets at display cadence", () => {
+    const state = makeRenderCadenceSchedulerState();
+    const frameMs = 1000 / 60;
+
+    expect(scheduleRenderCadenceFrame(state, "fixed30", frameMs, 400, 30)).toBeNull();
+    expect(
+      scheduleRenderCadenceFrame(state, "adaptive", frameMs, 400, 10),
+    ).toBeCloseTo(frameMs * 2);
+    expect(scheduleRenderCadenceFrame(state, "display", frameMs, 400, 30)).toBe(
+      frameMs,
+    );
+    expect(state).toMatchObject({
+      elapsedSincePublicationMs: 0,
+      cadenceElapsedMs: 0,
+      publicationCount: 2,
+    });
   });
 });

--- a/packages/react-native-livechart/tests/renderCadence.test.ts
+++ b/packages/react-native-livechart/tests/renderCadence.test.ts
@@ -1,0 +1,42 @@
+import { MS_PER_FRAME_60FPS } from "../src/constants";
+import {
+  FIXED_30FPS_INTERVAL_MS,
+  renderCadenceIntervalMs,
+  resolveRenderCadenceMode,
+} from "../src/core/renderCadence";
+
+describe("render cadence profiling", () => {
+  it("preserves display cadence by default", () => {
+    expect(resolveRenderCadenceMode(undefined)).toBe("display");
+    expect(resolveRenderCadenceMode("unknown")).toBe("display");
+    expect(renderCadenceIntervalMs("display", 400, 30)).toBe(0);
+  });
+
+  it("resolves the fixed and adaptive experiment modes", () => {
+    expect(resolveRenderCadenceMode("fixed30")).toBe("fixed30");
+    expect(resolveRenderCadenceMode("adaptive")).toBe("adaptive");
+    expect(renderCadenceIntervalMs("fixed30", 400, 30)).toBe(
+      FIXED_30FPS_INTERVAL_MS,
+    );
+  });
+
+  it("uses display cadence when a short window moves at least half a pixel", () => {
+    expect(renderCadenceIntervalMs("adaptive", 400, 10)).toBe(
+      MS_PER_FRAME_60FPS,
+    );
+  });
+
+  it("caps slow windows at 30 fps", () => {
+    expect(renderCadenceIntervalMs("adaptive", 400, 30)).toBe(
+      FIXED_30FPS_INTERVAL_MS,
+    );
+  });
+
+  it("chooses an intermediate interval from visible pixel velocity", () => {
+    expect(renderCadenceIntervalMs("adaptive", 400, 20)).toBe(25);
+  });
+
+  it("does not delay pre-layout engine settlement", () => {
+    expect(renderCadenceIntervalMs("adaptive", 0, 30)).toBe(0);
+  });
+});

--- a/profiling/live-renderer-matrix.json
+++ b/profiling/live-renderer-matrix.json
@@ -28,9 +28,22 @@
       "cadence": "fixed30"
     },
     {
+      "id": "live-monotone-round-adaptive-10s",
+      "description": "Adaptive cadence with a 10-second window; expected 60 fps.",
+      "cadence": "adaptive",
+      "timeWindowSeconds": 10
+    },
+    {
+      "id": "live-monotone-round-adaptive-20s",
+      "description": "Adaptive cadence with a 20-second window; expected 40 fps.",
+      "cadence": "adaptive",
+      "timeWindowSeconds": 20
+    },
+    {
       "id": "live-monotone-round-adaptive",
-      "description": "Uses visible pixel velocity to choose a 30–60 fps cadence.",
-      "cadence": "adaptive"
+      "description": "Adaptive cadence with a 30-second window; expected 30 fps.",
+      "cadence": "adaptive",
+      "timeWindowSeconds": 30
     },
     {
       "id": "live-monotone-sharp",

--- a/profiling/live-renderer-matrix.json
+++ b/profiling/live-renderer-matrix.json
@@ -28,10 +28,20 @@
       "cadence": "fixed30"
     },
     {
+      "id": "live-monotone-round-10s",
+      "description": "Display-cadence control for the adaptive 10-second window.",
+      "timeWindowSeconds": 10
+    },
+    {
       "id": "live-monotone-round-adaptive-10s",
       "description": "Adaptive cadence with a 10-second window; expected 60 fps.",
       "cadence": "adaptive",
       "timeWindowSeconds": 10
+    },
+    {
+      "id": "live-monotone-round-20s",
+      "description": "Display-cadence control for the adaptive 20-second window.",
+      "timeWindowSeconds": 20
     },
     {
       "id": "live-monotone-round-adaptive-20s",

--- a/profiling/live-renderer-matrix.json
+++ b/profiling/live-renderer-matrix.json
@@ -1,6 +1,7 @@
 {
   "defaults": {
     "mode": "live",
+    "cadence": "display",
     "curve": "monotone",
     "join": "round",
     "cap": "round",
@@ -20,6 +21,16 @@
     {
       "id": "live-monotone-round",
       "description": "Current production line renderer and canonical live baseline."
+    },
+    {
+      "id": "live-monotone-round-30fps",
+      "description": "Coalesces steady engine publications to a fixed 30 fps.",
+      "cadence": "fixed30"
+    },
+    {
+      "id": "live-monotone-round-adaptive",
+      "description": "Uses visible pixel velocity to choose a 30–60 fps cadence.",
+      "cadence": "adaptive"
     },
     {
       "id": "live-monotone-sharp",

--- a/profiling/liveRendererProfile.test.ts
+++ b/profiling/liveRendererProfile.test.ts
@@ -33,6 +33,15 @@ describe("live renderer profile matrix", () => {
     );
   });
 
+  it("selects fixed and adaptive cadence runs", () => {
+    expect(resolveLiveRendererProfile("live-monotone-round-30fps").cadence).toBe(
+      "fixed30",
+    );
+    expect(
+      resolveLiveRendererProfile("live-monotone-round-adaptive").cadence,
+    ).toBe("adaptive");
+  });
+
   it("keeps the original static/live environment variable as an override", () => {
     expect(
       resolveLiveRendererProfile("live-linear-sharp", "static"),

--- a/profiling/liveRendererProfile.test.ts
+++ b/profiling/liveRendererProfile.test.ts
@@ -40,6 +40,11 @@ describe("live renderer profile matrix", () => {
     expect(
       resolveLiveRendererProfile("live-monotone-round-adaptive").cadence,
     ).toBe("adaptive");
+    expect(
+      LIVE_RENDERER_PROFILES.filter(
+        (profile) => profile.cadence === "adaptive",
+      ).map((profile) => profile.timeWindowSeconds),
+    ).toEqual([10, 20, 30]);
   });
 
   it("keeps the original static/live environment variable as an override", () => {

--- a/profiling/liveRendererProfile.test.ts
+++ b/profiling/liveRendererProfile.test.ts
@@ -45,6 +45,17 @@ describe("live renderer profile matrix", () => {
         (profile) => profile.cadence === "adaptive",
       ).map((profile) => profile.timeWindowSeconds),
     ).toEqual([10, 20, 30]);
+    for (const adaptive of LIVE_RENDERER_PROFILES.filter(
+      (profile) => profile.cadence === "adaptive",
+    )) {
+      expect(
+        LIVE_RENDERER_PROFILES.some(
+          (profile) =>
+            profile.cadence === "display" &&
+            profile.timeWindowSeconds === adaptive.timeWindowSeconds,
+        ),
+      ).toBe(true);
+    }
   });
 
   it("keeps the original static/live environment variable as an override", () => {

--- a/profiling/liveRendererProfile.ts
+++ b/profiling/liveRendererProfile.ts
@@ -1,6 +1,7 @@
 import matrix from "./live-renderer-matrix.json";
 
 export type RendererProfileMode = "static" | "live";
+export type RendererProfileCadence = "display" | "fixed30" | "adaptive";
 export type RendererProfileCurve = "monotone" | "linear";
 export type RendererProfileJoin = "round" | "miter" | "bevel";
 export type RendererProfileCap = "round" | "butt" | "square";
@@ -9,6 +10,7 @@ export interface RendererProfile {
   id: string;
   description: string;
   mode: RendererProfileMode;
+  cadence: RendererProfileCadence;
   curve: RendererProfileCurve;
   join: RendererProfileJoin;
   cap: RendererProfileCap;

--- a/scripts/run_ios_renderer_matrix.py
+++ b/scripts/run_ios_renderer_matrix.py
@@ -96,7 +96,10 @@ def capture_run(
     worklets_mode: str | None,
 ) -> None:
     run_id = run["id"]
-    profile_env = {"EXPO_PUBLIC_MEMORY_PROFILE_RUN": run_id}
+    profile_env = {
+        "EXPO_PUBLIC_MEMORY_PROFILE_RUN": run_id,
+        "EXPO_PUBLIC_MEMORY_PROFILE_CADENCE": run["cadence"],
+    }
     if worklets_mode:
         profile_env["WORKLETS_BUNDLE_MODE"] = (
             "1" if worklets_mode == "bundle" else "0"

--- a/scripts/summarize_activity_monitor.py
+++ b/scripts/summarize_activity_monitor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Summarize physical-footprint phases from an xctrace Activity Monitor export."""
+"""Summarize physical-footprint and CPU phases from Activity Monitor XML."""
 
 from __future__ import annotations
 
@@ -21,10 +21,10 @@ def parse_phase(value: str) -> tuple[str, float, float]:
         ) from error
 
 
-def load_samples(path: Path) -> list[tuple[float, float]]:
+def load_samples(path: Path) -> list[tuple[float, float, float]]:
     root = ET.parse(path).getroot()
     referenced_values: dict[str, str | None] = {}
-    samples: list[tuple[float, float]] = []
+    samples: list[tuple[float, float, float]] = []
 
     for row in root.findall(".//row"):
         values: list[str | None] = []
@@ -37,10 +37,22 @@ def load_samples(path: Path) -> list[tuple[float, float]]:
                     referenced_values[identifier] = value
             values.append(value)
 
-        # activity-monitor-process-live column 0 is start time and column 10 is
-        # physical footprint. Values are nanoseconds and bytes respectively.
-        if len(values) > 10 and values[0] is not None and values[10] is not None:
-            samples.append((int(values[0]) / 1_000_000_000, int(values[10]) / MIB))
+        # activity-monitor-process-live columns 0, 6, and 10 are start time,
+        # CPU percentage, and physical footprint. The first sample has no CPU
+        # percentage, so omit it; measured phases begin after the warmup.
+        if (
+            len(values) > 10
+            and values[0] is not None
+            and values[6] is not None
+            and values[10] is not None
+        ):
+            samples.append(
+                (
+                    int(values[0]) / 1_000_000_000,
+                    int(values[10]) / MIB,
+                    float(values[6]),
+                )
+            )
 
     if not samples:
         raise ValueError(f"no Activity Monitor samples found in {path}")
@@ -65,16 +77,23 @@ def main() -> None:
     ]
     samples = load_samples(args.xml)
 
-    print("| Phase | Samples | Mean | Min | Max | Last |")
-    print("| --- | ---: | ---: | ---: | ---: | ---: |")
+    print(
+        "| Phase | Samples | Footprint mean | Footprint min | Footprint max "
+        "| Footprint last | CPU mean | CPU max |"
+    )
+    print("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for name, start, end in phases:
-        footprints = [value for time, value in samples if start <= time <= end]
-        if not footprints:
+        phase_samples = [sample for sample in samples if start <= sample[0] <= end]
+        if not phase_samples:
             raise ValueError(f"phase {name!r} has no samples between {start}s and {end}s")
+        footprints = [sample[1] for sample in phase_samples]
+        cpu_percentages = [sample[2] for sample in phase_samples]
         print(
-            f"| {name} | {len(footprints)} | {statistics.fmean(footprints):.2f} MiB "
+            f"| {name} | {len(phase_samples)} | {statistics.fmean(footprints):.2f} MiB "
             f"| {min(footprints):.2f} MiB | {max(footprints):.2f} MiB "
-            f"| {footprints[-1]:.2f} MiB |"
+            f"| {footprints[-1]:.2f} MiB "
+            f"| {statistics.fmean(cpu_percentages):.2f}% "
+            f"| {max(cpu_percentages):.2f}% |"
         )
 
 


### PR DESCRIPTION
## What

- rebase the cadence experiment onto current `main` while preserving pooled engine scratch objects and Worklets Bundle Mode profiling
- add fixed-30 and adaptive 10 s, 20 s, and 30 s matrix cases targeting 60, 40, and 30 publications per second
- add a pure cadence scheduler that retains phase remainder and accumulated engine time across 60/120 Hz callbacks, dropped frames, and cadence changes
- count actual engine publications during the mounted profiling phase
- keep the production display path direct, without per-frame canvas/window reads or cadence calculation

## Scope

This remains a profiling-only, single-series `LiveChart` experiment. It does not add a public production API or claim a shipped optimization.

## Measurement status

Simulator rendering QA remains directional evidence only. Physical-device Instruments captures are still required for allocations, physical footprint, CPU, and frame pacing/hitches. Trooper is paired but currently reported offline by `xctrace`, so no new physical trace was recorded in this update.

## Validation

- `npm run verify` — typecheck and lint passed; 97 suites passed, 1,370 tests passed, 5 skipped
- pre-commit test hook — 97 suites passed, 1,370 tests passed, 5 skipped
- cadence scheduler tests — 60/120 Hz, dropped frames, and cadence changes covered
- React Doctor — 100/100
- matrix runner dry-run — display, fixed30, adaptive 10/20/30, legacy, and Bundle Mode switches verified

## Remaining before ready

- capture physical-device A/B/A Instruments evidence for display, fixed30, and adaptive variants
- let rebased CI finish and obtain review
- keep the PR draft until the evidence is recorded