### PR TITLE
feat: add opt-in opaque Android canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Experimental opaque Skia canvas rendering.** `LiveChart` and `LiveChartSeries` accept
+  `canvasMode="opaque"`, which selects SurfaceView on Android, explicitly paints the palette
+  background, and uses opaque-safe alternatives for the left-edge fade, scrub dim, and loading
+  gap. The existing transparent TextureView path remains the default and fallback for charts
+  that reveal content behind them. Includes a visual demo and controlled release profiling
+  harness. ([#215](https://github.com/brandtnewlabs/react-native-livechart/issues/215))
+
 - **`LiveChartSeries` now supports custom React Native reference-line tags.**
   `renderReferenceLine` provides the same per-line built-in fallback, live Y / off-axis
   positioning, and left / center / right anchoring as `LiveChart`, while preserving

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -163,6 +163,11 @@ const SECTIONS: DemoSection[] = [
         title: "Extrema labels",
         blurb: 'topLabel / bottomLabel at the actual high / low point (position="extrema").',
       },
+      {
+        href: "/demo/android-surface-rendering",
+        title: "Android surface rendering",
+        blurb: "Experimental TextureView vs opaque SurfaceView rendering and mask fallbacks.",
+      },
     ],
   },
   {
@@ -230,6 +235,9 @@ export default function Index() {
   const insets = useSafeAreaInsets();
   if (process.env.EXPO_PUBLIC_THRESHOLD_SHADER_PROFILE_MODE) {
     return <Redirect href={"/threshold-shader-profile" as Href} />;
+  }
+  if (process.env.EXPO_PUBLIC_ANDROID_SURFACE_PROFILE_MODE) {
+    return <Redirect href={"/android-surface-profile" as Href} />;
   }
   if (
     process.env.EXPO_PUBLIC_MEMORY_PROFILE_MODE ||

--- a/app/android-surface-profile.tsx
+++ b/app/android-surface-profile.tsx
@@ -1,0 +1,54 @@
+import { StyleSheet, Text, View } from "react-native";
+import { LiveChart, type CanvasMode } from "react-native-livechart";
+import { useSimulatedChartData } from "../sim/useSimulatedChartData";
+
+const requestedMode = process.env.EXPO_PUBLIC_ANDROID_SURFACE_PROFILE_MODE;
+const canvasMode: CanvasMode =
+  requestedMode === "opaque" ? "opaque" : "transparent";
+
+/** Fixed-workload release-build harness for TextureView vs SurfaceView captures. */
+export default function AndroidSurfaceProfileScreen() {
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    tradesPerSecond: 30,
+    maxPoints: 10_000,
+    historySpanSeconds: 120,
+    historyRange: "1m",
+  });
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.label}>ANDROID SURFACE PROFILE · {canvasMode}</Text>
+      <View style={styles.chart}>
+        <LiveChart
+          data={data}
+          value={value}
+          canvasMode={canvasMode}
+          timeWindow={120}
+          scrub={false}
+          accessibilityLabel={`${canvasMode} profiling chart`}
+        />
+        <View pointerEvents="none" style={styles.overlay}>
+          <Text style={styles.overlayText}>RN OVERLAY</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, paddingTop: 80, backgroundColor: "#09090b" },
+  label: { color: "#ffffff", padding: 12, fontSize: 16, fontWeight: "700" },
+  chart: { flex: 1, overflow: "hidden", borderRadius: 24, margin: 12 },
+  overlay: {
+    position: "absolute",
+    left: 16,
+    top: 16,
+    padding: 8,
+    borderRadius: 8,
+    backgroundColor: "#ec4899",
+  },
+  overlayText: { color: "#ffffff", fontSize: 12, fontWeight: "800" },
+});

