### PR TITLE
repro: isolate Skia animated-path mask churn

### DIFF
--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -102,6 +102,44 @@ allocations were destroyed, so the post-unmount physical footprint should be
 treated as an allocator/VM high-water observation rather than 198 MiB of proven
 live objects.
 
+## Stack-wide physical verification (2026-07-14)
+
+The complete performance stack was rebuilt in Release mode and recaptured on
+Trooper. Every run used a distinct bundled matrix selection and the fixed phase
+timeline above. Activity Monitor and Allocations traces were saved for every
+listed variant.
+
+The renderer matrix isolated path shape, point density, and mask area:
+
+| Variant | Baseline mean | Mounted mean | Mounted max | Unmounted last |
+| --- | ---: | ---: | ---: | ---: |
+| `static-control` | 123.88 MiB | 344.46 MiB | 355.88 MiB | 304.45 MiB |
+| `live-monotone-round` | 124.45 MiB | 512.47 MiB | 580.55 MiB | 536.52 MiB |
+| `live-monotone-sharp` | 124.26 MiB | 505.55 MiB | 566.36 MiB | 523.58 MiB |
+| `live-linear-round` | 124.39 MiB | 519.29 MiB | 595.74 MiB | 548.77 MiB |
+| `live-linear-sharp` | 124.28 MiB | 532.51 MiB | 621.52 MiB | 567.80 MiB |
+| `live-monotone-round-dense` | 126.01 MiB | 507.84 MiB | 560.83 MiB | 523.14 MiB |
+| `live-monotone-round-tall` | 123.85 MiB | 612.78 MiB | 636.99 MiB | 580.94 MiB |
+
+Curve simplification did not improve the footprint, and tripling point density
+did not make it worse. Doubling chart height increased the mounted mean by about
+100 MiB. That makes mask/raster area a materially stronger target than point
+arrays or path-verb count.
+
+The cadence experiment then held the renderer at `live-monotone-round`:
+
+| Cadence | Baseline mean | Mounted mean | Mounted max | Unmounted last |
+| --- | ---: | ---: | ---: | ---: |
+| Display cadence | 124.13 MiB | 523.17 MiB | 597.74 MiB | 547.09 MiB |
+| Fixed 30 fps | 124.08 MiB | 429.12 MiB | 478.53 MiB | 430.27 MiB |
+| Adaptive | 124.08 MiB | 419.92 MiB | 447.89 MiB | 401.91 MiB |
+
+Adaptive cadence reduced the mounted mean by 103.25 MiB (19.7%) and the peak by
+149.85 MiB (25.1%) relative to display cadence. A separate capture of the
+production-promoted adaptive implementation measured 421.31 MiB mean and
+452.89 MiB max, reproducing the experiment rather than regressing back toward
+display cadence.
+
 ## Allocation volume and lifetime
 
 Whole-run Allocations statistics make the static/live distinction clear:

--- a/reproductions/skia-animated-path-mask-churn/.gitignore
+++ b/reproductions/skia-animated-path-mask-churn/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.expo/
+ios/
+android/
+*.trace

