### PR TITLE
Candles vanish when transitions={false} is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each rendered line's identity; existing lines fall back to a deterministic
   visual-config key.
 
+- **Candles no longer vanish with `transitions={false}`.** `transitions={false}` resolves to a
+  candle-width lerp speed of `1`, and the frame-rate-independent lerp evaluated
+  `0 ** (dt / frame)` — `Infinity` for a negative frame delta. When the current and target
+  widths matched, the resulting `0 * -Infinity` turned the shared candle width into a
+  permanent `NaN`, so every body and wick drew at `NaN` width. `lerp` now snaps straight to
+  the target at `speed >= 1`.
+
 ### Documentation
 
 - Added an end-to-end guide and runnable example for loading older REST history while time-scrolling,

--- a/packages/react-native-livechart/src/math/lerp.ts
+++ b/packages/react-native-livechart/src/math/lerp.ts
@@ -12,6 +12,13 @@ export function lerp(
   dt = MS_PER_FRAME_60FPS,
 ): number {
   "worklet";
+  // speed >= 1 means "snap in one frame". Computing it through the exponential
+  // would evaluate 0 ** (dt / frame), which is Infinity for a negative frame
+  // delta. When current === target, the resulting 0 * -Infinity becomes NaN
+  // and is permanent once written back into a SharedValue. No broader guard:
+  // NaN inputs must keep propagating (the engine tick relies on a NaN
+  // displayValue staying NaN so the y-range block stays skipped).
+  if (speed >= 1) return target;
   const factor = 1 - Math.pow(1 - speed, dt / MS_PER_FRAME_60FPS);
   return current + (target - current) * factor;
 }

--- a/packages/react-native-livechart/tests/math/lerp.test.ts
+++ b/packages/react-native-livechart/tests/math/lerp.test.ts
@@ -10,4 +10,26 @@ describe("lerp", () => {
   it("uses default dt 16.67", () => {
     expect(lerp(0, 10, 0.5)).toBe(lerp(0, 10, 0.5, 16.67));
   });
+
+  it("snaps to target at speed 1", () => {
+    expect(lerp(0, 100, 1)).toBe(100);
+  });
+
+  it("snaps at speed 1 with a zero or negative dt", () => {
+    // At dt=0 the exponential form stalls instead of snapping. With a negative
+    // dt and equal values, 0 ** (dt / frame) is Infinity and 0 * -Infinity
+    // poisons the result with NaN.
+    expect(lerp(0, 100, 1, 0)).toBe(100);
+    expect(lerp(100, 100, 1, -5)).toBe(100);
+  });
+
+  it("recovers a NaN current value when snapping", () => {
+    expect(lerp(Number.NaN, 100, 1)).toBe(100);
+  });
+
+  it("keeps propagating NaN inputs below speed 1", () => {
+    // The engine tick relies on this: a NaN displayValue must stay NaN so the
+    // y-range block stays skipped (see liveChartEngineTick).
+    expect(lerp(Number.NaN, 100, 0.5)).toBeNaN();
+  });
 });


### PR DESCRIPTION
## What happens

- Set `transitions={false}` on a candle chart.
- All candle bodies and wicks disappear.
- Axis, crosshair, badge, and scrub keep working — only the bars are gone.

## Why

- `resolveTransitions(false)` returns `candleLerpSpeed: 1`.
- The frame-rate-independent width lerp evaluates `0 ** (dt / frame)`.
- For a negative frame delta that becomes `Infinity`; when the current and target widths match, the resulting `0 * -Infinity` produces `NaN`.
- The width lives in a SharedValue, so the `NaN` persists and every bar draws at `NaN` width.
- With a zero frame delta, the old exponential form stalls instead of honoring the documented one-frame snap.

## Fix

- `lerp` now returns the target directly when `speed >= 1`, matching the documented snap behavior.
- `NaN` inputs below speed 1 still propagate — the engine tick relies on a `NaN` display value staying `NaN` so its y-range block stays skipped.

## Tests

- Speed 1 snaps with default, zero, and negative frame deltas.
- The negative-delta test covers the exact equal-current-and-target `NaN` case.
- Speed 1 recovers an already-`NaN` current value.
- Speeds below 1 retain existing `NaN` propagation.
- `npm run verify` passes.
- Manual iOS QA passes for `transitions={false}`, `candleLerpSpeed: 1`, and the default eased candle resize.
