### PR TITLE
perf: add Worklets Bundle Mode profiling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run tests
         run: npm test -- --no-coverage --ci --forceExit
+
+      - name: Verify packed Bundle Mode consumer export
+        run: npm run verify:bundle-mode-consumer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Bundle Mode builds.** Set `WORKLETS_BUNDLE_MODE=1` to apply matching Babel and
   Metro configuration; the renderer-matrix runner accepts repeatable
   `--worklets-mode legacy|bundle` selectors for controlled memory captures.
+  Public installation docs now include the opt-in consumer setup, and CI verifies
+  that a packed npm artifact completes a clean Bundle Mode production export.
   ([#212](https://github.com/brandtnewlabs/react-native-livechart/issues/212))
 
 - **Loading, reveal, engine, multi-series path, marker Atlas, and degen Atlas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The example and iOS profiling harness can compare Worklets legacy eval and
+  Bundle Mode builds.** Set `WORKLETS_BUNDLE_MODE=1` to apply matching Babel and
+  Metro configuration; the renderer-matrix runner accepts repeatable
+  `--worklets-mode legacy|bundle` selectors for controlled memory captures.
+  ([#212](https://github.com/brandtnewlabs/react-native-livechart/issues/212))
+
 ## [4.10.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ If you omit Worklets or reorder plugins, worklets in the chart may fail at build
 
 From **Expo SDK 53+**, Metro resolves `import` using `package.json` **`exports`**, including the **`react-native`** condition (see [Expo Metro: ES Module resolution](https://docs.expo.dev/versions/latest/config/metro/#es-module-resolution)). This library's runtime entry is **`src/index.ts`** under that condition. If you disabled package exports (`unstable_enablePackageExports: false`), align your resolver or re-enable exports so resolution matches the published map.
 
+### Optional: Worklets Bundle Mode
+
+Bundle Mode is app-level build configuration—there is no LiveChart prop to enable. Because the package ships source, your app automatically compiles LiveChart's worklets in Bundle Mode when Babel and Metro are configured for it. The setup below was verified with **`react-native-worklets` 0.10.0**, Expo 57, and React Native 0.86; check Worklets compatibility before applying it to a different stack.
+
+```js
+// babel.config.js — Worklets must remain the last plugin
+plugins: [
+  [
+    "react-native-worklets/plugin",
+    { bundleMode: true, strictGlobal: true },
+  ],
+];
+```
+
+```js
+// metro.config.js (Expo)
+const { getDefaultConfig } = require("expo/metro-config");
+const { getBundleModeMetroConfig } = require("react-native-worklets/bundleMode");
+
+module.exports = getBundleModeMetroConfig(getDefaultConfig(__dirname));
+```
+
+Follow the [official Bundle Mode setup](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup/) to apply the version-matched `metro` and `metro-runtime` patches, then clear Metro's cache and rebuild. Those patches belong in the consuming app; this package does not mutate a consumer's toolchain during installation. Legacy Eval Mode remains supported.
+
 ## Quick start
 
 ```tsx

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,16 @@
 module.exports = function (api) {
-  api.cache(true);
+  const bundleMode = process.env.WORKLETS_BUNDLE_MODE === "1";
+  api.cache.using(() => bundleMode);
   return {
     presets: ["babel-preset-expo"],
-    plugins: ["react-native-worklets/plugin"],
+    // The Worklets plugin must remain last. Bundle Mode is app-level build
+    // configuration, so the example/profiling app selects it via an explicit
+    // environment variable while legacy mode remains reproducible.
+    plugins: [
+      [
+        "react-native-worklets/plugin",
+        bundleMode ? { bundleMode: true, strictGlobal: true } : {},
+      ],
+    ],
   };
 };

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -64,6 +64,66 @@ your Metro + Babel pipeline compiles it.
 If you disabled package exports (`unstable_enablePackageExports: false`), re-enable them or align
 your resolver so resolution matches the published map.
 
+## Optional: Worklets Bundle Mode
+
+LiveChart does not need a separate prop or runtime API for Bundle Mode. The package ships source,
+so enabling Bundle Mode in your app's Babel and Metro configuration also compiles LiveChart's
+worklets in Bundle Mode.
+
+The setup below was verified with **`react-native-worklets` 0.10.0**, Expo 57, and React Native
+0.86. Bundle Mode configuration is app-wide and must be enabled in both Babel and Metro. Check the
+Worklets compatibility and setup docs before applying it to a different toolchain version.
+
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      // ...your other plugins
+      [
+        "react-native-worklets/plugin",
+        { bundleMode: true, strictGlobal: true },
+      ], // must be last
+    ],
+  };
+};
+```
+
+For an Expo app, wrap your existing Metro configuration:
+
+```js metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const {
+  getBundleModeMetroConfig,
+} = require("react-native-worklets/bundleMode");
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = getBundleModeMetroConfig(config);
+```
+
+For a bare React Native app, use the React Native Community variant from the
+[official Bundle Mode setup](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup/).
+
+<Warning>
+  Worklets 0.10 recommends version-matched patches for `metro` and `metro-runtime`. The Metro patch
+  indexes generated worklet modules synchronously; the `metro-runtime` patch enables Fast Refresh
+  on Worklet Runtimes. Apply the official patches in your app—the LiveChart package cannot safely
+  patch a consumer's toolchain transitively.
+</Warning>
+
+After changing Babel, Metro, or the patches, clear Metro's cache and rebuild the native app:
+
+```bash
+npx expo start --clear
+# React Native Community CLI:
+npm start -- --reset-cache
+```
+
+Legacy Eval Mode remains supported. Remove the Bundle Mode options and wrapper to return to your
+normal Worklets configuration.
+
 ## Gesture handler root
 
 Scrubbing uses Gesture Handler, so wrap your app (or the screen hosting the chart) in a

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -28,6 +28,13 @@ original `EXPO_PUBLIC_MEMORY_PROFILE_MODE=static|live` switch remains available
 as a compatibility override. The ordinary demo index is unchanged when neither
 variable is present.
 
+Set `WORKLETS_BUNDLE_MODE=1` at build time to enable Worklets 0.10 Bundle Mode
+in both Babel and Metro. Omit it (or set it to `0`) for the legacy eval mode.
+The Metro cache key includes this selector so sequential A/B builds cannot reuse
+transforms from the other mode. `npm install` applies the official Worklets 0.10
+patches for Metro 0.84.4 and `metro-runtime`; these are required for generated
+worklet-module indexing and Bundle Mode Fast Refresh.
+
 ## Renderer experiment matrix
 
 `profiling/live-renderer-matrix.json` is the source of truth for controlled
@@ -64,11 +71,61 @@ python3 scripts/run_ios_renderer_matrix.py \
   --run live-linear-sharp
 ```
 
+Compare legacy eval and Bundle Mode with identical phases and renderer inputs:
+
+```sh
+python3 scripts/run_ios_renderer_matrix.py \
+  --device Trooper --udid DEVICE_UDID \
+  --capture both \
+  --run static-control \
+  --worklets-mode legacy \
+  --worklets-mode bundle
+```
+
+The mode is included in every trace, XML, and summary filename. Bundle Mode is
+application-level configuration; published library consumers must configure
+their own Babel and Metro setup. See the official
+[Worklets Bundle Mode setup](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup/).
+
 The runner builds a Release bundle for each selection, records the same 65-second
 timeline, exports Activity Monitor XML, and writes one Markdown phase summary
 beside each trace. It refuses to overwrite traces unless `--force` is supplied.
 Metro's transform cache is keyed by the selected run, mode, and cadence so a
 sequential matrix cannot silently reuse the previous run's inlined environment.
+
+## Bundle Mode simulator screen
+
+The initial compatibility screen used Release builds of `static-control` on an
+iPhone 17 simulator (iOS 26.5). It is an A/B/A process-RSS comparison: each app
+was terminated, launched from its embedded bundle, sampled once per second for
+the fixed 60-second route, and rebuilt whenever the Worklets mode changed.
+Means exclude each phase's warm-up samples.
+
+| Build | Baseline mean | Mounted mean | Unmounted mean | Mount delta |
+| --- | ---: | ---: | ---: | ---: |
+| Legacy A1 | 610.67 MiB | 744.88 MiB | 747.07 MiB | 134.21 MiB |
+| Bundle Mode | 529.14 MiB | 552.95 MiB | 554.63 MiB | 23.81 MiB |
+| Legacy A2 | 610.61 MiB | 744.69 MiB | 746.85 MiB | 134.08 MiB |
+
+The two legacy passes agree within 0.2 MiB. Against their mean, Bundle Mode used
+25.8% less RSS while the chart was mounted and reduced the incremental mount
+delta by 82.3% (134.14 MiB to 23.81 MiB). This is a simulator screening result,
+not a physical-device performance claim. It supports continuing the experiment
+but does not replace the physical iOS/Android Activity Monitor, PSS/native-heap,
+startup, CPU, and frame-time measurements required before recommending Bundle
+Mode as the example-app default.
+
+A single clean `expo export --platform ios --clear` per mode produced the
+following build artifacts:
+
+| Build | Metro modules | Hermes bytecode | Export wall time | Bundler max RSS |
+| --- | ---: | ---: | ---: | ---: |
+| Legacy | 2,089 | 5,648,356 B | 10.57 s | 3,154,755,584 B |
+| Bundle Mode | 3,410 | 5,676,999 B | 10.33 s | 2,958,934,016 B |
+
+Bundle Mode added 1,324 generated worklet modules and increased final Hermes
+bytecode by 28,643 bytes (0.51%). The wall-time and bundler-RSS figures are
+single-run diagnostics and should not be treated as benchmark conclusions.
 
 ## Physical footprint
 

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -110,10 +110,10 @@ Means exclude each phase's warm-up samples.
 The two legacy passes agree within 0.2 MiB. Against their mean, Bundle Mode used
 25.8% less RSS while the chart was mounted and reduced the incremental mount
 delta by 82.3% (134.14 MiB to 23.81 MiB). This is a simulator screening result,
-not a physical-device performance claim. It supports continuing the experiment
-but does not replace the physical iOS/Android Activity Monitor, PSS/native-heap,
-startup, CPU, and frame-time measurements required before recommending Bundle
-Mode as the example-app default.
+not a physical-device performance claim. The physical iOS screen below validates
+the direction of the result; Android PSS/native-heap, startup, CPU, and frame-time
+measurements remain open before recommending Bundle Mode as the example-app
+default.
 
 A single clean `expo export --platform ios --clear` per mode produced the
 following build artifacts:
@@ -126,6 +126,31 @@ following build artifacts:
 Bundle Mode added 1,324 generated worklet modules and increased final Hermes
 bytecode by 28,643 bytes (0.51%). The wall-time and bundler-RSS figures are
 single-run diagnostics and should not be treated as benchmark conclusions.
+
+## Bundle Mode physical-device screen
+
+The physical compatibility screen used Release `static-control` builds on an
+iPhone 17 Pro Max (Trooper), iOS 26.6. The phone was connected over USB; each
+mode change rebuilt and reinstalled the app, and Activity Monitor recorded the
+same 65-second fixed-phase route. USB is recommended for physical-device traces
+because Wi-Fi transport delayed launch and trace finalization during the first
+attempt.
+
+| Run | Baseline mean | Mounted mean | Unmounted mean |
+| --- | ---: | ---: | ---: |
+| Bundle A | 99.27 MiB | 165.73 MiB | 124.27 MiB |
+| Legacy B | 281.70 MiB | 350.57 MiB | 309.71 MiB |
+| Bundle A repeat | 116.44 MiB | 153.08 MiB | 116.95 MiB |
+
+Against legacy, Bundle Mode reduced mounted physical memory by 52.7–56.3%.
+Using the mean of the two Bundle passes, mounted memory fell from 350.57 MiB to
+159.41 MiB (54.5%). Post-unmount physical memory fell by 59.9–62.2%. Baseline
+includes startup transients, so mounted and unmounted phases are the more useful
+comparisons.
+
+Functional QA passed through baseline, mounted chart, and unmounted phases with
+no JS, Worklets, fatal, exception, or crash errors. A Bundle Mode Allocations
+trace also completed and saved successfully over USB.
 
 ## Physical footprint
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 const { getDefaultConfig } = require("expo/metro-config");
+const { getBundleModeMetroConfig } = require("react-native-worklets/bundleMode");
 const path = require("path");
 
 const projectRoot = __dirname;
@@ -13,6 +14,7 @@ const livechartRoot = path.resolve(
 );
 
 const config = getDefaultConfig(projectRoot);
+const bundleMode = process.env.WORKLETS_BUNDLE_MODE === "1";
 // Expo inlines EXPO_PUBLIC_* values during transformation, but Metro's default
 // cache key does not include those values. Profiling builds run sequentially with
 // different matrix selections, so give each selection its own transform cache;
@@ -21,11 +23,16 @@ const rendererProfileCacheKey = [
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_RUN ?? "default",
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ?? "default",
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE ?? "default",
+  bundleMode ? "worklets-bundle" : "worklets-legacy",
 ].join(":");
 
 // Metro types mark `watchFolders` readonly — merge a new object instead of mutating.
-module.exports = {
+const livechartConfig = {
   ...config,
   cacheVersion: `${config.cacheVersion ?? "1"}:renderer-profile:${rendererProfileCacheKey}`,
   watchFolders: [...(config.watchFolders ?? []), livechartRoot],
 };
+
+module.exports = bundleMode
+  ? getBundleModeMetroConfig(livechartConfig)
+  : livechartConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "react-native-livechart-expo-example",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "workspaces": [
         "packages/*"
       ],
@@ -50,6 +51,7 @@
         "eslint": "^9.25.0",
         "eslint-config-expo": "~57.0.0",
         "husky": "^9.1.7",
+        "patch-package": "^8.0.1",
         "react-doctor": "^0.2.16",
         "react-test-renderer": "19.2.3",
         "typescript": "~6.0.3"
@@ -5992,6 +5994,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -9740,6 +9749,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -9812,6 +9831,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -12370,6 +12414,26 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12396,6 +12460,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -12420,6 +12517,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -14425,6 +14532,59 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -16704,6 +16864,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "verify": "npm run typecheck && npm run lint && npm test",
     "verify:coverage": "npm run typecheck && npm run lint && npm run test:coverage",
     "prepare": "husky",
+    "postinstall": "patch-package",
     "doctor": "npx react-doctor@latest",
     "docs": "cd docs && npx mint@latest dev"
   },
@@ -66,6 +67,7 @@
     "eslint": "^9.25.0",
     "eslint-config-expo": "~57.0.0",
     "husky": "^9.1.7",
+    "patch-package": "^8.0.1",
     "react-doctor": "^0.2.16",
     "react-test-renderer": "19.2.3",
     "typescript": "~6.0.3"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:lib": "npm run build -w react-native-livechart",
     "build:lib:types:watch": "npm run build:types:watch -w react-native-livechart",
     "pack:lib": "npm pack -w react-native-livechart",
+    "verify:bundle-mode-consumer": "node scripts/verify_bundle_mode_consumer.mjs",
     "verify": "npm run typecheck && npm run lint && npm test",
     "verify:coverage": "npm run typecheck && npm run lint && npm run test:coverage",
     "prepare": "husky",

--- a/patches/metro+0.84.4.patch
+++ b/patches/metro+0.84.4.patch
@@ -1,0 +1,31 @@
+diff --git a/node_modules/metro/src/node-haste/DependencyGraph.js b/node_modules/metro/src/node-haste/DependencyGraph.js
+index 8222d8c..e36770d 100644
+--- a/node_modules/metro/src/node-haste/DependencyGraph.js
++++ b/node_modules/metro/src/node-haste/DependencyGraph.js
+@@ -32,6 +32,11 @@ function getOrCreateMap(map, field) {
+   }
+   return subMap;
+ }
++
++const workletsDirPath = _path.default.join(
++  "react-native-worklets",
++  ".worklets",
++);
+ class DependencyGraph extends _events.default {
+   #packageCache;
+   #dependencyPlugin;
+@@ -197,6 +202,14 @@ class DependencyGraph extends _events.default {
+     return (0, _nullthrows.default)(this._fileSystem).getAllFiles();
+   }
+   async getOrComputeSha1(mixedPath) {
++    if (mixedPath.includes(workletsDirPath)) {
++      const createHash = require("crypto").createHash;
++      return {
++        sha1: createHash("sha1")
++          .update(performance.now().toString())
++          .digest("hex"),
++      };
++    }
+     const result = await this._fileSystem.getOrComputeSha1(mixedPath);
+     if (!result || !result.sha1) {
+       throw new Error(`Failed to get the SHA-1 for: ${mixedPath}.

--- a/patches/metro-runtime+0.84.4.patch
+++ b/patches/metro-runtime+0.84.4.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/metro-runtime/src/modules/HMRClient.js b/node_modules/metro-runtime/src/modules/HMRClient.js
+index 534ac87..5773985 100644
+--- a/node_modules/metro-runtime/src/modules/HMRClient.js
++++ b/node_modules/metro-runtime/src/modules/HMRClient.js
+@@ -3,6 +3,9 @@
+ const EventEmitter = require("./vendor/eventemitter3");
+ const HEARTBEAT_INTERVAL_MS = 20_000;
+ const inject = ({ module: [id, code], sourceURL }) => {
++  if (global.__workletsModuleProxy?.propagateModuleUpdate) {
++    global.__workletsModuleProxy.propagateModuleUpdate(code, sourceURL);
++  }
+   if (global.globalEvalWithSourceUrl) {
+     global.globalEvalWithSourceUrl(code, sourceURL);
+   } else {

--- a/profiling/metroConfig.test.ts
+++ b/profiling/metroConfig.test.ts
@@ -7,6 +7,7 @@ function loadCacheVersion(
   run: string,
   mode: string,
   cadence: string,
+  workletsBundleMode = "0",
 ): string {
   return execFileSync(
     process.execPath,
@@ -22,6 +23,7 @@ function loadCacheVersion(
         EXPO_PUBLIC_MEMORY_PROFILE_RUN: run,
         EXPO_PUBLIC_MEMORY_PROFILE_MODE: mode,
         EXPO_PUBLIC_MEMORY_PROFILE_CADENCE: cadence,
+        WORKLETS_BUNDLE_MODE: workletsBundleMode,
       },
     },
   ).trim();
@@ -43,5 +45,8 @@ describe("renderer profiling Metro cache", () => {
     expect(loadCacheVersion("static-control", "static", "adaptive")).not.toBe(
       baseline,
     );
+    expect(
+      loadCacheVersion("static-control", "static", "display", "1"),
+    ).not.toBe(baseline);
   });
 });

--- a/profiling/workletsBundleModeConfig.test.ts
+++ b/profiling/workletsBundleModeConfig.test.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const projectRoot = path.resolve(__dirname, "..");
+
+function loadConfig(bundleMode: boolean) {
+  const script = `
+    const babel = require('./babel.config')({ cache: { using() {} } });
+    const metro = require('./metro.config');
+    const plugin = babel.plugins.at(-1);
+    process.stdout.write(JSON.stringify({
+      plugin,
+      cacheVersion: metro.cacheVersion,
+      moduleIdFactory: metro.serializer.createModuleIdFactory.name,
+    }));
+  `;
+  return JSON.parse(
+    execFileSync(process.execPath, ["-e", script], {
+      cwd: projectRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WORKLETS_BUNDLE_MODE: bundleMode ? "1" : "0",
+      },
+    }),
+  );
+}
+
+describe("Worklets Bundle Mode build configuration", () => {
+  it("keeps legacy mode reproducible", () => {
+    const config = loadConfig(false);
+    expect(config.plugin).toEqual(["react-native-worklets/plugin", {}]);
+    expect(config.cacheVersion).toContain("worklets-legacy");
+    expect(config.moduleIdFactory).not.toBe("bundleModeCreateModuleIdFactory");
+  });
+
+  it("enables matching Babel and Metro bundle-mode transforms", () => {
+    const config = loadConfig(true);
+    expect(config.plugin).toEqual([
+      "react-native-worklets/plugin",
+      { bundleMode: true, strictGlobal: true },
+    ]);
+    expect(config.cacheVersion).toContain("worklets-bundle");
+    expect(config.moduleIdFactory).toBe("bundleModeCreateModuleIdFactory");
+  });
+});

--- a/scripts/run_ios_renderer_matrix.py
+++ b/scripts/run_ios_renderer_matrix.py
@@ -72,9 +72,12 @@ def select_runs(
     return [by_id[run_id] for run_id in selected_ids]
 
 
-def trace_path(output_dir: Path, run_id: str, template: str) -> Path:
+def trace_path(
+    output_dir: Path, run_id: str, template: str, worklets_mode: str | None
+) -> Path:
     suffix = "activity" if template == "Activity Monitor" else "allocations"
-    return output_dir / f"{run_id}.{suffix}.trace"
+    mode_suffix = f".{worklets_mode}" if worklets_mode else ""
+    return output_dir / f"{run_id}{mode_suffix}.{suffix}.trace"
 
 
 def remove_output(path: Path) -> None:
@@ -90,10 +93,16 @@ def capture_run(
     run: dict[str, Any],
     *,
     args: argparse.Namespace,
+    worklets_mode: str | None,
 ) -> None:
     run_id = run["id"]
     profile_env = {"EXPO_PUBLIC_MEMORY_PROFILE_RUN": run_id}
-    print(f"\n## {run_id}: {run['description']}", flush=True)
+    if worklets_mode:
+        profile_env["WORKLETS_BUNDLE_MODE"] = (
+            "1" if worklets_mode == "bundle" else "0"
+        )
+    mode_label = f" [{worklets_mode}]" if worklets_mode else ""
+    print(f"\n## {run_id}{mode_label}: {run['description']}", flush=True)
 
     if not args.skip_build:
         run_command(
@@ -118,7 +127,7 @@ def capture_run(
         templates.append("Allocations")
 
     for template in templates:
-        trace = trace_path(args.output_dir, run_id, template)
+        trace = trace_path(args.output_dir, run_id, template, worklets_mode)
         if trace.exists() and not args.force and not args.dry_run:
             raise FileExistsError(f"refusing to overwrite existing trace: {trace}")
         if trace.exists() and args.force and not args.dry_run:
@@ -144,8 +153,9 @@ def capture_run(
 
         if template != "Activity Monitor":
             continue
-        xml = args.output_dir / f"{run_id}.activity.xml"
-        summary = args.output_dir / f"{run_id}.activity.md"
+        mode_suffix = f".{worklets_mode}" if worklets_mode else ""
+        xml = args.output_dir / f"{run_id}{mode_suffix}.activity.xml"
+        summary = args.output_dir / f"{run_id}{mode_suffix}.activity.md"
         if args.force and not args.dry_run:
             remove_output(xml)
             remove_output(summary)
@@ -198,6 +208,16 @@ def main() -> None:
         default=Path("/tmp/livechart-renderer-matrix"),
     )
     parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument(
+        "--worklets-mode",
+        action="append",
+        choices=("legacy", "bundle"),
+        default=[],
+        help=(
+            "Worklets runtime mode; repeat with legacy and bundle for an A/B "
+            "capture. Omit to preserve the historical runner behavior."
+        ),
+    )
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--list", action="store_true")
@@ -212,12 +232,16 @@ def main() -> None:
         parser.error("--udid is required unless --list is used")
 
     selected = select_runs(runs, args.run)
-    if args.skip_build and len(selected) != 1:
-        parser.error("--skip-build requires exactly one --run selection")
+    worklets_modes: list[str | None] = args.worklets_mode or [None]
+    if args.skip_build and (len(selected) != 1 or len(worklets_modes) != 1):
+        parser.error(
+            "--skip-build requires exactly one --run and one Worklets mode"
+        )
     if not args.dry_run:
         args.output_dir.mkdir(parents=True, exist_ok=True)
-    for run in selected:
-        capture_run(run, args=args)
+    for worklets_mode in worklets_modes:
+        for run in selected:
+            capture_run(run, args=args, worklets_mode=worklets_mode)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_bundle_mode_consumer.mjs
+++ b/scripts/verify_bundle_mode_consumer.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scratchRoot = path.join(root, ".expo");
+mkdirSync(scratchRoot, { recursive: true });
+const consumerRoot = mkdtempSync(
+  path.join(scratchRoot, "bundle-mode-consumer-"),
+);
+
+function run(command, args, cwd = consumerRoot) {
+  console.log(`$ ${command} ${args.join(" ")}`);
+  execFileSync(command, args, {
+    cwd,
+    env: {
+      ...process.env,
+      CI: "1",
+      EXPO_NO_TELEMETRY: "1",
+    },
+    stdio: "inherit",
+  });
+}
+
+function write(relativePath, contents) {
+  const target = path.join(consumerRoot, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+function findFiles(directory, predicate) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return findFiles(target, predicate);
+    }
+    return predicate(target) ? [target] : [];
+  });
+}
+
+try {
+  write(
+    "package.json",
+    `${JSON.stringify(
+      {
+        name: "livechart-packed-bundle-mode-smoke",
+        version: "1.0.0",
+        private: true,
+        main: "index.js",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  run(
+    "npm",
+    [
+      "pack",
+      "--workspace",
+      "react-native-livechart",
+      "--pack-destination",
+      consumerRoot,
+    ],
+    root,
+  );
+
+  const tarballs = readdirSync(consumerRoot).filter((name) =>
+    name.endsWith(".tgz"),
+  );
+  assert.equal(tarballs.length, 1, "expected one packed library tarball");
+  const tarball = path.join(consumerRoot, tarballs[0]);
+
+  run("npm", [
+    "install",
+    "--ignore-scripts",
+    "--legacy-peer-deps",
+    "--no-audit",
+    "--no-fund",
+    "--no-package-lock",
+    "--no-save",
+    tarball,
+  ]);
+
+  const rootManifest = JSON.parse(
+    readFileSync(path.join(root, "package.json"), "utf8"),
+  );
+  write(
+    "package.json",
+    `${JSON.stringify(
+      {
+        name: "livechart-packed-bundle-mode-smoke",
+        version: "1.0.0",
+        private: true,
+        main: "index.js",
+        dependencies: {
+          ...rootManifest.dependencies,
+          "react-native-livechart": `file:${tarball}`,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  write(
+    "app.json",
+    `${JSON.stringify(
+      {
+        expo: {
+          name: "LiveChart Bundle Mode Smoke",
+          slug: "livechart-bundle-mode-smoke",
+          version: "1.0.0",
+          platforms: ["ios"],
+          ios: {
+            bundleIdentifier: "com.brandtnewlabs.livechart-bundle-mode-smoke",
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  write(
+    "babel.config.js",
+    `module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      [
+        "react-native-worklets/plugin",
+        { bundleMode: true, strictGlobal: true },
+      ],
+    ],
+  };
+};
+`,
+  );
+
+  write(
+    "metro.config.js",
+    `const { getDefaultConfig } = require("expo/metro-config");
+const {
+  getBundleModeMetroConfig,
+} = require("react-native-worklets/bundleMode");
+
+module.exports = getBundleModeMetroConfig(getDefaultConfig(__dirname));
+`,
+  );
+
+  write(
+    "index.js",
+    `import React from "react";
+import { View } from "react-native";
+import { registerRootComponent } from "expo";
+import { useSharedValue } from "react-native-reanimated";
+import { LiveChart } from "react-native-livechart";
+
+function App() {
+  const data = useSharedValue([
+    { timestamp: 0, value: 100 },
+    { timestamp: 1, value: 101 },
+  ]);
+  const value = useSharedValue(101);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <LiveChart data={data} value={value} />
+    </View>
+  );
+}
+
+registerRootComponent(App);
+`,
+  );
+
+  const installedManifestPath = path.join(
+    consumerRoot,
+    "node_modules",
+    "react-native-livechart",
+    "package.json",
+  );
+  const installedManifest = JSON.parse(
+    readFileSync(installedManifestPath, "utf8"),
+  );
+  assert.equal(
+    installedManifest.exports["."]["react-native"],
+    "./src/index.ts",
+    "packed package must expose source to the consumer Babel pipeline",
+  );
+  assert.match(
+    readFileSync(
+      path.join(
+        consumerRoot,
+        "node_modules",
+        "react-native-livechart",
+        "README.md",
+      ),
+      "utf8",
+    ),
+    /Optional: Worklets Bundle Mode/,
+    "packed package must include the Bundle Mode consumer setup",
+  );
+
+  const expoCli = path.join(root, "node_modules", "expo", "bin", "cli");
+  run(process.execPath, [
+    expoCli,
+    "export",
+    "--platform",
+    "ios",
+    "--clear",
+    "--output-dir",
+    path.join(consumerRoot, "dist"),
+  ]);
+
+  const outputRoot = path.join(consumerRoot, "dist");
+  const bundles = findFiles(
+    outputRoot,
+    (file) =>
+      statSync(file).size > 0 &&
+      (file.endsWith(".hbc") || file.endsWith(".js")),
+  );
+  assert.ok(bundles.length > 0, "expected a non-empty exported iOS bundle");
+
+  console.log(
+    `Packed consumer Bundle Mode export passed (${bundles.length} bundle artifact(s)).`,
+  );
+} finally {
+  rmSync(consumerRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- add opt-in Worklets Bundle Mode to the example/profiling app with matching Babel and Metro configuration
- apply the official Worklets 0.10 Metro 0.84.4 and `metro-runtime` patches after install
- extend the iOS renderer-matrix runner with reproducible legacy/Bundle A/B captures and mode-specific artifacts
- document production-export, simulator A/B/A, and physical-device A/B/A memory results
- document the consumer setup and verify the packed npm artifact with a clean Bundle Mode production export in CI

Bundle Mode is application-level build configuration, not a LiveChart prop or runtime API. Consumers opt in through their app's Babel, Metro, and version-matched Worklets patches. Legacy mode remains supported.

## Simulator before / after

Release `static-control` builds, iPhone 17 simulator (iOS 26.5), process RSS sampled through the fixed baseline → mounted → unmounted route. Means exclude phase warm-up. The app was rebuilt whenever mode changed.

| Build | Baseline mean | Mounted mean | Unmounted mean | Mount delta |
| --- | ---: | ---: | ---: | ---: |
| Legacy A1 | 610.67 MiB | 744.88 MiB | 747.07 MiB | 134.21 MiB |
| Bundle Mode | 529.14 MiB | 552.95 MiB | 554.63 MiB | 23.81 MiB |
| Legacy A2 | 610.61 MiB | 744.69 MiB | 746.85 MiB | 134.08 MiB |

Against the mean of the two legacy passes:

- mounted RSS: **744.79 → 552.95 MiB (-25.8%)**
- incremental chart-mount delta: **134.14 → 23.81 MiB (-82.3%)**
- final Hermes bytecode: **5,648,356 → 5,676,999 bytes (+0.51%)**
- Metro module count: **2,089 → 3,410** (including 1,324 generated worklet modules)

The two legacy simulator passes agree within 0.2 MiB.

## Physical-device validation

Release `static-control` builds on **Trooper — iPhone 17 Pro Max, iOS 26.6**, connected over USB. Each mode change rebuilt and reinstalled the app. Activity Monitor used matching 65-second launch/attach timing across the Bundle → Legacy → Bundle repeat.

| Run | Baseline mean | Mounted mean | Unmounted mean |
| --- | ---: | ---: | ---: |
| Bundle A | 99.27 MiB | 165.73 MiB | 124.27 MiB |
| Legacy B | 281.70 MiB | 350.57 MiB | 309.71 MiB |
| Bundle A repeat | 116.44 MiB | 153.08 MiB | 116.95 MiB |

Against legacy:

- mounted physical memory: **350.57 → 153.08–165.73 MiB (-52.7% to -56.3%)**
- mounted physical memory using the two Bundle runs' mean: **350.57 → 159.41 MiB (-54.5%)**
- post-unmount physical memory: **309.71 → 116.95–124.27 MiB (-59.9% to -62.2%)**

Baseline includes startup transients, so mounted and unmounted phases are the more useful physical-device comparisons.

Functional device QA passed: Bundle Mode launched, rendered the chart during the mounted phase, and removed it during unmount with no JS, Worklets, fatal, exception, or crash errors. The Bundle Mode Allocations trace also completed and saved successfully over USB.

One earlier cold Bundle build hit a Metro SHA-1 error for a generated `.worklets/*.js` file; two subsequent Bundle Release builds succeeded, so this remains a single observed flake rather than a deterministic failure. An earlier delayed app launch also completed and was a connection delay, not a runner launch failure.

Android PSS/native-heap, startup, CPU, and frame-time validation remain outside this PR's completed validation scope. Bundle Mode remains opt-in rather than a default change.

## Verification

- `npm run verify` — 94 suites passed; 1,343 passed, 5 skipped
- focused config tests — 2 suites / 3 tests passed
- React Doctor — 100/100
- packed npm artifact installed into a clean consumer and completed a clean Bundle Mode iOS production export locally and in CI
- legacy and Bundle Mode production iOS exports completed
- legacy and Bundle Mode Release simulator builds launched successfully
- renderer-matrix legacy/Bundle dry run emitted isolated environment values and artifact names
- physical iPhone Bundle → Legacy → Bundle Activity Monitor captures completed
- physical iPhone Bundle Mode Allocations capture completed
- CodeQL and GitHub Test workflows passed on commit `83fa676`

Refs #212
