### PR TITLE
Fix iOS parent scrolling for scrub-enabled charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scrub-enabled charts no longer block vertical parent scrolling on iOS.**
+  Plain `LiveChart` and `LiveChartSeries` scrubs now wait for clear horizontal
+  intent and fail quickly on vertical movement, without attaching zero-valued
+  pan activation modifiers that could preempt a parent `ScrollView` or list.
+  Scrub-action hold gestures keep their existing behavior. ([#220](https://github.com/brandtnewlabs/react-native-livechart/issues/220))
+
 ### Changed
 
 - **Multi-series drawing worklets now scale with the active series count.**

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -73,6 +73,11 @@ const SECTIONS: DemoSection[] = [
         blurb: "Scrub modes, styled tooltip, onScrub readout, candle OHLC.",
       },
       {
+        href: "/demo/scroll-interaction",
+        title: "Scroll interaction",
+        blurb: "Vertical parent scrolling vs. horizontal scrub, for LiveChart and LiveChartSeries.",
+      },
+      {
         href: "/demo/candle-scrub",
         title: "Candle scrub",
         blurb: "Brokerage-style: OHLC header above the chart, time pinned to the top edge, crosshair kept.",

--- a/app/demo/scroll-interaction.tsx
+++ b/app/demo/scroll-interaction.tsx
@@ -1,0 +1,299 @@
+import { useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { LiveChart, LiveChartSeries } from "react-native-livechart";
+
+import {
+  APP_FONT_FAMILY,
+  APP_FONT_FAMILY_MEDIUM,
+  APP_FONT_FAMILY_SEMIBOLD,
+} from "../../demo-lib/fonts";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME, colors } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Scroll interaction" };
+
+type ActiveChart = "single" | "series" | "none";
+
+export default function ScrollInteractionScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { data, value, series } = useSimulatedChartData({
+    multiSeries: true,
+    tradeStream: false,
+    historySpanSeconds: 40,
+  });
+
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [singleScrubs, setSingleScrubs] = useState(0);
+  const [seriesScrubs, setSeriesScrubs] = useState(0);
+  const [activeChart, setActiveChart] = useState<ActiveChart>("none");
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    setScrollOffset(Math.round(event.nativeEvent.contentOffset.y));
+  };
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Back to demos"
+        >
+          <Text style={styles.backChevron}>‹</Text>
+          <Text style={styles.backText}>Demos</Text>
+        </Pressable>
+        <Text style={styles.heading}>Scroll interaction</Text>
+        <Text style={styles.description}>
+          Both charts are children of this vertical ScrollView. Start every test
+          gesture inside the plot.
+        </Text>
+      </View>
+
+      <View style={styles.statusPanel}>
+        <Text style={styles.statusPrimary}>
+          Parent offset: {scrollOffset}px
+        </Text>
+        <Text
+          accessibilityLabel={`single scrubs ${singleScrubs}, series scrubs ${seriesScrubs}, active ${activeChart}`}
+          style={styles.statusSecondary}
+        >
+          Single scrubs: {singleScrubs} · Series scrubs: {seriesScrubs} ·
+          Active: {activeChart}
+        </Text>
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        onScroll={handleScroll}
+        scrollEventThrottle={100}
+        showsVerticalScrollIndicator
+      >
+        <View style={styles.instructions}>
+          <Text style={styles.instructionsTitle}>Expected result</Text>
+          <Text style={styles.instructionsText}>
+            Vertical or mostly vertical: the offset changes and scrub count
+            stays still. Horizontal: the offset stays still and that
+            chart&apos;s scrub count increases.
+          </Text>
+        </View>
+
+        <Text style={styles.chartTitle}>LiveChart</Text>
+        <Text style={styles.chartHint}>
+          Try vertical, diagonal, then horizontal.
+        </Text>
+        <View
+          style={styles.chartCard}
+          accessibilityLabel="Single-series scroll test chart"
+        >
+          <LiveChart
+            data={data}
+            value={value}
+            accentColor={ACCENT}
+            theme={APP_THEME}
+            timeWindow={30}
+            scrub
+            onGestureStart={() => {
+              setSingleScrubs((count) => count + 1);
+              setActiveChart("single");
+            }}
+            onGestureEnd={() => setActiveChart("none")}
+          />
+        </View>
+
+        <View style={styles.betweenCharts}>
+          <Text style={styles.betweenText}>
+            Keep scrolling to repeat the same checks with LiveChartSeries.
+          </Text>
+        </View>
+
+        <Text style={styles.chartTitle}>LiveChartSeries</Text>
+        <Text style={styles.chartHint}>
+          Try vertical, diagonal, then horizontal.
+        </Text>
+        <View
+          style={styles.chartCard}
+          accessibilityLabel="Multi-series scroll test chart"
+        >
+          <LiveChartSeries
+            series={series}
+            accentColor={ACCENT}
+            theme={APP_THEME}
+            timeWindow={30}
+            scrub
+            onGestureStart={() => {
+              setSeriesScrubs((count) => count + 1);
+              setActiveChart("series");
+            }}
+            onGestureEnd={() => setActiveChart("none")}
+          />
+        </View>
+
+        <View style={styles.footerCard}>
+          <Text style={styles.footerTitle}>Done when</Text>
+          <Text style={styles.footerText}>
+            Both charts let vertical movement scroll this page, while horizontal
+            movement scrubs immediately without a hold.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingTop: 4,
+    paddingBottom: 10,
+  },
+  backButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    paddingVertical: 6,
+    marginBottom: 2,
+  },
+  backChevron: {
+    color: colors.link,
+    fontSize: 22,
+    lineHeight: 22,
+    marginRight: 2,
+    marginTop: -2,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+  },
+  backText: {
+    color: colors.link,
+    fontSize: 15,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+  },
+  heading: {
+    color: colors.text,
+    fontSize: 22,
+    fontFamily: APP_FONT_FAMILY_SEMIBOLD,
+    marginBottom: 4,
+  },
+  description: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 18,
+    fontFamily: APP_FONT_FAMILY,
+  },
+  statusPanel: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.chipBackground,
+  },
+  statusPrimary: {
+    color: colors.text,
+    fontSize: 14,
+    fontVariant: ["tabular-nums"],
+    fontFamily: APP_FONT_FAMILY_SEMIBOLD,
+  },
+  statusSecondary: {
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 2,
+    fontVariant: ["tabular-nums"],
+    fontFamily: APP_FONT_FAMILY,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 48,
+  },
+  instructions: {
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: colors.chipBackground,
+    marginBottom: 24,
+  },
+  instructionsTitle: {
+    color: colors.text,
+    fontSize: 14,
+    fontFamily: APP_FONT_FAMILY_SEMIBOLD,
+    marginBottom: 4,
+  },
+  instructionsText: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 19,
+    fontFamily: APP_FONT_FAMILY,
+  },
+  chartTitle: {
+    color: colors.text,
+    fontSize: 18,
+    fontFamily: APP_FONT_FAMILY_SEMIBOLD,
+  },
+  chartHint: {
+    color: colors.textFaint,
+    fontSize: 12,
+    fontFamily: APP_FONT_FAMILY,
+    marginTop: 3,
+    marginBottom: 10,
+  },
+  chartCard: {
+    height: 260,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    overflow: "hidden",
+  },
+  betweenCharts: {
+    height: 220,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 36,
+  },
+  betweenText: {
+    color: colors.textFaint,
+    fontSize: 13,
+    lineHeight: 19,
+    textAlign: "center",
+    fontFamily: APP_FONT_FAMILY,
+  },
+  footerCard: {
+    minHeight: 280,
+    marginTop: 28,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: colors.chipBackground,
+  },
+  footerTitle: {
+    color: colors.text,
+    fontSize: 14,
+    fontFamily: APP_FONT_FAMILY_SEMIBOLD,
+    marginBottom: 4,
+  },
+  footerText: {
+    color: colors.textMuted,
+    fontSize: 13,
+    lineHeight: 19,
+    fontFamily: APP_FONT_FAMILY,
+  },
+});

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -14,6 +14,11 @@ const TOOLTIP_EDGE_GAP = 4;
 const TOOLTIP_TOP_MARGIN = 8;
 const FADE_ZONE = 4;
 
