### PR TITLE
chore: add publish, update-library, and skia-paths agent skills

### DIFF
--- a/.agents/skills/publish-library/SKILL.md
+++ b/.agents/skills/publish-library/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: publish-library
+description: >-
+  Publish the react-native-livechart library to npm from this monorepo. Use
+  this whenever the user wants to publish, ship, or release the package to npm —
+  including the first-ever publish — or asks how publishing works here. Covers
+  the workspace-scoping gotcha (a bare `npm publish` targets the Expo example
+  app, not the library), the `private: false` gate, the source-shipping/prepack
+  model, dry-run verification, and the required post-publish steps (push, tag,
+  and a GitHub Release). Trigger even if the
+  user just says "push it to npm", "can we publish now", or "ship the package"
+  without naming the skill. For deciding a version bump + CHANGELOG first, see
+  the update-library skill.
+---
+
+# Publish react-native-livechart to npm
+
+This repo is an **npm-workspaces monorepo**. The publishable library lives at
+`packages/react-native-livechart/`; the repo root is the **Expo example app**
+(`react-native-livechart-expo-example`, kept `"private": true`).
+
+## The one rule that breaks everything: scope to the workspace
+
+Every npm command that touches the library **must** be scoped with
+`-w react-native-livechart`. A bare `npm publish` / `npm pack` run from the root
+operates on the **example app**, not the library — it'll sweep the whole repo
+(demo screens, assets, tests) into a tarball named `react-native-livechart-expo-example`.
+
+The root's `"private": true` is the safety net that stops an accidental root
+publish, but don't rely on it — always pass `-w`.
+
+```bash
+npm pack    --dry-run -w react-native-livechart   # inspect what would ship
+npm publish           -w react-native-livechart   # publish
+```
+
+## Mental model (why the steps below look the way they do)
+
+- **The library ships TypeScript _source_.** `main`/`module`/`react-native` and
+  every `exports` condition except `types` point at `src/index.ts`. The
+  consumer's Metro + Babel compiles it — so worklets get processed by the
+  consumer's `react-native-worklets/plugin`. `dist/` contains **only `.d.ts`**.
+- **`prepack` builds for you.** `npm publish` runs `prepare` → `prepack`
+  automatically, which does `tsc -p tsconfig.build.json` (emits `dist/*.d.ts`)
+  and copies the repo-root `README.md` into the package. **Do not** hand-build
+  or hand-copy the README — let the lifecycle do it.
+- **`react`, `react-native`, Skia, Reanimated, Worklets, and Gesture Handler
+  are peer dependencies.** They must never appear in `dependencies`.
+
+## Preflight checklist
+
+1. **Branch & tree.** Be on the branch you intend to release from with a clean
+   working tree (`git status`). Releases normally go from `main`.
+2. **Green build.** `npm run verify` (typecheck + lint + test) passes. The
+   husky pre-commit hook also runs tests, but verify explicitly here.
+3. **`private` gate.** Open `packages/react-native-livechart/package.json` and
+   confirm `"private": false`. **On the first-ever publish it is `true`** — flip
+   it to `false` and commit that change. (Leave the root `package.json` private.)
+4. **Version sanity.** Check the `version` field is the one you intend and isn't
+   already on the registry: `npm view react-native-livechart version`. An E404
+   means it's never been published (expected for the first release). If you need
+   to bump the version, stop and use the **update-library** skill first.
+5. **Auth.** `npm whoami` (run `npm login` if it errors). Have your 2FA code
+   ready if the account enforces OTP.
+
+## Inspect what will ship — always dry-run first
+
+```bash
+npm pack --dry-run -w react-native-livechart
+```
+
+Verify in the output:
+- **`name: react-native-livechart`** (NOT `...-expo-example` — if you see that,
+  you forgot `-w`).
+- Contents are `src/**` + `dist/**/*.d.ts` + `README.md` + `LICENSE` only.
+- **No** `tests/`, `tsconfig*.json`, `babel.lib.config.cjs`, or other configs.
+
+The `files` allowlist (`dist`, `src`, `LICENSE`) plus the package `.npmignore`
+control this; `README` and `LICENSE` are always included by npm regardless.
+
+## Publish
+
+```bash
+npm publish -w react-native-livechart
+```
+
+- `react-native-livechart` is **unscoped and public**, so you do **not** need
+  `--access public` (that flag is only for `@scope/...` packages).
+- If 2FA is on: append `--otp=<6-digit-code>`.
+- `npm publish --dry-run -w react-native-livechart` does a full rehearsal
+  (including the registry handshake) without uploading — use it if you want one
+  more confirmation beyond `npm pack --dry-run`.
+
+## Post-publish — ALL FOUR steps are required, do not stop early
+
+A release is **not done** until the GitHub Release exists. Shipping to npm + a git
+tag without the GitHub Release has bitten us before — the releases page silently
+fell behind. Run all four:
+
+1. **Confirm it's live.** ⚠️ `npm view react-native-livechart version` and
+   `... dist-tags` can lag the registry CDN by minutes and show the *previous*
+   version even when the publish succeeded — do **not** treat that as a failure.
+   Confirm the *specific* version instead, which is not cached the same way:
+   ```bash
+   npm view react-native-livechart@<X.Y.Z> version   # echoes <X.Y.Z> when live
+   ```
+2. **Push the release commit.** The `chore(release): vX.Y.Z` commit is usually
+   still local — push it before tagging so the tag has a pushed commit to point at:
+   ```bash
+   git push origin main
+   ```
+3. **Tag the release** (convention: `vX.Y.Z`, established across the repo):
+   ```bash
+   git tag v$(node -p "require('./packages/react-native-livechart/package.json').version")
+   git push origin "v$(node -p "require('./packages/react-native-livechart/package.json').version")"
+   ```
+4. **Cut the GitHub Release — REQUIRED, not optional.** Every version has one and
+   the root `CHANGELOG.md` links to `/releases/tag/vX.Y.Z`, so a missing release =
+   a dead link. Title convention is **`vX.Y.Z — <short feature name>`** (e.g.
+   "v3.6.0 — Custom markers", "v3.5.1 — Crisp markers", "v3.5.0 — Threshold
+   split"); body is that version's `CHANGELOG.md` section. Mark the newest the
+   latest:
+   ```bash
+   # Put the version's CHANGELOG section in /tmp/relnotes.md first, then:
+   gh release create v<X.Y.Z> --repo brandtnewlabs/react-native-livechart \
+     --title "v<X.Y.Z> — <feature>" --notes-file /tmp/relnotes.md --verify-tag --latest
+   ```
+   Then verify: `gh release list --repo brandtnewlabs/react-native-livechart` shows
+   the new version as `Latest`.
+
+If you publish to npm but get blocked (e.g. a safety prompt) before finishing
+2–4, the release is **incomplete** — come back and finish every remaining step.
+
+## If something's wrong after publishing
+
+You generally **cannot** silently overwrite a published version — npm forbids
+re-publishing the same version number. Within 72 hours you can
+`npm unpublish react-native-livechart@<version>` (use sparingly; it breaks
+consumers). Otherwise bump a new patch via the **update-library** skill, or
+`npm deprecate react-native-livechart@<version> "<reason>"` to warn installers.

--- a/.agents/skills/skia-paths/SKILL.md
+++ b/.agents/skills/skia-paths/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skia-paths
+description: >-
+  Use when building or changing Skia paths in this repo — anything touching
+  SkPath, PathBuilder, per-frame path construction in worklets/useDerivedValue,
+  drawSpline, the `.reset()` + ping-pong path-pool pattern, or the
+  react-native-skia path-migration (immutable SkPath / PathBuilder). Covers the
+  installed 2.6.4 mutable API, the PathBuilder API, the static path factories,
+  the worklet per-frame patterns, and how the repo's useChartPaths pool/ping-pong
+  optimization maps onto the new model. Trigger on "Skia path", "SkPath",
+  "PathBuilder", "build a path each frame", "migrate path building", or a Skia
+  upgrade.
+version: "1.0.0"
+---
+
+# Skia paths in react-native-livechart
+
+How `@shopify/react-native-skia` paths work here, what changes in the path-API
+migration, and the per-frame patterns that matter for a 60 fps chart.
+
+Reference: https://shopify.github.io/react-native-skia/docs/shapes/path-migration/
+
+## TL;DR
+
+- **Installed: Skia 2.6.4.** The **mutable `SkPath` API is still present and
+  un-deprecated** (`moveTo`/`lineTo`/`cubicTo`/`quadTo`/`close`/`reset`/`addRect`…).
+  All existing path code keeps working. Don't change it for its own sake.
+- **`Skia.PathBuilder` also exists in 2.6.4** — the mutable builder that produces
+  an **immutable** `SkPath` via `build()` / `detach()`. This is the direction
+  Skia is moving (immutable `SkPath`, enforced in 3.0).
+- This repo deliberately **reuses + ping-pongs two pooled `SkPath`s per curve**
+  (see `useChartPaths.ts`) to avoid per-frame allocation. `PathBuilder.build()`
+  changes that tradeoff — read "Migrating the per-frame builders" before
+  switching, and **measure on-device** (iOS native GC lags under a steady
+  per-frame allocation firehose).
+
+## The two models
+
+### Mutable `SkPath` (current — what the code uses)
+
+```ts
+const path = Skia.Path.Make();        // allocate once
+path.reset();                          // clear each frame
+path.moveTo(x0, y0);
+path.cubicTo(c1x, c1y, c2x, c2y, x, y);
+// …render the SAME object reference
+```
+
+`SkPath` is mutable; you mutate and render the same instance. Still fully
+supported in 2.x.
+
+### `PathBuilder` → immutable `SkPath` (forward-looking, 3.0 direction)
+
+```ts
+const builder = Skia.PathBuilder.Make();   // mutable builder
+builder.reset();
+builder.moveTo(x0, y0).cubicTo(c1x, c1y, c2x, c2y, x, y);
+const path = builder.build();              // NEW immutable SkPath; builder stays usable
+// or: const path = builder.detach();      // NEW SkPath AND resets the builder
+```
+
+`PathBuilder` methods (verified in 2.6.4): `moveTo`/`rMoveTo`, `lineTo`/`rLineTo`,
+`quadTo`, `conicTo`, `cubicTo` (+ relative variants), `arcToOval`/`arcToRotated`/
+`arcToTangent`/`addArc`, `close`, `addRect`/`addOval`/`addRRect`/`addCircle`/
+`addPoly`/`addPath`, `setFillType`/`setIsVolatile`, `offset`/`transform`,
+`reset`, `computeBounds`/`isEmpty`/`getLastPt`/`countPoints`, and
+`build()` (returns an `SkPath`, builder remains usable) / `detach()` (returns an
+`SkPath` and resets the builder).
+
+## Migration map (old mutable `SkPath` → new immutable model)
+
+When Skia eventually makes `SkPath` query-only:
+
+| Old (mutating instance method)                | New                                         |
+| --------------------------------------------- | ------------------------------------------- |
+| `Skia.Path.Make()` + `moveTo`/`lineTo`/`cubicTo` | `Skia.PathBuilder.Make()` + same methods + `build()` |
+| `path.reset()`                                | `builder.reset()` (or a fresh builder)      |
+| `path.addCircle(...)` / `path.addRect(...)`   | `Skia.Path.Circle(...)` / `Skia.Path.Rect(...)` (immutable factories) |
+| `path.stroke(opts)`                           | `Skia.Path.Stroke(path, opts)` → new path (or null) |
+| `path.simplify()`                             | `Skia.Path.Simplify(path)`                  |
+| `path.trim/dash/offset/transform/op(...)`     | corresponding `Skia.Path.*` static returning a new path |
+
+In **2.6.4 today** the left column still works — treat the right column as the
+target when bumping toward 3.0 or when a perf measurement justifies it.
+
+## Worklet per-frame patterns
+
+### The docs' recommended pattern
+
+A `PathBuilder` kept in a shared value, rebuilt inside a derived value:
+
+```ts
+const builder = useSharedValue(Skia.PathBuilder.Make());
+// in a gesture/frame worklet: builder.value.reset(); builder.value.moveTo(...); …
+const path = useDerivedValue(() => builder.value.build());
+```
+
+`build()` returns a **new reference each frame**, so Reanimated's value-equality
+check notifies subscribers automatically — no ping-pong needed.
+
+### This repo's current optimization (`src/hooks/useChartPaths.ts`)
+
+Two persistent `SkPath`s per curve (`lineA`/`lineB`, `fillA`/`fillB`) are
+allocated **once**; each frame the code picks the off-parity one, `reset()`s it,
+re-emits the verbs (`moveTo` + `drawSpline`'s `cubicTo` loop), and returns it.
+The ping-pong exists for one reason: a reused object has the **same reference**,
+which would trip Reanimated's value-equality early-return and **skip the repaint**
+— alternating two buffers changes the reference every frame without allocating.
+The flat point buffers (`ptsA`/`ptsB`) ping-pong for the same reason one level up.
+
+Why not just `Skia.Path.Make()` per frame (which also changes the reference)?
+Because on iOS the native GC lags the JS GC under a steady allocation firehose, so
+resident memory climbs for as long as the chart is mounted (see the file's header
+comment).
+
+### Migrating the per-frame builders to PathBuilder — the tradeoff
+
+`PathBuilder.build()`/`detach()` would:
+
+- ✅ **remove the ping-pong** — a fresh reference each frame triggers the notify
+  for free, so the `lineA`/`lineB`, `ptsA`/`ptsB` double-buffering can go.
+- ⚠️ **reintroduce per-frame allocation** — `build()` allocates a new immutable
+  `SkPath` every frame, which is exactly what the pool avoids. `detach()` may be
+  cheaper (hands off the buffer and resets), but it still yields a new path.
+- ➖ **not reduce the imperative call count** — `PathBuilder` still uses
+  `moveTo`/`cubicTo`; it is not a command-array (`MakeFromCmds`) API.
+
+So this is **measure-then-decide**, not a guaranteed win. Profile on-device
+(iOS sim / Android emulator: frame rate, CPU, memory on a dense, wide-`timeWindow`
+chart) and compare pool+ping-pong vs `PathBuilder.build()` vs `detach()` before
+landing a switch. If allocation regresses memory, the pool stays.
+
+## Where paths are built in this repo
+
+- `src/hooks/useChartPaths.ts` — line + fill `SkPath` (pool + ping-pong; the hot path)
+- `src/hooks/useCandlePaths.ts` — candle body/wick paths
+- `src/math/spline.ts` — `drawSpline` (the `cubicTo` loop; monotone Fritsch–Carlson)
+- `src/components/YAxisOverlay.tsx`, `ReferenceLineOverlay.tsx`, `ValueLineOverlay.tsx`,
+  `MarkerOverlay.tsx`, `MultiSeriesValueLines.tsx`, `XAxisOverlay.tsx` — overlay paths
+- `src/hooks/useBadge.ts` — badge pill path
+
+All call `path.reset()` (there are **zero** `.rewind()` call sites) and re-emit.
+
+## Gotchas
+
+- **Don't allocate `Skia.Path.Make()` (or, later, `build()`) per frame without
+  measuring memory on iOS.** Per-frame allocation is the reason the pool exists.
+- **Reanimated only notifies on a changed reference.** Any reused-object approach
+  must change the returned reference each frame (ping-pong) or the repaint is
+  silently skipped.
+- **`PathBuilder` is worklet-safe** — usable inside `useDerivedValue` /
+  frame/gesture worklets, same as the mutable API.
+- **Keep `react-native-worklets/plugin` last in Babel plugins** (unrelated to
+  paths but a frequent worklet-compilation footgun in this repo).

--- a/.agents/skills/update-library/SKILL.md
+++ b/.agents/skills/update-library/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: update-library
+description: >-
+  Cut and release a NEW version of the react-native-livechart library: choose
+  the semver bump, update the version field, update the CHANGELOG, verify, then
+  publish. Use this whenever the user wants to release a new version, bump the
+  version, ship an update/patch/minor/major, publish changes since the last
+  release, or "cut a release" of the package — even if they don't name the
+  skill. This skill owns the versioning + changelog decisions; for the npm
+  publish mechanics themselves it hands off to the publish-library skill.
+---
+
+# Release a new version of react-native-livechart
+
+Use this to turn merged changes into a published version. The flow is: **decide
+the bump → write it down (version + CHANGELOG) → verify → publish**. The actual
+`npm publish` mechanics (workspace scoping, the `private` gate, dry-run, tagging)
+live in the **publish-library** skill — follow it for the final step rather than
+duplicating those commands here.
+
+All version/changelog edits target the **library** package
+(`packages/react-native-livechart/`), never the repo root (the root is the
+private example app).
+
+## Step 1 — Choose the semver bump
+
+The package is past `1.0.0`, so semver is in full effect. Decide based on what
+changed since the last release, paying special attention to the **public API**
+(exported components, props, types) and **peer dependency ranges**:
+
+- **patch** (`x.y.Z`) — bug fixes, internal/perf changes, doc-only changes. No
+  consumer code or install changes required.
+- **minor** (`x.Y.0`) — new backward-compatible surface: new props, new exports,
+  new optional config. Existing code keeps working untouched.
+- **major** (`X.0.0`) — anything that can break a consumer: removed/renamed
+  props or exports, changed default behavior, or **widening/raising a peer
+  dependency requirement** (e.g. requiring a newer Reanimated/Skia). Peer-range
+  changes are easy to forget — treat them as breaking.
+
+If you're unsure which changes landed, `git log --oneline v<last-version>..HEAD`
+(or since the last release commit) is the source of truth.
+
+## Step 2 — Bump the version
+
+Edit `version` in `packages/react-native-livechart/package.json`, or let npm do
+it **without** touching git (workspace git-tagging behaves inconsistently, so we
+tag explicitly later in publish-library):
+
+```bash
+npm version <patch|minor|major> -w react-native-livechart --no-git-tag-version
+```
+
+This rewrites only the library's `version`. Note the new version for the
+CHANGELOG and the eventual tag.
+
+### ⚠️ Keep `package-lock.json` CI-consistent — use npm 10, not your local npm
+
+CI (`.github/workflows/test.yml`) runs **node 22 / npm 10** and gates merges with
+`npm ci`. This machine typically runs a newer npm (11+). npm 11 and npm 10 prune
+the optional `@emnapi/*` transitive deps differently, so **regenerating the
+lockfile with a newer local npm drops `@emnapi/*` entries that CI's `npm ci`
+needs** → CI fails with `npm ci can only install packages when your package.json
+and package-lock.json ... are in sync / Missing: @emnapi/core...`. The trap:
+local `npm ci` still **passes** on macOS with the broken lockfile, so
+`npm run verify` does **not** catch it. This has burned multiple CI runs.
+
+So after any change that touches the lockfile — the `npm version` bump above, or a
+new dependency (`expo install ...`) — reset the lockfile and re-apply with npm 10:
+
+```bash
+git checkout origin/main -- package-lock.json          # known-good base
+npx -y npm@10 install --package-lock-only              # apply version/dep change
+npx -y npm@10 ci                                       # verify — mirrors CI exactly (exit 0)
+```
+
+Then sanity-check the diff is **minimal** (only the intended version/dep lines)
+and that `@emnapi` entries are **not** removed:
+
+```bash
+git diff package-lock.json | grep "^[+-]" | grep -v "^[+-][+-]"   # expect just version/dep lines
+git diff package-lock.json | grep -c "^-.*@emnapi"                # expect 0
+```
+
+## Step 3 — Update the CHANGELOG
+
+Maintain `CHANGELOG.md` at the **repo root** (it's the single README/changelog
+home for the project). If it doesn't exist yet, create it using the
+[Keep a Changelog](https://keepachangelog.com/) format with a `## [Unreleased]`
+section at the top.
+
+For this release, move the relevant `Unreleased` notes (or write fresh ones)
+under a new heading:
+
+```markdown
+## [X.Y.Z] — YYYY-MM-DD
+
+### Added
+- ...
+### Changed
+- ...
+### Fixed
+- ...
+### Breaking  (only for a major)
+- ...
+```
+
+Group entries from the user's perspective (props, behavior, peers) — not by
+commit. Keep `### Breaking` honest; it's what tells consumers whether the
+upgrade is safe.
+
+## Step 4 — Verify
+
+```bash
+npm run verify
+```
+
+Typecheck + lint + test must pass before you publish a release.
+
+## Step 5 — Commit the release
+
+Include `package-lock.json` — the bump updates the library's version entry there
+too (regenerated via npm 10 in Step 2), and CI's `npm ci` needs it in sync:
+
+```bash
+git add packages/react-native-livechart/package.json CHANGELOG.md package-lock.json
+git commit -m "chore(release): v<X.Y.Z>"
+```
+
+(If the repo's convention is to release via PR into `main`, open the PR here and
+let it merge before publishing. Otherwise commit on the release branch / `main`
+per the user's flow.)
+
+## Step 6 — Publish AND finish every post-publish step
+
+Hand off to the **publish-library** skill — it's the source of truth for the npm
+mechanics (workspace scoping, the `private` gate, dry-run) **and** the required
+post-publish steps. A release is **not done** at `npm publish`: you must also push
+`main`, push the `vX.Y.Z` tag, **and cut the GitHub Release** (title
+`vX.Y.Z — <feature>`, body = this version's CHANGELOG section). Skipping the
+GitHub Release has happened before and leaves the releases page + CHANGELOG links
+broken. Follow publish-library's "Post-publish — ALL FOUR steps" to the end; if a
+safety prompt blocks the `npm publish` itself, still finish push + tag + GitHub
+Release once it's published.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.agent-device]
+command = "agent-device"
+args = ["mcp"]

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ app-example
 .mint/
 .mintlify/
 docs/.mint/
+
+/reproductions/*


### PR DESCRIPTION
### TL;DR

Adds three agent skill documents for publishing, Skia path building, and library versioning workflows, along with a Codex MCP server config and a reproductions gitignore entry.

### What changed?

- **`.agents/skills/publish-library/SKILL.md`** — Documents the full npm publish flow for the `react-native-livechart` package, including the critical workspace-scoping requirement (`-w react-native-livechart`), the `private: false` gate, dry-run verification, and all four required post-publish steps (push, tag, GitHub Release).
- **`.agents/skills/skia-paths/SKILL.md`** — Documents how Skia paths are built in this repo: the current mutable `SkPath` API (2.6.4), the forward-looking `PathBuilder` → immutable `SkPath` model, the ping-pong path-pool optimization in `useChartPaths.ts`, and the tradeoffs involved in migrating between the two approaches.
- **`.agents/skills/update-library/SKILL.md`** — Documents the end-to-end release flow: choosing a semver bump, running `npm version` with `--no-git-tag-version`, regenerating `package-lock.json` using npm 10 to stay consistent with CI, updating `CHANGELOG.md`, verifying, committing, and handing off to the publish-library skill.
- **`.codex/config.toml`** — Registers the `agent-device` MCP server for Codex.
- **`.gitignore`** — Adds `/reproductions/*` to the ignore list.

### How to test?

These are documentation and configuration files with no runtime behavior. Verify by reviewing each skill document for accuracy against the actual repo structure, confirming the Codex config loads the `agent-device` MCP server correctly, and ensuring the reproductions directory is properly ignored by git.

### Why make this change?

The skill documents capture hard-won institutional knowledge — the workspace-scoping gotcha, the npm 10 lockfile consistency requirement, the Skia ping-pong pool rationale — that has caused real CI failures and incomplete releases in the past. Encoding these as agent skills makes them available as structured, triggerable guidance rather than tribal knowledge.