### PR TITLE
perf: pool remaining frame allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Loading, reveal, engine, multi-series path, marker Atlas, and degen Atlas
+  frame loops now reuse JavaScript scratch containers.** Published arrays
+  ping-pong to preserve Reanimated/Skia invalidation, while immutable paths and
+  dynamic transform/color host values retain their safe ownership model.
+  ([#211](https://github.com/brandtnewlabs/react-native-livechart/issues/211))
+
 ## [4.10.0] - 2026-07-16
 
 ### Added

--- a/docs/ios-memory-profiling.md
+++ b/docs/ios-memory-profiling.md
@@ -130,6 +130,41 @@ For context, reducing optional and duplicate chart worklets lowered the retained
 to 173.00 MiB (692 regions). It also reduced the original 144 KiB allocation
 volume from 81.14 MiB (577 allocations) to 1.83 MiB (13 allocations).
 
+## JavaScript frame-allocation pooling
+
+A follow-up source inventory isolated the remaining deterministic JavaScript
+containers created at frame cadence. Focused identity tests drive the reusable
+math, particle, and engine helpers repeatedly; the existing loading, reveal,
+multi-series, and marker-variant component suites cover the integration paths.
+Together they verify that caller-owned buffers are reused, truncated when inputs
+shrink, and ping-ponged whenever a new SharedValue reference is required for
+invalidation.
+
+| Frame path | Before | After | Removed at 60 fps |
+| --- | ---: | ---: | ---: |
+| Loading squiggle | 1 number array/frame | 0 | 60 arrays/s |
+| Reveal morph | 2 number arrays/frame | 0 | 120 arrays/s |
+| Single-series engine | state + input objects | 0 | 120 objects/s |
+| Multi-series engine | refs + state + input objects | 0 | 180 objects/s |
+| Multi-series path list | 1 array/frame | 0 | 60 arrays/s |
+| Marker Atlas lists | 2 arrays + result object | 0 | 180 containers/s |
+| Degen Atlas (`N` active) | `N + 5` JS objects/containers + `N` sprite rects/frame | 0 of these classes | `300 + 60N` JS allocations/s + `60N` rects/s |
+
+For example, a 32-particle burst avoids 2,220 JavaScript object/container
+allocations and 1,920 identical sprite-rect host values per second while active.
+The single-series steady engine removes 120 objects per second even with all
+optional overlays disabled. These are exact call-site/identity counts, not
+heap-size or frame-time claims; physical-device allocation rate, GC pauses,
+CPU, and p90/p99 frame time still need to be recaptured.
+
+The pools deliberately do not mutate published buffers in place: numeric and
+Atlas result arrays ping-pong, so Reanimated/Skia still observe a reference
+change while the previous frame remains readable. Immutable `SkPath` instances
+returned by `PathBuilder.detach()` remain per-frame by design. Marker/particle
+`Skia.RSXform` values and per-particle `Skia.Color` values also remain dynamic;
+their contents change every frame and reusing them without an explicit Skia
+ownership guarantee would risk mutating data still consumed by the renderer.
+
 ## Reproduce
 
 Build and install each Release variant:
@@ -165,5 +200,6 @@ python3 scripts/summarize_activity_monitor.py /tmp/livechart.xml
 The next useful experiments are rendering-specific: avoid redraws when geometry
 has not changed, cap the redraw rate below the display refresh rate, reduce path
 or antialiasing complexity, and determine why this workload selects Ganesh's
-software path renderer. Pooling JavaScript or SkPath wrappers is unlikely to
-address the measured mask-pixmap churn.
+software path renderer. The completed JavaScript pooling should reduce secondary
+GC pressure, but it does not address the measured mask-pixmap churn. Pooling
+immutable SkPath wrappers is still unlikely to affect that dominant native cost.

--- a/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
+++ b/packages/react-native-livechart/src/components/DegenParticlesOverlay.tsx
@@ -5,6 +5,7 @@ import {
   type SkRSXform,
   type SkRect,
 } from "@shopify/react-native-skia";
+import { useRef } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import {
   buildParticleInstances,
@@ -63,14 +64,46 @@ export function DegenParticlesOverlay({
   // memoizes this on `colorList`.
   const colorRgb = colorList.map((c) => parseColorRgb(c));
 
+  const poolRef = useRef<{
+    a: { transforms: SkRSXform[]; sprites: SkRect[]; colors: SkColor[] };
+    b: { transforms: SkRSXform[]; sprites: SkRect[]; colors: SkColor[] };
+    tick: boolean;
+    instances: ReturnType<typeof buildParticleInstances>;
+    instancePool: ReturnType<typeof buildParticleInstances>;
+    spriteRect: SkRect;
+  } | null>(null);
+  if (poolRef.current === null) {
+    const instancePool = Array.from({ length: particleSlotCount }, () => ({
+      x: 0,
+      y: 0,
+      scale: 0,
+      alpha: 0,
+      colorIndex: 0,
+    }));
+    poolRef.current = {
+      a: { transforms: [], sprites: [], colors: [] },
+      b: { transforms: [], sprites: [], colors: [] },
+      tick: false,
+      instances: [],
+      instancePool,
+      spriteRect: Skia.XYWHRect(0, 0, sprite.size, sprite.size),
+    };
+  }
+
   // Single per-frame worklet. Reads `packRevision` so it re-runs each frame
   // while a burst is alive (the pack buffer is mutated in place, so its
   // reference is stable and wouldn't otherwise re-notify).
   const atlasData = useDerivedValue(() => {
     const rev = packRevision.get();
-    const transforms: SkRSXform[] = [];
-    const sprites: SkRect[] = [];
-    const colorsOut: SkColor[] = [];
+    const pool = poolRef.current!;
+    pool.tick = !pool.tick;
+    const frame = pool.tick ? pool.a : pool.b;
+    const transforms = frame.transforms;
+    const sprites = frame.sprites;
+    const colorsOut = frame.colors;
+    transforms.length = 0;
+    sprites.length = 0;
+    colorsOut.length = 0;
     if (rev >= 0) {
       const instances = buildParticleInstances(
         pack.get(),
@@ -79,6 +112,8 @@ export function DegenParticlesOverlay({
         particleBurstDurationSec,
         particleOpacity,
         sprite.radius,
+        pool.instances,
+        pool.instancePool,
       );
       const half = sprite.size / 2;
       for (let i = 0; i < instances.length; i++) {
@@ -92,12 +127,12 @@ export function DegenParticlesOverlay({
             inst.y - inst.scale * half,
           ),
         );
-        sprites.push(Skia.XYWHRect(0, 0, sprite.size, sprite.size));
+        sprites.push(pool.spriteRect);
         const [r, g, b] = colorRgb[inst.colorIndex % colorRgb.length];
         colorsOut.push(Skia.Color(`rgba(${r}, ${g}, ${b}, ${inst.alpha})`));
       }
     }
-    return { transforms, sprites, colors: colorsOut };
+    return frame;
   }, [
     pack,
     packRevision,

--- a/packages/react-native-livechart/src/components/LoadingOverlay.tsx
+++ b/packages/react-native-livechart/src/components/LoadingOverlay.tsx
@@ -8,6 +8,7 @@ import {
   vec,
   type SkFont,
 } from "@shopify/react-native-skia";
+import { useRef } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import {
   BADGE_METRICS_DEFAULTS,
@@ -108,6 +109,7 @@ export function LoadingOverlay({
 
   // Squiggly path — built into a reused PathBuilder and detach()-ed each frame.
   const squigglyBuilder = usePathBuilder();
+  const squigglyPtsRef = useRef<number[]>([]);
 
   // Squiggly path — animated each frame via timestamp
   const squigglyPath = useDerivedValue(() => {
@@ -122,6 +124,7 @@ export function LoadingOverlay({
       engine.timestamp.get(),
       waveAmplitude,
       waveSpeed,
+      squigglyPtsRef.current,
     );
     return buildSplineDetached(b, pts);
   });

--- a/packages/react-native-livechart/src/components/MarkerOverlay.tsx
+++ b/packages/react-native-livechart/src/components/MarkerOverlay.tsx
@@ -351,6 +351,18 @@ export function MarkerOverlay({
   if (projRef.current === null) {
     projRef.current = { a: [], b: [], tick: false };
   }
+  const atlasFrameRef = useRef<{
+    a: { transforms: SkRSXform[]; sprites: SkRect[] };
+    b: { transforms: SkRSXform[]; sprites: SkRect[] };
+    tick: boolean;
+  } | null>(null);
+  if (atlasFrameRef.current === null) {
+    atlasFrameRef.current = {
+      a: { transforms: [], sprites: [] },
+      b: { transforms: [], sprites: [] },
+      tick: false,
+    };
+  }
 
   // Single per-frame worklet: project all markers, then emit a transform +
   // source rect for each visible atlas marker. Three mappers total regardless
@@ -377,8 +389,13 @@ export function MarkerOverlay({
         lineLinear,
       });
       clusterMarkers(ms, buf, { config: cluster });
-      const transforms: SkRSXform[] = [];
-      const sprites: SkRect[] = [];
+      const atlasFrames = atlasFrameRef.current!;
+      atlasFrames.tick = !atlasFrames.tick;
+      const frame = atlasFrames.tick ? atlasFrames.a : atlasFrames.b;
+      const transforms = frame.transforms;
+      const sprites = frame.sprites;
+      transforms.length = 0;
+      sprites.length = 0;
       for (let i = 0; i < ms.length; i++) {
         const pt = buf[i];
         // Collapsed-cluster members fold into their representative's badge.
@@ -455,7 +472,7 @@ export function MarkerOverlay({
         );
         sprites.push(cell.rect);
       }
-      return { transforms, sprites };
+      return frame;
     },
     [
       cells,

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -18,7 +18,11 @@ import {
 } from "react-native-reanimated";
 import { MS_PER_FRAME_60FPS, RETURN_TO_LIVE_MS } from "../constants";
 import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
-import { tickLiveChartEngineFrame } from "./liveChartEngineTick";
+import {
+  tickLiveChartEngineFrame,
+  type EngineTickInput,
+  type EngineTickMutable,
+} from "./liveChartEngineTick";
 
 export interface EngineConfig {
   data: SharedValue<LiveChartPoint[]>;
@@ -229,6 +233,42 @@ export interface EngineFrameRefs {
   extremaMaxTime: SharedValue<number>;
 }
 
+/** Stable state/input containers reused by the UI-thread frame callback. */
+export interface EngineFrameScratch {
+  state: EngineTickMutable;
+  input: EngineTickInput;
+}
+
+/** Allocate one single-series frame scratch. Call once per engine instance. */
+export function makeEngineFrameScratch(): EngineFrameScratch {
+  return {
+    state: {
+      displayValue: 0,
+      displayMin: 0,
+      displayMax: 1,
+      displayWindow: 0,
+      timestamp: 0,
+      liveEdge: 0,
+      edgeValue: 0,
+      extremaMinValue: NaN,
+      extremaMaxValue: NaN,
+      extremaMinTime: NaN,
+      extremaMaxTime: NaN,
+    },
+    input: {
+      dt: MS_PER_FRAME_60FPS,
+      canvasWidth: 0,
+      canvasHeight: 0,
+      timeWindow: 0,
+      smoothing: 0,
+      exaggerate: false,
+      referenceValue: undefined,
+      targetValue: 0,
+      points: [],
+    },
+  };
+}
+
 /**
  * Shared between the `useFrameCallback` worklet and unit tests.
  * Mutates shared values from a snapshot tick (`tickLiveChartEngineFrame`).
@@ -236,54 +276,77 @@ export interface EngineFrameRefs {
 export function applyLiveChartEngineFrame(
   frameInfo: { timeSincePreviousFrame?: number | null },
   sv: EngineFrameRefs,
+  scratch?: EngineFrameScratch,
 ): void {
   "worklet";
   const dt = frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
   // One-shot settle: a `snapKey` change set this flag; consume it for this tick
   // and clear it below so only this frame snaps (live ticks stay smoothed).
   const snap = sv.snapSV?.value ?? false;
-  const state = {
-    displayValue: sv.displayValue.value,
-    displayMin: sv.displayMin.value,
-    displayMax: sv.displayMax.value,
-    displayWindow: sv.displayWindow.value,
-    timestamp: sv.timestamp.value,
-    liveEdge: sv.liveEdgeSV?.value ?? 0,
-    edgeValue: sv.edgeValueSV?.value ?? 0,
-    extremaMinValue: sv.extremaMinValue.value,
-    extremaMaxValue: sv.extremaMaxValue.value,
-    extremaMinTime: sv.extremaMinTime.value,
-    extremaMaxTime: sv.extremaMaxTime.value,
+  const state: EngineTickMutable = scratch?.state ?? {
+    displayValue: 0,
+    displayMin: 0,
+    displayMax: 1,
+    displayWindow: 0,
+    timestamp: 0,
+    liveEdge: 0,
+    edgeValue: 0,
+    extremaMinValue: NaN,
+    extremaMaxValue: NaN,
+    extremaMinTime: NaN,
+    extremaMaxTime: NaN,
   };
-  tickLiveChartEngineFrame(state, {
+  state.displayValue = sv.displayValue.value;
+  state.displayMin = sv.displayMin.value;
+  state.displayMax = sv.displayMax.value;
+  state.displayWindow = sv.displayWindow.value;
+  state.timestamp = sv.timestamp.value;
+  state.liveEdge = sv.liveEdgeSV?.value ?? 0;
+  state.edgeValue = sv.edgeValueSV?.value ?? 0;
+  state.extremaMinValue = sv.extremaMinValue.value;
+  state.extremaMaxValue = sv.extremaMaxValue.value;
+  state.extremaMinTime = sv.extremaMinTime.value;
+  state.extremaMaxTime = sv.extremaMaxTime.value;
+
+  const input: EngineTickInput = scratch?.input ?? {
     dt,
-    canvasWidth: sv.canvasWidth.value,
-    canvasHeight: sv.canvasHeight.value,
-    timeWindow: sv.timeWindow.value,
-    smoothing: sv.smoothing.value,
-    adaptiveSpeedBoost: sv.adaptiveSpeedBoostSV?.value,
-    exaggerate: sv.exaggerateSV.value,
-    referenceValue: sv.referenceValue.value,
-    referenceValues: sv.referenceValues?.value,
-    thresholdRangePoints: sv.thresholdRangePoints?.value,
-    thresholdRangeExtendToNow: sv.thresholdRangeExtendToNow?.value ?? true,
-    nonNegative: sv.nonNegativeSV?.value ?? false,
-    maxValue: sv.maxValueSV?.value,
-    nowOverride: sv.nowOverrideSV?.value,
-    windowBuffer: sv.windowBufferSV?.value ?? 0,
-    targetValue: sv.value.value,
-    points: sv.data.value,
-    nowSeconds: Date.now() / 1000,
-    paused: sv.pausedSV.value,
-    snap,
-    viewEnd: sv.viewEndSV?.value,
-    returnT: sv.returnTSV?.value,
-    returnFrom: sv.returnFromSV?.value,
-    viewWindow: sv.viewWindowSV?.value,
-    mode: sv.modeSV.value,
-    candles: sv.candles?.value,
-    liveCandle: sv.liveCandle?.value,
-  });
+    canvasWidth: 0,
+    canvasHeight: 0,
+    timeWindow: 0,
+    smoothing: 0,
+    exaggerate: false,
+    referenceValue: undefined,
+    targetValue: 0,
+    points: [],
+  };
+  input.dt = dt;
+  input.canvasWidth = sv.canvasWidth.value;
+  input.canvasHeight = sv.canvasHeight.value;
+  input.timeWindow = sv.timeWindow.value;
+  input.smoothing = sv.smoothing.value;
+  input.adaptiveSpeedBoost = sv.adaptiveSpeedBoostSV?.value;
+  input.exaggerate = sv.exaggerateSV.value;
+  input.referenceValue = sv.referenceValue.value;
+  input.referenceValues = sv.referenceValues?.value;
+  input.thresholdRangePoints = sv.thresholdRangePoints?.value;
+  input.thresholdRangeExtendToNow = sv.thresholdRangeExtendToNow?.value ?? true;
+  input.nonNegative = sv.nonNegativeSV?.value ?? false;
+  input.maxValue = sv.maxValueSV?.value;
+  input.nowOverride = sv.nowOverrideSV?.value;
+  input.windowBuffer = sv.windowBufferSV?.value ?? 0;
+  input.targetValue = sv.value.value;
+  input.points = sv.data.value;
+  input.nowSeconds = Date.now() / 1000;
+  input.paused = sv.pausedSV.value;
+  input.snap = snap;
+  input.viewEnd = sv.viewEndSV?.value;
+  input.returnT = sv.returnTSV?.value;
+  input.returnFrom = sv.returnFromSV?.value;
+  input.viewWindow = sv.viewWindowSV?.value;
+  input.mode = sv.modeSV.value;
+  input.candles = sv.candles?.value;
+  input.liveCandle = sv.liveCandle?.value;
+  tickLiveChartEngineFrame(state, input);
   sv.displayValue.value = state.displayValue;
   sv.displayMin.value = state.displayMin;
   sv.displayMax.value = state.displayMax;
@@ -467,12 +530,16 @@ export function useLiveChartEngine(
     extremaMinTime,
     extremaMaxTime,
   };
+  const frameScratchRef = useRef<EngineFrameScratch | null>(null);
+  if (frameScratchRef.current === null) {
+    frameScratchRef.current = makeEngineFrameScratch();
+  }
 
   // `autostart=false` registers the frame callback without running it — the live
   // loop is fully inert in static mode (the invariant that makes this worth it).
   useFrameCallback((frameInfo) => {
     "worklet";
-    applyLiveChartEngineFrame(frameInfo, frameRefs);
+    applyLiveChartEngineFrame(frameInfo, frameRefs, frameScratchRef.current!);
   }, !config.static);
 
   // When time-scroll is disabled while scrolled back, return the window to the
@@ -532,6 +599,7 @@ export function useLiveChartEngine(
       applyLiveChartEngineFrame(
         { timeSincePreviousFrame: MS_PER_FRAME_60FPS },
         frameRefs,
+        frameScratchRef.current!,
       );
     },
   );

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -11,7 +11,11 @@ import {
 } from "react-native-reanimated";
 import { MS_PER_FRAME_60FPS, RETURN_TO_LIVE_MS } from "../constants";
 import type { LiveChartPoint, SeriesConfig } from "../types";
-import { tickLiveChartSeriesEngineFrame } from "./liveChartSeriesEngineTick";
+import {
+  tickLiveChartSeriesEngineFrame,
+  type MultiEngineTickInput,
+  type MultiEngineTickMutable,
+} from "./liveChartSeriesEngineTick";
 import type { ChartEngineScroll, MultiEngineState } from "./useLiveChartEngine";
 
 export interface MultiSeriesEngineConfig {
@@ -94,10 +98,10 @@ export interface MultiEngineFrameRefs {
 }
 
 /**
- * Reusable per-frame scratch for {@link applyLiveChartSeriesEngineFrame}. The two
+ * Reusable per-frame scratch for {@link applyLiveChartSeriesEngineFrame}. The
  * output arrays ping-pong so the assigned reference still changes each frame
- * (Reanimated propagates on reference change) without allocating a fresh array
- * per frame. Create one per engine (the React Compiler keeps it stable).
+ * (Reanimated propagates on reference change), while the state/input containers
+ * are mutated in place. Create one per engine.
  */
 export interface MultiSeriesEngineScratch {
   dvA: number[];
@@ -105,6 +109,46 @@ export interface MultiSeriesEngineScratch {
   opA: number[];
   opB: number[];
   tick: boolean;
+  state: MultiEngineTickMutable;
+  input: MultiEngineTickInput;
+}
+
+/** Allocate one multi-series frame scratch. Call once per engine instance. */
+export function makeMultiSeriesEngineScratch(): MultiSeriesEngineScratch {
+  const dvA: number[] = [];
+  const dvB: number[] = [];
+  const opA: number[] = [];
+  const opB: number[] = [];
+  return {
+    dvA,
+    dvB,
+    opA,
+    opB,
+    tick: false,
+    state: {
+      displayMin: 0,
+      displayMax: 1,
+      displayWindow: 0,
+      timestamp: 0,
+      liveEdge: 0,
+      displayValues: dvA,
+      opacities: opA,
+      extremaMinValue: NaN,
+      extremaMaxValue: NaN,
+      extremaMinTime: NaN,
+      extremaMaxTime: NaN,
+    },
+    input: {
+      dt: MS_PER_FRAME_60FPS,
+      canvasWidth: 0,
+      canvasHeight: 0,
+      timeWindow: 0,
+      smoothing: 0,
+      exaggerate: false,
+      referenceValue: undefined,
+      series: [],
+    },
+  };
 }
 
 /**
@@ -113,8 +157,8 @@ export interface MultiSeriesEngineScratch {
  * to lerp per-series display values and opacities. Extracted as a
  * pure function so it can be called from both `useFrameCallback` and tests.
  *
- * Pass `scratch` to reuse the output arrays across frames instead of allocating
- * two via `.slice()` each frame; omit it (tests) to fall back to allocation.
+ * Pass `scratch` to reuse the output arrays plus state/input containers across
+ * frames; omit it (tests) to retain the standalone allocation fallback.
  */
 export function applyLiveChartSeriesEngineFrame(
   frameInfo: { timeSincePreviousFrame?: number | null },
@@ -143,42 +187,63 @@ export function applyLiveChartSeriesEngineFrame(
     displayValues = curDv.slice();
     opacities = curOp.slice();
   }
-  const state = {
-    displayMin: sv.displayMin.value,
-    displayMax: sv.displayMax.value,
-    displayWindow: sv.displayWindow.value,
-    timestamp: sv.timestamp.value,
-    liveEdge: sv.liveEdgeSV?.value ?? 0,
+  const state: MultiEngineTickMutable = scratch?.state ?? {
+    displayMin: 0,
+    displayMax: 1,
+    displayWindow: 0,
+    timestamp: 0,
+    liveEdge: 0,
     displayValues,
     opacities,
-    extremaMinValue: sv.extremaMinValue.value,
-    extremaMaxValue: sv.extremaMaxValue.value,
-    extremaMinTime: sv.extremaMinTime.value,
-    extremaMaxTime: sv.extremaMaxTime.value,
+    extremaMinValue: NaN,
+    extremaMaxValue: NaN,
+    extremaMinTime: NaN,
+    extremaMaxTime: NaN,
   };
-  tickLiveChartSeriesEngineFrame(state, {
+  state.displayMin = sv.displayMin.value;
+  state.displayMax = sv.displayMax.value;
+  state.displayWindow = sv.displayWindow.value;
+  state.timestamp = sv.timestamp.value;
+  state.liveEdge = sv.liveEdgeSV?.value ?? 0;
+  state.displayValues = displayValues;
+  state.opacities = opacities;
+  state.extremaMinValue = sv.extremaMinValue.value;
+  state.extremaMaxValue = sv.extremaMaxValue.value;
+  state.extremaMinTime = sv.extremaMinTime.value;
+  state.extremaMaxTime = sv.extremaMaxTime.value;
+
+  const input: MultiEngineTickInput = scratch?.input ?? {
     dt,
-    canvasWidth: sv.canvasWidth.value,
-    canvasHeight: sv.canvasHeight.value,
-    timeWindow: sv.timeWindow.value,
-    smoothing: sv.smoothing.value,
-    adaptiveSpeedBoost: sv.adaptiveSpeedBoostSV?.value,
-    exaggerate: sv.exaggerateSV.value,
-    referenceValue: sv.referenceValue.value,
-    referenceValues: sv.referenceValues?.value,
-    nonNegative: sv.nonNegativeSV?.value ?? false,
-    maxValue: sv.maxValueSV?.value,
-    nowOverride: sv.nowOverrideSV?.value,
-    windowBuffer: sv.windowBufferSV?.value ?? 0,
+    canvasWidth: 0,
+    canvasHeight: 0,
+    timeWindow: 0,
+    smoothing: 0,
+    exaggerate: false,
+    referenceValue: undefined,
     series: seriesSnap,
-    nowSeconds: Date.now() / 1000,
-    paused: sv.pausedSV.value,
-    snap,
-    viewEnd: sv.viewEndSV?.value,
-    returnT: sv.returnTSV?.value,
-    returnFrom: sv.returnFromSV?.value,
-    viewWindow: sv.viewWindowSV?.value,
-  });
+  };
+  input.dt = dt;
+  input.canvasWidth = sv.canvasWidth.value;
+  input.canvasHeight = sv.canvasHeight.value;
+  input.timeWindow = sv.timeWindow.value;
+  input.smoothing = sv.smoothing.value;
+  input.adaptiveSpeedBoost = sv.adaptiveSpeedBoostSV?.value;
+  input.exaggerate = sv.exaggerateSV.value;
+  input.referenceValue = sv.referenceValue.value;
+  input.referenceValues = sv.referenceValues?.value;
+  input.nonNegative = sv.nonNegativeSV?.value ?? false;
+  input.maxValue = sv.maxValueSV?.value;
+  input.nowOverride = sv.nowOverrideSV?.value;
+  input.windowBuffer = sv.windowBufferSV?.value ?? 0;
+  input.series = seriesSnap;
+  input.nowSeconds = Date.now() / 1000;
+  input.paused = sv.pausedSV.value;
+  input.snap = snap;
+  input.viewEnd = sv.viewEndSV?.value;
+  input.returnT = sv.returnTSV?.value;
+  input.returnFrom = sv.returnFromSV?.value;
+  input.viewWindow = sv.viewWindowSV?.value;
+  tickLiveChartSeriesEngineFrame(state, input);
   sv.displayMin.value = state.displayMin;
   sv.displayMax.value = state.displayMax;
   sv.displayWindow.value = state.displayWindow;
@@ -272,46 +337,48 @@ export function useLiveChartSeriesEngine(
   // Reused per-frame output buffers (ping-ponged) — see applyLiveChartSeriesEngineFrame.
   const scratchRef = useRef<MultiSeriesEngineScratch | null>(null);
   if (scratchRef.current === null) {
-    scratchRef.current = { dvA: [], dvB: [], opA: [], opB: [], tick: false };
+    scratchRef.current = makeMultiSeriesEngineScratch();
   }
+
+  const frameRefs: MultiEngineFrameRefs = {
+    series,
+    displaySeriesValues,
+    seriesOpacities,
+    displayMin,
+    displayMax,
+    displayWindow,
+    timestamp,
+    canvasWidth,
+    canvasHeight,
+    timeWindow,
+    smoothing,
+    adaptiveSpeedBoostSV,
+    exaggerateSV,
+    referenceValue,
+    referenceValues,
+    nonNegativeSV,
+    maxValueSV,
+    nowOverrideSV,
+    windowBufferSV,
+    pausedSV,
+    viewEndSV: viewEnd,
+    returnTSV: returnT,
+    returnFromSV: returnFrom,
+    viewWindowSV: viewWindow,
+    liveEdgeSV: liveEdge,
+    snapSV,
+    extremaMinValue,
+    extremaMaxValue,
+    extremaMinTime,
+    extremaMaxTime,
+  };
 
   useFrameCallback((frameInfo) => {
     "worklet";
     const scratch = scratchRef.current!;
     applyLiveChartSeriesEngineFrame(
       frameInfo,
-      {
-        series,
-        displaySeriesValues,
-        seriesOpacities,
-        displayMin,
-        displayMax,
-        displayWindow,
-        timestamp,
-        canvasWidth,
-        canvasHeight,
-        timeWindow,
-        smoothing,
-        adaptiveSpeedBoostSV,
-        exaggerateSV,
-        referenceValue,
-        referenceValues,
-        nonNegativeSV,
-        maxValueSV,
-        nowOverrideSV,
-        windowBufferSV,
-        pausedSV,
-        viewEndSV: viewEnd,
-        returnTSV: returnT,
-        returnFromSV: returnFrom,
-        viewWindowSV: viewWindow,
-        liveEdgeSV: liveEdge,
-        snapSV,
-        extremaMinValue,
-        extremaMaxValue,
-        extremaMinTime,
-        extremaMaxTime,
-      },
+      frameRefs,
       scratch,
     );
   });

--- a/packages/react-native-livechart/src/draw/particleAtlas.ts
+++ b/packages/react-native-livechart/src/draw/particleAtlas.ts
@@ -62,7 +62,8 @@ export interface ParticleInstance {
  *   scale = r / spriteRadius
  *   alpha = life * particleOpacity
  * Inactive (active <= 0.5), pre-spawn (dt < 0) and fully-faded (life <= 0)
- * slots are skipped.
+ * slots are skipped. Pass distinct `out` and `pool` arrays to retain inactive
+ * instance objects for later bursts while returning only the active prefix.
  */
 export function buildParticleInstances(
   buf: Float64Array,
@@ -71,9 +72,13 @@ export function buildParticleInstances(
   burstDur: number,
   particleOpacity: number,
   spriteRadius: number,
+  out?: ParticleInstance[],
+  pool?: ParticleInstance[],
 ): ParticleInstance[] {
   "worklet";
-  const out: ParticleInstance[] = [];
+  const target = out ?? [];
+  const instances = pool ?? target;
+  let count = 0;
   for (let i = 0; i < slots; i++) {
     const base = i * DEGEN_STRIDE;
     if (!(buf[base + 5] > 0.5)) continue;
@@ -83,13 +88,19 @@ export function buildParticleInstances(
     if (life <= 0) continue;
     const size = buf[base + 6] || 1;
     const r = size * (0.5 + life * 0.5);
-    out.push({
-      x: buf[base + 0],
-      y: buf[base + 1],
-      scale: r / spriteRadius,
-      alpha: life * particleOpacity,
-      colorIndex: Math.max(0, Math.floor(buf[base + 7])),
-    });
+    let instance = instances[count];
+    if (!instance) {
+      instance = { x: 0, y: 0, scale: 0, alpha: 0, colorIndex: 0 };
+      instances[count] = instance;
+    }
+    instance.x = buf[base + 0];
+    instance.y = buf[base + 1];
+    instance.scale = r / spriteRadius;
+    instance.alpha = life * particleOpacity;
+    instance.colorIndex = Math.max(0, Math.floor(buf[base + 7]));
+    target[count] = instance;
+    count += 1;
   }
-  return out;
+  target.length = count;
+  return target;
 }

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -55,6 +55,10 @@ export function useChartPaths(
     ptsA: number[];
     ptsB: number[];
     ptsTick: boolean;
+    squigglePts: number[];
+    morphA: number[];
+    morphB: number[];
+    morphTick: boolean;
     scratch: ReturnType<typeof makeSplineScratch>;
   } | null>(null);
   if (cacheRef.current === null) {
@@ -63,6 +67,10 @@ export function useChartPaths(
       ptsA: [] as number[],
       ptsB: [] as number[],
       ptsTick: false,
+      squigglePts: [] as number[],
+      morphA: [] as number[],
+      morphB: [] as number[],
+      morphTick: false,
       scratch: makeSplineScratch(),
     };
   }
@@ -102,15 +110,18 @@ export function useChartPaths(
       centerY,
       squiggleAmplitude,
       squiggleSpeed,
+      cache.squigglePts,
     );
 
     // Blend center-out: centre of chart reveals first, edges last
+    cache.morphTick = !cache.morphTick;
     return blendPtsY(
       squigglyPts,
       realPts,
       t,
       padding,
       engine.canvasWidth.get(),
+      cache.morphTick ? cache.morphA : cache.morphB,
     );
   });
 

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -26,12 +26,18 @@ export function useMultiSeriesLinePaths(
   const poolRef = useRef<{
     empty: SkPath;
     ptsBuf: number[];
+    pathsA: SkPath[];
+    pathsB: SkPath[];
+    pathsTick: boolean;
     scratch: ReturnType<typeof makeSplineScratch>;
   } | null>(null);
   if (poolRef.current === null) {
     poolRef.current = {
       empty: Skia.Path.Make(),
       ptsBuf: [] as number[],
+      pathsA: [] as SkPath[],
+      pathsB: [] as SkPath[],
+      pathsTick: false,
       scratch: makeSplineScratch(),
     };
   }
@@ -41,7 +47,9 @@ export function useMultiSeriesLinePaths(
     const slots = builders.value;
     const s = engine.series.get();
     const displays = engine.displaySeriesValues.get();
-    const out: SkPath[] = [];
+    pool.pathsTick = !pool.pathsTick;
+    const out = pool.pathsTick ? pool.pathsA : pool.pathsB;
+    out.length = 0;
     for (let i = 0; i < MAX_MULTI_SERIES; i++) {
       if (i >= s.length) {
         out.push(pool.empty);

--- a/packages/react-native-livechart/src/math/squiggly.ts
+++ b/packages/react-native-livechart/src/math/squiggly.ts
@@ -31,6 +31,7 @@ export function squigglyYAt(
  * Build a flat [x0,y0,x1,y1,...] point array for a standalone squiggly line
  * spanning the full chart area (used in loading / empty state).
  * Points are spaced ~4px apart for smooth curves.
+ * Pass `out` to reuse a caller-owned frame scratch.
  */
 export function buildSquigglyPts(
   canvasWidth: number,
@@ -39,17 +40,22 @@ export function buildSquigglyPts(
   t: number,
   base = 14,
   speed = 1,
+  out?: number[],
 ): number[] {
   "worklet";
+  const pts = out ?? [];
   const leftEdge = padding.left;
   const rightEdge = canvasWidth - padding.right;
   const chartW = rightEdge - leftEdge;
-  if (chartW <= 0 || canvasHeight <= 0) return [];
+  if (chartW <= 0 || canvasHeight <= 0) {
+    pts.length = 0;
+    return pts;
+  }
 
   const centerY = (canvasHeight - padding.bottom + padding.top) / 2;
   const step = 4;
   const count = Math.ceil(chartW / step) + 1;
-  const pts: number[] = new Array(count * 2);
+  pts.length = count * 2;
   for (let i = 0; i < count; i++) {
     const x = leftEdge + Math.min(i * step, chartW);
     pts[i * 2] = x;
@@ -61,6 +67,7 @@ export function buildSquigglyPts(
 /**
  * Given a real flat-pts array (from buildLinePoints), replace each Y with the
  * squiggly Y at the same X. Used during the morph reveal.
+ * Pass `out` to reuse a caller-owned frame scratch.
  */
 export function squigglifyPts(
   flatPts: number[],
@@ -68,15 +75,17 @@ export function squigglifyPts(
   centerY: number,
   base = 14,
   speed = 1,
+  out?: number[],
 ): number[] {
   "worklet";
   const n = flatPts.length;
-  const out: number[] = new Array(n);
+  const target = out ?? [];
+  target.length = n;
   for (let i = 0; i < n; i += 2) {
-    out[i] = flatPts[i];
-    out[i + 1] = squigglyYAt(flatPts[i], centerY, t, base, speed);
+    target[i] = flatPts[i];
+    target[i + 1] = squigglyYAt(flatPts[i], centerY, t, base, speed);
   }
-  return out;
+  return target;
 }
 
 /**
@@ -97,6 +106,7 @@ export function smoothstep(t: number): number {
  *   distFromCentre = |x - chartCentreX| / (chartW / 2)   // 0=centre, 1=edge
  *   weight = smoothstep((morphT - distFromCentre * 0.5) / 0.5)
  *   blendedY = fromY + (toY - fromY) * weight
+ * Pass `out` to reuse a caller-owned frame scratch.
  */
 export function blendPtsY(
   from: number[],
@@ -104,19 +114,26 @@ export function blendPtsY(
   morphT: number,
   padding: ChartPadding,
   canvasWidth: number,
+  out?: number[],
 ): number[] {
   "worklet";
   const n = from.length;
-  if (n === 0) return to;
+  if (n === 0 && !out) return to;
   const chartCentreX = (padding.left + canvasWidth - padding.right) / 2;
   const halfChartW = (canvasWidth - padding.left - padding.right) / 2;
-  const out: number[] = new Array(n);
+  const target = out ?? [];
+  const outputLength = n === 0 ? to.length : n;
+  target.length = outputLength;
+  if (n === 0) {
+    for (let i = 0; i < to.length; i++) target[i] = to[i];
+    return target;
+  }
   for (let i = 0; i < n; i += 2) {
-    out[i] = to[i]; // X always from real pts
+    target[i] = to[i]; // X always from real pts
     const distFromCentre =
       halfChartW > 0 ? Math.abs(from[i] - chartCentreX) / halfChartW : 0;
     const weight = smoothstep((morphT - distFromCentre * 0.5) / 0.5);
-    out[i + 1] = from[i + 1] + (to[i + 1] - from[i + 1]) * weight;
+    target[i + 1] = from[i + 1] + (to[i + 1] - from[i + 1]) * weight;
   }
-  return out;
+  return target;
 }

--- a/packages/react-native-livechart/tests/draw/particleAtlas.test.ts
+++ b/packages/react-native-livechart/tests/draw/particleAtlas.test.ts
@@ -47,7 +47,9 @@ describe("buildParticleInstances", () => {
   it("defaults size to 1 when the slot's size field is 0", () => {
     const buf = bufWith(0, 2, { t0: 0, size: 0 });
     // dt=0 → life=1 → r = 1*(0.5+0.5) = 1.
-    const out = buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius);
+    const out: ReturnType<typeof buildParticleInstances> = [];
+    const pool: ReturnType<typeof buildParticleInstances> = [];
+    buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius, out, pool);
     expect(out[0].scale).toBeCloseTo(1 / spriteRadius, 6);
   });
 
@@ -95,6 +97,35 @@ describe("buildParticleInstances", () => {
     expect(
       buildParticleInstances(new Float64Array(0), 0, 0, burstDur, 1, spriteRadius),
     ).toEqual([]);
+  });
+
+  it("reuses its output array and particle objects, then truncates stale slots", () => {
+    const buf = new Float64Array(2 * DEGEN_STRIDE);
+    for (let i = 0; i < 2; i++) {
+      const b = i * DEGEN_STRIDE;
+      buf[b + 0] = 10 + i;
+      buf[b + 5] = 1;
+      buf[b + 6] = 2;
+    }
+    const out: ReturnType<typeof buildParticleInstances> = [];
+    const pool: ReturnType<typeof buildParticleInstances> = [];
+    buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius, out, pool);
+    const first = out[0];
+    const second = out[1];
+
+    buf[0] = 99;
+    buf[DEGEN_STRIDE + 5] = 0;
+    expect(
+      buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius, out, pool),
+    ).toBe(out);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(first);
+    expect(out[0].x).toBe(99);
+    expect(out).not.toContain(second);
+
+    buf[DEGEN_STRIDE + 5] = 1;
+    buildParticleInstances(buf, 2, 0, burstDur, 1, spriteRadius, out, pool);
+    expect(out[1]).toBe(second);
   });
 });
 

--- a/packages/react-native-livechart/tests/math/squiggly.test.ts
+++ b/packages/react-native-livechart/tests/math/squiggly.test.ts
@@ -70,6 +70,14 @@ describe("buildSquigglyPts", () => {
     );
     expect(diff).toBe(true);
   });
+
+  it("reuses and truncates a caller-owned output buffer", () => {
+    const out = [1, 2, 3, 4];
+    expect(buildSquigglyPts(400, 300, padding, 0, 14, 1, out)).toBe(out);
+    expect(out.length).toBeGreaterThan(4);
+    expect(buildSquigglyPts(0, 0, padding, 0, 14, 1, out)).toBe(out);
+    expect(out).toEqual([]);
+  });
 });
 
 // ─── squigglifyPts ───────────────────────────────────────────────────────────
@@ -93,6 +101,13 @@ describe("squigglifyPts", () => {
   it("returns same length as input", () => {
     const pts = [10, 20, 30, 40, 50, 60, 70, 80];
     expect(squigglifyPts(pts, 1, 150).length).toBe(8);
+  });
+
+  it("reuses a caller-owned output buffer", () => {
+    const pts = [10, 20, 30, 40];
+    const out: number[] = [];
+    expect(squigglifyPts(pts, 1, 150, 14, 1, out)).toBe(out);
+    expect(out).toHaveLength(pts.length);
   });
 });
 
@@ -160,5 +175,15 @@ describe("blendPtsY", () => {
     const to = [12, 50, 80, 60];
     const result = blendPtsY(from, to, 0.5, padding, zeroW);
     expect(result).toHaveLength(from.length);
+  });
+
+  it("reuses a caller-owned output buffer without aliasing the inputs", () => {
+    const from = [12, 100, 166, 100];
+    const to = [12, 50, 166, 60];
+    const out: number[] = [];
+    expect(blendPtsY(from, to, 0.5, padding, canvasWidth, out)).toBe(out);
+    expect(out).toHaveLength(from.length);
+    expect(out).not.toBe(from);
+    expect(out).not.toBe(to);
   });
 });

--- a/packages/react-native-livechart/tests/useLiveChartEngine.test.tsx
+++ b/packages/react-native-livechart/tests/useLiveChartEngine.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react-native";
 import { useSharedValue } from "react-native-reanimated";
 import {
   applyLiveChartEngineFrame,
+  makeEngineFrameScratch,
   type EngineFrameRefs,
   useLiveChartEngine,
 } from "../src/core/useLiveChartEngine";
@@ -33,10 +34,23 @@ describe("applyLiveChartEngineFrame", () => {
       extremaMinTime: { value: NaN },
       extremaMaxTime: { value: NaN },
     };
+    const scratch = makeEngineFrameScratch();
+    const stateIdentity = scratch.state;
+    const inputIdentity = scratch.input;
     applyLiveChartEngineFrame(
       { timeSincePreviousFrame: 16.67 },
       sv as unknown as EngineFrameRefs,
+      scratch,
     );
+    applyLiveChartEngineFrame(
+      { timeSincePreviousFrame: 17 },
+      sv as unknown as EngineFrameRefs,
+      scratch,
+    );
+    expect(scratch.state).toBe(stateIdentity);
+    expect(scratch.input).toBe(inputIdentity);
+    expect(scratch.input.dt).toBe(17);
+    expect(scratch.input.points).toBe(sv.data.value);
     expect(sv.displayValue.value).not.toBe(0);
     // The data point's value + time become the live extrema.
     expect(sv.extremaMinValue.value).toBe(10);

--- a/packages/react-native-livechart/tests/useLiveChartSeriesEngine.test.tsx
+++ b/packages/react-native-livechart/tests/useLiveChartSeriesEngine.test.tsx
@@ -3,6 +3,7 @@ import { useSharedValue } from "react-native-reanimated";
 import type { SeriesConfig } from "../src/types";
 import {
   applyLiveChartSeriesEngineFrame,
+  makeMultiSeriesEngineScratch,
   type MultiEngineFrameRefs,
   useLiveChartSeriesEngine,
 } from "../src/core/useLiveChartSeriesEngine";
@@ -41,10 +42,30 @@ describe("applyLiveChartSeriesEngineFrame", () => {
       extremaMinTime: { value: NaN },
       extremaMaxTime: { value: NaN },
     };
+    const scratch = makeMultiSeriesEngineScratch();
+    const stateIdentity = scratch.state;
+    const inputIdentity = scratch.input;
     applyLiveChartSeriesEngineFrame(
       { timeSincePreviousFrame: 16.67 },
       sv as unknown as MultiEngineFrameRefs,
+      scratch,
     );
+    const firstOutput = sv.displaySeriesValues.value;
+    applyLiveChartSeriesEngineFrame(
+      { timeSincePreviousFrame: 16.67 },
+      sv as unknown as MultiEngineFrameRefs,
+      scratch,
+    );
+    const secondOutput = sv.displaySeriesValues.value;
+    applyLiveChartSeriesEngineFrame(
+      { timeSincePreviousFrame: 16.67 },
+      sv as unknown as MultiEngineFrameRefs,
+      scratch,
+    );
+    expect(scratch.state).toBe(stateIdentity);
+    expect(scratch.input).toBe(inputIdentity);
+    expect(secondOutput).not.toBe(firstOutput);
+    expect(sv.displaySeriesValues.value).toBe(firstOutput);
     expect(sv.displaySeriesValues.value.length).toBe(1);
     // The single series' lone point becomes the live extrema.
     expect(sv.extremaMinValue.value).toBe(10);


### PR DESCRIPTION
## Summary

- reuse loading and reveal numeric scratch buffers, ping-ponging published morph output so SharedValue invalidation still observes a new reference
- reuse single- and multi-series engine state/input containers and hoist the multi-series refs object out of the frame callback
- ping-pong multi-series path-list and marker/degen Atlas result containers
- preallocate/reuse particle projection objects and the identical particle sprite rect
- retain immutable `PathBuilder.detach()` paths plus dynamic Skia transform/color values under their existing safe ownership model

## Before / after

Exact source-callsite allocation inventory at 60 fps, backed by repeated identity tests for reusable helpers and the existing loading/reveal/series/marker integration suites:

| Frame path | Before | After | Removed at 60 fps |
| --- | ---: | ---: | ---: |
| Loading squiggle | 1 number array/frame | 0 | 60 arrays/s |
| Reveal morph | 2 number arrays/frame | 0 | 120 arrays/s |
| Single-series engine | state + input objects/frame | 0 | 120 objects/s |
| Multi-series engine + path list | 4 objects/containers/frame | 0 | 240 objects/containers/s |
| Marker Atlas lists | 2 arrays + result object/frame | 0 | 180 containers/s |
| Degen Atlas (`N` active) | `N + 5` JS objects/containers + `N` sprite rects/frame | 0 of these classes | `300 + 60N` JS object/container allocations/s + `60N` rects/s |

At 32 active particles, that last row removes **2,220 JavaScript object/container allocations/s** and **1,920 duplicate SkRect values/s** while the burst is active. A steady single-series chart removes **120 objects/s** even without optional overlays.

This is an exact structural allocation-class comparison, not a physical-device GC or frame-time claim. Both available iPhones and Android devices were offline, so Allocations/PSS, GC pauses, UI/JS CPU, p90/p99 frame time, and missed-frame validation remain open. This is why the PR is a draft.

## Correctness / ownership

- caller-owned buffers truncate when inputs shrink
- published numeric, path-list, and Atlas arrays ping-pong instead of being mutated while visible
- particle objects survive inactive periods in a separate capacity pool
- immutable detached `SkPath`s remain per-frame
- marker/particle `Skia.RSXform` and per-particle `Skia.Color` values remain dynamic and unpooled

## Verification

- `npm run verify` — 93 suites passed; 1,341 passed, 5 skipped
- focused allocation/integration tests — 8 suites / 70 tests passed before the final full run
- production iOS export (`live-monotone-round`) completed with 2,089 modules
- React Doctor 0.7.8 — workspace 91/100; library package 100/100; no diagnostics reported
- `git diff --check`

Refs #211
