### PR TITLE
fix: align tooltip sizing and variants

### DIFF
--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -240,7 +240,9 @@ export default function ScrubbingScreen() {
           tooltipPlacement,
           tooltipMargin,
           tooltipShowValue: !dateOnly,
-          tooltipShowTime: timeRow,
+          // Date only means hide the value while keeping the date visible. The
+          // separate Time row toggle can add the date to the normal value view.
+          tooltipShowTime: dateOnly || timeRow,
           tooltipBorderRadius: roundedTip ? 16 : 5,
           // `true` → default [4,4] dash; pass explicit [on, off] intervals for
           // finer control. Omit / `false` → solid.

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -142,6 +142,11 @@ export function CrosshairOverlay({
   const line1Y = useDerivedValue(() => tooltipLayout.value.line1Y);
   const line2Y = useDerivedValue(() => tooltipLayout.value.line2Y);
 
+  // Keep the built-in body in sync with computeTooltipLayout: when both rows
+  // are disabled, retain the time row so the tooltip never renders empty.
+  const effectiveTooltipShowTime =
+    tooltipShowTime || (!tooltipShowValue && !tooltipShowTime);
+
   // dstOut erase color: alpha = how much of the trailing content to remove,
   // ramped by the crosshair fade-in. Color RGB is irrelevant for dstOut.
   const dimErase = useDerivedValue(
@@ -231,7 +236,7 @@ export function CrosshairOverlay({
                     color={tooltipColor ?? palette.tooltipText}
                   />
                 )}
-                {tooltipShowTime && (
+                {effectiveTooltipShowTime && (
                   <SkiaText
                     x={timeTextX}
                     y={tooltipShowValue ? line2Y : line1Y}

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -14,6 +14,17 @@ const TOOLTIP_EDGE_GAP = 4;
 const TOOLTIP_TOP_MARGIN = 8;
 const FADE_ZONE = 4;
 
+/** Measure rendered text so the pill and its content share the same centre. */
+function measureTooltipTextWidth(
+  font: SkFont,
+  text: string,
+  monoCharWidth: number,
+): number {
+  "worklet";
+  const measured = measureFontTextWidth(font, text);
+  return measured > 0 ? measured : text.length * monoCharWidth;
+}
+
 export interface TooltipLayout {
   x: number;
   y: number;
@@ -197,10 +208,7 @@ export function computeTooltipLayout(
   formatValue: (v: number) => string,
   formatTime: (t: number) => string,
   font: SkFont,
-  /** Monospace advance width. When > 0, text width is `len * monoCharWidth`
-   *  instead of a per-frame Skia `measureText` — scrubbing re-runs this worklet
-   *  every frame, and `measureText` shapes text each call (a real cost,
-   *  especially in the simulator). Falls back to `measureText` when 0. */
+  /** Monospace advance width fallback when font measurement returns zero. */
   monoCharWidth = 0,
   /** Where the pill sits relative to the scrub line. `"side"` offsets it right
    *  (flipping left near the edge); `"top"`/`"bottom"` center it over the line,
@@ -243,14 +251,11 @@ export function computeTooltipLayout(
   const totalH =
     TOOLTIP_PAD_Y * 2 + lineH * rowCount + TOOLTIP_LINE_GAP * (rowCount - 1);
 
-  const valueW =
-    monoCharWidth > 0
-      ? valueStr.length * monoCharWidth
-      : measureFontTextWidth(font, valueStr);
-  const timeW =
-    monoCharWidth > 0
-      ? timeStr.length * monoCharWidth
-      : measureFontTextWidth(font, timeStr);
+  // Use actual glyph bounds for every visible-row variant. The old
+  // character-count approximation made punctuation-heavy dates/times appear
+  // off-centre even when the pill itself was positioned correctly.
+  const valueW = measureTooltipTextWidth(font, valueStr, monoCharWidth);
+  const timeW = measureTooltipTextWidth(font, timeStr, monoCharWidth);
   // Only the visible rows contribute to the pill width.
   const contentW = Math.max(sv ? valueW : 0, st ? timeW : 0);
   const pillW = contentW + TOOLTIP_PAD_X * 2;
@@ -333,8 +338,7 @@ export function computeTooltipLayoutMulti(
   padding: ChartPadding,
   canvasWidth: number,
   font: SkFont,
-  /** Monospace advance width; when > 0, sizes text by length instead of a
-   *  per-frame Skia `measureText`. See {@link computeTooltipLayout}. */
+  /** Monospace advance width fallback when font measurement returns zero. */
   monoCharWidth = 0,
 ): TooltipLayout {
   "worklet";
@@ -349,10 +353,7 @@ export function computeTooltipLayoutMulti(
   let contentW = 0;
   const lineWidths: number[] = [];
   for (let i = 0; i < n; i++) {
-    const w =
-      monoCharWidth > 0
-        ? lines[i].text.length * monoCharWidth
-        : measureFontTextWidth(font, lines[i].text);
+    const w = measureTooltipTextWidth(font, lines[i].text, monoCharWidth);
     lineWidths.push(w);
     if (w > contentW) contentW = w;
   }

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -539,6 +539,44 @@ describe("CrosshairOverlay", () => {
     expect(tree).toContain('"r":9');
   });
 
+  it("keeps the time row when both built-in tooltip rows are disabled", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(1);
+      const tooltipLayout = useSharedValue<TooltipLayout>({
+        x: 110,
+        y: 20,
+        w: 80,
+        h: 24,
+        valueStr: "42.00",
+        timeStr: "12:00:00",
+        valueTextX: 115,
+        timeTextX: 115,
+        line1Y: 30,
+        line2Y: 45,
+        stackedLines: undefined,
+      });
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          showTooltip
+          tooltipShowValue={false}
+          tooltipShowTime={false}
+        />
+      );
+    }
+    const { toJSON } = render(<Fixture />);
+    const tree = JSON.stringify(toJSON());
+    expect(tree).not.toContain("42.00");
+    expect(tree).toContain("12:00:00");
+  });
+
   it("renders stacked multi-series tooltip lines", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -235,7 +235,7 @@ describe("computeTooltipLayout", () => {
     expect(layout.timeStr.length).toBeGreaterThan(0);
   });
 
-  it("sizes text by character count when monoCharWidth is set (skips measureText)", () => {
+  it("sizes text using measured widths", () => {
     const layout = computeTooltipLayout(
       true,
       50,
@@ -248,9 +248,9 @@ describe("computeTooltipLayout", () => {
       font,
       8, // monospace advance
     );
-    // timeStr "HH:MM:SS" (8 chars) is the widest line; pill = 8*8 + 2*PAD_X(8)
+    // timeStr "HH:MM:SS" (8 chars) is the widest line; the mock font is 7px/char.
     expect(layout.timeStr.length).toBe(8);
-    expect(layout.w).toBe(8 * 8 + 16);
+    expect(layout.w).toBe(8 * 7 + 16);
   });
 
   it("places tooltip to the right of crosshair when space is available", () => {
@@ -542,7 +542,42 @@ describe("computeTooltipLayout", () => {
     );
     // Single row: height = PAD_Y*2 + lineH = 12 + 12 = 24; sized by the time row.
     expect(layout.h).toBe(24);
-    expect(layout.w).toBe(layout.timeStr.length * 8 + 16);
+    expect(layout.w).toBe(layout.timeStr.length * 7 + 16);
+  });
+
+  it("centers a date-only row using its measured text width", () => {
+    const dateFont = {
+      ...font,
+      measureText: (s: string) => ({
+        x: 0,
+        y: 0,
+        // Deliberately make punctuation narrower than the digit advance.
+        width: s.length * 7 - (s.match(/:/g)?.length ?? 0) * 2,
+        height: 12,
+      }),
+    } as unknown as SkFont;
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      () => "06:39:29",
+      dateFont,
+      7,
+      "bottom",
+      false,
+      true,
+      300,
+      8,
+    );
+    const textW = dateFont.measureText(layout.timeStr).width;
+
+    expect(layout.w).toBe(textW + 16);
+    expect(layout.x + layout.w / 2).toBeCloseTo(200);
+    expect(layout.timeTextX + textW / 2).toBeCloseTo(200);
   });
 
   it("drops the time row when showTime is false (single row sized by value)", () => {
@@ -562,7 +597,38 @@ describe("computeTooltipLayout", () => {
       false, // showTime
     );
     expect(layout.h).toBe(24);
-    expect(layout.w).toBe(layout.valueStr.length * 8 + 16);
+    expect(layout.w).toBe(layout.valueStr.length * 7 + 16);
+  });
+
+  it("centers both value and time rows using their measured widths", () => {
+    const mixedFont = {
+      ...font,
+      measureText: (s: string) => ({
+        x: 0,
+        y: 0,
+        width: s.length * 7 - (s.match(/:/g)?.length ?? 0) * 2,
+        height: 12,
+      }),
+    } as unknown as SkFont;
+    const layout = computeTooltipLayout(
+      true,
+      200,
+      42,
+      985,
+      padding,
+      400,
+      formatValue,
+      () => "06:39:29",
+      mixedFont,
+      7,
+    );
+    const valueW = mixedFont.measureText(layout.valueStr).width;
+    const timeW = mixedFont.measureText(layout.timeStr).width;
+    const pillCenter = layout.x + layout.w / 2;
+
+    expect(layout.w).toBe(Math.max(valueW, timeW) + 16);
+    expect(layout.valueTextX + valueW / 2).toBeCloseTo(pillCenter);
+    expect(layout.timeTextX + timeW / 2).toBeCloseTo(pillCenter);
   });
 
   it("falls back to the time row when both content rows are off", () => {
@@ -582,7 +648,7 @@ describe("computeTooltipLayout", () => {
       false,
     );
     expect(layout.h).toBe(24);
-    expect(layout.w).toBe(layout.timeStr.length * 8 + 16);
+    expect(layout.w).toBe(layout.timeStr.length * 7 + 16);
   });
 });
 
@@ -599,7 +665,7 @@ describe("computeTooltipLayoutMulti", () => {
     expect(layout.x).toBeLessThan(0);
   });
 
-  it("sizes rows by character count when monoCharWidth is set (skips measureText)", () => {
+  it("sizes rows using measured text widths", () => {
     const layout = computeTooltipLayoutMulti(
       true,
       50,
@@ -612,8 +678,8 @@ describe("computeTooltipLayoutMulti", () => {
       font,
       8, // monospace advance
     );
-    // widest row is 5 chars; pill = 5*8 + 2*PAD_X(8)
-    expect(layout.w).toBe(5 * 8 + 16);
+    // widest row is 5 chars at 7px each; pill = 5*7 + 2*PAD_X(8)
+    expect(layout.w).toBe(5 * 7 + 16);
   });
 
   it("builds stackedLines for each row", () => {


### PR DESCRIPTION
## What changed

- Center built-in tooltip rows using measured glyph widths, including date-only and multi-row variants.
- Keep the time row visible when both built-in rows are disabled so the pill is never empty.
- Make the Scrubbing demo's Date only toggle keep its date visible.
- Add regression coverage for tooltip rendering and centering.

## Root cause

Tooltip geometry and rendering used different row visibility rules, and character-count sizing was inaccurate for punctuation-heavy timestamps.

## Validation

- `npm run verify`
- 90 test suites passed; 1321 tests passed, 5 skipped