### PR TITLE
fix: keep marker cluster counts legible with proportional fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Multi-digit marker-cluster counts remain legible with proportional fonts.**
+  Count badges no longer apply a hard-coded negative kern derived from the
+  widest digit, and `markerCluster.groupBadge.letterSpacing` can tune the count
+  (including custom-badge corner counts). ([#205](https://github.com/brandtnewlabs/react-native-livechart/issues/205))
 - **Y-axis labels no longer render underneath the live value badge.** Labels
   whose line box intersects a right-side badge pill are hidden while their grid
   lines remain visible, including floating-axis layouts and configured vertical

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -168,6 +168,7 @@ provided; everything else has a default.
 
   ```tsx
   markerCluster={{ mode: "stacked", groupBadge: { image: buy5Badge }, showGroupCount: true }}
+  markerCluster={{ mode: "stacked", groupBadge: { letterSpacing: 1 } }}
   ```
 </ParamField>
 

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -107,9 +107,10 @@ interface MarkerClusterConfig {
                           // dedicated custom badge you supply (object form)
   showGroupCount?: boolean; // with a non-count badge, stamp the count in the corner; default false
 }
-// A dedicated badge for a collapsed cluster — your own glyph, independent of the
-// members (set as groupBadge). Needs image or icon. @experimental
+// Badge options for a collapsed cluster. Use letterSpacing by itself to tune the
+// built-in count, or add image/icon for a dedicated glyph. @experimental
 interface MarkerGroupBadge {
+  letterSpacing?: number; // extra px between count digits; default 0
   image?: SkImage; // custom Skia image (precedence over icon)
   icon?: string;   // text/emoji glyph (when image unset)
   color?: string;  // icon / pill color; defaults to a palette accent

--- a/docs/guides/markers-and-trades.mdx
+++ b/docs/guides/markers-and-trades.mdx
@@ -78,6 +78,13 @@ markerCluster={{ direction: "vertical", overlap: 0.6, maxBeforeGroup: 20 }}
 A collapsed group draws a round **count badge** by default (`groupBadge: "count"`). Two ways to give
 it your own Skia look:
 
+The built-in count uses the measured width of each digit, so proportional fonts such as `System`
+remain readable. Pass an object with `letterSpacing` to add or remove space between count digits:
+
+```tsx
+markerCluster={{ mode: "stacked", groupBadge: { letterSpacing: 1 } }}
+```
+
 **1. Reuse the members' look** — `groupBadge: "marker"` draws the **representative marker's own glyph**
 (the newest marker in the run: its `image` → `icon`/`pill` → `kind`). So a run of green `+` buy pills
 collapses to a single buy pill, not a generic count.

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -25,6 +25,7 @@ import {
   GROUP_BADGE_SIG,
   groupBgSig,
   groupCountText,
+  groupCountTextWidth,
   groupGlyphSig,
   isConnectorMarker,
   markerAppearanceSig,
@@ -58,7 +59,7 @@ const GROUP_CORNER_INSET = 0.82;
 
 /**
  * Append a collapsed-cluster count badge (round bg + centered, proportionally
- * kerned digits) to the atlas blit lists at `(cx, cy)`, scaled by `mul` — full
+ * laid-out digits) to the atlas blit lists at `(cx, cy)`, scaled by `mul` — full
  * size as the default group badge, shrunk in a glyph's corner for `showGroupCount`.
  *
  * A **module-level** worklet (not a closure inside the per-frame derived value):
@@ -77,6 +78,7 @@ function pushGroupCountBadge(
   repColor: string,
   count: number,
   mul: number,
+  letterSpacing: number,
 ): void {
   "worklet";
   const text = groupCountText(count);
@@ -87,20 +89,11 @@ function pushGroupCountBadge(
     );
     sprites.push(bg.rect);
   }
-  // Lay digits out proportionally (each by its own ink width), scaled to fit the
-  // small round badge, centered. A negative kern (fraction of a digit) closes the
-  // font's side-bearing gap so "12" reads tight, not "1 2".
+  // Lay digits out proportionally (each by its own ink width), centered. The
+  // configurable spacing is applied between glyph ink bounds, not inferred from
+  // the widest digit — proportional fonts otherwise overlap narrow digits.
   const S = BADGE_TEXT_SCALE;
-  let maxDW = 1;
-  for (let d = 0; d < 10; d++) {
-    const dw = digitWidths["" + d] ?? 0;
-    if (dw > maxDW) maxDW = dw;
-  }
-  const kern = -maxDW * S * 0.42;
-  let totalW = 0;
-  for (let c = 0; c < text.length; c++) {
-    totalW += (digitWidths[text[c]] ?? 0) * S + (c > 0 ? kern : 0);
-  }
+  const totalW = groupCountTextWidth(text, digitWidths, letterSpacing);
   let dx = cx - (totalW * mul) / 2;
   for (let c = 0; c < text.length; c++) {
     const w = (digitWidths[text[c]] ?? 0) * S * mul;
@@ -117,7 +110,7 @@ function pushGroupCountBadge(
       );
       sprites.push(gc.rect);
     }
-    dx += w + kern * mul;
+    dx += w + letterSpacing * mul;
   }
 }
 
@@ -326,7 +319,7 @@ export function MarkerOverlay({
     typeof cluster.groupBadge === "object" ? cluster.groupBadge : undefined;
   const groupBadgeImage = groupBadgeCfg?.image;
   const groupBadgeKey = groupBadgeCfg
-    ? `${groupBadgeCfg.icon ?? ""}|${groupBadgeCfg.color ?? ""}|${groupBadgeCfg.pill ? 1 : 0}|${groupBadgeCfg.size ?? ""}`
+    ? `${groupBadgeCfg.icon ?? ""}|${groupBadgeCfg.color ?? ""}|${groupBadgeCfg.pill ? 1 : 0}|${groupBadgeCfg.size ?? ""}|${groupBadgeCfg.letterSpacing ?? ""}`
     : "";
   const atlas = useMemo(
     () =>
@@ -431,6 +424,7 @@ export function MarkerOverlay({
                 repColor,
                 pt.groupCount,
                 GROUP_CORNER_SCALE,
+                groupBadgeCfg?.letterSpacing ?? 0,
               );
             }
             continue;
@@ -448,6 +442,7 @@ export function MarkerOverlay({
             repColor,
             pt.groupCount,
             1,
+            groupBadgeCfg?.letterSpacing ?? 0,
           );
           continue;
         }

--- a/packages/react-native-livechart/src/draw/markerAtlas.ts
+++ b/packages/react-native-livechart/src/draw/markerAtlas.ts
@@ -59,6 +59,21 @@ export function groupCountText(count: number): string {
   return count > 99 ? "99" : `${count}`;
 }
 
+/** Width of proportionally laid-out count-badge text at its on-canvas scale. */
+export function groupCountTextWidth(
+  text: string,
+  digitWidths: Record<string, number>,
+  letterSpacing = 0,
+): number {
+  "worklet";
+  let width = 0;
+  for (let i = 0; i < text.length; i++) {
+    width += (digitWidths[text[i]] ?? 0) * BADGE_TEXT_SCALE;
+    if (i > 0) width += letterSpacing;
+  }
+  return width;
+}
+
 /** Default glyph color per kind when `marker.color` is unset. Worklet-safe so the
  *  per-frame overlay worklet can resolve a collapsed cluster's badge color. */
 export function defaultMarkerColor(
@@ -333,10 +348,12 @@ function groupBgCellSpec(
   bgColor: string,
   uw: number,
   gh: number,
+  letterSpacing: number,
 ): CellSpec {
   const m2 = CELL_MARGIN * 2;
   // Inner circle fits a centered two-digit string at BADGE_TEXT_SCALE plus padding.
-  const innerR = Math.ceil(Math.max(2 * uw, gh) * BADGE_TEXT_SCALE) / 2 + BADGE_PAD;
+  const textWidth = 2 * uw * BADGE_TEXT_SCALE + Math.max(0, letterSpacing);
+  const innerR = Math.ceil(Math.max(textWidth, gh * BADGE_TEXT_SCALE)) / 2 + BADGE_PAD;
   const outerR = innerR + BADGE_BORDER;
   const diameter = 2 * outerR;
   return {
@@ -429,7 +446,10 @@ export function buildMarkerAtlas(
       colors.add(m.color ?? defaultMarkerColor(m.kind, palette));
     }
     for (const color of colors) {
-      specs.push({ sig: groupBgSig(color), spec: groupBgCellSpec(color, bgColor, uw, gh) });
+      specs.push({
+        sig: groupBgSig(color),
+        spec: groupBgCellSpec(color, bgColor, uw, gh, groupBadge?.letterSpacing ?? 0),
+      });
     }
   }
 

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1236,10 +1236,15 @@ export interface MarkerClusterConfig {
  * A dedicated badge drawn for a collapsed marker cluster — your own Skia design,
  * independent of the member markers. Pass it as
  * {@link MarkerClusterConfig.groupBadge}. Glyph precedence mirrors a single marker:
- * `image` → `icon` (`pill`) → a filled dot. Requires `image` or `icon` (otherwise
- * the group falls back to the count badge).
+ * `image` → `icon` (`pill`) → the built-in count badge. An object containing only
+ * {@link letterSpacing} customizes that built-in count badge.
  */
 export interface MarkerGroupBadge {
+  /**
+   * Extra spacing in px between digits in the built-in count badge. Also applies
+   * to the optional corner count on a custom group badge. Default `0`.
+   */
+  letterSpacing?: number;
   /** Custom Skia image for the collapsed group (e.g. from `useImage`). Takes
    *  precedence over {@link icon}. */
   image?: SkImage;

--- a/packages/react-native-livechart/tests/draw/markerAtlas.test.ts
+++ b/packages/react-native-livechart/tests/draw/markerAtlas.test.ts
@@ -3,6 +3,7 @@ import {
   defaultMarkerColor,
   groupBgSig,
   groupCountText,
+  groupCountTextWidth,
   groupGlyphSig,
   isConnectorMarker,
   markerAppearanceSig,
@@ -157,5 +158,24 @@ describe("groupCountText", () => {
     expect(groupCountText(2)).toBe("2");
     expect(groupCountText(42)).toBe("42");
     expect(groupCountText(100)).toBe("99");
+  });
+});
+
+describe("groupCountTextWidth", () => {
+  it("uses proportional glyph widths without forcing digits to overlap", () => {
+    const widths = { "1": 4, "2": 7 };
+    expect(groupCountTextWidth("12", widths)).toBe((4 + 7) * 0.75);
+    expect(groupCountTextWidth("12", widths, 2)).toBe((4 + 7) * 0.75 + 2);
+  });
+
+  it("widens the count background for positive letter spacing", () => {
+    const marker = m({ id: "t", color: "#16a34a" });
+    const plain = buildMarkerAtlas([marker], palette, font, 1, true);
+    const spaced = buildMarkerAtlas([marker], palette, font, 1, true, {
+      letterSpacing: 4,
+    });
+    expect(spaced.cells[groupBgSig("#16a34a")].w).toBeGreaterThan(
+      plain.cells[groupBgSig("#16a34a")].w,
+    );
   });
 });


### PR DESCRIPTION
Closes #205.

## What changed

- remove the hard-coded negative kern derived from the widest count digit
- lay out each count digit from its measured width
- add `markerCluster.groupBadge.letterSpacing` for built-in and corner counts
- grow the count background when positive spacing needs more room
- document and test the public option

## Verification

- reproduced with 12 co-located markers and `fontFamily: "System"` on an iPhone 17 Pro simulator
- `npm run verify` (93 suites, 1,337 passed, 5 skipped)
- React Doctor: 100/100 for the library diff, no diagnostics