### PR TITLE
perf: scale multi-series mappers to active count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Multi-series drawing worklets now scale with the active series count.**
+  Stroke, dot, live-value label, and optional value-line slots no longer mount
+  the fixed 12-series capacity. A three-series chart registers 36 default
+  per-series derived-value mappers instead of 144. Candle tooltips likewise
+  reserve their five actual rows instead of 13. ([#214](https://github.com/brandtnewlabs/react-native-livechart/issues/214))
+
 ## [4.10.0] - 2026-07-16
 
 ### Added

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -256,6 +256,14 @@ function useLiveChartSeriesController({
     setSeriesSnapshot(series.get().slice());
   }, [series]);
 
+  // Mount per-series drawing worklets only for real series. The previous fixed
+  // 12-slot render kept 144 derived-value mappers alive for the default stroke,
+  // dot, and value-label layers even when a chart contained only one line.
+  const activeSeriesCount = Math.min(
+    seriesSnapshot.length,
+    MAX_MULTI_SERIES,
+  );
+
   const maxSeriesLabelWidth = dotCfg.valueLabel
     ? Math.max(
         0,
@@ -336,7 +344,11 @@ function useLiveChartSeriesController({
     nowOverride,
   });
   const { layoutHeight, onLayout } = useCanvasLayout(engine);
-  const linePaths = useMultiSeriesLinePaths(engine, effectivePadding);
+  const linePaths = useMultiSeriesLinePaths(
+    engine,
+    effectivePadding,
+    activeSeriesCount,
+  );
 
   // Per-series colors and stroke styles, derived from the off-render snapshot
   // (React state — so no Reanimated read-during-render). The reaction below
@@ -540,6 +552,7 @@ function useLiveChartSeriesController({
     layoutHeight,
     onLayout,
     linePaths,
+    activeSeriesCount,
     lineColors,
     lineStyles,
     degenPack,
@@ -610,6 +623,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     loadingStrokeWidth,
     loadingAmplitude,
     loadingSpeed,
+    activeSeriesCount,
   } = model;
 
   return (
@@ -654,12 +668,13 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
             padding={effectivePadding}
             colors={lineColors}
             config={dotCfg.valueLine}
+            seriesCount={activeSeriesCount}
           />
         </Group>
       )}
 
       <Group opacity={reveal.lineOpacity}>
-        {Array.from({ length: MAX_MULTI_SERIES }, (_, i) => (
+        {Array.from({ length: activeSeriesCount }, (_, i) => (
           <MultiSeriesStroke
             key={i}
             index={i}
@@ -694,6 +709,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
             color={dotCfg.color}
             pulse={dotCfg.pulse}
             viewEnd={engine.viewEnd}
+            seriesCount={activeSeriesCount}
           />
         </Group>
       )}
@@ -767,6 +783,7 @@ function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
     skiaFont,
     reveal,
     degenShakeTransform,
+    activeSeriesCount,
   } = model;
   if (!dotCfg.valueLabel) return null;
   return (
@@ -778,6 +795,7 @@ function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
           colors={lineColors}
           font={skiaFont}
           dotRadius={dotOuterRadius}
+          seriesCount={activeSeriesCount}
         />
       </Group>
     </Group>

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -643,12 +643,13 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         </Group>
       )}
 
-      {/* Index keys: reference lines are a positional array and two may share
-          value + label (e.g. duplicate working orders at the same price), which a
-          content-derived key would collapse to one. Fade group lets
-          `scrub.hideOverlaysOnScrub` ease the lines out while scrubbing. */}
+      {/* Reference lines are index-addressed throughout the drag/press API, and
+          duplicate working orders may share all visible content. Positional keys
+          keep both orders mounted without collapsing them to one React child.
+          Fade group lets `scrub.hideOverlaysOnScrub` ease the lines out. */}
       <Group opacity={overlayScrubFade}>
         {allRefLines.map((rl, i) => (
+          /* react-doctor-disable-next-line react-doctor/no-array-index-as-key */
           <ReferenceLineOverlay
             key={i}
             engine={engine}
@@ -819,6 +820,7 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
   return (
     <Group transform={degenShakeTransform} opacity={overlayScrubFade}>
       {allRefLines.map((rl, i) => (
+        /* react-doctor-disable-next-line react-doctor/no-array-index-as-key */
         <ReferenceLineOverlay
           key={i}
           engine={engine}

--- a/packages/react-native-livechart/src/components/MultiSeriesDots.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesDots.tsx
@@ -1,7 +1,6 @@
 import { Circle, Group } from "@shopify/react-native-skia";
 
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
 import type {
   ResolvedDotRingConfig,
@@ -118,6 +117,7 @@ export function MultiSeriesDots({
   color,
   pulse,
   viewEnd,
+  seriesCount,
 }: {
   engine: MultiEngineState;
   padding: ChartPadding;
@@ -132,10 +132,12 @@ export function MultiSeriesDots({
   pulse: ResolvedPulseConfig | null;
   /** Pan/zoom right-edge override — pulse is frozen-out while scrolled back. */
   viewEnd?: SharedValue<number | null>;
+  /** Number of live series slots to mount. */
+  seriesCount: number;
 }) {
   return (
     <Group>
-      {Array.from({ length: MAX_MULTI_SERIES }, (_, i) => (
+      {Array.from({ length: seriesCount }, (_, i) => (
         <SeriesDotAtIndex
           key={i}
           index={i}

--- a/packages/react-native-livechart/src/components/MultiSeriesTooltipStack.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesTooltipStack.tsx
@@ -4,11 +4,13 @@ import {
   type SkFont,
 } from "@shopify/react-native-skia";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import { MAX_MULTI_SERIES } from "../constants";
 import type { TooltipLayout } from "../hooks/crosshairShared";
 import type { LiveChartPalette } from "../types";
 
-const TOOLTIP_STACK_SLOTS = MAX_MULTI_SERIES + 1;
+// Candle tooltips have exactly O/H/L/C + time. This component is only mounted
+// for candle mode, so reserving the multi-series capacity registered 40 unused
+// derived-value mappers (8 empty rows × 5 mappers).
+const TOOLTIP_STACK_SLOTS = 5;
 
 function TooltipStackLine({
   index,

--- a/packages/react-native-livechart/src/components/MultiSeriesValueLabels.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesValueLabels.tsx
@@ -5,7 +5,6 @@ import {
 } from "@shopify/react-native-skia";
 import { useDerivedValue } from "react-native-reanimated";
 
-import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 
@@ -78,16 +77,19 @@ export function MultiSeriesValueLabels({
   colors,
   font,
   dotRadius,
+  seriesCount,
 }: {
   engine: MultiEngineState;
   padding: ChartPadding;
   colors: string[];
   font: SkFont;
   dotRadius: number;
+  /** Number of live series slots to mount. */
+  seriesCount: number;
 }) {
   return (
     <Group>
-      {Array.from({ length: MAX_MULTI_SERIES }, (_, i) => (
+      {Array.from({ length: seriesCount }, (_, i) => (
         <SeriesValueLabelAtIndex
           key={i}
           index={i}

--- a/packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx
+++ b/packages/react-native-livechart/src/components/MultiSeriesValueLines.tsx
@@ -1,7 +1,6 @@
 import { DashPathEffect, Group, Path } from "@shopify/react-native-skia";
 
 import { useDerivedValue } from "react-native-reanimated";
-import { MAX_MULTI_SERIES } from "../constants";
 import type { ChartPadding } from "../draw/line";
 import type { ResolvedValueLineConfig } from "../core/resolveConfig";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
@@ -72,15 +71,18 @@ export function MultiSeriesValueLines({
   padding,
   colors,
   config,
+  seriesCount,
 }: {
   engine: MultiEngineState;
   padding: ChartPadding;
   colors: string[];
   config: ResolvedValueLineConfig;
+  /** Number of live series slots to mount. */
+  seriesCount: number;
 }) {
   return (
     <Group>
-      {Array.from({ length: MAX_MULTI_SERIES }, (_, i) => (
+      {Array.from({ length: seriesCount }, (_, i) => (
         <SeriesValueLineAtIndex
           key={i}
           index={i}

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -8,18 +8,19 @@ import { drawSpline, makeSplineScratch } from "../math/spline";
 import { usePathBuilders } from "./usePathBuilder";
 
 /**
- * One derived shared value holding up to `MAX_MULTI_SERIES` Skia paths (unused
- * slots reuse one cached empty path).
+ * One derived shared value holding only the active series' Skia paths, capped at
+ * `MAX_MULTI_SERIES`.
  *
  * Each visible series' path is built into a per-slot `Skia.PathBuilder` (reused
  * across frames via a SharedValue) and finalized with `detach()` — a fresh
  * immutable `SkPath` per frame, so `MultiSeriesStroke`'s per-slot
  * `useDerivedValue(() => paths.value[index])` repaints without the two-SkPath
- * ping-pong. Only visible series allocate a path.
+ * ping-pong. Only active series allocate and publish a path.
  */
 export function useMultiSeriesLinePaths(
   engine: MultiEngineState,
   padding: ChartPadding,
+  activeSeriesCount = MAX_MULTI_SERIES,
 ): SharedValue<SkPath[]> {
   const builders = usePathBuilders(MAX_MULTI_SERIES);
 
@@ -42,11 +43,8 @@ export function useMultiSeriesLinePaths(
     const s = engine.series.get();
     const displays = engine.displaySeriesValues.get();
     const out: SkPath[] = [];
-    for (let i = 0; i < MAX_MULTI_SERIES; i++) {
-      if (i >= s.length) {
-        out.push(pool.empty);
-        continue;
-      }
+    const count = Math.min(activeSeriesCount, s.length, MAX_MULTI_SERIES);
+    for (let i = 0; i < count; i++) {
       const pts = buildLinePoints(
         s[i].data,
         displays[i] ?? s[i].value,

--- a/packages/react-native-livechart/tests/components/MultiSeriesDots.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesDots.test.tsx
@@ -45,6 +45,7 @@ describe("MultiSeriesDots", () => {
           ringColor="#ffffff"
           color={undefined}
           pulse={null}
+          seriesCount={1}
         />
       );
     }
@@ -88,6 +89,7 @@ describe("MultiSeriesDots", () => {
           ringColor="#ffffff"
           color={undefined}
           pulse={null}
+          seriesCount={1}
         />
       );
     }
@@ -131,6 +133,7 @@ describe("MultiSeriesDots", () => {
           ringColor="#ffffff"
           color={undefined}
           pulse={null}
+          seriesCount={1}
         />
       );
     }

--- a/packages/react-native-livechart/tests/components/MultiSeriesMapperCount.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesMapperCount.test.tsx
@@ -1,0 +1,122 @@
+import { Skia } from "@shopify/react-native-skia";
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+const mockUseDerivedValue = jest.fn();
+
+jest.mock("react-native-reanimated", () => {
+  const actual = jest.requireActual("react-native-reanimated");
+  return {
+    ...actual,
+    useDerivedValue: (...args: unknown[]) => {
+      mockUseDerivedValue();
+      return actual.useDerivedValue(...args);
+    },
+  };
+});
+
+import { MultiSeriesDots } from "../../src/components/MultiSeriesDots";
+import { MultiSeriesStroke } from "../../src/components/MultiSeriesStroke";
+import { MultiSeriesTooltipStack } from "../../src/components/MultiSeriesTooltipStack";
+import { MultiSeriesValueLabels } from "../../src/components/MultiSeriesValueLabels";
+import type { MultiEngineState } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import { resolveTheme } from "../../src/theme";
+import type { SeriesConfig } from "../../src/types";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+const font = {
+  getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+} as never;
+
+function shared<T>(value: T) {
+  return withSharedValueAccessors({ value }) as never;
+}
+
+function makeEngine(seriesCount: number): MultiEngineState {
+  const series: SeriesConfig[] = Array.from({ length: seriesCount }, (_, i) => ({
+    id: `series-${i}`,
+    label: `Series ${i}`,
+    data: [],
+    value: i + 1,
+    color: "#3b82f6",
+  }));
+  return {
+    data: shared([]),
+    value: shared(0),
+    displayValue: shared(0),
+    series: shared(series),
+    displaySeriesValues: shared(series.map((item) => item.value)),
+    seriesOpacities: shared(series.map(() => 1)),
+    displayMin: shared(0),
+    displayMax: shared(seriesCount + 1),
+    displayWindow: shared(30),
+    timeWindow: shared(30),
+    canvasWidth: shared(400),
+    canvasHeight: shared(300),
+    timestamp: shared(1_700_000_000),
+    extremaMinValue: shared(NaN),
+    extremaMaxValue: shared(NaN),
+    extremaMinTime: shared(NaN),
+    extremaMaxTime: shared(NaN),
+  };
+}
+
+describe("multi-series mapper count", () => {
+  it("mounts 36 default per-series mappers for three active series", () => {
+    mockUseDerivedValue.mockClear();
+    const seriesCount = 3;
+    const engine = makeEngine(seriesCount);
+    const paths = shared(Array.from({ length: seriesCount }, () => Skia.Path.Make()));
+
+    render(
+      <>
+        {Array.from({ length: seriesCount }, (_, index) => (
+          <MultiSeriesStroke
+            key={index}
+            index={index}
+            paths={paths}
+            opacities={engine.seriesOpacities}
+            series={engine.series}
+            strokeWidth={2}
+          />
+        ))}
+        <MultiSeriesDots
+          engine={engine}
+          padding={DEFAULT_PADDING}
+          colors={["#3b82f6", "#3b82f6", "#3b82f6"]}
+          radius={3.5}
+          ring={null}
+          ringColor="#ffffff"
+          color={undefined}
+          pulse={null}
+          seriesCount={seriesCount}
+        />
+        <MultiSeriesValueLabels
+          engine={engine}
+          padding={DEFAULT_PADDING}
+          colors={["#3b82f6", "#3b82f6", "#3b82f6"]}
+          font={font}
+          dotRadius={3.5}
+          seriesCount={seriesCount}
+        />
+      </>,
+    );
+
+    // 3 stroke + 5 dot + 4 value-label mappers per active series.
+    expect(mockUseDerivedValue).toHaveBeenCalledTimes(seriesCount * 12);
+  });
+
+  it("mounts only the five fixed candle-tooltip rows", () => {
+    mockUseDerivedValue.mockClear();
+    render(
+      <MultiSeriesTooltipStack
+        tooltipLayout={shared({ stackedLines: [] })}
+        font={font}
+        palette={resolveTheme("#3b82f6", "dark")}
+      />,
+    );
+
+    expect(mockUseDerivedValue).toHaveBeenCalledTimes(5 * 5);
+  });
+});

--- a/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
+++ b/packages/react-native-livechart/tests/components/MultiSeriesValueLines.test.tsx
@@ -86,6 +86,7 @@ function EngineHarness({
         padding={DEFAULT_PADDING}
         colors={lineColors}
         config={config}
+        seriesCount={series.length}
       />
     </Canvas>
   );

--- a/packages/react-native-livechart/tests/hooks/useMultiSeriesLinePaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useMultiSeriesLinePaths.test.tsx
@@ -37,7 +37,7 @@ describe("useMultiSeriesLinePaths", () => {
       const padding = { top: 12, right: 44, bottom: 28, left: 12 };
       return useMultiSeriesLinePaths(engine, padding);
     });
-    expect(result.current.value.length).toBeGreaterThan(0);
+    expect(result.current.value).toHaveLength(1);
   });
 
   it("builds a straight-polyline path for a series with curve: \"linear\"", () => {


### PR DESCRIPTION
## What changed

- mount stroke, dot, live-value-label, and optional value-line worklets only for active series
- cap path publication to the active series count instead of emitting 12 slots
- reserve the candle tooltip's five real O/H/L/C/time rows instead of 13 generic slots
- add an exact mapper-count regression test and changelog entry

## Why

`LiveChartSeries` previously mounted its full 12-series capacity. The default per-series subtree contains 3 stroke, 5 dot, and 4 value-label `useDerivedValue` mappers, so even a one-series chart registered 144 mappers. This is the per-node UI-thread fan-out highlighted by [Andrei Calazans' animation-library benchmark](https://andrei-calazans.com/posts/2026-07-15-which-react-native-animation-library/).

## Before / after measurement

Method: count actual `useDerivedValue` registrations while mounting the production stroke, dot, and value-label components. `MultiSeriesMapperCount.test.tsx` locks the three-series result to 36 registrations.

| Active series | Before | After | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 144 | 12 | 132 (91.7%) |
| 3 | 144 | 36 | 108 (75.0%) |
| 6 | 144 | 72 | 72 (50.0%) |
| 12 | 144 | 144 | 0 |

Additional measured reductions:

- optional value-line layer: 24 fixed mappers → `2 × activeSeriesCount`
- candle tooltip: 65 mappers (13 rows × 5) → 25 (5 rows × 5), a 61.5% reduction
- per-frame path result length: 12 entries → `activeSeriesCount`

These are exact structural measurements, not estimated FPS. No physical device was online during this run, so this PR intentionally makes no device CPU/frame-time claim.

## Impact

Charts with fewer than 12 series compile, retain, and execute fewer UI-thread mappers. The public API and 12-series maximum are unchanged.

## Validation

- `npm run verify` — 94 suites passed; 1,339 passed, 5 skipped
- focused mapper/series tests — 76 passed
- React Doctor 0.7.8 changed-file scan — no diagnostics

Closes #214