--- a/reproductions/skia-animated-path-mask-churn/App.tsx
+++ b/reproductions/skia-animated-path-mask-churn/App.tsx
@@ -1,5 +1,5 @@
 import { Canvas, Group, Path, Skia } from "@shopify/react-native-skia";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, StyleSheet, Text, View } from "react-native";
 import {
   useDerivedValue,
@@ -16,6 +16,23 @@ const POINT_COUNT = 900;
 
 type Phase = "baseline" | "static" | "animated" | "unmounted";
 
+// One immutable fixture for the entire process. Keeping path construction out of
+// the component makes both remounts and animated frames reuse the exact object.
+const DENSE_PATH = (() => {
+  const result = Skia.Path.Make();
+  for (let index = 0; index < POINT_COUNT; index++) {
+    const t = index / (POINT_COUNT - 1);
+    const x = 8 + t * (CANVAS_WIDTH - 16);
+    const y =
+      CANVAS_HEIGHT / 2 +
+      Math.sin(t * Math.PI * 18) * 120 +
+      Math.sin(t * Math.PI * 74) * 26;
+    if (index === 0) result.moveTo(x, y);
+    else result.lineTo(x, y);
+  }
+  return result;
+})();
+
 function DensePathScene({ animated }: { animated: boolean }) {
   const animatedSV = useSharedValue(animated);
   const translateX = useSharedValue(0);
@@ -24,23 +41,6 @@ function DensePathScene({ animated }: { animated: boolean }) {
     animatedSV.set(animated);
     if (!animated) translateX.set(0);
   }, [animated, animatedSV, translateX]);
-
-  // Construct one immutable SkPath on the JS thread. The animated phase only
-  // changes its transform, so per-frame SkPath/array construction is excluded.
-  const path = useMemo(() => {
-    const result = Skia.Path.Make();
-    for (let index = 0; index < POINT_COUNT; index++) {
-      const t = index / (POINT_COUNT - 1);
-      const x = 8 + t * (CANVAS_WIDTH - 16);
-      const y =
-        CANVAS_HEIGHT / 2 +
-        Math.sin(t * Math.PI * 18) * 120 +
-        Math.sin(t * Math.PI * 74) * 26;
-      if (index === 0) result.moveTo(x, y);
-      else result.lineTo(x, y);
-    }
-    return result;
-  }, []);
 
   useFrameCallback((frameInfo) => {
     "worklet";
@@ -58,7 +58,7 @@ function DensePathScene({ animated }: { animated: boolean }) {
     <Canvas style={styles.canvas}>
       <Group transform={transform}>
         <Path
-          path={path}
+          path={DENSE_PATH}
           color="#66e3ff"
           style="stroke"
           strokeWidth={3}

--- a/reproductions/skia-animated-path-mask-churn/App.tsx
+++ b/reproductions/skia-animated-path-mask-churn/App.tsx
@@ -1,0 +1,162 @@
+import { Canvas, Group, Path, Skia } from "@shopify/react-native-skia";
+import { useEffect, useMemo, useState } from "react";
+import { Button, StyleSheet, Text, View } from "react-native";
+import {
+  useDerivedValue,
+  useFrameCallback,
+  useSharedValue,
+} from "react-native-reanimated";
+
+const BASELINE_SECONDS = 15;
+const STATIC_SECONDS = 20;
+const ANIMATED_SECONDS = 30;
+const CANVAS_WIDTH = 360;
+const CANVAS_HEIGHT = 440;
+const POINT_COUNT = 900;
+
+type Phase = "baseline" | "static" | "animated" | "unmounted";
+
+function DensePathScene({ animated }: { animated: boolean }) {
+  const animatedSV = useSharedValue(animated);
+  const translateX = useSharedValue(0);
+
+  useEffect(() => {
+    animatedSV.set(animated);
+    if (!animated) translateX.set(0);
+  }, [animated, animatedSV, translateX]);
+
+  // Construct one immutable SkPath on the JS thread. The animated phase only
+  // changes its transform, so per-frame SkPath/array construction is excluded.
+  const path = useMemo(() => {
+    const result = Skia.Path.Make();
+    for (let index = 0; index < POINT_COUNT; index++) {
+      const t = index / (POINT_COUNT - 1);
+      const x = 8 + t * (CANVAS_WIDTH - 16);
+      const y =
+        CANVAS_HEIGHT / 2 +
+        Math.sin(t * Math.PI * 18) * 120 +
+        Math.sin(t * Math.PI * 74) * 26;
+      if (index === 0) result.moveTo(x, y);
+      else result.lineTo(x, y);
+    }
+    return result;
+  }, []);
+
+  useFrameCallback((frameInfo) => {
+    "worklet";
+    if (!animatedSV.get()) return;
+    // A subpixel translation invalidates the same wide antialiased stroke each
+    // frame without changing the path object itself.
+    translateX.set(Math.sin(frameInfo.timestamp / 500) * 2);
+  });
+
+  const transform = useDerivedValue(() => [
+    { translateX: translateX.get() },
+  ]);
+
+  return (
+    <Canvas style={styles.canvas}>
+      <Group transform={transform}>
+        <Path
+          path={path}
+          color="#66e3ff"
+          style="stroke"
+          strokeWidth={3}
+          strokeCap="round"
+          strokeJoin="round"
+          antiAlias
+        />
+      </Group>
+    </Canvas>
+  );
+}
+
+function phaseAt(seconds: number): Phase {
+  if (seconds < BASELINE_SECONDS) return "baseline";
+  if (seconds < BASELINE_SECONDS + STATIC_SECONDS) return "static";
+  if (seconds < BASELINE_SECONDS + STATIC_SECONDS + ANIMATED_SECONDS) {
+    return "animated";
+  }
+  return "unmounted";
+}
+
+export default function App() {
+  const [automaticPhase, setAutomaticPhase] = useState<Phase>("baseline");
+  const [manualPhase, setManualPhase] = useState<Phase | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const startedAt = Date.now();
+    const interval = setInterval(() => {
+      const seconds = Math.floor((Date.now() - startedAt) / 1000);
+      setElapsed(seconds);
+      setAutomaticPhase(phaseAt(seconds));
+    }, 250);
+    return () => clearInterval(interval);
+  }, []);
+
+  const phase = manualPhase ?? automaticPhase;
+  const mounted = phase === "static" || phase === "animated";
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Skia animated path mask churn</Text>
+        <Text style={styles.metric}>Phase: {phase}</Text>
+        <Text style={styles.metric}>Elapsed: {elapsed}s</Text>
+        <Text style={styles.detail}>
+          One 900-segment immutable path. Only the animated phase changes a
+          subpixel transform at display cadence.
+        </Text>
+        <View style={styles.buttons}>
+          <Button title="Static" onPress={() => setManualPhase("static")} />
+          <Button title="Animate" onPress={() => setManualPhase("animated")} />
+          <Button title="Unmount" onPress={() => setManualPhase("unmounted")} />
+        </View>
+      </View>
+      {mounted ? <DensePathScene animated={phase === "animated"} /> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 16,
+    padding: 16,
+    backgroundColor: "#080d19",
+  },
+  card: {
+    width: CANVAS_WIDTH,
+    gap: 8,
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: "#151d30",
+  },
+  title: {
+    color: "white",
+    fontSize: 21,
+    fontWeight: "700",
+  },
+  metric: {
+    color: "#9ee7ff",
+    fontSize: 16,
+    fontVariant: ["tabular-nums"],
+  },
+  detail: {
+    color: "#c4ccdf",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  buttons: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  canvas: {
+    width: CANVAS_WIDTH,
+    height: CANVAS_HEIGHT,
+    backgroundColor: "#111827",
+  },
+});

--- a/reproductions/skia-animated-path-mask-churn/README.md
+++ b/reproductions/skia-animated-path-mask-churn/README.md
@@ -16,6 +16,10 @@ path builders, and per-frame `SkPath` construction from the experiment.
 | 35–65 s | animated | the same path moves at display cadence |
 | 65 s onward | unmounted | no Skia canvas mounted |
 
+The canvas is intentionally absent during the first 15 seconds. A dark empty
+app background at launch is the baseline phase, not a failed render. The phase
+label and cyan path appear when the static phase begins.
+
 ## Run on a physical iPhone
 
 From this directory:
@@ -57,5 +61,23 @@ software path renderer and 816.75 MiB through mask pixmap allocation. Almost all
 of it was destroyed before the interval ended. This reproduction is meant to
 confirm that the same transient mask churn survives after chart data, path
 construction, and wrapper lifetime are removed.
+
+## Physical-device result (2026-07-14)
+
+A Release capture on an iPhone 17 Pro Max running iOS 26.6 measured:
+
+| Phase | Physical-footprint mean | Min | Max | Last |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline | 104.32 MiB | 103.78 MiB | 105.08 MiB | 105.08 MiB |
+| Static path | 212.09 MiB | 198.41 MiB | 221.75 MiB | 221.75 MiB |
+| Animated path | 492.97 MiB | 491.99 MiB | 494.94 MiB | 492.72 MiB |
+| Unmounted | 430.03 MiB | 430.02 MiB | 430.06 MiB | 430.06 MiB |
+
+The immutable path therefore added about 281 MiB when display-cadence redraws
+were enabled, without changing JavaScript data or rebuilding the `SkPath`.
+Across the complete Allocations run, 4.76 GiB flowed through heap and anonymous
+VM allocations while only 115.37 MiB remained. The 48 KiB allocation class
+accounted for 749.48 MiB across 15,989 allocations but retained only 288 KiB.
+This independently reproduces high-volume transient native rendering churn.
 
 The Static, Animate, and Unmount buttons allow repeating each phase manually.

--- a/reproductions/skia-animated-path-mask-churn/README.md
+++ b/reproductions/skia-animated-path-mask-churn/README.md
@@ -1,0 +1,61 @@
+# Skia animated-path mask-churn reproduction
+
+This standalone Expo app isolates transient native allocation churn from
+redrawing one antialiased Skia path on iOS. It imports neither LiveChart nor any
+application data pipeline.
+
+The `SkPath` is created once on the JavaScript thread and contains 900 line
+segments. During animation, only a two-pixel subpixel translation changes at
+display cadence. This intentionally excludes JavaScript arrays, chart worklets,
+path builders, and per-frame `SkPath` construction from the experiment.
+
+| Time | Phase | Canvas behavior |
+| --- | --- | --- |
+| 0–15 s | baseline | no Skia canvas mounted |
+| 15–35 s | static | immutable path drawn once |
+| 35–65 s | animated | the same path moves at display cadence |
+| 65 s onward | unmounted | no Skia canvas mounted |
+
+## Run on a physical iPhone
+
+From this directory:
+
+```sh
+npm install
+npx expo run:ios --device --configuration Release --no-bundler
+```
+
+Record the installed Release app with Instruments' Allocations template for at
+least 75 seconds. Do not use the simulator: its command-line Activity Monitor
+recording does not produce a valid trace for this workflow.
+
+```sh
+xcrun xctrace record \
+  --template Allocations \
+  --device DEVICE_UDID \
+  --time-limit 75s \
+  --output /tmp/skia-animated-path-mask-churn.trace \
+  --launch com.brandtnewlabs.skia-animated-path-mask-churn
+```
+
+Compare allocations created in the static interval (15–35 s) with the animated
+interval (35–65 s). The expected animated-only call tree is:
+
+```text
+RNSkView::requestRedraw
+  → RNSkPictureRenderer::renderImmediate
+  → SkCanvas::drawPicture
+  → Device::drawPath
+  → SoftwarePathRenderer::onDrawPath
+  → GrSWMaskHelper::init
+  → SkAutoPixmapStorage::tryAlloc
+```
+
+The parent LiveChart capture sent about 2.03 GiB through the redraw/render stack
+in its selected steady-live interval, including about 1.61 GiB through the
+software path renderer and 816.75 MiB through mask pixmap allocation. Almost all
+of it was destroyed before the interval ended. This reproduction is meant to
+confirm that the same transient mask churn survives after chart data, path
+construction, and wrapper lifetime are removed.
+
+The Static, Animate, and Unmount buttons allow repeating each phase manually.

--- a/reproductions/skia-animated-path-mask-churn/app.json
+++ b/reproductions/skia-animated-path-mask-churn/app.json
@@ -9,7 +9,8 @@
     "jsEngine": "hermes",
     "ios": {
       "bundleIdentifier": "com.brandtnewlabs.skia-animated-path-mask-churn",
-      "appleTeamId": "MCL33ZBD7G"
+      "appleTeamId": "MCL33ZBD7G",
+      "deploymentTarget": "16.4"
     }
   }
 }

