### PR TITLE
Fix Y-axis labels rendering under live badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Y-axis labels no longer render underneath the live value badge.** Labels
+  whose line box intersects a right-side badge pill are hidden while their grid
+  lines remain visible, including floating-axis layouts and configured vertical
+  badge offsets. ([#200](https://github.com/brandtnewlabs/react-native-livechart/issues/200))
 - **Short taps no longer strand a delayed scrub crosshair on iOS.** When a
   stationary press ended before `scrub.panGestureDelay` /
   `timeScroll.scrubHoldMs`, React Native Gesture Handler could fire its pending

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1412,8 +1412,10 @@ function ChartYAxisLayer({
     effectivePadding,
     palette,
     skiaFont,
+    dotY,
     badgeUsesRightGutter,
     badgeCfg,
+    badgeFont,
     metricsCfg,
     gridStyleCfg,
     yAxisFloat,
@@ -1431,6 +1433,9 @@ function ChartYAxisLayer({
         badge={badgeUsesRightGutter}
         badgeTail={badgeCfg?.tail ?? true}
         badgeMetrics={metricsCfg.badge}
+        badgeCenterY={badgeUsesRightGutter ? dotY : undefined}
+        badgeFontSize={badgeUsesRightGutter ? badgeFont.getSize() : undefined}
+        badgeOffsetY={badgeCfg?.offsetY ?? 0}
         gridStyle={gridStyleCfg}
       />
     </Group>

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -24,6 +24,22 @@ import { AnimatedLabel } from "./AnimatedLabel";
 /** Right margin (px) for floating labels — keeps them just off the canvas edge. */
 const FLOAT_LABEL_RIGHT_MARGIN = 6;
 
+/** Returns true when a Y-axis label's line box intersects the live badge pill. */
+export function yAxisLabelIntersectsBadge(
+  labelCenterY: number,
+  labelHeight: number,
+  badgeCenterY: number,
+  badgeHeight: number,
+) {
+  "worklet";
+  const labelHalfHeight = labelHeight / 2;
+  const badgeHalfHeight = badgeHeight / 2;
+  return (
+    labelCenterY + labelHalfHeight > badgeCenterY - badgeHalfHeight &&
+    labelCenterY - labelHalfHeight < badgeCenterY + badgeHalfHeight
+  );
+}
+
 export function YAxisOverlay({
   entries,
   engine,
@@ -33,6 +49,9 @@ export function YAxisOverlay({
   badge = false,
   badgeTail = true,
   badgeMetrics = BADGE_METRICS_DEFAULTS,
+  badgeCenterY,
+  badgeFontSize,
+  badgeOffsetY = 0,
   seriesLabelInset = 0,
   gridStyle,
   variant = "all",
@@ -49,6 +68,12 @@ export function YAxisOverlay({
   badgeTail?: boolean;
   /** Badge pill geometry tokens (kept in sync with useBadge). */
   badgeMetrics?: BadgeMetrics;
+  /** Live badge center before its configured Y offset. Enables label collision suppression. */
+  badgeCenterY?: SharedValue<number>;
+  /** Live badge font size, used to reconstruct the pill's vertical bounds. */
+  badgeFontSize?: number;
+  /** Configured live badge Y offset. */
+  badgeOffsetY?: number;
   /** When > 0, series labels occupy the left portion of the gutter; Y-axis labels right-align. */
   seriesLabelInset?: number;
   /** Grid-line styling overrides. Omit for the legacy solid 1px line. */
@@ -92,6 +117,14 @@ export function YAxisOverlay({
     const w = engine.canvasWidth.get();
     const fm = font.getMetrics();
     const baselineOffset = (fm.ascent + fm.descent) / 2;
+    const labelHeight = fm.descent - fm.ascent;
+    const resolvedBadgeCenterY = badgeCenterY
+      ? badgeCenterY.get() + badgeOffsetY
+      : null;
+    const badgeHeight =
+      badgeFontSize === undefined
+        ? 0
+        : badgeFontSize + badgeMetrics.padY * 2;
     const result: { x: number; y: number; label: string; alpha: number }[] = [];
     for (let i = 0; i < items.length; i++) {
       const e = items[i];
@@ -107,7 +140,16 @@ export function YAxisOverlay({
         x,
         y: e.y - baselineOffset,
         label: e.label,
-        alpha: e.alpha,
+        alpha:
+          resolvedBadgeCenterY !== null &&
+          yAxisLabelIntersectsBadge(
+            e.y,
+            labelHeight,
+            resolvedBadgeCenterY,
+            badgeHeight,
+          )
+            ? 0
+            : e.alpha,
       });
     }
     return result;

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -15,7 +15,10 @@ import type { TooltipLayout } from "../../src/hooks/crosshairShared";
 import type { SelectionDotProps } from "../../src/types";
 import { ValueLineOverlay } from "../../src/components/ValueLineOverlay";
 import { XAxisOverlay } from "../../src/components/XAxisOverlay";
-import { YAxisOverlay } from "../../src/components/YAxisOverlay";
+import {
+  YAxisOverlay,
+  yAxisLabelIntersectsBadge,
+} from "../../src/components/YAxisOverlay";
 import { render } from "@testing-library/react-native";
 import {
   resolvePulse,
@@ -108,6 +111,11 @@ describe("BadgeOverlay", () => {
 });
 
 describe("YAxisOverlay", () => {
+  it("detects vertical overlap with the live badge pill", () => {
+    expect(yAxisLabelIntersectsBadge(100, 12, 100, 18)).toBe(true);
+    expect(yAxisLabelIntersectsBadge(100, 12, 116, 18)).toBe(false);
+  });
+
   it("renders grid lines and labels", () => {
     function Fixture() {
       const entries = useSharedValue([{ y: 40, label: "10", alpha: 1 }]);
@@ -118,6 +126,27 @@ describe("YAxisOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+        />
+      );
+    }
+    render(<Fixture />);
+  });
+
+  it("renders with live-badge collision suppression enabled", () => {
+    function Fixture() {
+      const entries = useSharedValue([{ y: 40, label: "10", alpha: 1 }]);
+      const badgeCenterY = useSharedValue(40);
+      return (
+        <YAxisOverlay
+          entries={entries}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          badge
+          badgeCenterY={badgeCenterY}
+          badgeFontSize={12}
+          badgeOffsetY={2}
         />
       );
     }


### PR DESCRIPTION
## Summary

- suppress Y-axis labels whose font bounds intersect the right-side live badge pill
- preserve the corresponding grid line and support floating axes and vertical badge offsets
- add focused overlap coverage and document the fix

## Root cause

The Y-axis overlay and live badge calculated their geometry independently. The axis always rendered every label, even when a label occupied the same vertical bounds as the badge.

## Verification

- iPhone 17 Pro simulator before/after reproduction
- `npm run verify`
- 93 test suites passed; 1,335 tests passed and 5 skipped
- React Doctor reported no diagnostics on the changed files

Closes #200