+/** Horizontal travel required before a plain scrub claims the touch. */
+export const SCRUB_ACTIVATE_X_PX = 20;
+/** Vertical travel that fails a plain scrub so a parent scroll gesture can win. */
+export const SCRUB_FAIL_Y_PX = 10;
+
 /** Measure rendered text so the pill and its content share the same centre. */
 function measureTooltipTextWidth(
   font: SkFont,

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -1,5 +1,4 @@
 import { type SkFont } from "@shopify/react-native-skia";
-import { Platform } from "react-native";
 import { Gesture } from "react-native-gesture-handler";
 import {
   useAnimatedReaction,
@@ -33,6 +32,8 @@ import {
   HIDDEN_TIME_BADGE,
   HIDDEN_TOOLTIP,
   pointInRect,
+  SCRUB_ACTIVATE_X_PX,
+  SCRUB_FAIL_Y_PX,
   snapPrice,
   type CrosshairState,
 } from "./crosshairShared";
@@ -501,12 +502,6 @@ export function useCrosshair(
       : panGestureDelay;
 
   let gesture = Gesture.Pan()
-    // Scrub-action: minDistance 0 — the press-hold above is the sole activator
-    // (movement during the hold fails the pan), so the crosshair never appears
-    // from a tap's travel. The Tap (maxDistance SCRUB_ACTION_TAP_SLOP) owns quick
-    // gestures; only a held press becomes a scrub/adjust drag.
-    .minDistance(!hasScrubAction && Platform.OS === "android" ? 10 : 0)
-    .activateAfterLongPress(longPressMs)
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
     .onTouchesDown(
@@ -620,11 +615,22 @@ export function useCrosshair(
       },
     );
 
-  /* istanbul ignore next -- Android-only gesture axis config */
-  if (Platform.OS === "android" && !hasScrubAction) {
+  // Passing zero-valued activation modifiers lets RNGH's iOS pan recognizer
+  // activate before the axis constraints classify the drag. Only configure a
+  // hold when one is requested, and reserve minDistance(0) for scrub-action's
+  // deliberate press-hold interaction.
+  if (longPressMs > 0) {
+    gesture = gesture.activateAfterLongPress(longPressMs);
+  }
+
+  if (hasScrubAction) {
+    gesture = gesture.minDistance(0);
+  } else {
     // Lock mode needs free vertical drag (Y = price), so the failOffsetY clamp —
     // which would kill a vertical adjust — is applied only outside scrub-action.
-    gesture = gesture.activeOffsetX([-25, 25]).failOffsetY([-25, 25]);
+    gesture = gesture
+      .activeOffsetX([-SCRUB_ACTIVATE_X_PX, SCRUB_ACTIVATE_X_PX])
+      .failOffsetY([-SCRUB_FAIL_Y_PX, SCRUB_FAIL_Y_PX]);
   }
 
   // Axis-drag time-scroll: carve the bottom "time ruler" band out of the scrub's

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -1,4 +1,3 @@
-import { Platform } from "react-native";
 import { Gesture } from "react-native-gesture-handler";
 import {
   useAnimatedReaction,
@@ -18,6 +17,8 @@ import {
   computeScrubDotY,
   computeScrubTime,
   HIDDEN_TOOLTIP,
+  SCRUB_ACTIVATE_X_PX,
+  SCRUB_FAIL_Y_PX,
   type CrosshairState,
 } from "./crosshairShared";
 import {
@@ -165,8 +166,6 @@ export function useCrosshairSeries(
   );
 
   let gesture = Gesture.Pan()
-    .minDistance(Platform.OS === "android" ? 10 : 0)
-    .activateAfterLongPress(panGestureDelay)
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
     .onTouchesDown(
@@ -228,10 +227,16 @@ export function useCrosshairSeries(
       },
     );
 
-  /* istanbul ignore next */
-  if (Platform.OS === "android") {
-    gesture = gesture.activeOffsetX([-25, 25]).failOffsetY([-25, 25]);
+  // Omit zero-valued activation modifiers so RNGH can classify direction before
+  // the pan activates on iOS. A vertical drag then remains available to a parent
+  // ScrollView/list, while a clear horizontal drag starts scrubbing.
+  if (panGestureDelay > 0) {
+    gesture = gesture.activateAfterLongPress(panGestureDelay);
   }
+
+  gesture = gesture
+    .activeOffsetX([-SCRUB_ACTIVATE_X_PX, SCRUB_ACTIVATE_X_PX])
+    .failOffsetY([-SCRUB_FAIL_Y_PX, SCRUB_FAIL_Y_PX]);
 
   return {
     scrubX,

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -20,14 +20,26 @@ import {
 
 jest.mock("react-native-gesture-handler", () => {
   const makeGesture = () => {
-    const g: Record<string, unknown> = {};
+    const g: Record<string, unknown> = { config: {} };
     const proxy: typeof g = new Proxy(g, {
-      get: (_t, _k) => () => proxy,
+      get: (target, key) => {
+        if (key in target) return target[key as string];
+        return (...args: unknown[]) => {
+          (target.config as Record<string, unknown[]>)[String(key)] = args;
+          return proxy;
+        };
+      },
     });
     return proxy;
   };
   return { Gesture: { Pan: makeGesture, Tap: makeGesture } };
 });
+
+type GestureConfig = Record<string, unknown[]>;
+
+function getGestureConfig(gesture: unknown): GestureConfig {
+  return (gesture as { config: GestureConfig }).config;
+}
 
 const palette = resolveTheme("#3b82f6", "dark");
 
@@ -875,12 +887,39 @@ describe("useCrosshair (hook)", () => {
     expect(onGestureEnd).not.toHaveBeenCalled();
   });
 
-  it("uses Android pan minDistance when Platform.OS is android", () => {
-    const prev = Platform.OS;
-    Object.defineProperty(Platform, "OS", {
-      configurable: true,
-      value: "android",
-    });
+  it.each(["ios", "android"] as const)(
+    "waits for horizontal intent and yields vertical drags on %s",
+    (platform) => {
+      const prev = Platform.OS;
+      Object.defineProperty(Platform, "OS", {
+        configurable: true,
+        value: platform,
+      });
+      const engine = makeEngine();
+      const { result } = renderHook(() =>
+        useCrosshair(
+          engine,
+          padding,
+          palette,
+          formatValue,
+          formatTime,
+          font,
+          true,
+        ),
+      );
+      const config = getGestureConfig(result.current.gesture);
+      expect(config.minDistance).toBeUndefined();
+      expect(config.activateAfterLongPress).toBeUndefined();
+      expect(config.activeOffsetX).toEqual([[-20, 20]]);
+      expect(config.failOffsetY).toEqual([[-10, 10]]);
+      Object.defineProperty(Platform, "OS", {
+        configurable: true,
+        value: prev,
+      });
+    },
+  );
+
+  it("only configures a long-press modifier for a positive delay", () => {
     const engine = makeEngine();
     const { result } = renderHook(() =>
       useCrosshair(
@@ -891,13 +930,16 @@ describe("useCrosshair (hook)", () => {
         formatTime,
         font,
         true,
+        undefined,
+        undefined,
+        250,
       ),
     );
-    expect(result.current.gesture).toBeDefined();
-    Object.defineProperty(Platform, "OS", {
-      configurable: true,
-      value: prev,
-    });
+    const config = getGestureConfig(result.current.gesture);
+    expect(config.activateAfterLongPress).toEqual([250]);
+    expect(config.minDistance).toBeUndefined();
+    expect(config.activeOffsetX).toEqual([[-20, 20]]);
+    expect(config.failOffsetY).toEqual([[-10, 10]]);
   });
 
   it("does not build a tap gesture or lock state without scrubAction", () => {
@@ -940,6 +982,11 @@ describe("useCrosshair (hook)", () => {
     expect(result.current.lockPrice?.value).toBeNull();
     expect(result.current.actionBadge?.value.visible).toBe(false);
     expect(result.current.tapGesture).toBeDefined();
+    const config = getGestureConfig(result.current.gesture);
+    expect(config.activateAfterLongPress).toEqual([200]);
+    expect(config.minDistance).toEqual([0]);
+    expect(config.activeOffsetX).toBeUndefined();
+    expect(config.failOffsetY).toBeUndefined();
     // The callback fires only from the UI-thread tap worklet (istanbul-ignored).
     expect(onScrubAction).not.toHaveBeenCalled();
   });

--- a/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
@@ -12,14 +12,26 @@ import { withSharedValueAccessors } from "../support/sharedValueMock";
 
 jest.mock("react-native-gesture-handler", () => {
   const makeGesture = () => {
-    const g: Record<string, unknown> = {};
+    const g: Record<string, unknown> = { config: {} };
     const proxy: typeof g = new Proxy(g, {
-      get: (_t, _k) => () => proxy,
+      get: (target, key) => {
+        if (key in target) return target[key as string];
+        return (...args: unknown[]) => {
+          (target.config as Record<string, unknown[]>)[String(key)] = args;
+          return proxy;
+        };
+      },
     });
     return proxy;
   };
   return { Gesture: { Pan: makeGesture } };
 });
+
+type GestureConfig = Record<string, unknown[]>;
+
+function getGestureConfig(gesture: unknown): GestureConfig {
+  return (gesture as { config: GestureConfig }).config;
+}
 
 const font = {
   getSize: () => 12,
@@ -359,12 +371,42 @@ describe("useCrosshairSeries (hook)", () => {
     expect(onGestureEnd).not.toHaveBeenCalled();
   });
 
-  it("uses Android pan minDistance when Platform.OS is android", () => {
-    const prev = Platform.OS;
-    Object.defineProperty(Platform, "OS", {
-      configurable: true,
-      value: "android",
-    });
+  it.each(["ios", "android"] as const)(
+    "waits for horizontal intent and yields vertical drags on %s",
+    (platform) => {
+      const prev = Platform.OS;
+      Object.defineProperty(Platform, "OS", {
+        configurable: true,
+        value: platform,
+      });
+      const engine = makeEngine({
+        series: {
+          value: [
+            {
+              id: "a",
+              data: [{ time: 1_700_000_000, value: 5 }],
+              value: 5,
+              color: "#00f",
+            },
+          ],
+        },
+      });
+      const { result } = renderHook(() =>
+        useCrosshairSeries(engine, padding, true),
+      );
+      const config = getGestureConfig(result.current.gesture);
+      expect(config.minDistance).toBeUndefined();
+      expect(config.activateAfterLongPress).toBeUndefined();
+      expect(config.activeOffsetX).toEqual([[-20, 20]]);
+      expect(config.failOffsetY).toEqual([[-10, 10]]);
+      Object.defineProperty(Platform, "OS", {
+        configurable: true,
+        value: prev,
+      });
+    },
+  );
+
+  it("only configures a long-press modifier for a positive delay", () => {
     const engine = makeEngine({
       series: {
         value: [
@@ -378,12 +420,12 @@ describe("useCrosshairSeries (hook)", () => {
       },
     });
     const { result } = renderHook(() =>
-      useCrosshairSeries(engine, padding, true),
+      useCrosshairSeries(engine, padding, true, undefined, 250),
     );
-    expect(result.current.gesture).toBeDefined();
-    Object.defineProperty(Platform, "OS", {
-      configurable: true,
-      value: prev,
-    });
+    const config = getGestureConfig(result.current.gesture);
+    expect(config.activateAfterLongPress).toEqual([250]);
+    expect(config.minDistance).toBeUndefined();
+    expect(config.activeOffsetX).toEqual([[-20, 20]]);
+    expect(config.failOffsetY).toEqual([[-10, 10]]);
   });
 });


### PR DESCRIPTION
## Summary

- gate plain `LiveChart` and `LiveChartSeries` scrubbing on clear horizontal intent on both iOS and Android
- fail the scrub recognizer quickly on vertical movement so a parent `ScrollView` or list can win
- omit zero-valued `minDistance` / `activateAfterLongPress` modifiers for normal scrubbing while preserving delayed and scrub-action behavior
- add regression coverage for both platforms, positive delays, and scrub-action mode
- add a permanent **Demos → Interaction → Scroll interaction** screen with both chart variants inside an instrumented vertical parent
- document the fix in the changelog

## Root cause

The plain scrub pan attached `minDistance(0)` and `activateAfterLongPress(0)` on iOS. Those explicit zero values could activate React Native Gesture Handler's pan recognizer before the drag-direction constraints classified the gesture. The axis constraints were also only configured on Android.

## Impact

Vertical and vertical-diagonal swipes beginning over an interactive chart can remain available to a parent vertical scroll container. A clear horizontal drag still starts chart scrubbing without requiring a hold.

## Validation

- hands-on iOS Simulator QA on iPhone 17 / iOS 26.5 using the permanent demo screen and native touch automation:
  - `LiveChart`: vertical and diagonal swipes moved offset `0 → 137` with zero scrub starts; a 100 ms horizontal swipe kept offset `0` and produced one scrub start
  - `LiveChartSeries`: vertical and diagonal swipes moved offset `707 → 570` with zero scrub starts; a 100 ms horizontal swipe kept offset `707` and produced one scrub start
- `npm run verify` — typecheck, lint, 95 Jest suites; 1,349 passed and 5 skipped
- focused crosshair hook suites — 83 passed
- `npx react-doctor@latest --verbose --diff` — 100/100 for both projects

Closes #220
