### PR TITLE
perf: reduce dynamic threshold shader fragment cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Time-varying threshold shaders select samples in logarithmic time.** The
+  stroke and profit/loss fill shader now reaches one of its 63 sample segments
+  through at most six constant-index comparisons instead of walking every
+  segment for every covered fragment. The sampled boundary and public API are
+  unchanged. ([#213](https://github.com/brandtnewlabs/react-native-livechart/issues/213))
 - **Multi-series drawing worklets now scale with the active series count.**
   Stroke, dot, live-value label, and optional value-line slots no longer mount
   the fixed 12-series capacity. A three-series chart registers 36 default

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -223,6 +223,9 @@ const Footer = () => (
 
 export default function Index() {
   const insets = useSafeAreaInsets();
+  if (process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE) {
+    return <Redirect href={"/threshold-shader-profile" as Href} />;
+  }
   if (
     process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ||
     process.env.EXPO_PUBLIC_MEMORY_PROFILE_RUN

--- a/app/threshold-shader-profile.tsx
+++ b/app/threshold-shader-profile.tsx
@@ -1,0 +1,101 @@
+/**
+ * Deterministic worst-case screen for physical-device threshold shader traces.
+ *
+ * Build with `EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE=fill` (or `stroke`) to
+ * redirect here. The wide band keeps fragment coverage stable while the normal
+ * LiveChart engine, path builders, uniforms, and Skia paint remain in the trace.
+ */
+import { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { LiveChart, type LiveChartPoint } from "react-native-livechart";
+
+const MODE =
+  process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE === "stroke"
+    ? "stroke"
+    : "fill";
+const HISTORY_SECONDS = 120;
+const SAMPLE_INTERVAL = 0.1;
+
+function buildProfileSeries(now: number): {
+  price: LiveChartPoint[];
+  threshold: LiveChartPoint[];
+} {
+  const price: LiveChartPoint[] = [];
+  const threshold: LiveChartPoint[] = [];
+  const count = HISTORY_SECONDS / SAMPLE_INTERVAL;
+  for (let index = 0; index <= count; index++) {
+    const time = now - HISTORY_SECONDS + index * SAMPLE_INTERVAL;
+    price.push({
+      time,
+      value: 112 + Math.sin(index * 0.027) + 0.35 * Math.sin(index * 0.11),
+    });
+    threshold.push({
+      time,
+      value: 88 + 2.8 * Math.sin(index * 0.019) + Math.sin(index * 0.071),
+    });
+  }
+  return { price, threshold };
+}
+
+export default function ThresholdShaderProfileScreen() {
+  const [initial] = useState(() => buildProfileSeries(Date.now() / 1000));
+  const data = useSharedValue(initial.price);
+  const value = useSharedValue(initial.price[initial.price.length - 1].value);
+  const thresholdSeries = useSharedValue(initial.threshold);
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.label}>THRESHOLD SHADER PROFILE · {MODE}</Text>
+      <Text style={styles.detail}>
+        64 samples · 30s window · deterministic wide band
+      </Text>
+      <View style={styles.chart}>
+        <LiveChart
+          data={data}
+          value={value}
+          timeWindow={30}
+          line={{ width: MODE === "stroke" ? 12 : 3 }}
+          gradient={false}
+          badge={false}
+          pulse={false}
+          dot={false}
+          valueLine={false}
+          xAxis={false}
+          yAxis={false}
+          scrub={false}
+          threshold={{
+            series: thresholdSeries,
+            fill: MODE === "fill" ? { opacity: 1 } : false,
+            includeInRange: true,
+            aboveColor: "#22c55e",
+            belowColor: "#ef4444",
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    gap: 8,
+    paddingTop: 64,
+    paddingHorizontal: 8,
+    backgroundColor: "#09090b",
+  },
+  label: {
+    color: "#ffffff",
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  detail: {
+    color: "#a1a1aa",
+    fontSize: 13,
+  },
+  chart: {
+    flex: 1,
+    width: "100%",
+  },
+});

--- a/app/threshold-shader-profile.tsx
+++ b/app/threshold-shader-profile.tsx
@@ -7,7 +7,11 @@
  */
 import { useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { useSharedValue } from "react-native-reanimated";
+import {
+  runOnJS,
+  useFrameCallback,
+  useSharedValue,
+} from "react-native-reanimated";
 import { LiveChart, type LiveChartPoint } from "react-native-livechart";
 
 const MODE =
@@ -16,6 +20,69 @@ const MODE =
     : "fill";
 const HISTORY_SECONDS = 120;
 const SAMPLE_INTERVAL = 0.1;
+const FRAME_PROFILE_WARMUP_MS = 3_000;
+const FRAME_PROFILE_DURATION_MS = 12_000;
+const FRAME_PROFILE_LABEL =
+  process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_LABEL ?? "candidate";
+const REQUESTED_LAYER_COUNT = Number(
+  process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_LAYERS ?? "1",
+);
+const PROFILE_LAYER_COUNT =
+  Number.isInteger(REQUESTED_LAYER_COUNT) &&
+  REQUESTED_LAYER_COUNT >= 1 &&
+  REQUESTED_LAYER_COUNT <= 12
+    ? REQUESTED_LAYER_COUNT
+    : 1;
+const PROFILE_LAYERS = Array.from(
+  { length: PROFILE_LAYER_COUNT },
+  (_, index) => index,
+);
+
+type FrameProfileStats = {
+  phaseStart: number;
+  warmupMinMs: number;
+  nominalMs: number;
+  count: number;
+  totalMs: number;
+  maximumMs: number;
+  overOneAndQuarter: number;
+  overOneAndHalf: number;
+  overTwo: number;
+  measuring: boolean;
+  reported: boolean;
+};
+
+function nearestNominalFrameMs(observedMinimumMs: number): number {
+  "worklet";
+  const candidates = [1000 / 120, 1000 / 90, 1000 / 60];
+  let nearest = candidates[0];
+  let nearestDistance = Math.abs(observedMinimumMs - nearest);
+  for (let index = 1; index < candidates.length; index++) {
+    const distance = Math.abs(observedMinimumMs - candidates[index]);
+    if (distance < nearestDistance) {
+      nearest = candidates[index];
+      nearestDistance = distance;
+    }
+  }
+  return nearest;
+}
+
+function formatFrameProfile(stats: FrameProfileStats): string {
+  "worklet";
+  const meanMs = stats.totalMs / stats.count;
+  const expectedIntervals = Math.max(
+    stats.count,
+    Math.round(stats.totalMs / stats.nominalMs),
+  );
+  const missedIntervals = expectedIntervals - stats.count;
+  const percent = (count: number, total: number) =>
+    total === 0 ? "0.00" : ((count / total) * 100).toFixed(2);
+
+  return [
+    `${Math.round(1000 / stats.nominalMs)} Hz · ${stats.count} intervals · mean ${meanMs.toFixed(2)} ms · max ${stats.maximumMs.toFixed(2)} ms`,
+    `>1.25× ${percent(stats.overOneAndQuarter, stats.count)}% · >1.5× ${percent(stats.overOneAndHalf, stats.count)}% · >2× ${percent(stats.overTwo, stats.count)}% · missed ${missedIntervals} (${percent(missedIntervals, expectedIntervals)}%)`,
+  ].join("\n");
+}
 
 function buildProfileSeries(now: number): {
   price: LiveChartPoint[];
@@ -40,38 +107,108 @@ function buildProfileSeries(now: number): {
 
 export default function ThresholdShaderProfileScreen() {
   const [initial] = useState(() => buildProfileSeries(Date.now() / 1000));
+  const [frameProfile, setFrameProfile] = useState<string | null>(null);
   const data = useSharedValue(initial.price);
   const value = useSharedValue(initial.price[initial.price.length - 1].value);
   const thresholdSeries = useSharedValue(initial.threshold);
+  const frameStats = useSharedValue<FrameProfileStats | null>(null);
+
+  useFrameCallback(({ timestamp, timeSincePreviousFrame }) => {
+    if (timeSincePreviousFrame === null) return;
+
+    if (frameStats.value === null) {
+      frameStats.value = {
+        phaseStart: timestamp,
+        warmupMinMs: 1_000,
+        nominalMs: 1000 / 60,
+        count: 0,
+        totalMs: 0,
+        maximumMs: 0,
+        overOneAndQuarter: 0,
+        overOneAndHalf: 0,
+        overTwo: 0,
+        measuring: false,
+        reported: false,
+      };
+      return;
+    }
+
+    const stats = frameStats.value;
+    if (stats.reported) return;
+
+    if (!stats.measuring) {
+      // Ignore sub-frame scheduling noise when inferring 60/90/120 Hz.
+      if (timeSincePreviousFrame >= 4) {
+        stats.warmupMinMs = Math.min(stats.warmupMinMs, timeSincePreviousFrame);
+      }
+      if (timestamp - stats.phaseStart >= FRAME_PROFILE_WARMUP_MS) {
+        stats.nominalMs = nearestNominalFrameMs(stats.warmupMinMs);
+        stats.phaseStart = timestamp;
+        stats.measuring = true;
+      }
+      return;
+    }
+
+    stats.count += 1;
+    stats.totalMs += timeSincePreviousFrame;
+    stats.maximumMs = Math.max(stats.maximumMs, timeSincePreviousFrame);
+    if (timeSincePreviousFrame > stats.nominalMs * 1.25) {
+      stats.overOneAndQuarter += 1;
+    }
+    if (timeSincePreviousFrame > stats.nominalMs * 1.5) {
+      stats.overOneAndHalf += 1;
+    }
+    if (timeSincePreviousFrame > stats.nominalMs * 2) {
+      stats.overTwo += 1;
+    }
+
+    if (timestamp - stats.phaseStart >= FRAME_PROFILE_DURATION_MS) {
+      stats.reported = true;
+      runOnJS(setFrameProfile)(formatFrameProfile(stats));
+    }
+  });
 
   return (
     <View style={styles.root}>
       <Text style={styles.label}>THRESHOLD SHADER PROFILE · {MODE}</Text>
       <Text style={styles.detail}>
-        64 samples · 30s window · deterministic wide band
+        64 samples · 30s window · {PROFILE_LAYER_COUNT} shader layer
+        {PROFILE_LAYER_COUNT === 1 ? "" : "s"}
       </Text>
       <View style={styles.chart}>
-        <LiveChart
-          data={data}
-          value={value}
-          timeWindow={30}
-          line={{ width: MODE === "stroke" ? 12 : 3 }}
-          gradient={false}
-          badge={false}
-          pulse={false}
-          dot={false}
-          valueLine={false}
-          xAxis={false}
-          yAxis={false}
-          scrub={false}
-          threshold={{
-            series: thresholdSeries,
-            fill: MODE === "fill" ? { opacity: 1 } : false,
-            includeInRange: true,
-            aboveColor: "#22c55e",
-            belowColor: "#ef4444",
-          }}
-        />
+        {PROFILE_LAYERS.map((layer) => (
+          <View key={layer} style={StyleSheet.absoluteFill}>
+            <LiveChart
+              data={data}
+              value={value}
+              timeWindow={30}
+              line={{ width: MODE === "stroke" ? 12 : 3 }}
+              gradient={false}
+              badge={false}
+              pulse={false}
+              dot={false}
+              valueLine={false}
+              xAxis={false}
+              yAxis={false}
+              scrub={false}
+              threshold={{
+                series: thresholdSeries,
+                fill: MODE === "fill" ? { opacity: 1 } : false,
+                includeInRange: true,
+                aboveColor: "#22c55e",
+                belowColor: "#ef4444",
+              }}
+            />
+          </View>
+        ))}
+      </View>
+      <View style={styles.profile}>
+        <Text style={styles.profileLabel}>
+          FRAME PROFILE · {FRAME_PROFILE_LABEL}
+        </Text>
+        <Text style={styles.profileValue}>
+          {frameProfile ?? "3s warmup + 12s UI-frame capture…"}
+        </Text>
       </View>
     </View>
   );
@@ -97,5 +234,25 @@ const styles = StyleSheet.create({
   chart: {
     flex: 1,
     width: "100%",
+  },
+  profile: {
+    position: "absolute",
+    right: 16,
+    bottom: 24,
+    left: 16,
+    gap: 2,
+    padding: 8,
+    borderRadius: 6,
+    backgroundColor: "rgba(9, 9, 11, 0.86)",
+  },
+  profileLabel: {
+    color: "#ffffff",
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  profileValue: {
+    color: "#d4d4d8",
+    fontSize: 10,
+    fontVariant: ["tabular-nums"],
   },
 });

--- a/docs/threshold-shader-perf.md
+++ b/docs/threshold-shader-perf.md
@@ -102,7 +102,11 @@ checks, this supports keeping the branch-tree implementation.
 The regular threshold demo was also opened directly on the same physical device.
 The live line crossed the benchmark repeatedly; above/below colors, fill
 boundaries, marker line and label, and chart edges rendered without visible
-banding or clipping.
+banding or clipping. A test-only deterministic build then moved both the price
+and threshold series around the same center. That exercised the optimized
+time-varying-series shader through several red/green fill crossings; the
+interpolated boundaries and left/right clipping also rendered cleanly. The
+crossing dataset was not committed.
 
 These are UI-frame-callback results, not direct GPU timings. Instruments could
 not attach to this device through `xctrace`, so the results must not be presented

--- a/docs/threshold-shader-perf.md
+++ b/docs/threshold-shader-perf.md
@@ -1,0 +1,60 @@
+# Time-varying threshold shader lookup
+
+Issue: [#213](https://github.com/brandtnewlabs/react-native-livechart/issues/213)
+
+## Problem
+
+The time-varying threshold shader receives 64 evenly spaced Y samples. SkSL
+requires uniform-array indices to be compile-time constants, so the original
+shader used a constant-bound loop over all 63 segments for every covered
+fragment. That is especially expensive for the optional profit/loss fill, where
+the shader can cover most of a high-DPR chart.
+
+## Decision
+
+Keep the existing 64 samples and identical linear interpolation, but generate a
+balanced constant-index branch tree. A fragment now reaches its segment in at
+most six comparisons instead of visiting all 63 segments.
+
+This was selected over the other candidates because it preserves the current
+pixel semantics and uniform payload:
+
+- A 1D texture would introduce per-frame texture/image upload and filtering
+  behavior, plus more native-resource lifecycle complexity.
+- Gradient stops cannot express an arbitrary time-varying 2D boundary for both
+  the stroke and filled band in a single equivalent paint.
+- Reducing the 64-sample resolution would trade visual accuracy for speed. The
+  branch tree removes lookup work without changing that resolution.
+
+Those alternatives should only be revisited if physical GPU profiling shows the
+branch tree is still a material bottleneck.
+
+## Isolated screening benchmark
+
+The reproducible harness renders a full rectangle with only the threshold
+RuntimeEffect. It removes React, Reanimated, engine ticks, and path construction
+from the measurement, compares the legacy loop with the branch tree in A/B/A
+order, and fails unless their RGBA output is byte-identical.
+
+```bash
+npm run benchmark:threshold-shader
+npm run benchmark:threshold-shader -- --width=200 --height=400 --iterations=10 --warmup=2
+```
+
+CanvasKit software-raster results on 2026-07-19:
+
+| Raster size | Result |
+| ---: | ---: |
+| 100 × 200 | 11.30–14.29% lower mean across repeated A/B/A runs |
+| 200 × 400 | 20.07% lower mean in the A/B/A run |
+
+Both runs produced byte-identical output. These numbers establish that the
+lookup itself is cheaper in Skia's software RuntimeEffect path; they are not a
+claim about on-device GPU frame time or FPS. Physical-device Release profiling
+remains the authority for the final runtime conclusion.
+
+The larger generated source added roughly 1 ms to a warmed CanvasKit software
+RuntimeEffect compilation (about 1.22 ms versus 0.09–0.22 ms for the loop in the
+recorded A/B/A compile run). Compilation happens once at module initialization,
+not per frame; the benchmark reports it separately so the startup trade-off stays
+visible.

--- a/docs/threshold-shader-perf.md
+++ b/docs/threshold-shader-perf.md
@@ -58,3 +58,53 @@ RuntimeEffect compilation (about 1.22 ms versus 0.09–0.22 ms for the loop in t
 recorded A/B/A compile run). Compilation happens once at module initialization,
 not per frame; the benchmark reports it separately so the startup trade-off stays
 visible.
+
+## Physical-device validation
+
+Release builds were compared on 2026-07-19 on a wired iPhone 16 (iPhone17,3),
+iOS 26.5.2, with a 60 Hz display. Each run used a 3-second warmup followed by a
+12-second Reanimated UI-frame capture. The builds were installed in alternating
+legacy/tree order, and their embedded Hermes bundles were checked before the run
+to confirm that each contained the intended shader.
+
+At the normal one-layer workload, both implementations remained comfortably
+within the frame budget:
+
+| Run | Intervals | Mean | Maximum | Delayed / estimated missed |
+| --- | ---: | ---: | ---: | ---: |
+| Legacy A | 722 | 16.64 ms | 16.64 ms | 0 / 0 |
+| Branch tree B | 722 | 16.64 ms | 16.64 ms | 0 / 0 |
+| Legacy C | 722 | 16.64 ms | 16.78 ms | 0 / 0 |
+
+This means the optimization does not produce a user-visible FPS change for one
+ordinary full-screen threshold fill on this device: both versions are already
+locked to 60 Hz.
+
+To make shader cost observable without creating a broad device/series matrix,
+one amplified condition stacked eight identical full-screen threshold fills.
+All other inputs stayed fixed:
+
+| Run | Intervals | Mean | Maximum | >1.25x | Estimated missed |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Legacy A | 722 | 16.64 ms | 16.64 ms | 0.00% | 0 (0.00%) |
+| Branch tree B | 722 | 16.64 ms | 16.77 ms | 0.00% | 0 (0.00%) |
+| Legacy C | 706 | 17.02 ms | 49.92 ms | 1.13% | 15 (2.08%) |
+| Branch tree D | 722 | 16.64 ms | 16.77 ms | 0.00% | 0 (0.00%) |
+| Legacy E | 534 | 22.50 ms | 49.92 ms | 17.98% | 187 (25.94%) |
+| Branch tree F | 722 | 16.64 ms | 16.77 ms | 0.00% | 0 (0.00%) |
+
+The amplified condition is an isolation test, not a recommendation to stack
+eight charts. It shows that the branch tree retains frame-budget headroom under
+heavy fragment load: every optimized repeat stayed locked to 60 Hz, while two
+of three legacy repeats missed frames. Together with the byte-identical output
+checks, this supports keeping the branch-tree implementation.
+
+The regular threshold demo was also opened directly on the same physical device.
+The live line crossed the benchmark repeatedly; above/below colors, fill
+boundaries, marker line and label, and chart edges rendered without visible
+banding or clipping.
+
+These are UI-frame-callback results, not direct GPU timings. Instruments could
+not attach to this device through `xctrace`, so the results must not be presented
+as per-frame GPU duration. The on-screen “missed” value is an estimate derived
+from elapsed capture time and the detected 60 Hz interval.

--- a/metro.config.js
+++ b/metro.config.js
@@ -24,6 +24,8 @@ const rendererProfileCacheKey = [
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ?? "default",
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE ?? "default",
   process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE ?? "default",
+  process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_LABEL ?? "default",
+  process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_LAYERS ?? "default",
   bundleMode ? "worklets-bundle" : "worklets-legacy",
 ].join(":");
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -23,6 +23,7 @@ const rendererProfileCacheKey = [
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_RUN ?? "default",
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ?? "default",
   process.env.EXPO_PUBLIC_MEMORY_PROFILE_CADENCE ?? "default",
+  process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE ?? "default",
   bundleMode ? "worklets-bundle" : "worklets-legacy",
 ].join(":");
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "jest --watch",
     "test:lib": "jest packages/react-native-livechart",
     "test:coverage": "jest --coverage",
+    "benchmark:threshold-shader": "node scripts/benchmark-threshold-shader.mjs",
     "build:lib": "npm run build -w react-native-livechart",
     "build:lib:types:watch": "npm run build:types:watch -w react-native-livechart",
     "pack:lib": "npm pack -w react-native-livechart",

--- a/packages/react-native-livechart/src/components/ThresholdSplitShader.tsx
+++ b/packages/react-native-livechart/src/components/ThresholdSplitShader.tsx
@@ -2,6 +2,7 @@ import { Shader, Skia, type Uniforms } from "@shopify/react-native-skia";
 import type { SharedValue } from "react-native-reanimated";
 
 import { THRESHOLD_SAMPLE_COUNT } from "../math/threshold";
+import { buildThresholdSplitShaderSource } from "./thresholdSplitShaderSource";
 
 /**
  * Per-fragment split shader for a *time-varying* threshold. For each fragment it
@@ -15,49 +16,16 @@ import { THRESHOLD_SAMPLE_COUNT } from "../math/threshold";
  * alpha-reduced colors). Output is premultiplied — Skia's shader convention, as in
  * `AreaDotsOverlay`. One GPU draw, no per-frame clip / `saveLayer`.
  */
-const SPLIT_SKSL = `
-// Pixel-X span of the sample grid (thresholdSampleSpanX) — overhangs the plot
-// and glides with the window so features move fluidly, frame to frame.
-uniform float sampleLeft;
-uniform float sampleRight;
-// X where the threshold ends (extendToNow: false → the last point's pixel-X,
-// else a huge sentinel). Fragments right of it paint restColor: the plain line
-// color for the stroke, transparent for the band.
-uniform float clipRight;
-uniform vec4 aboveColor; // straight-alpha rgba, 0..1
-uniform vec4 belowColor; // straight-alpha rgba, 0..1
-uniform vec4 restColor;  // straight-alpha rgba, 0..1
-uniform float samples[${THRESHOLD_SAMPLE_COUNT}];
-
-half4 main(vec2 xy) {
-  if (xy.x > clipRight) {
-    return half4(half3(restColor.rgb) * restColor.a, restColor.a);
-  }
-  float span = sampleRight - sampleLeft;
-  float u = span > 0.0 ? (xy.x - sampleLeft) / span : 0.0;
-  u = clamp(u, 0.0, 1.0) * float(${THRESHOLD_SAMPLE_COUNT - 1});
-  // SkSL forbids indexing a uniform array with a non-constant index, so walk the
-  // segments in an unrolled, constant-bound loop — the index is the loop variable
-  // (a compile-time constant per unrolled iteration) — and keep the last segment
-  // whose left edge is at or before the fragment's u.
-  float thrY = samples[0];
-  for (int j = 0; j < ${THRESHOLD_SAMPLE_COUNT - 1}; j++) {
-    if (u >= float(j)) {
-      thrY = mix(samples[j], samples[j + 1], clamp(u - float(j), 0.0, 1.0));
-    }
-  }
-  // 1 above the boundary, 0 below, with ~1px antialiasing across it.
-  float above = clamp(thrY - xy.y + 0.5, 0.0, 1.0);
-  vec4 c = mix(belowColor, aboveColor, above);
-  return half4(half3(c.rgb) * c.a, c.a);
-}`;
+const THRESHOLD_SPLIT_SKSL = buildThresholdSplitShaderSource(
+  THRESHOLD_SAMPLE_COUNT,
+);
 
 // Compiled once. `RuntimeEffect.Make` THROWS on a compile error, so guard it —
 // a shader failure must degrade to "no split" (the line keeps its plain color),
 // never crash every chart screen at import. Null → the component no-ops.
 let SPLIT_EFFECT: ReturnType<typeof Skia.RuntimeEffect.Make> = null;
 try {
-  SPLIT_EFFECT = Skia.RuntimeEffect.Make(SPLIT_SKSL);
+  SPLIT_EFFECT = Skia.RuntimeEffect.Make(THRESHOLD_SPLIT_SKSL);
 } catch {
   SPLIT_EFFECT = null;
 }

--- a/packages/react-native-livechart/src/components/thresholdSplitShaderSource.ts
+++ b/packages/react-native-livechart/src/components/thresholdSplitShaderSource.ts
@@ -1,0 +1,70 @@
+/**
+ * Build a balanced constant-index lookup for the threshold sample array.
+ *
+ * SkSL does not allow a runtime value to index a uniform array. A linear loop
+ * works around that restriction, but makes every covered fragment visit every
+ * segment. This tree keeps every array index constant while selecting the same
+ * segment in at most `ceil(log2(sampleCount - 1))` comparisons (six for the
+ * production 64-sample shader).
+ */
+export function buildThresholdLookupTree(sampleCount: number): string {
+  if (!Number.isInteger(sampleCount) || sampleCount < 2) {
+    throw new Error("Threshold shader needs at least two samples");
+  }
+
+  const build = (first: number, end: number, indent: string): string => {
+    if (end - first === 1) {
+      return `${indent}return mix(samples[${first}], samples[${first + 1}], clamp(u - float(${first}), 0.0, 1.0));`;
+    }
+
+    const middle = Math.floor((first + end) / 2);
+    const childIndent = `${indent}  `;
+    return `${indent}if (u < float(${middle})) {
+${build(first, middle, childIndent)}
+${indent}} else {
+${build(middle, end, childIndent)}
+${indent}}`;
+  };
+
+  return build(0, sampleCount - 1, "  ");
+}
+
+/** Build the complete time-varying threshold split shader. */
+export function buildThresholdSplitShaderSource(sampleCount: number): string {
+  const lookup = buildThresholdLookupTree(sampleCount);
+  return `
+// Pixel-X span of the sample grid (thresholdSampleSpanX) — overhangs the plot
+// and glides with the window so features move fluidly, frame to frame.
+uniform float sampleLeft;
+uniform float sampleRight;
+// X where the threshold ends (extendToNow: false → the last point's pixel-X,
+// else a huge sentinel). Fragments right of it paint restColor: the plain line
+// color for the stroke, transparent for the band.
+uniform float clipRight;
+uniform vec4 aboveColor; // straight-alpha rgba, 0..1
+uniform vec4 belowColor; // straight-alpha rgba, 0..1
+uniform vec4 restColor;  // straight-alpha rgba, 0..1
+uniform float samples[${sampleCount}];
+
+float thresholdAt(float u) {
+${lookup}
+}
+
+half4 main(vec2 xy) {
+  if (xy.x > clipRight) {
+    return half4(half3(restColor.rgb) * restColor.a, restColor.a);
+  }
+  float span = sampleRight - sampleLeft;
+  float u = span > 0.0 ? (xy.x - sampleLeft) / span : 0.0;
+  u = clamp(u, 0.0, 1.0) * float(${sampleCount - 1});
+  // Uniform-array indices must stay compile-time constants in SkSL. The
+  // generated branch tree selects the same segment as floor(u), including the
+  // clamped final endpoint, in logarithmic comparisons instead of walking every
+  // segment for every fragment.
+  float thrY = thresholdAt(u);
+  // 1 above the boundary, 0 below, with ~1px antialiasing across it.
+  float above = clamp(thrY - xy.y + 0.5, 0.0, 1.0);
+  vec4 c = mix(belowColor, aboveColor, above);
+  return half4(half3(c.rgb) * c.a, c.a);
+}`;
+}

--- a/packages/react-native-livechart/src/math/threshold.ts
+++ b/packages/react-native-livechart/src/math/threshold.ts
@@ -12,8 +12,8 @@ import type { LiveChartPoint } from "../types";
  * projected to this many evenly-spaced pixel-Y values across the plot, which the
  * shader linearly interpolates between. ~one sample per 6px on a phone plot —
  * fine enough that the line's crossing point is coloured accurately. The shader
- * walks these in an unrolled loop (`THRESHOLD_SAMPLE_COUNT - 1` iterations), so
- * keep it modest to stay within SkSL's unroll limits.
+ * selects between them through a balanced constant-index branch tree, so 64
+ * samples require at most six comparisons per covered fragment.
  */
 export const THRESHOLD_SAMPLE_COUNT = 64;
 

--- a/packages/react-native-livechart/tests/components/ThresholdSplitShader.test.ts
+++ b/packages/react-native-livechart/tests/components/ThresholdSplitShader.test.ts
@@ -1,0 +1,64 @@
+import {
+  buildThresholdLookupTree,
+  buildThresholdSplitShaderSource,
+} from "../../src/components/thresholdSplitShaderSource";
+import { THRESHOLD_SAMPLE_COUNT } from "../../src/math/threshold";
+
+const THRESHOLD_SPLIT_SKSL = buildThresholdSplitShaderSource(
+  THRESHOLD_SAMPLE_COUNT,
+);
+
+describe("ThresholdSplitShader lookup", () => {
+  it("builds one constant-index interpolation leaf per sample segment", () => {
+    const tree = buildThresholdLookupTree(5);
+
+    expect(tree.match(/return mix\(samples\[/g)).toHaveLength(4);
+    expect(tree).toContain("if (u < float(2))");
+    expect(tree).toContain("if (u < float(1))");
+    expect(tree).toContain("if (u < float(3))");
+
+    for (let segment = 0; segment < 4; segment++) {
+      expect(tree).toContain(
+        `return mix(samples[${segment}], samples[${segment + 1}], clamp(u - float(${segment}), 0.0, 1.0));`,
+      );
+    }
+  });
+
+  it("uses a balanced lookup instead of the previous per-fragment loop", () => {
+    const leaves = [
+      ...THRESHOLD_SPLIT_SKSL.matchAll(
+        /return mix\(samples\[(\d+)]\s*,\s*samples\[(\d+)]/g,
+      ),
+    ];
+
+    expect(THRESHOLD_SPLIT_SKSL).not.toContain("for (");
+    expect(THRESHOLD_SPLIT_SKSL).toContain("float thrY = thresholdAt(u);");
+    expect(leaves).toHaveLength(THRESHOLD_SAMPLE_COUNT - 1);
+    const maximumComparisons = Math.max(
+      ...THRESHOLD_SPLIT_SKSL.split("\n")
+        .filter((line) => line.trimStart().startsWith("return mix(samples["))
+        .map((line) => line.length - line.trimStart().length)
+        // The function body starts with one indentation level; each additional
+        // two spaces represents one comparison on the route to that leaf.
+        .map((spaces) => spaces / 2 - 1),
+    );
+    expect(maximumComparisons).toBe(6);
+    expect(
+      leaves.map((match) => [Number(match[1]), Number(match[2])]),
+    ).toEqual(
+      Array.from({ length: THRESHOLD_SAMPLE_COUNT - 1 }, (_, index) => [
+        index,
+        index + 1,
+      ]),
+    );
+  });
+
+  it("rejects an invalid sample count", () => {
+    expect(() => buildThresholdLookupTree(1)).toThrow(
+      "Threshold shader needs at least two samples",
+    );
+    expect(() => buildThresholdLookupTree(2.5)).toThrow(
+      "Threshold shader needs at least two samples",
+    );
+  });
+});

--- a/profiling/metroConfig.test.ts
+++ b/profiling/metroConfig.test.ts
@@ -9,6 +9,8 @@ function loadCacheVersion(
   cadence: string,
   workletsBundleMode = "0",
   thresholdShaderMode = "default",
+  thresholdShaderLabel = "default",
+  thresholdShaderLayers = "default",
 ): string {
   return execFileSync(
     process.execPath,
@@ -25,6 +27,8 @@ function loadCacheVersion(
         EXPO_PUBLIC_MEMORY_PROFILE_MODE: mode,
         EXPO_PUBLIC_MEMORY_PROFILE_CADENCE: cadence,
         EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE: thresholdShaderMode,
+        EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_LABEL: thresholdShaderLabel,
+        EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_LAYERS: thresholdShaderLayers,
         WORKLETS_BUNDLE_MODE: workletsBundleMode,
       },
     },
@@ -51,12 +55,27 @@ describe("renderer profiling Metro cache", () => {
       loadCacheVersion("static-control", "static", "display", "1"),
     ).not.toBe(baseline);
     expect(
+      loadCacheVersion("static-control", "static", "display", "0", "fill"),
+    ).not.toBe(baseline);
+    expect(
       loadCacheVersion(
         "static-control",
         "static",
         "display",
         "0",
-        "fill",
+        "default",
+        "legacy",
+      ),
+    ).not.toBe(baseline);
+    expect(
+      loadCacheVersion(
+        "static-control",
+        "static",
+        "display",
+        "0",
+        "default",
+        "default",
+        "8",
       ),
     ).not.toBe(baseline);
   });

--- a/profiling/metroConfig.test.ts
+++ b/profiling/metroConfig.test.ts
@@ -8,6 +8,7 @@ function loadCacheVersion(
   mode: string,
   cadence: string,
   workletsBundleMode = "0",
+  thresholdShaderMode = "default",
 ): string {
   return execFileSync(
     process.execPath,
@@ -23,6 +24,7 @@ function loadCacheVersion(
         EXPO_PUBLIC_MEMORY_PROFILE_RUN: run,
         EXPO_PUBLIC_MEMORY_PROFILE_MODE: mode,
         EXPO_PUBLIC_MEMORY_PROFILE_CADENCE: cadence,
+        EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE: thresholdShaderMode,
         WORKLETS_BUNDLE_MODE: workletsBundleMode,
       },
     },
@@ -47,6 +49,15 @@ describe("renderer profiling Metro cache", () => {
     );
     expect(
       loadCacheVersion("static-control", "static", "display", "1"),
+    ).not.toBe(baseline);
+    expect(
+      loadCacheVersion(
+        "static-control",
+        "static",
+        "display",
+        "0",
+        "fill",
+      ),
     ).not.toBe(baseline);
   });
 });

--- a/scripts/benchmark-threshold-shader.mjs
+++ b/scripts/benchmark-threshold-shader.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import CanvasKitInit from "canvaskit-wasm";
+import ts from "typescript";
+
+const SAMPLE_COUNT = 64;
+const args = Object.fromEntries(
+  process.argv.slice(2).map((arg) => {
+    const [key, value = "true"] = arg.replace(/^--/, "").split("=");
+    return [key, value];
+  }),
+);
+const width = Number(args.width ?? 100);
+const height = Number(args.height ?? 200);
+const iterations = Number(args.iterations ?? 30);
+const warmup = Number(args.warmup ?? 5);
+
+if (
+  !Number.isInteger(width) ||
+  !Number.isInteger(height) ||
+  !Number.isInteger(iterations) ||
+  !Number.isInteger(warmup) ||
+  width <= 0 ||
+  height <= 0 ||
+  iterations <= 0 ||
+  warmup < 0
+) {
+  throw new Error(
+    "width, height, and iterations must be positive integers; warmup must be a non-negative integer",
+  );
+}
+
+async function loadSourceBuilder() {
+  const filename = path.resolve(
+    "packages/react-native-livechart/src/components/thresholdSplitShaderSource.ts",
+  );
+  const source = await fs.readFile(filename, "utf8");
+  const javascript = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  }).outputText;
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(javascript).toString("base64")}`;
+  return import(moduleUrl);
+}
+
+function buildLegacySource(optimizedSource) {
+  const lookupStart = optimizedSource.indexOf("float thresholdAt(float u)");
+  const mainStart = optimizedSource.indexOf("half4 main(vec2 xy)");
+  if (lookupStart < 0 || mainStart < 0) {
+    throw new Error("Could not locate the optimized lookup in the shader source");
+  }
+
+  return (
+    optimizedSource.slice(0, lookupStart) + optimizedSource.slice(mainStart)
+  ).replace(
+    "float thrY = thresholdAt(u);",
+    `float thrY = samples[0];
+  for (int j = 0; j < ${SAMPLE_COUNT - 1}; j++) {
+    if (u >= float(j)) {
+      thrY = mix(samples[j], samples[j + 1], clamp(u - float(j), 0.0, 1.0));
+    }
+  }`,
+  );
+}
+
+function compile(CanvasKit, source, label) {
+  let compileError = "";
+  const effect = CanvasKit.RuntimeEffect.Make(source, (error) => {
+    compileError = error;
+  });
+  if (!effect) throw new Error(`${label} shader did not compile: ${compileError}`);
+  return effect;
+}
+
+function measureCompile(CanvasKit, source, label) {
+  const samples = [];
+  for (let index = 0; index < 10; index++) {
+    // Keep each source unique so Skia's RuntimeEffect cache cannot turn this
+    // into a lookup benchmark after the first compilation.
+    const uniqueSource = `${source}\n// compile benchmark ${label} ${index}`;
+    const start = performance.now();
+    const effect = compile(CanvasKit, uniqueSource, label);
+    samples.push(performance.now() - start);
+    effect.delete();
+  }
+  return {
+    mean: samples.reduce((sum, value) => sum + value, 0) / samples.length,
+    minimum: Math.min(...samples),
+    maximum: Math.max(...samples),
+  };
+}
+
+function makeUniforms(effect) {
+  const samples = Array.from(
+    { length: SAMPLE_COUNT },
+    (_, index) => height * (0.5 + 0.3 * Math.sin(index * 0.47)),
+  );
+  const uniforms = [
+    0,
+    width,
+    width + 1,
+    0.1,
+    0.85,
+    0.25,
+    1,
+    0.9,
+    0.15,
+    0.2,
+    1,
+    0.4,
+    0.4,
+    0.4,
+    1,
+    ...samples,
+  ];
+  if (uniforms.length !== effect.getUniformFloatCount()) {
+    throw new Error(
+      `Expected ${uniforms.length} uniform floats, shader requires ${effect.getUniformFloatCount()}`,
+    );
+  }
+  return uniforms;
+}
+
+function makeRenderer(CanvasKit, source, label) {
+  const surface = CanvasKit.MakeSurface(width, height);
+  if (!surface) throw new Error(`Could not create the ${label} raster surface`);
+  const effect = compile(CanvasKit, source, label);
+  const shader = effect.makeShader(makeUniforms(effect));
+  const paint = new CanvasKit.Paint();
+  paint.setShader(shader);
+  const canvas = surface.getCanvas();
+  const rect = CanvasKit.XYWHRect(0, 0, width, height);
+
+  return {
+    draw() {
+      canvas.drawRect(rect, paint);
+      surface.flush();
+    },
+    pixels() {
+      return canvas.readPixels(0, 0, {
+        width,
+        height,
+        colorType: CanvasKit.ColorType.RGBA_8888,
+        alphaType: CanvasKit.AlphaType.Premul,
+        colorSpace: CanvasKit.ColorSpace.SRGB,
+      });
+    },
+    dispose() {
+      paint.delete();
+      shader.delete();
+      effect.delete();
+      surface.delete();
+    },
+  };
+}
+
+function percentile(sorted, quantile) {
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * quantile))];
+}
+
+function measure(renderer) {
+  for (let index = 0; index < warmup; index++) renderer.draw();
+  const samples = [];
+  for (let index = 0; index < iterations; index++) {
+    const start = performance.now();
+    renderer.draw();
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    mean: samples.reduce((sum, value) => sum + value, 0) / samples.length,
+    p50: percentile(samples, 0.5),
+    p90: percentile(samples, 0.9),
+    p99: percentile(samples, 0.99),
+  };
+}
+
+function assertIdenticalPixels(a, b) {
+  if (!a || !b || a.length !== b.length) {
+    throw new Error("Could not read comparable shader pixels");
+  }
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) {
+      throw new Error(
+        `Shader output differs at byte ${index}: legacy=${a[index]}, optimized=${b[index]}`,
+      );
+    }
+  }
+}
+
+const { buildThresholdSplitShaderSource } = await loadSourceBuilder();
+const optimizedSource = buildThresholdSplitShaderSource(SAMPLE_COUNT);
+const legacySource = buildLegacySource(optimizedSource);
+const CanvasKit = await CanvasKitInit({
+  locateFile: (file) => path.resolve("node_modules/canvaskit-wasm/bin", file),
+});
+// Pay CanvasKit's one-time compiler initialization before comparing sources.
+compile(CanvasKit, "half4 main(vec2 xy) { return half4(1); }", "warmup").delete();
+const legacyCompileA = measureCompile(CanvasKit, legacySource, "legacy A");
+const optimizedCompile = measureCompile(CanvasKit, optimizedSource, "optimized");
+const legacyCompileB = measureCompile(CanvasKit, legacySource, "legacy B");
+const legacy = makeRenderer(CanvasKit, legacySource, "legacy");
+const optimized = makeRenderer(CanvasKit, optimizedSource, "optimized");
+
+try {
+  legacy.draw();
+  optimized.draw();
+  assertIdenticalPixels(legacy.pixels(), optimized.pixels());
+
+  // A/B/A order limits one-time warm-up and thermal drift from favouring the
+  // implementation that happens to run second.
+  const legacyA = measure(legacy);
+  const optimizedResult = measure(optimized);
+  const legacyB = measure(legacy);
+  const legacyMean = (legacyA.mean + legacyB.mean) / 2;
+
+  console.log(
+    JSON.stringify(
+      {
+        backend: "CanvasKit software raster",
+        dimensions: { width, height, pixels: width * height },
+        iterations,
+        warmup,
+        output: "byte-identical",
+        compileMilliseconds: {
+          legacyA: legacyCompileA,
+          optimized: optimizedCompile,
+          legacyB: legacyCompileB,
+        },
+        millisecondsPerFrame: {
+          legacyA,
+          optimized: optimizedResult,
+          legacyB,
+        },
+        meanReductionPercent: ((legacyMean - optimizedResult.mean) / legacyMean) * 100,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  legacy.dispose();
+  optimized.dispose();
+}


### PR DESCRIPTION
## Summary

- replace the per-fragment 63-segment walk in the time-varying threshold shader with a balanced constant-index branch tree
- keep all 64 samples, interpolation, clipping, colors, and public behavior unchanged
- add a deterministic Release profiling screen, UI-frame cadence capture, and isolated CanvasKit A/B/A benchmark
- document the decision, rejected alternatives, software measurements, physical results, and limitations

Each covered fragment now reaches its sample segment in at most 6 comparisons instead of visiting all 63 segments.

## Scope decision

This PR focuses on **dynamic fill**, the shader's worst case because it can cover most of a high-DPR chart. Threshold-off and static-threshold charts never execute this RuntimeEffect. Dynamic stroke uses the same lookup over far fewer covered pixels, so it received functional regression coverage without a separate performance matrix.

The texture and gradient-stop prototypes were not implemented because the branch tree preserves exact pixel semantics and avoids new per-frame resources.

## Physical-device result

Release builds were alternated on a wired iPhone 16 (iPhone17,3), iOS 26.5.2, at 60 Hz. Every run used the same 3-second warmup and 12-second UI-frame capture, and the embedded Hermes bundles were verified before testing.

At the normal one-layer workload, legacy and optimized A/B/A runs were identical: 16.64 ms mean, zero delayed frames, and zero estimated missed frames. One normal chart is already comfortably inside the device's frame budget.

One focused 8-layer amplification made shader headroom observable without expanding into a broad matrix:

- optimized branch tree: all 3 runs stayed at 16.64 ms mean, max 16.77 ms, and 0 missed frames
- legacy loop: 1 clean run; 1 run at 17.02 ms with 15 estimated missed frames; 1 run at 22.50 ms with 187 estimated missed frames

This is an isolation/stress condition, not a recommendation to stack eight charts. It shows that the optimized shader retains cadence headroom when fragment load becomes heavy.

The regular threshold demo and a test-only time-varying-series crossing fixture were both checked on the physical device. Crossings, red/green fills, interpolated boundaries, marker/label behavior, and chart edges rendered without visible banding or clipping.

These are UI-frame-callback measurements, not direct GPU durations: `xctrace` could not attach to this device. The on-screen missed-frame value is an estimate from elapsed capture time and the detected 60 Hz interval.

## Other evidence

- isolated CanvasKit output is byte-identical
- repeated 100x200 software-raster runs reduced mean shader draw time by 11.30-14.29%
- one 200x400 run reduced mean shader draw time by 20.07%
- generated shader compilation costs roughly 1 ms more in the recorded warmed CanvasKit run, paid once at module initialization
- Release iOS simulator QA passed
- React Doctor: 100/100

## Verification

- `npm run verify`: 96 suites passed; 1,348 tests passed; 5 skipped
- pre-commit test rerun after documenting device results: 96 suites passed; 1,348 tests passed; 5 skipped
- dedicated shader-source tests verify 63 constant-index leaves, at most 6 comparisons, and removal of the loop
- CanvasKit benchmark fails unless legacy and optimized RGBA bytes match
- library package dry-run passed

## Merge gate

- [x] A/B Release profile baseline and optimized commits on connected high-DPR hardware
- [x] capture tail behavior and estimated missed frames, not average FPS alone
- [x] confirm dynamic fill crossings, banding, clipping, and edges on the physical device
- [x] latest pushed CI checks pass

Detailed results: [docs/threshold-shader-perf.md](https://github.com/brandtnewlabs/react-native-livechart/blob/codex/threshold-shader-cost/docs/threshold-shader-perf.md)

Closes #213

