### PR TITLE
perf: reduce live redraw publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chained derived values.** Scrub and locked-reticle state still expose the same
   individual SharedValues, but compile fewer Hermes worklets and no longer pass
   through intermediate mixed-frame geometry while dependent mappers settle.
+- **Steady live scrolling now publishes chart state at a pixel-aware 30–60 fps.**
+  The engine coalesces display callbacks until time movement reaches half a
+  pixel, while snap and return-to-live transitions retain display cadence. The
+  canonical 400 px / 30 s window therefore requests about half as many steady
+  Skia redraws without changing animation duration or gesture-driven updates.
 
 ## [4.9.1] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Screens demonstrate candlestick mode, multi-series, scrub, momentum tuning, dege
 - **Reanimated** owns timeline layout, smoothing, and scrub state; hooks feed a small engine API on the UI thread.
 - **Gesture Handler** drives scrubbing and chart interactions.
 
-A frame-callback engine (`useFrameCallback`) runs a pure tick function on the UI thread each frame, updating display range, time window, and smoothed values, then writing results to `SharedValue`s. Path builders and overlays read those `SharedValue`s inside `useDerivedValue`, so React re-renders stay minimal.
+A frame-callback engine (`useFrameCallback`) runs a pure tick function on the UI thread, updating display range, time window, and smoothed values, then writing results to `SharedValue`s. Steady live scrolling publishes adaptively at 30–60 fps from visible pixel velocity (while fast snap/return transitions retain display cadence), avoiding redraws that would move the chart by less than half a pixel. Path builders and overlays read those `SharedValue`s inside `useDerivedValue`, so React re-renders stay minimal.
 
 ## Contributing
 

--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -18,6 +18,15 @@ const PROFILE = resolveLiveRendererProfile(
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE,
 );
 