--- a/app/demo/android-surface-rendering.tsx
+++ b/app/demo/android-surface-rendering.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import {
+  LiveChart,
+  type CanvasMode,
+  type ThemeMode,
+} from "react-native-livechart";
+import { ChipRow, ToggleChip, ControlRow } from "../../demo-lib/ChipRow";
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { colors } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Android surface rendering" };
+
+const MODES: { value: CanvasMode; label: string }[] = [
+  { value: "transparent", label: "TextureView" },
+  { value: "opaque", label: "SurfaceView" },
+];
+
+const THEMES: { value: ThemeMode; label: string }[] = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
+export default function AndroidSurfaceRenderingScreen() {
+  const [canvasMode, setCanvasMode] = useState<CanvasMode>("transparent");
+  const [theme, setTheme] = useState<ThemeMode>("light");
+  const [loading, setLoading] = useState(false);
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    historySpanSeconds: 60,
+    historyRange: "1m",
+  });
+
+  return (
+    <DemoScreen
+      title="Android surface rendering"
+      docs="guides/android-surface-rendering"
+      description="Compare the default transparent TextureView with the experimental opaque SurfaceView path."
+      chart={
+        <View style={styles.chartShell}>
+          <LiveChart
+            data={data}
+            value={value}
+            canvasMode={canvasMode}
+            theme={theme}
+            loading={loading}
+            accessibilityLabel={`${canvasMode} ${theme} live chart`}
+          />
+          <View pointerEvents="none" style={styles.siblingOverlay}>
+            <Text style={styles.siblingText}>RN sibling overlay</Text>
+          </View>
+        </View>
+      }
+    >
+      <ChipRow
+        label="Android backing view"
+        options={MODES}
+        value={canvasMode}
+        onChange={setCanvasMode}
+      />
+      <ChipRow
+        label="Background"
+        options={THEMES}
+        value={theme}
+        onChange={setTheme}
+      />
+      <ControlRow label="States">
+        <ToggleChip
+          label="Loading / empty mask"
+          value={loading}
+          onChange={setLoading}
+        />
+      </ControlRow>
+    </DemoScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  chartShell: { flex: 1, overflow: "hidden", borderRadius: 16 },
+  siblingOverlay: {
+    position: "absolute",
+    left: 12,
+    top: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    backgroundColor: "rgba(236,72,153,0.9)",
+  },
+  siblingText: { color: colors.background, fontSize: 11, fontWeight: "700" },
+});

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -11,8 +11,12 @@ import { LiveChartSeries } from "react-native-livechart";
 `LiveChartSeries` draws several line series sharing an axis, time window, and crosshair. It
 accepts all the shared theming, axis, range, layout, and text props from
 [`LiveChart`](/api-reference/livechart) (`theme`, `accentColor`, `palette`, `metrics`, `font`,
-`timeWindow`, `smoothing`, [`snapKey`](/api-reference/livechart#param-snap-key), `yAxis`,
+`canvasMode`, `timeWindow`, `smoothing`, [`snapKey`](/api-reference/livechart#param-snap-key), `yAxis`,
 `referenceLines`, `formatValue`, …), plus the multi-series props below.
+
+On Android, the shared experimental `canvasMode="opaque"` option selects an opaque SurfaceView and
+paints the palette background inside the canvas. See
+[Android surface rendering](/guides/android-surface-rendering) for constraints and profiling guidance.
 
 ## Reference-line tags
 

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -450,6 +450,13 @@ provided; everything else has a default.
 
 ## Theming & layout
 
+<ParamField body="canvasMode" type='"transparent" | "opaque"' default='"transparent"'>
+  Experimental canvas composition mode. On Android, `"transparent"` uses Skia's default
+  TextureView path; `"opaque"` owns and paints the palette background and selects SurfaceView.
+  Keep the default when content behind the chart must remain visible. Profile release builds on
+  physical hardware before enabling broadly. See [Android surface rendering](/guides/android-surface-rendering).
+</ParamField>
+
 <ParamField body="theme" type='"light" | "dark"' default='"dark"'>
   Color scheme.
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -16,6 +16,14 @@ the most-used shapes are reproduced here.
 ## Data
 
 ```ts
+type CanvasMode = "transparent" | "opaque";
+```
+
+`CanvasMode` controls whether the Skia canvas participates in transparent composition or owns its
+background. On Android, opaque mode selects SurfaceView. See
+[Android surface rendering](/guides/android-surface-rendering).
+
+```ts
 interface LiveChartPoint {
   time: number;  // unix seconds
   value: number;

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,7 +80,8 @@
               "guides/theming",
               "guides/badge-styling",
               "guides/axes-and-grid",
-              "guides/extrema-labels"
+              "guides/extrema-labels",
+              "guides/android-surface-rendering"
             ]
           },
           {

--- a/docs/guides/android-surface-rendering.mdx
+++ b/docs/guides/android-surface-rendering.mdx
@@ -1,0 +1,76 @@
+---
+title: Android surface rendering
+icon: "mobile-screen"
+description: "Profile the experimental opaque SurfaceView canvas and know when to keep TextureView."
+---
+
+`LiveChart` and `LiveChartSeries` use Skia's transparent canvas mode by default. On Android,
+that is backed by a `TextureView`, which composes naturally with content behind the chart.
+
+For an opaque chart, you can profile Skia's `SurfaceView` path:
+
+```tsx
+<LiveChart data={data} value={value} canvasMode="opaque" />
+```
+
+`canvasMode="opaque"` is experimental and opt-in. The chart paints the resolved palette
+background as the first canvas draw, then uses background-color composites for the left-edge
+fade, scrub dim, and loading/empty label gap. This preserves those effects without relying on
+destination alpha.
+
+## When to keep the default
+
+Keep `canvasMode="transparent"` when the chart must reveal an image, gradient, blur, video, or
+other content behind it. It is also the fallback if a consuming layout shows SurfaceView-specific
+problems with sibling ordering, clipping, transforms, parent scrolling, gestures, screenshots,
+or accessibility overlays.
+
+The mode name describes composition, not the theme: opaque mode supports both light and dark
+palettes and responds to palette changes. A custom `style.backgroundColor` does not replace the
+canvas-owned background; set `theme` or `palette.bgRgb` so the painted background and surrounding
+container agree.
+
+## Profiling
+
+Do not choose SurfaceView from emulator timings. Compare identical release builds on representative
+physical Android devices and hold the workload, refresh rate, temperature, and power mode constant.
+Capture at least:
+
+- frame-time p90/p99 and missed frames;
+- `dumpsys gfxinfo`;
+- Perfetto RenderThread and GPU/compositor slices;
+- SurfaceFlinger layers;
+- visual screenshots while scrubbing and loading.
+
+This repository includes a fixed workload at `app/android-surface-profile.tsx`. Select the backing
+view at bundle time with `EXPO_PUBLIC_ANDROID_SURFACE_PROFILE_MODE=transparent` or `opaque`.
+
+## Physical-device result
+
+The controlled harness was captured on a physical Samsung Galaxy S24 (`SM-S921B`) at 120 Hz using
+release builds, 10,000 retained points, a 120-second visible window, and 30 incoming updates per
+second. Each row is normalized to the active Perfetto animation span so the two trace lengths do not
+skew the comparison.
+
+| Metric | Transparent TextureView | Opaque SurfaceView |
+| --- | ---: | ---: |
+| Animation callbacks per second | 119.75 | 101.35 |
+| Animation slice p90 / p99 | 6.51 / 7.77 ms | 10.51 / 12.30 ms |
+| Animation slices over the 8.33 ms budget | 0.3% | 99.5% |
+| App scheduled CPU | 1,601 ms/s | 1,318 ms/s |
+| Main-thread scheduled CPU | 746 ms/s | 981 ms/s |
+| Android RenderThread scheduled CPU | 438 ms/s | 0 ms/s |
+| SurfaceFlinger scheduled CPU | 471 ms/s | 404 ms/s |
+
+SurfaceView eliminated the Android RenderThread composition pass and reduced total app scheduled CPU
+by about 18%, but moved rendering onto the main thread and failed the 120 Hz frame budget. The
+transparent run's `dumpsys gfxinfo` window reported p90 / p99 of 10 / 11 ms and no modern frame
+deadline misses. Android does not include the separately composed SurfaceView's chart frames in that
+counter, so the opaque row uses Perfetto rather than treating its zero-frame `gfxinfo` report as a
+performance result.
+
+SurfaceFlinger confirmed a separate, device-composed, opaque layer for SurfaceView. Physical
+screenshots also preserved the chart, rounded clipping, and a React Native sibling overlay. The
+result supports keeping `"transparent"` as the default and exposing `"opaque"` only as a profiled,
+layout-specific opt-in. Repeat the matrix on the consuming app's representative devices before
+enabling it broadly.

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -25,6 +25,7 @@ export function CrosshairLine({
   crosshairLineColor,
   crosshairDash,
   crosshairDimColor,
+  opaqueCanvas = false,
 }: {
   scrubX: SharedValue<number>;
   crosshairOpacity: SharedValue<number>;
@@ -52,6 +53,8 @@ export function CrosshairLine({
   /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
   crosshairDash?: number[];
   crosshairDimColor?: string;
+  /** Paint the owned background instead of erasing destination alpha. */
+  opaqueCanvas?: boolean;
 }) {
   // Explicit dependency arrays: with React Compiler enabled, Reanimated's
   // auto-detected worklet dependencies can change array size between renders
@@ -89,6 +92,11 @@ export function CrosshairLine({
     () => `rgba(0,0,0,${(1 - dimOpacity) * crosshairOpacity.value})`,
     [dimOpacity, crosshairOpacity],
   );
+  const opaqueDimOpacity = useDerivedValue(
+    () => (1 - dimOpacity) * crosshairOpacity.value,
+    [dimOpacity, crosshairOpacity],
+  );
+  const backgroundColor = `rgb(${palette.bgRgb[0]},${palette.bgRgb[1]},${palette.bgRgb[2]})`;
 
   return (
     <>
@@ -103,6 +111,15 @@ export function CrosshairLine({
             color={crosshairDimColor}
           />
         </Group>
+      ) : dimOpacity < 1 && opaqueCanvas ? (
+        <Rect
+          x={scrubX}
+          y={padding.top}
+          width={dimWidth}
+          height={dimHeight}
+          color={backgroundColor}
+          opacity={opaqueDimOpacity}
+        />
       ) : dimOpacity < 1 ? (
         // Erase the trailing content's alpha so it fades to the real background.
         <Group blendMode="dstOut">

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -43,6 +43,7 @@ export function CrosshairOverlay({
   tooltipBorderRadius = 5,
   tooltipShowValue = true,
   tooltipShowTime = true,
+  opaqueCanvas = false,
 }: {
   scrubX: SharedValue<number>;
   crosshairOpacity: SharedValue<number>;
@@ -94,6 +95,8 @@ export function CrosshairOverlay({
   tooltipShowValue?: boolean;
   /** Draw the time row of the default tooltip body. Default true. */
   tooltipShowTime?: boolean;
+  /** Paint the owned background instead of erasing destination alpha. */
+  opaqueCanvas?: boolean;
 }) {
   // Explicit dependency arrays: with React Compiler enabled, Reanimated's
   // auto-detected worklet dependencies can change array size between renders
@@ -101,18 +104,15 @@ export function CrosshairOverlay({
   // React's "final argument changed size between renders" error. Listing the
   // captured plain values keeps the dependency array a constant size. SharedValue
   // reads stay reactive regardless of this list.
-  const p1 = useDerivedValue(
-    () => {
-      // A top-pinned custom tooltip pushes the line's start down to its measured
-      // bottom (lineTop) so the line stops at the label; -1 → no top tooltip.
-      const lt = lineTop?.value ?? -1;
-      return {
-        x: scrubX.value,
-        y: lt >= 0 ? lt : padding.top,
-      };
-    },
-    [scrubX, padding.top, lineTop],
-  );
+  const p1 = useDerivedValue(() => {
+    // A top-pinned custom tooltip pushes the line's start down to its measured
+    // bottom (lineTop) so the line stops at the label; -1 → no top tooltip.
+    const lt = lineTop?.value ?? -1;
+    return {
+      x: scrubX.value,
+      y: lt >= 0 ? lt : padding.top,
+    };
+  }, [scrubX, padding.top, lineTop]);
   const p2 = useDerivedValue(
     () => ({
       x: scrubX.value,
@@ -153,6 +153,11 @@ export function CrosshairOverlay({
     () => `rgba(0,0,0,${(1 - dimOpacity) * crosshairOpacity.value})`,
     [dimOpacity, crosshairOpacity],
   );
+  const opaqueDimOpacity = useDerivedValue(
+    () => (1 - dimOpacity) * crosshairOpacity.value,
+    [dimOpacity, crosshairOpacity],
+  );
+  const backgroundColor = `rgb(${palette.bgRgb[0]},${palette.bgRgb[1]},${palette.bgRgb[2]})`;
 
   return (
     <>
@@ -167,6 +172,15 @@ export function CrosshairOverlay({
             color={crosshairDimColor}
           />
         </Group>
+      ) : dimOpacity < 1 && opaqueCanvas ? (
+        <Rect
+          x={scrubX}
+          y={padding.top}
+          width={dimWidth}
+          height={dimHeight}
+          color={backgroundColor}
+          opacity={opaqueDimOpacity}
+        />
       ) : dimOpacity < 1 ? (
         // Erase the trailing content's alpha so it fades to the real background
         // (works on any background color, unlike a colored mask).
@@ -203,29 +217,28 @@ export function CrosshairOverlay({
         />
 
         {showTooltip && (
-        <>
-          <RoundedRect
-            x={tipX}
-            y={tipY}
-            width={tipW}
-            height={tipH}
-            r={tooltipBorderRadius}
-            color={tooltipBackground ?? palette.tooltipBg}
-          />
+          <>
+            <RoundedRect
+              x={tipX}
+              y={tipY}
+              width={tipW}
+              height={tipH}
+              r={tooltipBorderRadius}
+              color={tooltipBackground ?? palette.tooltipBg}
+            />
 
-          <RoundedRect
-            x={tipX}
-            y={tipY}
-            width={tipW}
-            height={tipH}
-            r={tooltipBorderRadius}
-            color={tooltipBorderColor ?? palette.tooltipBorder}
-            style="stroke"
-            strokeWidth={1}
-          />
+            <RoundedRect
+              x={tipX}
+              y={tipY}
+              width={tipW}
+              height={tipH}
+              r={tooltipBorderRadius}
+              color={tooltipBorderColor ?? palette.tooltipBorder}
+              style="stroke"
+              strokeWidth={1}
+            />
 
-          {children ??
-            renderTooltip?.() ?? (
+            {children ?? renderTooltip?.() ?? (
               <Group>
                 {tooltipShowValue && (
                   <SkiaText
@@ -247,8 +260,8 @@ export function CrosshairOverlay({
                 )}
               </Group>
             )}
-        </>
-      )}
+          </>
+        )}
       </Group>
     </>
   );

--- a/packages/react-native-livechart/src/components/LeftEdgeFade.tsx
+++ b/packages/react-native-livechart/src/components/LeftEdgeFade.tsx
@@ -2,6 +2,7 @@ import { Group, LinearGradient, Rect, vec } from "@shopify/react-native-skia";
 
 import { useDerivedValue } from "react-native-reanimated";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import { parseColorRgba } from "../theme";
 
 export function LeftEdgeFade({
   paddingLeft,
@@ -9,27 +10,32 @@ export function LeftEdgeFade({
   startColor,
   endColor,
   engine,
+  opaqueBackgroundRgb,
 }: {
   paddingLeft: number;
   fadeWidth: number;
   startColor: string;
   endColor: string;
   engine: ChartEngineLayout;
+  /** When set, paint the owned background instead of erasing destination alpha. */
+  opaqueBackgroundRgb?: [number, number, number];
 }) {
   const rectWidth = paddingLeft + fadeWidth;
   const height = useDerivedValue(() => engine.canvasHeight.value);
 
   const gStart = vec(paddingLeft, 0);
   const gEnd = vec(paddingLeft + fadeWidth, 0);
+  const colors = opaqueBackgroundRgb
+    ? [
+        `rgba(${opaqueBackgroundRgb[0]},${opaqueBackgroundRgb[1]},${opaqueBackgroundRgb[2]},${parseColorRgba(startColor)[3]})`,
+        `rgba(${opaqueBackgroundRgb[0]},${opaqueBackgroundRgb[1]},${opaqueBackgroundRgb[2]},${parseColorRgba(endColor)[3]})`,
+      ]
+    : [startColor, endColor];
 
   return (
-    <Group blendMode="dstOut">
+    <Group blendMode={opaqueBackgroundRgb ? undefined : "dstOut"}>
       <Rect x={0} y={0} width={rectWidth} height={height}>
-        <LinearGradient
-          start={gStart}
-          end={gEnd}
-          colors={[startColor, endColor]}
-        />
+        <LinearGradient start={gStart} end={gEnd} colors={colors} />
       </Rect>
     </Group>
   );

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -27,6 +21,7 @@ import {
   Group,
   LinearGradient,
   Path,
+  Rect,
   vec,
 } from "@shopify/react-native-skia";
 
@@ -253,6 +248,7 @@ function useLiveChartController({
   font: fontProp,
   insets,
   style,
+  canvasMode = "transparent",
 
   // ── Candlestick ─────────────────────────────────────────────────────────
   mode = "line",
@@ -1204,6 +1200,7 @@ function useLiveChartController({
   return {
     // passthrough props the render needs
     style,
+    canvasMode,
     accessibilityLabel,
     accessibilityRole,
     emptyText,
@@ -1362,9 +1359,7 @@ function ChartWithDegen({
     onDegenShake,
     isStatic,
   );
-  return (
-    <ChartView model={model} yAxisEntries={yAxisEntries} degen={state} />
-  );
+  return <ChartView model={model} yAxisEntries={yAxisEntries} degen={state} />;
 }
 
 /**
@@ -1721,6 +1716,7 @@ function ChartStack({
     loadingStrokeWidth,
     loadingAmplitude,
     loadingSpeed,
+    canvasMode,
   } = model;
   return (
     <Group transform={degen?.shakeTransform}>
@@ -1939,6 +1935,7 @@ function ChartStack({
         lineStrokeWidth={loadingStrokeWidth}
         waveAmplitude={loadingAmplitude}
         waveSpeed={loadingSpeed}
+        opaqueCanvas={canvasMode === "opaque"}
       />
     </Group>
   );
@@ -2003,6 +2000,7 @@ function ChartScrubLayer({
     selectionDot,
     selectionColor,
     renderTooltip,
+    canvasMode,
   } = model;
   // A custom tooltip is an RN overlay (sibling of <Canvas>), so the built-in
   // Skia tooltip is suppressed here while it's active — the line pill in line
@@ -2047,6 +2045,7 @@ function ChartScrubLayer({
           tooltipBorderRadius={scrubCfg.tooltipBorderRadius}
           tooltipShowValue={scrubCfg.tooltipShowValue}
           tooltipShowTime={scrubCfg.tooltipShowTime}
+          opaqueCanvas={canvasMode === "opaque"}
         >
           {/* Candle charts render a multi-line OHLC tooltip; the line
               chart falls back to CrosshairOverlay's default value/time
@@ -2364,6 +2363,7 @@ function ChartView({
     extremaTimeOffset,
     topConnector,
     bottomConnector,
+    canvasMode,
   } = model;
 
   return (
@@ -2375,7 +2375,21 @@ function ChartView({
         accessibilityLabel={accessibilityLabel}
         accessibilityRole={accessibilityRole}
       >
-        <Canvas style={{ flex: 1 }}>
+        {/* Skia chooses TextureView vs SurfaceView when the native Canvas mounts. */}
+        <Canvas
+          key={canvasMode}
+          style={{ flex: 1 }}
+          opaque={canvasMode === "opaque"}
+        >
+          {canvasMode === "opaque" && (
+            <Rect
+              x={0}
+              y={0}
+              width={engine.canvasWidth}
+              height={engine.canvasHeight}
+              color={backgroundColor}
+            />
+          )}
           {/* Background fills first, then the left-edge fade (a canvas-space sibling
               so dstOut blends correctly), then the line stack on top — so the fade
               softens only the fills and the line stays crisp at the left edge. */}
@@ -2392,15 +2406,14 @@ function ChartView({
               startColor={leftEdgeFadeCfg.startColor}
               endColor={leftEdgeFadeCfg.endColor}
               engine={engine}
+              opaqueBackgroundRgb={
+                canvasMode === "opaque" ? palette.bgRgb : undefined
+              }
             />
           )}
 
           {/* Line stack above the fade so the line stays crisp at the left edge. */}
-          <ChartStack
-            model={model}
-            yAxisEntries={yAxisEntries}
-            degen={degen}
-          />
+          <ChartStack model={model} yAxisEntries={yAxisEntries} degen={degen} />
 
           {/* "extrema-edge" connector lines (dot → edge readout), above the chart
               content so the dashed guide reads over the line / candles. */}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -4,7 +4,7 @@
  *
  * @see https://github.com/benjitaylor/liveline
  */
-import { Canvas, Group } from "@shopify/react-native-skia";
+import { Canvas, Group, Rect } from "@shopify/react-native-skia";
 import { useLayoutEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -132,6 +132,7 @@ function useLiveChartSeriesController({
   font: fontProp,
   insets,
   style,
+  canvasMode = "transparent",
   timeWindow = 30,
   paused = false,
   loading = false,
@@ -271,10 +272,7 @@ function useLiveChartSeriesController({
   // Mount per-series drawing worklets only for real series. The previous fixed
   // 12-slot render kept 144 derived-value mappers alive for the default stroke,
   // dot, and value-label layers even when a chart contained only one line.
-  const activeSeriesCount = Math.min(
-    seriesSnapshot.length,
-    MAX_MULTI_SERIES,
-  );
+  const activeSeriesCount = Math.min(seriesSnapshot.length, MAX_MULTI_SERIES);
 
   const maxSeriesLabelWidth = dotCfg.valueLabel
     ? Math.max(
@@ -527,6 +525,7 @@ function useLiveChartSeriesController({
     // passthrough props the render needs
     series,
     style,
+    canvasMode,
     accessibilityLabel,
     accessibilityRole,
     emptyText,
@@ -637,6 +636,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     loadingStrokeWidth,
     loadingAmplitude,
     loadingSpeed,
+    canvasMode,
     activeSeriesCount,
   } = model;
 
@@ -780,6 +780,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         lineStrokeWidth={loadingStrokeWidth}
         waveAmplitude={loadingAmplitude}
         waveSpeed={loadingSpeed}
+        opaqueCanvas={canvasMode === "opaque"}
       />
     </Group>
   );
@@ -830,6 +831,7 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
     skiaFont,
     degenShakeTransform,
     overlayScrubFade,
+    canvasMode,
   } = model;
   if (allRefLines.length === 0) return null;
   return (
@@ -888,6 +890,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     allRefLines,
     refLineCustom,
     overlayScrubFade,
+    canvasMode,
   } = model;
 
   // Mirror the Skia overlay fade onto the RN custom-marker sibling so
@@ -930,7 +933,21 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
           else points map into a taller area and the x-axis draws past the edge. */}
       <GestureDetector gesture={rootGesture}>
         <View style={{ flex: 1 }} onLayout={onLayout}>
-          <Canvas style={{ flex: 1, minHeight: layoutHeight || 1 }}>
+          {/* Skia chooses TextureView vs SurfaceView when the native Canvas mounts. */}
+          <Canvas
+            key={canvasMode}
+            style={{ flex: 1, minHeight: layoutHeight || 1 }}
+            opaque={canvasMode === "opaque"}
+          >
+            {canvasMode === "opaque" && (
+              <Rect
+                x={0}
+                y={0}
+                width={engine.canvasWidth}
+                height={engine.canvasHeight}
+                color={backgroundColor}
+              />
+            )}
             <SeriesChartStack model={model} />
 
             {/* "extrema-edge" connector lines (dot → edge readout). Outside the
@@ -949,6 +966,9 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 startColor={leftEdgeFadeCfg.startColor}
                 endColor={leftEdgeFadeCfg.endColor}
                 engine={engine}
+                opaqueBackgroundRgb={
+                  canvasMode === "opaque" ? palette.bgRgb : undefined
+                }
               />
             )}
 
@@ -971,6 +991,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 crosshairLineColor={scrubCfg.crosshairLineColor}
                 crosshairDash={scrubCfg.crosshairDash}
                 crosshairDimColor={scrubCfg.crosshairDimColor}
+                opaqueCanvas={canvasMode === "opaque"}
               />
             )}
 

--- a/packages/react-native-livechart/src/components/LoadingOverlay.tsx
+++ b/packages/react-native-livechart/src/components/LoadingOverlay.tsx
@@ -68,6 +68,7 @@ export function LoadingOverlay({
   lineStrokeWidth,
   waveAmplitude = 14,
   waveSpeed = 1,
+  opaqueCanvas = false,
 }: {
   engine: ChartEngineLayout;
   padding: ChartPadding;
@@ -87,6 +88,8 @@ export function LoadingOverlay({
   waveAmplitude?: number;
   /** Breathing-wave speed multiplier. */
   waveSpeed?: number;
+  /** Paint the owned background instead of erasing destination alpha. */
+  opaqueCanvas?: boolean;
   /** Mirror the badge prop so labels align with GridOverlay's label positions. */
   badge?: boolean;
   /** Whether the badge tail spike is shown; affects the left inset used for skeleton alignment. */
@@ -100,12 +103,22 @@ export function LoadingOverlay({
 }) {
   // Same left-inset formula as GridOverlay (only used when badge=true)
   const leftInset =
-    badgeMetrics.dotGap + badgeTailAndCap(font.getSize(), badgeTail, badgeMetrics);
+    badgeMetrics.dotGap +
+    badgeTailAndCap(font.getSize(), badgeTail, badgeMetrics);
 
   // Loading-shell color (squiggle + skeleton placeholders) and squiggle stroke,
   // both overridable via `loading={{ color, strokeWidth }}`.
   const loadingColor = lineColor ?? palette.gridLine;
   const loadingStroke = lineStrokeWidth ?? strokeWidth;
+  const [bgR, bgG, bgB] = palette.bgRgb;
+  const gapMaskColors = opaqueCanvas
+    ? [
+        `rgba(${bgR},${bgG},${bgB},0)`,
+        `rgb(${bgR},${bgG},${bgB})`,
+        `rgb(${bgR},${bgG},${bgB})`,
+        `rgba(${bgR},${bgG},${bgB},0)`,
+      ]
+    : ["rgba(0,0,0,0)", "rgba(0,0,0,1)", "rgba(0,0,0,1)", "rgba(0,0,0,0)"];
 
   // Squiggly path — built into a reused PathBuilder and detach()-ed each frame.
   const squigglyBuilder = usePathBuilder();
@@ -257,17 +270,15 @@ export function LoadingOverlay({
       />
 
       {/* Erase a soft horizontal band through the squiggle for the label (dstOut) */}
-      <Group opacity={showGapGroup} blendMode="dstOut">
+      <Group
+        opacity={showGapGroup}
+        blendMode={opaqueCanvas ? undefined : "dstOut"}
+      >
         <Rect x={gapLeft} y={gapTop} width={gapWidth} height={gapHeight}>
           <LinearGradient
             start={vec(0, 0)}
             end={gapGradEnd}
-            colors={[
-              "rgba(0,0,0,0)",
-              "rgba(0,0,0,1)",
-              "rgba(0,0,0,1)",
-              "rgba(0,0,0,0)",
-            ]}
+            colors={gapMaskColors}
             positions={gapGradientPositions}
           />
         </Rect>
@@ -282,7 +293,7 @@ export function LoadingOverlay({
             width={RECT_W}
             height={RECT_H}
             r={RECT_R}
-        color={loadingColor}
+            color={loadingColor}
           />
           <RoundedRect
             x={lx}
@@ -290,7 +301,7 @@ export function LoadingOverlay({
             width={RECT_W}
             height={RECT_H}
             r={RECT_R}
-        color={loadingColor}
+            color={loadingColor}
           />
           <RoundedRect
             x={lx}
@@ -298,7 +309,7 @@ export function LoadingOverlay({
             width={RECT_W}
             height={RECT_H}
             r={RECT_R}
-        color={loadingColor}
+            color={loadingColor}
           />
           <RoundedRect
             x={lx}
@@ -306,7 +317,7 @@ export function LoadingOverlay({
             width={RECT_W}
             height={RECT_H}
             r={RECT_R}
-        color={loadingColor}
+            color={loadingColor}
           />
         </>
       ) : null}

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -40,6 +40,7 @@ export type {
   BadgeVariant,
   CandleMetrics,
   CandlePoint,
+  CanvasMode,
   ChartInsets,
   ChartOverlayContext,
   ChartPlotRect,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -44,6 +44,10 @@ export type FontWeight =
 /** Color scheme for the chart background, grid, and derived palette colors. */
 export type ThemeMode = "light" | "dark";
 
+/** Skia canvas composition mode. Android uses TextureView for `"transparent"`
+ * and an opaque SurfaceView for `"opaque"`. */
+export type CanvasMode = "transparent" | "opaque";
+
 /**
  * Badge pill style.
  * - `"default"` — accent-colored background with white text.
@@ -1123,7 +1127,8 @@ export interface TradeEvent {
 }
 
 /** Built-in marker glyph kinds drawn into the chart canvas. */
-export type MarkerKind = "trade" | "boost" | "graduation" | "winner" | "clawback";
+export type MarkerKind =
+  "trade" | "boost" | "graduation" | "winner" | "clawback";
 
 /**
  * A marker rendered into the chart at `(time, y)`. Exactly one of `seriesId`
@@ -1749,6 +1754,18 @@ export interface LiveChartCoreProps {
   insets?: ChartInsets;
   /** Container View style. */
   style?: ViewStyle;
+  /**
+   * Canvas composition mode. `"transparent"` keeps Skia's default compositing
+   * path (TextureView on Android) and can reveal content behind the chart.
+   * `"opaque"` makes the canvas own and paint its palette background; on Android
+   * this selects SurfaceView and may reduce RenderThread work, but it cannot be
+   * used when the chart must reveal content behind it. Default `"transparent"`.
+   *
+   * @experimental Profile on representative physical Android hardware before
+   * enabling broadly; SurfaceView ordering, clipping, transforms, screenshots,
+   * and parent scrolling should be validated in the consuming layout.
+   */
+  canvasMode?: CanvasMode;
   /** Visible time window in seconds. Default `30`. */
   timeWindow?: number;
   /** Freeze chart scrolling. Resume catches up to real time. Default `false`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -169,6 +169,48 @@ describe("LiveChart", () => {
     });
   });
 
+  it("opts into an opaque canvas and replaces destination-alpha masks", () => {
+    const screen = render(
+      <Harness canvasMode="opaque" theme="light" loading />,
+    );
+    let views = screen.UNSAFE_getAllByType(View);
+
+    expect(views.some((view) => view.props.opaque === true)).toBe(true);
+    expect(views.some((view) => view.props.blendMode === "dstOut")).toBe(false);
+    expect(
+      views.some(
+        (view) =>
+          typeof view.props.color === "string" &&
+          view.props.color.includes("250, 250, 250"),
+      ),
+    ).toBe(true);
+
+    screen.rerender(
+      <Harness
+        canvasMode="opaque"
+        theme="dark"
+        palette={{ bgRgb: [12, 34, 56] }}
+      />,
+    );
+    views = screen.UNSAFE_getAllByType(View);
+    expect(
+      views.some(
+        (view) =>
+          typeof view.props.color === "string" &&
+          view.props.color.includes("12, 34, 56"),
+      ),
+    ).toBe(true);
+    expect(views.some((view) => view.props.blendMode === "dstOut")).toBe(false);
+  });
+
+  it("keeps the transparent canvas and destination-alpha masks as the fallback", () => {
+    const screen = render(<Harness canvasMode="transparent" />);
+    const views = screen.UNSAFE_getAllByType(View);
+
+    expect(views.some((view) => view.props.opaque === false)).toBe(true);
+    expect(views.some((view) => view.props.blendMode === "dstOut")).toBe(true);
+  });
+
   it("supports gradient off and overlays off", () => {
     render(<Harness gradient={false} yAxis={false} badge={false} />);
   });

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -10,6 +10,31 @@ import { DefaultSelectionDot } from "../src/components/SelectionDot";
 import type { SeriesConfig } from "../src/types";
 
 describe("LiveChartSeries", () => {
+  it("opts into an opaque canvas and replaces destination-alpha masks", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return <LiveChartSeries series={series} canvasMode="opaque" />;
+    }
+
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    const views = screen.UNSAFE_getAllByType(View);
+    expect(views.some((view) => view.props.opaque === true)).toBe(true);
+    expect(views.some((view) => view.props.blendMode === "dstOut")).toBe(false);
+  });
+
   it("renders with default scrub when scrub prop is omitted", async () => {
     const initial: SeriesConfig[] = [
       {


### PR DESCRIPTION
## Summary

- add experimental `canvasMode="opaque"` support to `LiveChart` and `LiveChartSeries`
- explicitly paint the owned palette background and use opaque-safe composites for fades, crosshair dimming, and loading masks
- preserve transparent TextureView rendering as the default and remount the Skia Canvas when switching renderer modes
- add tests, API documentation, changelog entry, an interactive demo, and a controlled Android release profiling harness

## Physical Android result

Profiled identical release workloads on a physical Samsung Galaxy S24 (`SM-S921B`) at 120 Hz with 10,000 retained points, a 120-second visible window, and 30 incoming updates per second.

| Metric | Transparent TextureView | Opaque SurfaceView |
| --- | ---: | ---: |
| Animation callbacks / second | 119.75 | 101.35 |
| Animation slice p90 / p99 | 6.51 / 7.77 ms | 10.51 / 12.30 ms |
| Animation slices over 8.33 ms | 0.3% | 99.5% |
| App scheduled CPU | 1,601 ms/s | 1,318 ms/s |
| Main-thread scheduled CPU | 746 ms/s | 981 ms/s |
| Android RenderThread CPU | 438 ms/s | 0 ms/s |
| SurfaceFlinger CPU | 471 ms/s | 404 ms/s |

SurfaceView reduced total app CPU by about 18% and removed the Android RenderThread composition pass, but shifted work onto the main thread and missed the 120 Hz frame budget. The implementation therefore remains an experimental opt-in; TextureView remains the default.

On-device checks covered runtime mode switching, light/dark backgrounds, loading masks, rounded clipping, screenshots, and React Native sibling overlays.

## Verification

- `npm run verify`
  - 96 test suites passed
  - 1,357 tests passed, 5 skipped
- `npm run build:lib`
- Android release builds for both renderer modes
- Perfetto, `dumpsys gfxinfo`, and SurfaceFlinger inspection on physical hardware

Closes #215