--- a/reproductions/skia-animated-path-mask-churn/app.json
+++ b/reproductions/skia-animated-path-mask-churn/app.json
@@ -1,0 +1,15 @@
+{
+  "expo": {
+    "name": "Skia Animated Path Mask Churn",
+    "slug": "skia-animated-path-mask-churn",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "dark",
+    "newArchEnabled": true,
+    "jsEngine": "hermes",
+    "ios": {
+      "bundleIdentifier": "com.brandtnewlabs.skia-animated-path-mask-churn",
+      "appleTeamId": "MCL33ZBD7G"
+    }
+  }
+}

--- a/reproductions/skia-animated-path-mask-churn/babel.config.js
+++ b/reproductions/skia-animated-path-mask-churn/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: ["react-native-worklets/plugin"],
+  };
+};

--- a/reproductions/skia-animated-path-mask-churn/package.json
+++ b/reproductions/skia-animated-path-mask-churn/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "skia-animated-path-mask-churn-repro",
+  "version": "1.0.0",
+  "private": true,
+  "main": "expo/AppEntry.js",
+  "scripts": {
+    "ios:release": "expo run:ios --configuration Release",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shopify/react-native-skia": "2.6.4",
+    "expo": "57.0.1",
+    "react": "19.2.3",
+    "react-native": "0.86.0",
+    "react-native-reanimated": "4.5.0",
+    "react-native-worklets": "0.10.0"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.14",
+    "babel-preset-expo": "57.0.0",
+    "typescript": "6.0.3"
+  }
+}