+// Keep Expo's bundle-time environment access in the example app. The library
+// reads this only when the profiling screen mounts, preserving its Node-free
+// declaration build and avoiding a public profiling prop.
+(
+  globalThis as typeof globalThis & {
+    __reactNativeLiveChartProfileCadence?: string;
+  }
+).__reactNativeLiveChartProfileCadence = PROFILE.cadence;
+
 const PHASES = [
   { name: "baseline", chartMounted: false, seconds: 15 },
   { name: PROFILE.id, chartMounted: true, seconds: 30 },

--- a/app/memory-profile.tsx
+++ b/app/memory-profile.tsx
@@ -57,7 +57,8 @@ export default function MemoryProfileScreen() {
         MEMORY PROFILE {phaseIndex}: {phase.name}
       </Text>
       <Text style={styles.detail}>
-        {PROFILE.mode} · {PROFILE.curve} · {PROFILE.join}/{PROFILE.cap}
+        {PROFILE.mode} · {PROFILE.cadence} · {PROFILE.curve} · {PROFILE.join}/
+        {PROFILE.cap}
       </Text>
       <Text style={styles.detail}>
         {PROFILE.tradesPerSecond} updates/s · {PROFILE.timeWindowSeconds}s window

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -39,6 +39,8 @@ dimension:
 | --- | --- |
 | `static-control` | How much cost remains without the continuous chart loop? |
 | `live-monotone-round` | What is the current production live baseline? |
+| `live-monotone-round-30fps` | How much churn disappears at a fixed 30 fps? |
+| `live-monotone-round-adaptive` | Can visible pixel velocity retain 60 fps only where it matters? |
 | `live-monotone-sharp` | Do round caps and joins drive mask churn? |
 | `live-linear-round` | Do cubic path verbs drive mask churn? |
 | `live-linear-sharp` | What does the simplest built-in stroke cost? |
@@ -69,6 +71,18 @@ timeline, exports Activity Monitor XML, and writes one Markdown phase summary
 beside each trace. It refuses to overwrite traces unless `--force` is supplied.
 Metro's transform cache is keyed by the selected run, mode, and cadence so a
 sequential matrix cannot silently reuse the previous run's inlined environment.
+
+Use a physical iOS device: simulator Activity Monitor recordings do not produce
+a valid Instruments trace for this workflow.
+
+The cadence variants are profiling-only bundle switches. `display` preserves the
+existing frame callback. `fixed30` accumulates adjacent display-frame deltas and
+publishes the engine at 30 fps. `adaptive` waits for one half-pixel of horizontal
+movement, clamped between 30 and 60 fps. The accumulated elapsed time is passed
+to the next tick, so easing duration is unchanged; only expensive publication
+and redraw frequency differs. With the canonical 400-point-wide, 30-second
+window, adaptive cadence resolves to 33.3 ms: one publication for every two
+60 Hz display callbacks, or about half as many steady-state redraw requests.
 
 ## Physical footprint
 

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -75,14 +75,14 @@ sequential matrix cannot silently reuse the previous run's inlined environment.
 Use a physical iOS device: simulator Activity Monitor recordings do not produce
 a valid Instruments trace for this workflow.
 
-The cadence variants are profiling-only bundle switches. `display` preserves the
-existing frame callback. `fixed30` accumulates adjacent display-frame deltas and
-publishes the engine at 30 fps. `adaptive` waits for one half-pixel of horizontal
-movement, clamped between 30 and 60 fps. The accumulated elapsed time is passed
-to the next tick, so easing duration is unchanged; only expensive publication
-and redraw frequency differs. With the canonical 400-point-wide, 30-second
-window, adaptive cadence resolves to 33.3 ms: one publication for every two
-60 Hz display callbacks, or about half as many steady-state redraw requests.
+`adaptive` is the production cadence; the matrix can force `display` and
+`fixed30` baselines at bundle time. Adaptive cadence waits for one half-pixel of
+horizontal movement, clamped between 30 and 60 fps. The accumulated elapsed time
+is passed to the next tick, so easing duration is unchanged; only expensive
+publication and redraw frequency differs. Snap and return-to-live transitions
+retain display cadence. With the canonical 400-point-wide, 30-second window,
+adaptive cadence resolves to 33.3 ms: one publication for every two 60 Hz
+display callbacks, or about half as many steady-state redraw requests.
 
 ## Physical footprint
 

--- a/packages/react-native-livechart/src/core/renderCadence.ts
+++ b/packages/react-native-livechart/src/core/renderCadence.ts
@@ -1,0 +1,39 @@
+import { MS_PER_FRAME_60FPS } from "../constants";
+
+export type RenderCadenceMode = "display" | "fixed30" | "adaptive";
+
+export const FIXED_30FPS_INTERVAL_MS = 1000 / 30;
+export const ADAPTIVE_PIXEL_STEP = 0.5;
+
+/** Bundle-time profiling mode. Unknown/absent values preserve display cadence. */
+export function resolveRenderCadenceMode(
+  value: string | undefined,
+): RenderCadenceMode {
+  return value === "fixed30" || value === "adaptive" ? value : "display";
+}
+
+/**
+ * Minimum time between expensive chart-state publications for a profiling mode.
+ *
+ * Adaptive cadence waits until steady horizontal scrolling would move by half a
+ * pixel, clamped to 30–60 fps. Short windows therefore retain display cadence;
+ * longer, slower windows coalesce adjacent display frames.
+ */
+export function renderCadenceIntervalMs(
+  mode: RenderCadenceMode,
+  canvasWidth: number,
+  displayWindowSeconds: number,
+): number {
+  "worklet";
+  if (mode === "display" || canvasWidth <= 0 || displayWindowSeconds <= 0) {
+    return 0;
+  }
+  if (mode === "fixed30") return FIXED_30FPS_INTERVAL_MS;
+
+  const pixelsPerSecond = canvasWidth / displayWindowSeconds;
+  const halfPixelInterval = (ADAPTIVE_PIXEL_STEP / pixelsPerSecond) * 1000;
+  return Math.max(
+    MS_PER_FRAME_60FPS,
+    Math.min(FIXED_30FPS_INTERVAL_MS, halfPixelInterval),
+  );
+}

--- a/packages/react-native-livechart/src/core/renderCadence.ts
+++ b/packages/react-native-livechart/src/core/renderCadence.ts
@@ -28,6 +28,17 @@ export function resolveRenderCadenceProfileOverride(
   return resolveRenderCadenceMode(value, fallback);
 }
 
+/** Whether the accumulated display time has reached the next publication. */
+export function shouldPublishRenderFrame(
+  intervalMs: number,
+  elapsedMs: number,
+): boolean {
+  "worklet";
+  // Avoid a 120 Hz device needing a fifth frame because four reported deltas
+  // sum a few floating-point microseconds below the 30 fps interval.
+  return intervalMs <= 0 || elapsedMs + 0.01 >= intervalMs;
+}
+
 /**
  * Minimum time between expensive chart-state publications for a profiling mode.
  *

--- a/packages/react-native-livechart/src/core/renderCadence.ts
+++ b/packages/react-native-livechart/src/core/renderCadence.ts
@@ -2,14 +2,30 @@ import { MS_PER_FRAME_60FPS } from "../constants";
 
 export type RenderCadenceMode = "display" | "fixed30" | "adaptive";
 
+type RenderCadenceProfileGlobal = typeof globalThis & {
+  __reactNativeLiveChartProfileCadence?: string;
+};
+
 export const FIXED_30FPS_INTERVAL_MS = 1000 / 30;
 export const ADAPTIVE_PIXEL_STEP = 0.5;
 
 /** Bundle-time profiling mode. Unknown/absent values preserve display cadence. */
 export function resolveRenderCadenceMode(
   value: string | undefined,
+  fallback: RenderCadenceMode = "display",
 ): RenderCadenceMode {
-  return value === "fixed30" || value === "adaptive" ? value : "display";
+  return value === "display" || value === "fixed30" || value === "adaptive"
+    ? value
+    : fallback;
+}
+
+/** Read the example app's bundle-time profiling override without Node globals. */
+export function resolveRenderCadenceProfileOverride(
+  fallback: RenderCadenceMode = "display",
+): RenderCadenceMode {
+  const value = (globalThis as RenderCadenceProfileGlobal)
+    .__reactNativeLiveChartProfileCadence;
+  return resolveRenderCadenceMode(value, fallback);
 }
 
 /**

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -19,6 +19,16 @@ import {
 import { MS_PER_FRAME_60FPS, RETURN_TO_LIVE_MS } from "../constants";
 import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
 import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
+import {
+  renderCadenceIntervalMs,
+  resolveRenderCadenceMode,
+} from "./renderCadence";
+
+// Profiling-only bundle switch. The production default remains `display` until
+// physical-device measurements justify a lower adaptive publication cadence.
+const PROFILE_RENDER_CADENCE = resolveRenderCadenceMode(
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE,
+);
 
 export interface EngineConfig {
   data: SharedValue<LiveChartPoint[]>;
@@ -397,6 +407,10 @@ export function useLiveChartEngine(
   // the live edge over that progress. `returnT` rests at 1 (no glide in flight).
   const returnT = useSharedValue(1);
   const returnFrom = useSharedValue(0);
+  // Time accumulated while an experiment coalesces adjacent display frames.
+  // This SharedValue has no renderer subscriber, so updating it does not request
+  // a Skia redraw. The full elapsed time is passed to the next engine tick.
+  const cadenceElapsedMs = useSharedValue(0);
 
   // Live data extrema (value + time of the visible high / low). NaN until the
   // first tick finds data — the extrema label stays hidden until then.
@@ -472,6 +486,28 @@ export function useLiveChartEngine(
   // loop is fully inert in static mode (the invariant that makes this worth it).
   useFrameCallback((frameInfo) => {
     "worklet";
+    const frameMs =
+      frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
+    const intervalMs = renderCadenceIntervalMs(
+      PROFILE_RENDER_CADENCE,
+      canvasWidth.get(),
+      displayWindow.get(),
+    );
+    if (intervalMs > 0) {
+      const elapsedMs = cadenceElapsedMs.get() + frameMs;
+      // Small tolerance avoids a 120 Hz device needing a fifth frame because
+      // four reported deltas sum a few floating-point microseconds below 1/30s.
+      if (elapsedMs + 0.01 < intervalMs) {
+        cadenceElapsedMs.set(elapsedMs);
+        return;
+      }
+      cadenceElapsedMs.set(0);
+      applyLiveChartEngineFrame(
+        { timeSincePreviousFrame: elapsedMs },
+        frameRefs,
+      );
+      return;
+    }
     applyLiveChartEngineFrame(frameInfo, frameRefs);
   }, !config.static);
 

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -22,8 +22,8 @@ import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
 import {
   renderCadenceIntervalMs,
   resolveRenderCadenceProfileOverride,
+  shouldPublishRenderFrame,
 } from "./renderCadence";
-
 export interface EngineConfig {
   data: SharedValue<LiveChartPoint[]>;
   value: SharedValue<number>;
@@ -313,7 +313,7 @@ export function useLiveChartEngine(
 ): SingleEngineState & ChartEngineScroll & ChartEngineEdge {
   // The example app can select a bundle-time experiment without making Node's
   // `process` global part of the publishable library's declaration build.
-  const profileRenderCadence = resolveRenderCadenceProfileOverride();
+  const profileRenderCadence = resolveRenderCadenceProfileOverride("adaptive");
   // Pinch-zoom window-width override (null = follow the configured window).
   // Declared first so `timeWindow` below can fold it in. Defaults to null so
   // charts without `zoom` behave exactly as before.
@@ -404,7 +404,7 @@ export function useLiveChartEngine(
   // the live edge over that progress. `returnT` rests at 1 (no glide in flight).
   const returnT = useSharedValue(1);
   const returnFrom = useSharedValue(0);
-  // Time accumulated while an experiment coalesces adjacent display frames.
+  // Time accumulated while adaptive cadence coalesces adjacent display frames.
   // This SharedValue has no renderer subscriber, so updating it does not request
   // a Skia redraw. The full elapsed time is passed to the next engine tick.
   const cadenceElapsedMs = useSharedValue(0);
@@ -485,16 +485,17 @@ export function useLiveChartEngine(
     "worklet";
     const frameMs =
       frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
+    // Snap and return-to-live can cover many pixels in one frame, so preserve
+    // display cadence until those explicit transitions settle.
+    const forceDisplayCadence = snapSV.get() || returnT.get() < 1;
     const intervalMs = renderCadenceIntervalMs(
-      profileRenderCadence,
+      forceDisplayCadence ? "display" : profileRenderCadence,
       canvasWidth.get(),
       displayWindow.get(),
     );
     if (intervalMs > 0) {
       const elapsedMs = cadenceElapsedMs.get() + frameMs;
-      // Small tolerance avoids a 120 Hz device needing a fifth frame because
-      // four reported deltas sum a few floating-point microseconds below 1/30s.
-      if (elapsedMs + 0.01 < intervalMs) {
+      if (!shouldPublishRenderFrame(intervalMs, elapsedMs)) {
         cadenceElapsedMs.set(elapsedMs);
         return;
       }
@@ -505,6 +506,7 @@ export function useLiveChartEngine(
       );
       return;
     }
+    cadenceElapsedMs.set(0);
     applyLiveChartEngineFrame(frameInfo, frameRefs);
   }, !config.static);
 

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -21,14 +21,8 @@ import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
 import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
 import {
   renderCadenceIntervalMs,
-  resolveRenderCadenceMode,
+  resolveRenderCadenceProfileOverride,
 } from "./renderCadence";
-
-// Profiling-only bundle switch. The production default remains `display` until
-// physical-device measurements justify a lower adaptive publication cadence.
-const PROFILE_RENDER_CADENCE = resolveRenderCadenceMode(
-  process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE,
-);
 
 export interface EngineConfig {
   data: SharedValue<LiveChartPoint[]>;
@@ -317,6 +311,9 @@ export function applyLiveChartEngineFrame(
 export function useLiveChartEngine(
   config: EngineConfig,
 ): SingleEngineState & ChartEngineScroll & ChartEngineEdge {
+  // The example app can select a bundle-time experiment without making Node's
+  // `process` global part of the publishable library's declaration build.
+  const profileRenderCadence = resolveRenderCadenceProfileOverride();
   // Pinch-zoom window-width override (null = follow the configured window).
   // Declared first so `timeWindow` below can fold it in. Defaults to null so
   // charts without `zoom` behave exactly as before.
@@ -489,7 +486,7 @@ export function useLiveChartEngine(
     const frameMs =
       frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
     const intervalMs = renderCadenceIntervalMs(
-      PROFILE_RENDER_CADENCE,
+      profileRenderCadence,
       canvasWidth.get(),
       displayWindow.get(),
     );

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -12,7 +12,17 @@ import {
 import { MS_PER_FRAME_60FPS, RETURN_TO_LIVE_MS } from "../constants";
 import type { LiveChartPoint, SeriesConfig } from "../types";
 import { tickLiveChartSeriesEngineFrame } from "./liveChartSeriesEngineTick";
+import {
+  renderCadenceIntervalMs,
+  resolveRenderCadenceMode,
+  shouldPublishRenderFrame,
+} from "./renderCadence";
 import type { ChartEngineScroll, MultiEngineState } from "./useLiveChartEngine";
+
+const LIVE_RENDER_CADENCE = resolveRenderCadenceMode(
+  process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE,
+  "adaptive",
+);
 
 export interface MultiSeriesEngineConfig {
   series: SharedValue<SeriesConfig[]>;
@@ -243,6 +253,9 @@ export function useLiveChartSeriesEngine(
   // animates it 0→1 from `returnFrom` when time-scroll is disabled while scrolled.
   const returnT = useSharedValue(1);
   const returnFrom = useSharedValue(0);
+  // No renderer subscribes to this accumulator; skipped callbacks therefore do
+  // not publish chart state or ask Skia to redraw.
+  const cadenceElapsedMs = useSharedValue(0);
 
   const displaySeriesValues = useSharedValue<number[]>([]);
   const seriesOpacities = useSharedValue<number[]>([]);
@@ -278,8 +291,28 @@ export function useLiveChartSeriesEngine(
   useFrameCallback((frameInfo) => {
     "worklet";
     const scratch = scratchRef.current!;
+    const frameMs =
+      frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
+    let tickFrameInfo: { timeSincePreviousFrame?: number | null } = frameInfo;
+    const forceDisplayCadence = snapSV.get() || returnT.get() < 1;
+    const intervalMs = renderCadenceIntervalMs(
+      forceDisplayCadence ? "display" : LIVE_RENDER_CADENCE,
+      canvasWidth.get(),
+      displayWindow.get(),
+    );
+    if (intervalMs > 0) {
+      const elapsedMs = cadenceElapsedMs.get() + frameMs;
+      if (!shouldPublishRenderFrame(intervalMs, elapsedMs)) {
+        cadenceElapsedMs.set(elapsedMs);
+        return;
+      }
+      cadenceElapsedMs.set(0);
+      tickFrameInfo = { timeSincePreviousFrame: elapsedMs };
+    } else {
+      cadenceElapsedMs.set(0);
+    }
     applyLiveChartSeriesEngineFrame(
-      frameInfo,
+      tickFrameInfo,
       {
         series,
         displaySeriesValues,

--- a/packages/react-native-livechart/tests/renderCadence.test.ts
+++ b/packages/react-native-livechart/tests/renderCadence.test.ts
@@ -3,6 +3,7 @@ import {
   FIXED_30FPS_INTERVAL_MS,
   renderCadenceIntervalMs,
   resolveRenderCadenceMode,
+  shouldPublishRenderFrame,
 } from "../src/core/renderCadence";
 
 describe("render cadence profiling", () => {
@@ -10,6 +11,12 @@ describe("render cadence profiling", () => {
     expect(resolveRenderCadenceMode(undefined)).toBe("display");
     expect(resolveRenderCadenceMode("unknown")).toBe("display");
     expect(renderCadenceIntervalMs("display", 400, 30)).toBe(0);
+  });
+
+  it("allows the production caller to choose an adaptive fallback", () => {
+    expect(resolveRenderCadenceMode(undefined, "adaptive")).toBe("adaptive");
+    expect(resolveRenderCadenceMode("unknown", "adaptive")).toBe("adaptive");
+    expect(resolveRenderCadenceMode("display", "adaptive")).toBe("display");
   });
 
   it("resolves the fixed and adaptive experiment modes", () => {
@@ -38,5 +45,18 @@ describe("render cadence profiling", () => {
 
   it("does not delay pre-layout engine settlement", () => {
     expect(renderCadenceIntervalMs("adaptive", 0, 30)).toBe(0);
+  });
+
+  it("publishes every other 60 Hz callback at the canonical cadence", () => {
+    const intervalMs = renderCadenceIntervalMs("adaptive", 400, 30);
+    let elapsedMs = 0;
+    let publications = 0;
+    for (let frame = 0; frame < 60; frame++) {
+      elapsedMs += MS_PER_FRAME_60FPS;
+      if (!shouldPublishRenderFrame(intervalMs, elapsedMs)) continue;
+      publications++;
+      elapsedMs = 0;
+    }
+    expect(publications).toBe(30);
   });
 });

--- a/packages/react-native-livechart/tests/renderCadence.test.ts
+++ b/packages/react-native-livechart/tests/renderCadence.test.ts
@@ -1,0 +1,42 @@
+import { MS_PER_FRAME_60FPS } from "../src/constants";
+import {
+  FIXED_30FPS_INTERVAL_MS,
+  renderCadenceIntervalMs,
+  resolveRenderCadenceMode,
+} from "../src/core/renderCadence";
+
+describe("render cadence profiling", () => {
+  it("preserves display cadence by default", () => {
+    expect(resolveRenderCadenceMode(undefined)).toBe("display");
+    expect(resolveRenderCadenceMode("unknown")).toBe("display");
+    expect(renderCadenceIntervalMs("display", 400, 30)).toBe(0);
+  });
+
+  it("resolves the fixed and adaptive experiment modes", () => {
+    expect(resolveRenderCadenceMode("fixed30")).toBe("fixed30");
+    expect(resolveRenderCadenceMode("adaptive")).toBe("adaptive");
+    expect(renderCadenceIntervalMs("fixed30", 400, 30)).toBe(
+      FIXED_30FPS_INTERVAL_MS,
+    );
+  });
+
+  it("uses display cadence when a short window moves at least half a pixel", () => {
+    expect(renderCadenceIntervalMs("adaptive", 400, 10)).toBe(
+      MS_PER_FRAME_60FPS,
+    );
+  });
+
+  it("caps slow windows at 30 fps", () => {
+    expect(renderCadenceIntervalMs("adaptive", 400, 30)).toBe(
+      FIXED_30FPS_INTERVAL_MS,
+    );
+  });
+
+  it("chooses an intermediate interval from visible pixel velocity", () => {
+    expect(renderCadenceIntervalMs("adaptive", 400, 20)).toBe(25);
+  });
+
+  it("does not delay pre-layout engine settlement", () => {
+    expect(renderCadenceIntervalMs("adaptive", 0, 30)).toBe(0);
+  });
+});

--- a/profiling/live-renderer-matrix.json
+++ b/profiling/live-renderer-matrix.json
@@ -1,6 +1,7 @@
 {
   "defaults": {
     "mode": "live",
+    "cadence": "display",
     "curve": "monotone",
     "join": "round",
     "cap": "round",
@@ -20,6 +21,16 @@
     {
       "id": "live-monotone-round",
       "description": "Current production line renderer and canonical live baseline."
+    },
+    {
+      "id": "live-monotone-round-30fps",
+      "description": "Coalesces steady engine publications to a fixed 30 fps.",
+      "cadence": "fixed30"
+    },
+    {
+      "id": "live-monotone-round-adaptive",
+      "description": "Uses visible pixel velocity to choose a 30–60 fps cadence.",
+      "cadence": "adaptive"
     },
     {
       "id": "live-monotone-sharp",

--- a/profiling/liveRendererProfile.test.ts
+++ b/profiling/liveRendererProfile.test.ts
@@ -33,6 +33,15 @@ describe("live renderer profile matrix", () => {
     );
   });
 
+  it("selects fixed and adaptive cadence runs", () => {
+    expect(resolveLiveRendererProfile("live-monotone-round-30fps").cadence).toBe(
+      "fixed30",
+    );
+    expect(
+      resolveLiveRendererProfile("live-monotone-round-adaptive").cadence,
+    ).toBe("adaptive");
+  });
+
   it("keeps the original static/live environment variable as an override", () => {
     expect(
       resolveLiveRendererProfile("live-linear-sharp", "static"),

--- a/profiling/liveRendererProfile.ts
+++ b/profiling/liveRendererProfile.ts
@@ -1,6 +1,7 @@
 import matrix from "./live-renderer-matrix.json";
 
 export type RendererProfileMode = "static" | "live";
+export type RendererProfileCadence = "display" | "fixed30" | "adaptive";
 export type RendererProfileCurve = "monotone" | "linear";
 export type RendererProfileJoin = "round" | "miter" | "bevel";
 export type RendererProfileCap = "round" | "butt" | "square";
@@ -9,6 +10,7 @@ export interface RendererProfile {
   id: string;
   description: string;
   mode: RendererProfileMode;
+  cadence: RendererProfileCadence;
   curve: RendererProfileCurve;
   join: RendererProfileJoin;
   cap: RendererProfileCap;

--- a/scripts/run_ios_renderer_matrix.py
+++ b/scripts/run_ios_renderer_matrix.py
@@ -92,7 +92,10 @@ def capture_run(
     args: argparse.Namespace,
 ) -> None:
     run_id = run["id"]
-    profile_env = {"EXPO_PUBLIC_MEMORY_PROFILE_RUN": run_id}
+    profile_env = {
+        "EXPO_PUBLIC_MEMORY_PROFILE_RUN": run_id,
+        "EXPO_PUBLIC_MEMORY_PROFILE_CADENCE": run["cadence"],
+    }
     print(f"\n## {run_id}: {run['description']}", flush=True)
 
     if not args.skip_build:


### PR DESCRIPTION
## What

- make pixel-velocity adaptive cadence the internal default for both `LiveChart` and `LiveChartSeries`
- coalesce steady engine publications until horizontal motion reaches half a pixel
- retain display cadence for snap and return-to-live transitions
- preserve accumulated elapsed time so smoothing duration is unchanged
- document the runtime behavior and changelog entry

## Expected win

The canonical 400 px / 30 s chart publishes about 30 times per second instead of 60, cutting the main path/redraw trigger in half. Short windows scale up toward 60 fps. Pan and pinch geometry remains gesture-driven and is not gated by this engine cadence.

## Merge gate

This remains a draft until #197 is captured on a physical iPhone and confirms lower allocation/redraw churn without a visual regression. Simulator Instruments traces are invalid for this workflow.

## Validation

- `npm run verify` — 92 suites passed; 1,332 passed, 5 skipped
- focused cadence + single/multi engine tests — 21 passed
- React Doctor — 100/100
- commit hook — 92 suites passed