### PR TITLE
Line mode draws an empty chart when the visible window lands in a data gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Line mode no longer draws an empty chart when the visible window lands in a data gap.**
+  While time-scrolled, a window whose whole span fell between two samples emitted a single
+  point, which every consumer discards — grid and axes rendered with no line, fill, or
+  threshold band. The line is now closed at the plot's right edge with the value the data
+  itself has there (linearly interpolated between the bracketing samples), which also removes
+  the "breathing" gap between the last sample and the right edge while dragging.
+
 ### Documentation
 
 - Added an end-to-end guide and runnable example for loading older REST history while time-scrolling,

--- a/packages/react-native-livechart/src/draw/line.ts
+++ b/packages/react-native-livechart/src/draw/line.ts
@@ -207,7 +207,9 @@ export function resolvePadding(
 /**
  * Build screen-space points as a flat number array [x0, y0, x1, y1, ...].
  * Includes one point before the window for smooth left-edge entry,
- * and appends a live tip at (now, displayValue).
+ * and appends a live tip at (now, displayValue) unless `appendLiveTip` is false —
+ * in which case the line is instead closed at the right edge with the
+ * interpolated *data* value there (see below).
  *
  * Flat layout avoids ~150 tuple object allocations per frame.
  *
@@ -217,6 +219,20 @@ export function resolvePadding(
  * busy / wide-window charts. Callers that pool `out` must ping-pong two buffers
  * so the returned reference still changes each frame (Reanimated's value-equality
  * check skips notifying subscribers when the reference is unchanged).
+ *
+ * The live tip is pinned to the plot's RIGHT EDGE (x = left + chartW), not to a
+ * time — it is only in the right place while the window follows the live edge
+ * (`now === liveEdge`). Pass `appendLiveTip: false` when the window is frozen
+ * behind the live edge, otherwise the tip drags the line from the last visible
+ * sample to an off-screen price. Candle mode needs no such flag: a candle is
+ * positioned from its own `time` and `appendCandleShapes` drops it once it
+ * leaves the window, so the live candle disappears on its own.
+ *
+ * With `appendLiveTip: false` the line is still closed at the right edge, but
+ * with the value the data itself has at `now` (linearly interpolated between the
+ * samples bracketing it) instead of the live price. That keeps the line reaching
+ * the edge while scrolled back, and keeps a window that lands inside a data gap
+ * from collapsing to a single point (which every consumer discards).
  */
 export function buildLinePoints(
   data: LiveChartPoint[],
@@ -229,6 +245,7 @@ export function buildLinePoints(
   canvasHeight: number,
   padding: ChartPadding,
   out?: number[],
+  appendLiveTip = true,
 ): number[] {
   "worklet";
   const pts: number[] = out ?? [];
@@ -329,10 +346,59 @@ export function buildLinePoints(
   }
 
   // Live tip at current time with smoothed value
-  pts.push(
-    padding.left + chartW,
-    padding.top + ((displayMax - displayValue) / valRange) * chartH,
-  );
+  if (appendLiveTip) {
+    pts.push(
+      padding.left + chartW,
+      padding.top + ((displayMax - displayValue) / valRange) * chartH,
+    );
+  } else if (pts.length >= 2) {
+    // No live tip: the window is frozen behind the live edge. Close the line at
+    // the plot's right edge with the value the DATA has at `now`, linearly
+    // interpolated between the two samples bracketing it. This is not the live
+    // tip in disguise — the tip draws the live (off-screen) price at the edge,
+    // this draws the price the frozen right edge actually points at, which is the
+    // correct value while scrolled back. It fixes two symptoms:
+    //  - A window whose whole span falls inside a data gap emits exactly ONE
+    //    point (the pre-window sample kept for left-edge entry). Every consumer
+    //    discards a run shorter than two points, so the chart drew grid and axes
+    //    with no line, no gradient fill and no threshold band at all.
+    //  - Otherwise the line stops at the last sample <= `now`, up to one bucket
+    //    short of the right edge, and that shortfall shrinks and grows as the
+    //    window slides — a gap that visibly breathes while dragging.
+    const exitX = padding.left + chartW;
+    // Skip a zero-width segment when the last emitted sample already sits on the
+    // edge (`data[endIdx - 1].time === now`): a duplicated x makes `drawSpline`
+    // treat the interval as flat and zero the final tangent on both ends of it.
+    if (exitX - pts[pts.length - 2] > 1e-3) {
+      // Reaching here means the loop above emitted at least one point, so
+      // `endIdx > startIdx >= 0` and `data[endIdx - 1]` is in bounds.
+      const a = data[endIdx - 1];
+      // `endIdx` is the first index after `now`; at or past the end of the array
+      // there is no later sample to interpolate towards (the window is scrolled
+      // past the newest data), so hold the last known value out to the edge
+      // instead of reading off the end.
+      const b = endIdx < data.length ? data[endIdx] : a;
+      const span = b.time - a.time;
+      // `frac` is clamped so the result can only ever be a convex blend of `a` and
+      // `b`, never an extrapolation into a spike off the plot.
+      //
+      // It cannot currently fire: `elo` reaches `endIdx` only via `elo = emid + 1`
+      // with `emid === endIdx - 1`, on the branch that tested
+      // `data[endIdx - 1].time <= now`; and `ehi` reaches `endIdx` only via
+      // `ehi = emid` with `emid === endIdx`, on the branch that tested
+      // `data[endIdx].time > now`. So `a.time <= now < b.time` — hence `span > 0`
+      // and `frac` in [0, 1) — holds for ANY input, sorted or not. The clamp keeps
+      // that a local, obvious invariant rather than a three-step argument about
+      // the index math above, so refactoring that search can't silently turn this
+      // interpolation into an extrapolation.
+      //
+      // `span === 0` only happens when `b === a` (no sample after the window), and
+      // then `frac = 0` holds `a`'s own value out to the edge.
+      const frac = span > 0 ? Math.min(1, Math.max(0, (now - a.time) / span)) : 0;
+      const exitValue = a.value + frac * (b.value - a.value);
+      pts.push(exitX, padding.top + (displayMax - exitValue) * yScale);
+    }
+  }
 
   return pts;
 }

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -1,7 +1,10 @@
 import { Skia, type SkPath } from "@shopify/react-native-skia";
 import { useRef } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import type { SingleEngineState } from "../core/useLiveChartEngine";
+import type {
+  ChartEngineScroll,
+  SingleEngineState,
+} from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline, makeSplineScratch } from "../math/spline";
 import { sampleThresholdYAt, thresholdSampleSpanX } from "../math/threshold";
@@ -20,7 +23,12 @@ import { usePathBuilder } from "./usePathBuilder";
  * fillPath.
  */
 export function useChartPaths(
-  engine: SingleEngineState,
+  /**
+   * `viewEnd` comes from {@link ChartEngineScroll}, which `useLiveChartEngine`
+   * intersects onto the returned state but which `SingleEngineState` itself does
+   * not declare — the live-tip gate below reads it, so ask for it explicitly.
+   */
+  engine: SingleEngineState & Pick<ChartEngineScroll, "viewEnd">,
   padding: ChartPadding,
   morphT?: SharedValue<number>,
   /** When set, also build `thresholdFillPath` — the band between the line and this
@@ -84,6 +92,16 @@ export function useChartPaths(
     // drops from the last visible point to the off-screen live value at the edge.
     const tipValue =
       followViewEdge && edgeValue ? edgeValue.get() : engine.displayValue.get();
+    // Without `followViewEdge` there is no in-view price to tip at, so drop the
+    // tip entirely: `buildLinePoints` pins it to the plot's right edge, which is
+    // `viewEnd` (not the live edge) while scrolled back, so the live price would
+    // be drawn at a time it doesn't belong to — a near-vertical run from the last
+    // visible sample up to an off-screen value. The line now simply ends at the
+    // last loaded sample in view. Same `viewEnd != null` gate the live dot and
+    // value line already use (see `liveDotOpacity` / `valueLineOpacity`), and the
+    // same end state candle mode reaches by positioning the live candle from its
+    // own timestamp.
+    const appendLiveTip = followViewEdge || engine.viewEnd.get() == null;
     const realPts = buildLinePoints(
       engine.data.get(),
       tipValue,
@@ -95,6 +113,7 @@ export function useChartPaths(
       engine.canvasHeight.get(),
       padding,
       buf,
+      appendLiveTip,
     );
 
     // Skip blending when fully revealed or no morphT provided

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -233,6 +233,84 @@ describe("buildLinePoints", () => {
     const n = out.length >> 1;
     expect(n).toBeGreaterThan(0);
   });
+
+  it("closes at the right edge with the interpolated data value when appendLiveTip is false", () => {
+    // Window [70, 100] falls entirely inside the gap between the two samples.
+    // Without the edge close this emits ONE point (the pre-window sample kept
+    // for left-edge entry) — a run every consumer discards, so nothing draws.
+    const now = 100;
+    const data = [
+      { time: 0, value: 1 },
+      { time: 500, value: 3 },
+    ];
+    const out = buildLinePoints(
+      data,
+      99, // live value — must NOT be drawn
+      now,
+      30,
+      0,
+      10,
+      200,
+      120,
+      pad,
+      undefined,
+      false,
+    );
+    expect(out.length).toBe(4);
+    const exitX = pad.left + (200 - pad.left - pad.right);
+    expect(out[2]).toBe(exitX);
+    // Interpolated data value at now: 1 + (100/500) * (3 - 1) = 1.4
+    const chartH = 120 - pad.top - pad.bottom;
+    expect(out[3]).toBeCloseTo(pad.top + ((10 - 1.4) / 10) * chartH);
+  });
+
+  it("holds the last value to the edge when scrolled past the newest sample", () => {
+    // No sample after the window: nothing to interpolate towards, so the last
+    // known value extends to the right edge instead of reading off the array.
+    const now = 100;
+    const data = [{ time: 50, value: 4 }];
+    const out = buildLinePoints(
+      data,
+      99,
+      now,
+      100,
+      0,
+      10,
+      200,
+      120,
+      pad,
+      undefined,
+      false,
+    );
+    expect(out.length).toBe(4);
+    const chartH = 120 - pad.top - pad.bottom;
+    expect(out[3]).toBeCloseTo(pad.top + ((10 - 4) / 10) * chartH);
+  });
+
+  it("skips the edge close when the last sample already sits on the edge", () => {
+    // A duplicated x would make drawSpline treat the interval as flat.
+    const now = 100;
+    const data = [
+      { time: 90, value: 2 },
+      { time: 100, value: 5 },
+    ];
+    const out = buildLinePoints(
+      data,
+      99,
+      now,
+      30,
+      0,
+      10,
+      200,
+      120,
+      pad,
+      undefined,
+      false,
+    );
+    const xs = [];
+    for (let i = 0; i < out.length; i += 2) xs.push(out[i]);
+    expect(new Set(xs).size).toBe(xs.length);
+  });
 });
 
 describe("badge geometry metrics overrides", () => {

--- a/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
@@ -1,14 +1,14 @@
 import { DEFAULT_PADDING } from "../../src/draw/line";
-import type { SingleEngineState } from "../../src/core/useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
 import { useChartPaths } from "../../src/hooks/useChartPaths";
 import { useSharedValue } from "react-native-reanimated";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
-function makeEngine(
-  overrides: Partial<SingleEngineState> = {},
-): SingleEngineState {
+type PathsEngine = Parameters<typeof useChartPaths>[0];
+
+function makeEngine(overrides: Partial<PathsEngine> = {}): PathsEngine {
   const base = {
+    viewEnd: { value: null },
     data: { value: [{ time: 1000, value: 1 }] },
     value: { value: 1 },
     displayValue: { value: 1 },
@@ -22,7 +22,7 @@ function makeEngine(
   return withSharedValueAccessors({
     ...base,
     ...overrides,
-  }) as unknown as SingleEngineState;
+  }) as unknown as PathsEngine;
 }
 
 describe("useChartPaths", () => {
@@ -41,7 +41,7 @@ describe("useChartPaths", () => {
           data: { value: [{ time: 1000, value: 1 }] },
           displayMin: { value: 0 },
           displayMax: { value: 0 },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<PathsEngine>),
         DEFAULT_PADDING,
       ),
     );
@@ -60,7 +60,7 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<PathsEngine>),
         DEFAULT_PADDING,
         undefined,
         thresholdY,
@@ -86,7 +86,7 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<PathsEngine>),
         DEFAULT_PADDING,
         undefined, // morphT
         undefined, // thresholdY (constant) — superseded by the samples below
@@ -113,7 +113,7 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<PathsEngine>),
         DEFAULT_PADDING,
         morphT,
       );
@@ -137,7 +137,7 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<PathsEngine>),
         DEFAULT_PADDING,
         undefined,
         undefined,


### PR DESCRIPTION
## What happens

- Enable `timeScroll` on a line chart whose data has a gap between samples.
- Scroll so the visible window sits entirely inside the gap.
- Grid and axes render, but there is no line, no fill, and no threshold band.

## Why

- The window emits exactly one point (the pre-window sample kept for left-edge entry).
- Every consumer drops runs shorter than two points, so nothing draws.
- A second symptom of the same root: while scrolled back, the live tip is pinned to the plot's right edge, dragging the line up to an off-screen price.

## Fix

- `buildLinePoints` gets an `appendLiveTip` flag; `useChartPaths` turns it off while scrolled back (`viewEnd != null`, no `followViewEdge`).
- The line instead closes at the right edge with the data's own value there, linearly interpolated between the two samples bracketing the edge.
- That guarantees at least two points, so a window inside a gap draws again — and the "breathing" shortfall between the last sample and the right edge while dragging is gone too.

## Tests

- New `buildLinePoints` tests: a gap window closes at the edge with the interpolated value, scrolling past the newest sample holds the last value, and no duplicate x is emitted when the last sample already sits on the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
