### PR TITLE
fix: stuck crosshair when a press ends before the scrub hold delay

### DIFF
--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -150,6 +150,15 @@ export function useCrosshair(
   // Tracks whether the active scrub phase actually began, so a tap that never
   // activates doesn't emit a spurious onGestureEnd.
   const gestureStarted = useSharedValue(false);
+  // Guards the `activateAfterLongPress` post-lift activation: on iOS, RNGH only
+  // cancels the long-press timer on >10pt movement or recognizer reset — NOT on
+  // touch-up. A still press shorter than the delay leaves the timer armed; it
+  // fires after the finger lifts, onStart runs with no finger down, and no END
+  // ever follows — stranding the crosshair. `onTouchesUp` fails a still-pending
+  // pan outright (killing the timer), and `fingerDown` lets onStart bail if an
+  // activation still slips in after the lift.
+  const fingerDown = useSharedValue(false);
+  const panActivated = useSharedValue(false);
   // Where the crosshair line should start (canvas Y) so it stops at a top-pinned
   // custom tooltip instead of running through it. -1 = no top tooltip → the line
   // starts at padding.top. Written by CustomTooltipOverlay, read by CrosshairOverlay.
@@ -498,6 +507,29 @@ export function useCrosshair(
     .activateAfterLongPress(longPressMs)
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
+    .onTouchesDown(
+      /* istanbul ignore next */ () => {
+        "worklet";
+        fingerDown.set(true);
+      },
+    )
+    .onTouchesUp(
+      /* istanbul ignore next */ (e, manager) => {
+        "worklet";
+        if (e.numberOfTouches > 0) return;
+        fingerDown.set(false);
+        // Last finger up while the pan is still pending (long-press timer not
+        // fired): fail it now so a timer landing after this UP can't activate
+        // a gesture that will never receive an END.
+        if (!panActivated.get()) manager.fail();
+      },
+    )
+    .onTouchesCancelled(
+      /* istanbul ignore next */ () => {
+        "worklet";
+        fingerDown.set(false);
+      },
+    )
     // Start scrubbing on ACTIVE (onStart), not on touch-down (onBegin):
     // `activateAfterLongPress` only delays activation, so onBegin still fires
     // immediately — using it would scrub instantly and ignore panGestureDelay,
@@ -505,7 +537,11 @@ export function useCrosshair(
     .onStart(
       /* istanbul ignore next */ (e) => {
         "worklet";
+        panActivated.set(true);
         if (!enabled) return;
+        // Activation raced a lift (see fingerDown above): don't engage — there
+        // is no finger to scrub with and no END coming to clean up.
+        if (!fingerDown.get()) return;
         // Scrub-action: once a reticle is placed, drag adjusts it (2D — the Y is
         // the price). The ephemeral live-scrub never engages, so scrubActive
         // stays false and the live crosshair hides itself.
@@ -569,6 +605,8 @@ export function useCrosshair(
     .onFinalize(
       /* istanbul ignore next */ () => {
         "worklet";
+        panActivated.set(false);
+        fingerDown.set(false);
         // A lock-adjust drag leaves the reticle in place (scrubActive was never
         // set); a live-scrub clears its crosshair. Always clear scrubActive so a
         // stray scrub can never linger behind a placed reticle.


### PR DESCRIPTION
## Bug

With `timeScroll: { gesture: "holdToScrub" }` (or any `panGestureDelay` > 0): press the chart for **less than** the hold delay without moving, then lift. The crosshair can appear *after* the finger is already up and stay stuck on screen (with an `onGestureStart` that never gets its `onGestureEnd`) until the chart is touched again.

## Root cause

The scrub pan activates via RNGH's `activateAfterLongPress`. On iOS that timer is scheduled on touch-down and only cancelled in two places — >10pt of movement, or recognizer reset ([RNPanHandler.m](https://github.com/software-mansion/react-native-gesture-handler/blob/main/apple/Handlers/RNPanHandler.m): `interactionsBegan` schedules it, `shouldFailUnderCustomCriteria` / `reset` cancel it). **Touch-up does not cancel it**, and RNGH parks the underlying `UIPanGestureRecognizer` at `minimumNumberOfTouches = 20` while custom criteria are pending, so a still, short press doesn't get failed/reset by UIKit on lift either.

Sequence: press < delay → lift (timer still armed) → timer fires → pan force-activates with no touches → `onStart` shows the crosshair → no END/FINALIZE ever arrives → `scrubActive` stuck.

## Fix

Two guards in `useCrosshair`'s scrub pan, both UI-thread worklets:

1. `onTouchesUp`: when the last finger lifts and the pan hasn't activated yet, `manager.fail()` — the fail resets the recognizer, which is the code path that cancels the armed timer. (A pending pan was going to fail on lift anyway; this just makes it explicit and immediate.)
2. `onStart`: bail before engaging scrub if no finger is down (`fingerDown` tracked via `onTouchesDown`/`Up`/`Cancelled`) — backstop if an activation still slips in after the lift.

Normal holds, taps, drags, and scrub-action lock-adjust are unaffected: a real hold has the finger down at activation, and `onFinalize` resets both flags.

`npm run verify` passes (typecheck, lint, 92 suites / 1324 tests). The new code is gesture worklets, `istanbul ignore`d like the surrounding handlers.

Found in production use — we're carrying this as a pnpm patch on 4.9.1 in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)