### PR TITLE
fix: harden delayed scrub lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Short taps no longer strand a delayed scrub crosshair on iOS.** When a
+  stationary press ended before `scrub.panGestureDelay` /
+  `timeScroll.scrubHoldMs`, React Native Gesture Handler could fire its pending
+  long-press timer after the finger was already up, leaving the crosshair active
+  without a matching gesture end. Both `LiveChart` and `LiveChartSeries` now
+  fail that pending pan on the final pointer-up and ignore any raced activation;
+  zero-delay scrubbing is unchanged. Thanks [@ianlapham](https://github.com/ianlapham).
+  ([#206](https://github.com/brandtnewlabs/react-native-livechart/pull/206))
+
 ## [4.9.2] - 2026-07-15
 
 ### Changed

--- a/packages/react-native-livechart/src/hooks/delayedPanGuard.ts
+++ b/packages/react-native-livechart/src/hooks/delayedPanGuard.ts
@@ -1,0 +1,80 @@
+import type { SharedValue } from "react-native-reanimated";
+
+type BooleanSharedValue = Pick<SharedValue<boolean>, "get" | "set">;
+
+type TouchCountEvent = {
+  numberOfTouches: number;
+};
+
+type GestureStateManager = {
+  fail: () => void;
+};
+
+/** Mark the first pointer of a delayed pan as down. Zero-delay pans are inert. */
+export function delayedPanTouchDown(
+  delayMs: number,
+  fingerDown: BooleanSharedValue,
+): void {
+  "worklet";
+  if (delayMs > 0) fingerDown.set(true);
+}
+
+/**
+ * Fail a delayed pan that is still pending when its final pointer lifts.
+ *
+ * RNGH 2.x on iOS can leave `activateAfterLongPress`'s timer armed after a
+ * stationary touch ends. Failing the pending recognizer forces the reset that
+ * cancels that timer. An already-active pan is left to finish normally.
+ */
+export function delayedPanTouchUp(
+  delayMs: number,
+  event: TouchCountEvent,
+  manager: GestureStateManager,
+  fingerDown: BooleanSharedValue,
+  panActivated: BooleanSharedValue,
+): void {
+  "worklet";
+  if (delayMs <= 0 || event.numberOfTouches > 0) return;
+  fingerDown.set(false);
+  if (!panActivated.get()) manager.fail();
+}
+
+/** Clear pointer state when the native touch stream is cancelled. */
+export function delayedPanTouchCancelled(
+  delayMs: number,
+  fingerDown: BooleanSharedValue,
+): void {
+  "worklet";
+  if (delayMs > 0) fingerDown.set(false);
+}
+
+/**
+ * Record a real delayed-pan activation, or reject an activation whose timer
+ * raced the final pointer-up. The rejected path deliberately keeps
+ * `panActivated` false so a missing native FINALIZE cannot poison the next
+ * interaction.
+ */
+export function shouldStartDelayedPan(
+  delayMs: number,
+  fingerDown: BooleanSharedValue,
+  panActivated: BooleanSharedValue,
+): boolean {
+  "worklet";
+  if (delayMs <= 0) return true;
+  if (!fingerDown.get()) {
+    panActivated.set(false);
+    return false;
+  }
+  panActivated.set(true);
+  return true;
+}
+
+/** Reset the delayed-pan lifecycle after native finalization. */
+export function resetDelayedPanGuard(
+  fingerDown: BooleanSharedValue,
+  panActivated: BooleanSharedValue,
+): void {
+  "worklet";
+  fingerDown.set(false);
+  panActivated.set(false);
+}

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -36,6 +36,13 @@ import {
   snapPrice,
   type CrosshairState,
 } from "./crosshairShared";
+import {
+  delayedPanTouchCancelled,
+  delayedPanTouchDown,
+  delayedPanTouchUp,
+  resetDelayedPanGuard,
+  shouldStartDelayedPan,
+} from "./delayedPanGuard";
 
 const ACTION_HIT_SLOP = 6;
 const RETICLE_HIT = 14;
@@ -150,13 +157,8 @@ export function useCrosshair(
   // Tracks whether the active scrub phase actually began, so a tap that never
   // activates doesn't emit a spurious onGestureEnd.
   const gestureStarted = useSharedValue(false);
-  // Guards the `activateAfterLongPress` post-lift activation: on iOS, RNGH only
-  // cancels the long-press timer on >10pt movement or recognizer reset — NOT on
-  // touch-up. A still press shorter than the delay leaves the timer armed; it
-  // fires after the finger lifts, onStart runs with no finger down, and no END
-  // ever follows — stranding the crosshair. `onTouchesUp` fails a still-pending
-  // pan outright (killing the timer), and `fingerDown` lets onStart bail if an
-  // activation still slips in after the lift.
+  // Guard state for RNGH's delayed-pan post-lift activation on iOS. The shared
+  // lifecycle helpers are also used by LiveChartSeries and unit-tested directly.
   const fingerDown = useSharedValue(false);
   const panActivated = useSharedValue(false);
   // Where the crosshair line should start (canvas Y) so it stops at a top-pinned
@@ -510,24 +512,25 @@ export function useCrosshair(
     .onTouchesDown(
       /* istanbul ignore next */ () => {
         "worklet";
-        fingerDown.set(true);
+        delayedPanTouchDown(longPressMs, fingerDown);
       },
     )
     .onTouchesUp(
       /* istanbul ignore next */ (e, manager) => {
         "worklet";
-        if (e.numberOfTouches > 0) return;
-        fingerDown.set(false);
-        // Last finger up while the pan is still pending (long-press timer not
-        // fired): fail it now so a timer landing after this UP can't activate
-        // a gesture that will never receive an END.
-        if (!panActivated.get()) manager.fail();
+        delayedPanTouchUp(
+          longPressMs,
+          e,
+          manager,
+          fingerDown,
+          panActivated,
+        );
       },
     )
     .onTouchesCancelled(
       /* istanbul ignore next */ () => {
         "worklet";
-        fingerDown.set(false);
+        delayedPanTouchCancelled(longPressMs, fingerDown);
       },
     )
     // Start scrubbing on ACTIVE (onStart), not on touch-down (onBegin):
@@ -537,11 +540,8 @@ export function useCrosshair(
     .onStart(
       /* istanbul ignore next */ (e) => {
         "worklet";
-        panActivated.set(true);
+        if (!shouldStartDelayedPan(longPressMs, fingerDown, panActivated)) return;
         if (!enabled) return;
-        // Activation raced a lift (see fingerDown above): don't engage — there
-        // is no finger to scrub with and no END coming to clean up.
-        if (!fingerDown.get()) return;
         // Scrub-action: once a reticle is placed, drag adjusts it (2D — the Y is
         // the price). The ephemeral live-scrub never engages, so scrubActive
         // stays false and the live crosshair hides itself.
@@ -605,8 +605,7 @@ export function useCrosshair(
     .onFinalize(
       /* istanbul ignore next */ () => {
         "worklet";
-        panActivated.set(false);
-        fingerDown.set(false);
+        resetDelayedPanGuard(fingerDown, panActivated);
         // A lock-adjust drag leaves the reticle in place (scrubActive was never
         // set); a live-scrub clears its crosshair. Always clear scrubActive so a
         // stray scrub can never linger behind a placed reticle.

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -20,6 +20,13 @@ import {
   HIDDEN_TOOLTIP,
   type CrosshairState,
 } from "./crosshairShared";
+import {
+  delayedPanTouchCancelled,
+  delayedPanTouchDown,
+  delayedPanTouchUp,
+  resetDelayedPanGuard,
+  shouldStartDelayedPan,
+} from "./delayedPanGuard";
 
 /**
  * LiveChartSeries crosshair + scrub. No tooltip — data is delivered via
@@ -40,6 +47,10 @@ export function useCrosshairSeries(
   // Tracks whether the active scrub phase actually began, so a tap that never
   // activates doesn't emit a spurious onGestureEnd.
   const gestureStarted = useSharedValue(false);
+  // Mirrors LiveChart's guard against RNGH's delayed-pan timer activating after
+  // the final pointer has already lifted on iOS.
+  const fingerDown = useSharedValue(false);
+  const panActivated = useSharedValue(false);
 
   const scrubTime = useDerivedValue(() =>
     computeScrubTime(
@@ -158,6 +169,30 @@ export function useCrosshairSeries(
     .activateAfterLongPress(panGestureDelay)
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
+    .onTouchesDown(
+      /* istanbul ignore next */ () => {
+        "worklet";
+        delayedPanTouchDown(panGestureDelay, fingerDown);
+      },
+    )
+    .onTouchesUp(
+      /* istanbul ignore next */ (e, manager) => {
+        "worklet";
+        delayedPanTouchUp(
+          panGestureDelay,
+          e,
+          manager,
+          fingerDown,
+          panActivated,
+        );
+      },
+    )
+    .onTouchesCancelled(
+      /* istanbul ignore next */ () => {
+        "worklet";
+        delayedPanTouchCancelled(panGestureDelay, fingerDown);
+      },
+    )
     // Start scrubbing on ACTIVE (onStart), not on touch-down (onBegin):
     // `activateAfterLongPress` only delays activation, so onBegin still fires
     // immediately — using it would scrub instantly and ignore panGestureDelay,
@@ -165,6 +200,8 @@ export function useCrosshairSeries(
     .onStart(
       /* istanbul ignore next */ (e) => {
         "worklet";
+        if (!shouldStartDelayedPan(panGestureDelay, fingerDown, panActivated))
+          return;
         if (!enabled) return;
         scrubX.set(e.x);
         scrubActive.set(true);
@@ -182,6 +219,7 @@ export function useCrosshairSeries(
     .onFinalize(
       /* istanbul ignore next */ () => {
         "worklet";
+        resetDelayedPanGuard(fingerDown, panActivated);
         scrubActive.set(false);
         if (gestureStarted.get()) {
           gestureStarted.set(false);

--- a/packages/react-native-livechart/tests/hooks/delayedPanGuard.test.ts
+++ b/packages/react-native-livechart/tests/hooks/delayedPanGuard.test.ts
@@ -1,0 +1,127 @@
+import type { SharedValue } from "react-native-reanimated";
+import {
+  delayedPanTouchCancelled,
+  delayedPanTouchDown,
+  delayedPanTouchUp,
+  resetDelayedPanGuard,
+  shouldStartDelayedPan,
+} from "../../src/hooks/delayedPanGuard";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+function booleanSharedValue(initial: boolean): SharedValue<boolean> {
+  const result = withSharedValueAccessors({
+    shared: { value: initial },
+  });
+  return result.shared as unknown as SharedValue<boolean>;
+}
+
+describe("delayed pan guard", () => {
+  it("fails a pending delayed pan when its final pointer lifts", () => {
+    const fingerDown = booleanSharedValue(false);
+    const panActivated = booleanSharedValue(false);
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(400, fingerDown);
+    expect(fingerDown.get()).toBe(true);
+
+    delayedPanTouchUp(
+      400,
+      { numberOfTouches: 0 },
+      manager,
+      fingerDown,
+      panActivated,
+    );
+
+    expect(fingerDown.get()).toBe(false);
+    expect(manager.fail).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for the final pointer before failing a pending pan", () => {
+    const fingerDown = booleanSharedValue(true);
+    const panActivated = booleanSharedValue(false);
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchUp(
+      400,
+      { numberOfTouches: 1 },
+      manager,
+      fingerDown,
+      panActivated,
+    );
+
+    expect(fingerDown.get()).toBe(true);
+    expect(manager.fail).not.toHaveBeenCalled();
+  });
+
+  it("allows a real hold activation and lets the active pan finish normally", () => {
+    const fingerDown = booleanSharedValue(false);
+    const panActivated = booleanSharedValue(false);
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(400, fingerDown);
+    expect(shouldStartDelayedPan(400, fingerDown, panActivated)).toBe(true);
+    expect(panActivated.get()).toBe(true);
+
+    delayedPanTouchUp(
+      400,
+      { numberOfTouches: 0 },
+      manager,
+      fingerDown,
+      panActivated,
+    );
+    expect(manager.fail).not.toHaveBeenCalled();
+
+    resetDelayedPanGuard(fingerDown, panActivated);
+    expect(fingerDown.get()).toBe(false);
+    expect(panActivated.get()).toBe(false);
+  });
+
+  it("rejects a post-lift activation without leaving stale activated state", () => {
+    const fingerDown = booleanSharedValue(false);
+    const panActivated = booleanSharedValue(false);
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(400, fingerDown);
+    delayedPanTouchUp(
+      400,
+      { numberOfTouches: 0 },
+      manager,
+      fingerDown,
+      panActivated,
+    );
+
+    expect(shouldStartDelayedPan(400, fingerDown, panActivated)).toBe(false);
+    expect(panActivated.get()).toBe(false);
+
+    delayedPanTouchDown(400, fingerDown);
+    expect(shouldStartDelayedPan(400, fingerDown, panActivated)).toBe(true);
+  });
+
+  it("leaves zero-delay pan behavior untouched", () => {
+    const fingerDown = booleanSharedValue(false);
+    const panActivated = booleanSharedValue(false);
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(0, fingerDown);
+    delayedPanTouchUp(
+      0,
+      { numberOfTouches: 0 },
+      manager,
+      fingerDown,
+      panActivated,
+    );
+
+    expect(shouldStartDelayedPan(0, fingerDown, panActivated)).toBe(true);
+    expect(fingerDown.get()).toBe(false);
+    expect(panActivated.get()).toBe(false);
+    expect(manager.fail).not.toHaveBeenCalled();
+  });
+
+  it("clears delayed pointer state on cancellation", () => {
+    const fingerDown = booleanSharedValue(true);
+
+    delayedPanTouchCancelled(400, fingerDown);
+
+    expect(fingerDown.get()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- share the delayed-pan lifecycle guard between `LiveChart` and `LiveChartSeries`
- keep zero-delay scrubbing on its existing activation path
- reject a post-lift timer race without leaving stale `panActivated` state
- add focused regression coverage and document the fix under `Unreleased`

## Root cause

Follow-up to #206. On iOS, RNGH 2.x can leave `activateAfterLongPress`'s timer armed after a stationary touch ends. The merged fix guarded the single-series crosshair. The multi-series hook used the same delayed-pan pattern, and the backstop could leave its internal activated flag stale if native activation raced pointer-up without a later `FINALIZE`.

This PR consolidates that state machine into worklet-safe helpers used by both hooks. The helpers only intervene when the configured delay is greater than zero.

## Validation

- `npm run verify` — 93 suites passed; 1,333 tests passed, 5 skipped
- focused delayed-pan and crosshair hook tests — 85 passed
- React Doctor against `origin/main` — 100/100

Native iOS interaction verification remains intentionally visible while this PR is a draft.
