### PR TITLE
Support renderReferenceLine in LiveChartSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`LiveChartSeries` now supports custom React Native reference-line tags.**
+  `renderReferenceLine` provides the same per-line built-in fallback, live Y / off-axis
+  positioning, and left / center / right anchoring as `LiveChart`, while preserving
+  the reference-line stroke. ([#219](https://github.com/brandtnewlabs/react-native-livechart/issues/219))
+
 ### Changed
 
 - **Multi-series drawing worklets now scale with the active series count.**

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -1,10 +1,12 @@
+import { Ionicons } from "@expo/vector-icons";
 import { useEffect, useRef, useState } from "react";
-import { TextInput } from "react-native";
+import { StyleSheet, Text, TextInput, View } from "react-native";
 import {
   formatTime,
   LiveChartSeries,
   type LegendConfig,
   type MultiSeriesDotConfig,
+  type ReferenceLineRenderProps,
   type SeriesConfig,
 } from "react-native-livechart";
 import Animated, {
@@ -22,6 +24,17 @@ import { APP_THEME } from "../../demo-lib/theme";
 export const options = { title: "Multi-series" };
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+function CustomTargetTag({ ctx }: { ctx: ReferenceLineRenderProps }) {
+  return (
+    <View style={styles.targetTag}>
+      <Ionicons name="arrow-up-circle" size={14} color="#86efac" />
+      <Text style={styles.targetTagText}>
+        {ctx.line.label}: {ctx.line.value?.toFixed(1)}%
+      </Text>
+    </View>
+  );
+}
 
 const DATA_OPTIONS: { value: boolean; label: string }[] = [
   { value: false, label: "Simulated series" },
@@ -213,7 +226,36 @@ export default function MultiSeriesScreen() {
             exaggerate={exaggerate}
             degen={degen ? true : undefined}
             referenceLines={
-              showRef ? [{ value: 33.3, label: "even" }] : undefined
+              showRef
+                ? [
+                    {
+                      value: 33.3,
+                      label: "Target",
+                      excludeFromRange: true,
+                      badge: { position: "right" },
+                    },
+                    {
+                      value: 35,
+                      label: "Built-in fallback",
+                      excludeFromRange: true,
+                      badge: { position: "center" },
+                    },
+                    {
+                      value: 110,
+                      label: "Above range",
+                      excludeFromRange: true,
+                      badge: { position: "left" },
+                    },
+                  ]
+                : undefined
+            }
+            renderReferenceLine={
+              showRef
+                ? (ctx) =>
+                    ctx.line.label === "Built-in fallback" ? null : (
+                      <CustomTargetTag ctx={ctx} />
+                    )
+                : undefined
             }
             yAxis={yOn}
             xAxis={xOn}
@@ -374,3 +416,22 @@ export default function MultiSeriesScreen() {
     </DemoScreen>
   );
 }
+
+const styles = StyleSheet.create({
+  targetTag: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "#22c55e",
+    backgroundColor: "#14532d",
+    paddingHorizontal: 7,
+    paddingVertical: 4,
+  },
+  targetTagText: {
+    color: "#f0fdf4",
+    fontSize: 11,
+    fontWeight: "700",
+  },
+});

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -14,6 +14,17 @@ accepts all the shared theming, axis, range, layout, and text props from
 `timeWindow`, `smoothing`, [`snapKey`](/api-reference/livechart#param-snap-key), `yAxis`,
 `referenceLines`, `formatValue`, …), plus the multi-series props below.
 
+## Reference-line tags
+
+<ParamField body="renderReferenceLine" type="(ctx: ReferenceLineRenderProps) => ReactElement | null">
+  Replace a Form-A reference line's built-in Skia badge or gutter label with any
+  React Native element. Return `null` or `undefined` for per-line fallback to the
+  built-in tag. The custom view tracks the line's live Y position, pins to the
+  nearest plot edge when off-axis, and respects left, center, and right badge
+  positions. The reference-line stroke remains visible. See
+  [Reference lines and bands](/guides/reference-lines-and-bands#custom-tags-renderreferenceline).
+</ParamField>
+
 ## Series data
 
 <ParamField body="series" type="SharedValue<SeriesConfig[]>" required>

--- a/docs/guides/reference-lines-and-bands.mdx
+++ b/docs/guides/reference-lines-and-bands.mdx
@@ -110,8 +110,9 @@ band around each draggable line is reserved for the drag.
 
 ## Custom tags (`renderReferenceLine`)
 
-Replace a line's built-in pill / gutter label with any **React Native** view — the same model as
-`renderMarker` / `renderTooltip`. The chart floats your element over the canvas and pins it to the
+On both `LiveChart` and `LiveChartSeries`, replace a line's built-in pill / gutter label with any
+**React Native** view — the same model as `renderMarker` / `renderTooltip`. The chart floats your
+element over the canvas and pins it to the
 line's value (vertically centered, horizontally at the badge / label position), tracking the
 rescaling axis and any drag without JS re-renders. Called per Form-A line; return `null` to keep
 that line's built-in tag (works with `badge: false` too). Bind the `ctx.value` / `ctx.valueStr`
@@ -131,6 +132,30 @@ renderReferenceLine={(ctx) =>
 
 `ctx` ([`ReferenceLineRenderProps`](/api-reference/types#annotations)) also carries `y`, `inRange`,
 `edge` (`"above"` / `"in"` / `"below"`, for a directional chevron), and `dragging` as SharedValues.
+
+For example, a multi-series market chart can use the app's native icon and localized target copy
+while leaving any other line on the built-in renderer:
+
+```tsx
+<LiveChartSeries
+  series={series}
+  referenceLines={[
+    { value: 0.66, label: "Target", badge: { position: "right" } },
+    { value: 0.5, label: "Midpoint", badge: { position: "center" } },
+  ]}
+  renderReferenceLine={({ line }) =>
+    line.label === "Target" ? (
+      <View style={styles.targetTag}>
+        <SolidUpIcon />
+        <Text>{t("market.target", { value: line.value })}</Text>
+      </View>
+    ) : null
+  }
+/>
+```
+
+The custom target owns only its tag: its dashed line still draws, while the midpoint keeps its
+built-in badge. The React Native tag is layered above the left-edge fade and scrub overlay.
 
 ## Grouping near-value lines (`referenceLineGrouping`)
 

--- a/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
@@ -126,6 +126,10 @@ function CustomReferenceLineView({
   // to the nearest plot edge (inset), matching the built-in off-axis badge.
   const y = useDerivedValue(() => {
     const ch = engine.canvasHeight.get();
+    // `computeScrubDotY` also returns negative values for legitimate prices above
+    // the visible range, so use the layout dimensions—not the projected Y—to
+    // distinguish an unmeasured canvas from an off-axis line.
+    if (ch - padding.top - padding.bottom <= 0) return -1;
     const raw = computeScrubDotY(
       value.get(),
       engine.displayMin.get(),
@@ -134,7 +138,6 @@ function CustomReferenceLineView({
       padding.top,
       padding.bottom,
     );
-    if (raw < 0) return -1;
     const top = padding.top + EDGE_INSET;
     const bottom = ch - padding.bottom - EDGE_INSET;
     return Math.min(bottom, Math.max(top, raw));

--- a/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
@@ -97,14 +97,16 @@ function CustomReferenceLineView({
   engine: ChartEngineLayout;
   padding: ChartPadding;
   formatValue: (v: number) => string;
-  dragValues: SharedValue<number[]>;
-  dragActive: SharedValue<boolean[]>;
+  /** Optional live overrides used by draggable single-series lines. */
+  dragValues?: SharedValue<number[]>;
+  /** Optional drag state used by draggable single-series lines. */
+  dragActive?: SharedValue<boolean[]>;
 }) {
   const staticValue = line.value ?? 0;
 
   // Live value: a drag override (if present) else the static prop value.
   const value = useDerivedValue<number>(() => {
-    const dv = dragValues.get()[index];
+    const dv = dragValues?.get()[index];
     return dv != null ? dv : staticValue;
   });
   const valueStr = useDerivedValue(() => formatValue(value.get()));
@@ -116,7 +118,9 @@ function CustomReferenceLineView({
     ),
   );
   const inRange = useDerivedValue(() => edge.get() === "in");
-  const dragging = useDerivedValue(() => dragActive.get()[index] === true);
+  const dragging = useDerivedValue(
+    () => dragActive?.get()[index] === true,
+  );
 
   // Canvas Y of the value (the element's vertical center). Off-screen values pin
   // to the nearest plot edge (inset), matching the built-in off-axis badge.
@@ -215,8 +219,10 @@ export function CustomReferenceLineOverlay({
   engine: ChartEngineLayout;
   padding: ChartPadding;
   formatValue: (v: number) => string;
-  dragValues: SharedValue<number[]>;
-  dragActive: SharedValue<boolean[]>;
+  /** Optional live overrides used by draggable single-series lines. */
+  dragValues?: SharedValue<number[]>;
+  /** Optional drag state used by draggable single-series lines. */
+  dragActive?: SharedValue<boolean[]>;
 }) {
   const children: React.ReactElement[] = [];
   for (let i = 0; i < lines.length; i++) {

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -83,6 +83,10 @@ import {
   labelConnector,
 } from "./ExtremaConnectorOverlay";
 import { CustomMarkerOverlay } from "./CustomMarkerOverlay";
+import {
+  CustomReferenceLineOverlay,
+  customReferenceLineFlags,
+} from "./CustomReferenceLineOverlay";
 import { CrosshairLine } from "./CrosshairLine";
 import { DegenParticlesOverlay } from "./DegenParticlesOverlay";
 import { LeftEdgeFade } from "./LeftEdgeFade";
@@ -172,6 +176,7 @@ function useLiveChartSeriesController({
   markerHitRadius = 16,
   markerCluster,
   renderMarker,
+  renderReferenceLine,
   leftEdgeFade = true,
 }: LiveChartSeriesProps) {
   const emptyMarkers = useSharedValue<Marker[]>([]);
@@ -224,6 +229,13 @@ function useLiveChartSeriesController({
 
   const allRefLines = referenceLines ?? [];
   const refValues = collectReferenceValues(allRefLines);
+  // Form-A lines a custom renderer owns keep their line stroke but suppress the
+  // built-in Skia tag. The callback is probed per line on the JS thread, matching
+  // LiveChart and CustomMarkerOverlay's per-item fallback model.
+  const refLineCustom = customReferenceLineFlags(
+    allRefLines,
+    renderReferenceLine,
+  );
 
   const palette = applyPaletteOverride(
     resolveTheme(accentColor, theme),
@@ -531,6 +543,7 @@ function useLiveChartSeriesController({
     degenCfg,
     metricsCfg,
     allRefLines,
+    refLineCustom,
     leftEdgeFadeCfg,
     // theme / layout / fonts
     palette,
@@ -568,6 +581,7 @@ function useLiveChartSeriesController({
     markerGroupOpacity,
     overlayScrubFade,
     renderMarker,
+    renderReferenceLine,
     // selection dot: resolved config + fallback color (the leading series' color)
     selectionDot: selectionDotCfg,
     selectionColor: lineColors[0],
@@ -808,6 +822,7 @@ function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
 function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
   const {
     allRefLines,
+    refLineCustom,
     engine,
     effectivePadding,
     palette,
@@ -830,6 +845,7 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
           formatValue={formatValue}
           font={skiaFont}
           badgeLayer
+          suppressTag={refLineCustom[i]}
         />
       ))}
     </Group>
@@ -868,6 +884,9 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     markersSV,
     markerClusterCfg,
     renderMarker,
+    renderReferenceLine,
+    allRefLines,
+    refLineCustom,
     overlayScrubFade,
   } = model;
 
@@ -972,23 +991,36 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
             padding={effectivePadding}
           />
 
-          {/* Custom-rendered markers — RN views floated over the canvas
-              (non-Skia), pinned to each marker's live position. Box-none fade
-              wrapper so `scrub.hideOverlaysOnScrub` hides them with the Skia
-              markers (full-bleed; children keep their own absolute positions). */}
-          {markersActive && renderMarker && (
+          {/* Custom annotations — RN views floated over the canvas (non-Skia),
+              pinned to their live positions. As a post-Canvas sibling they render
+              above the left-edge fade and scrub overlay. The box-none fade wrapper
+              keeps `scrub.hideOverlaysOnScrub` behavior aligned with Skia. */}
+          {((markersActive && renderMarker) ||
+            (renderReferenceLine && allRefLines.length > 0)) && (
             <Animated.View
               pointerEvents="box-none"
               style={[StyleSheet.absoluteFill, overlayFadeStyle]}
             >
-              <CustomMarkerOverlay
-                markers={markersSV}
-                renderMarker={renderMarker}
-                engine={engine}
-                padding={effectivePadding}
-                series={series}
-                cluster={markerClusterCfg}
-              />
+              {markersActive && renderMarker && (
+                <CustomMarkerOverlay
+                  markers={markersSV}
+                  renderMarker={renderMarker}
+                  engine={engine}
+                  padding={effectivePadding}
+                  series={series}
+                  cluster={markerClusterCfg}
+                />
+              )}
+              {renderReferenceLine && allRefLines.length > 0 && (
+                <CustomReferenceLineOverlay
+                  lines={allRefLines}
+                  renderReferenceLine={renderReferenceLine}
+                  custom={refLineCustom}
+                  engine={engine}
+                  padding={effectivePadding}
+                  formatValue={formatValue}
+                />
+              )}
             </Animated.View>
           )}
         </View>

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -249,8 +249,9 @@ export interface ReferenceLineBadgeConfig extends BadgeStyleConfig {
 }
 
 /**
- * Context passed to a custom {@link LiveChartProps.renderReferenceLine}. The chart
- * floats the element you return over the canvas and pins it to the line's value on
+ * Context passed to a custom {@link LiveChartProps.renderReferenceLine} or
+ * {@link LiveChartSeriesProps.renderReferenceLine}. The chart floats the element
+ * you return over the canvas and pins it to the line's value on
  * the UI thread (vertically centered on the line, horizontally at the badge /
  * label position) — so it tracks the rescaling axis and any drag smoothly without
  * JS re-renders, just like {@link TooltipRenderProps}. Replaces the built-in pill
@@ -2177,6 +2178,18 @@ export interface LiveChartProps extends LiveChartCoreProps {
 export interface LiveChartSeriesProps extends LiveChartCoreProps {
   /** Array of series definitions. Must be a SharedValue for UI-thread reads. */
   series: SharedValue<SeriesConfig[]>;
+  /**
+   * Render a Form-A reference line's tag as a custom **React Native** element
+   * instead of the built-in Skia pill / gutter label. The chart pins the returned
+   * element to the line's live Y position on the UI thread (see
+   * {@link ReferenceLineRenderProps}), including off-axis edge pinning. Return
+   * `null`/`undefined` to keep that line's built-in tag. The line stroke always
+   * remains visible, and `badge.position` / `labelPosition` controls the custom
+   * tag's left, center, or right anchor.
+   */
+  renderReferenceLine?: (
+    ctx: ReferenceLineRenderProps,
+  ) => ReactElement | null | undefined;
   /** Called when a series toggle chip is tapped. */
   onSeriesToggle?: (id: string, visible: boolean) => void;
   /**

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -5,6 +5,7 @@ import { useSharedValue } from "react-native-reanimated";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
+import { ReferenceLineOverlay } from "../src/components/ReferenceLineOverlay";
 import { DefaultSelectionDot } from "../src/components/SelectionDot";
 import type { SeriesConfig } from "../src/types";
 
@@ -92,6 +93,47 @@ describe("LiveChartSeries", () => {
     fireEvent(layoutView, "layout", {
       nativeEvent: { layout: { width: 400, height: 300 } },
     });
+  });
+
+  it("renders custom reference-line tags with per-line built-in fallback", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          referenceLines={[
+            { value: 11, label: "Target", badge: { position: "right" } },
+            { value: 12, label: "Built in", badge: { position: "center" } },
+          ]}
+          renderReferenceLine={({ line }) =>
+            line.label === "Target" ? <View testID="series-target" /> : null
+          }
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByTestId("series-target")).toBeTruthy());
+
+    const badgePass = screen
+      .UNSAFE_getAllByType(ReferenceLineOverlay)
+      .filter((overlay) => overlay.props.badgeLayer);
+    expect(badgePass.map((overlay) => overlay.props.suppressTag)).toEqual([
+      true,
+      false,
+    ]);
   });
 
   it("renders with per-series value lines", async () => {

--- a/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
@@ -147,19 +147,26 @@ describe("CustomReferenceLineOverlay", () => {
           { value: 50, badge: { position: "center" } },
           { value: 70, badge: { position: "right" } },
           { value: 150 }, // off-screen above → pinned to the top edge
+          { value: -50 }, // off-screen below → pinned to the bottom edge
         ]}
-        render={({ index }) => (
-          <View testID={`rl-${index}`} style={{ width: 40, height: 16 }} />
+        render={({ index, y }) => (
+          <View
+            testID={`rl-${index}`}
+            accessibilityLabel={`y:${y.get()}`}
+            style={{ width: 40, height: 16 }}
+          />
         )}
       />,
     );
     // Drive onLayout so the measure + transform branches execute for each anchor.
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 5; i++) {
       fireEvent(getByTestId(`rl-${i}`).parent!, "layout", {
         nativeEvent: { layout: { x: 0, y: 0, width: 40, height: 16 } },
       });
       expect(getByTestId(`rl-${i}`)).toBeTruthy();
     }
+    expect(getByTestId("rl-3").props.accessibilityLabel).toBe("y:24");
+    expect(getByTestId("rl-4").props.accessibilityLabel).toBe("y:260");
   });
 
   it("hides the element when the canvas is not laid out", () => {

--- a/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
@@ -123,6 +123,22 @@ describe("CustomReferenceLineOverlay", () => {
     expect(queryByTestId("rl-1")).toBeNull();
   });
 
+  it("uses the static line value when no drag state is provided", () => {
+    const { getByText } = render(
+      <CustomReferenceLineOverlay
+        lines={[{ value: 66 }]}
+        renderReferenceLine={({ value, dragging }) => (
+          <Text>{`${value.get()}:${dragging.get()}`}</Text>
+        )}
+        custom={[true]}
+        engine={engine()}
+        padding={DEFAULT_PADDING}
+        formatValue={fmt}
+      />,
+    );
+    expect(getByText("66:false")).toBeTruthy();
+  });
+
   it("pins across left / center / right anchors and an off-screen value", () => {
     const { getByTestId } = render(
       <Fixture


### PR DESCRIPTION
## Summary

- expose `renderReferenceLine` on `LiveChartSeriesProps` using `ReferenceLineRenderProps`
- reuse the live React Native reference-line overlay for multi-series charts, including in-range and off-axis positioning plus left, center, and right anchors
- suppress built-in tags only for custom-owned lines while preserving each line and per-line built-in fallback
- add integration coverage, API documentation, a multi-series example, and an Unreleased changelog entry

## Why

`LiveChartSeries` previously limited reference-line tags to the built-in Skia renderer, so consumers could not use app-native icons, localized copy, or design-system components for multi-series targets.

Closes #219.

## Validation

- `npm run verify` (typecheck, lint, 95 test suites / 1,347 passing tests)
- `npx react-doctor@latest --verbose --diff` (no changed-code regressions)