--- a/reproductions/skia-animated-path-mask-churn/tsconfig.json
+++ b/reproductions/skia-animated-path-mask-churn/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["App.tsx"]
+}


### PR DESCRIPTION
## What

Add a standalone Expo iOS reproduction that removes LiveChart and isolates one immutable 900-segment Skia path across four fixed phases: no canvas, static path, animated subpixel transform, and unmounted.

The animated phase changes only a two-pixel transform at display cadence. The path object is constructed once, so JavaScript arrays, chart worklets, PathBuilder lifetime, and per-frame SkPath construction are outside the experiment.

## Why

The #194 physical-device Allocations capture sent ~2.03 GiB through the redraw/render stack in a steady live interval, including ~1.61 GiB through `SoftwarePathRenderer` and 816.75 MiB through mask pixmap allocation. This repro makes that remaining upstream path suitable for a focused Skia report.

## Expected call tree

`RNSkView::requestRedraw -> RNSkPictureRenderer::renderImmediate -> Device::drawPath -> SoftwarePathRenderer::onDrawPath -> GrSWMaskHelper::init -> SkAutoPixmapStorage::tryAlloc`

## Capture status

The app is ready for a 75-second physical-iPhone Allocations capture. The connected phones were offline during this work, and simulator xctrace output is invalid, so no standalone trace is claimed here.

## Validation

- standalone TypeScript check passed
- standalone iOS Expo export passed (1,195 modules)
- standalone React Doctor — 100/100
- `npm run verify` — 92 suites passed; 1,332 passed, 5 skipped
- commit hook — 92 suites passed