### PR TITLE
chore(release): v4.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.2] - 2026-07-15
+
 ### Changed
 
 - **Disabled `LiveChart` subsystems no longer register their UI-thread worklets.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -17734,7 +17734,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "4.9.1",
+      "version": "4.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "4.9.1"
+  "version": "4.9.2"
 }


### PR DESCRIPTION
## Summary

Release `react-native-livechart` v4.9.2.

### Changed

- Disabled LiveChart subsystems no longer register unused UI-thread worklets.
- Crosshair geometry now publishes two coherent snapshots instead of twelve chained derived values.

### Validation

- `npm ci` with npm 10
- `npm run verify`
- 92 test suites passed
- 1,324 tests passed, 5 skipped
- Package dry run confirmed only the intended library artifacts are included