### PR TITLE
A scroll drag can also engage the scrub crosshair (and vice versa)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A drag can no longer scroll the chart and engage the scrub crosshair at once.**
+  The time-scroll pan and the hold-to-scrub pan are composed with `Gesture.Race`, which adds
+  no relation between its children — both could recognize on the same touch, so a scroll
+  drag whose hold timer fired mid-drag also placed a crosshair, and an engaged scrub let the
+  window keep sliding underneath the reticle. The two pans now arbitrate through shared
+  latches: an active scroll blocks scrub activation, an engaged scrub makes scrolling inert,
+  and a pending hold is cancelled outright once the finger drifts more than 12 px
+  (`HOLD_MAX_DRIFT_PX`) or the long-press timer fires implausibly early for the current
+  touch (a stale timer from a previous tap).
+
 ### Documentation
 
 - Added an end-to-end guide and runnable example for loading older REST history while time-scrolling,

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -997,6 +997,14 @@ function useLiveChartController({
       ? (timeScrollHoldMs ?? (scrubCfg?.panGestureDelay || HOLD_TO_SCRUB_MS))
       : (scrubCfg?.panGestureDelay ?? 0);
 
+  // Cross-gesture arbitration for the one-finger touch. `Gesture.Race` below is
+  // NOT arbitration — RNGH's Race adds no relation between its children, so both
+  // pans recognize independently and each can activate while the other already
+  // owns the touch. This latch (written by the scroll pan, read by the scrub's
+  // long-press guard) makes "the scroll already won" a hard fact; `scrubActive`
+  // (written by the crosshair, read by the scroll pan) is the mirror image.
+  const scrollActive = useSharedValue(false);
+
   const crosshair = useCrosshair(
     engine,
     effectivePadding,
@@ -1026,6 +1034,7 @@ function useLiveChartController({
     timeScrollEnabled && scrollGestureMode === "axisDrag"
       ? Math.max(effectivePadding.bottom, AXIS_GRAB_MIN_PX)
       : 0,
+    scrollActive,
   );
 
   // Capture only the shared value in the worklets below. Referencing
@@ -1048,6 +1057,10 @@ function useLiveChartController({
     minTime: scrollMinTime,
     enabled: timeScrollEnabled,
     mode: scrollGestureMode,
+    scrollActive,
+    // Once a scrub is engaged the chart is locked: scrolling goes inert so the
+    // finger only moves the price indicator across a fixed window.
+    scrubActive: crosshairScrubActive,
     // Clear any live crosshair when a scroll drag takes over.
     onScrollStart: () => {
       "worklet";

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -407,6 +407,14 @@ function useLiveChartSeriesController({
     skiaFont,
   );
 
+  // Cross-gesture arbitration for the one-finger touch. `Gesture.Race` below is
+  // NOT arbitration — RNGH's Race adds no relation between its children, so both
+  // pans recognize independently and each can activate while the other already
+  // owns the touch. This latch (written by the scroll pan, read by the scrub's
+  // long-press guard) makes "the scroll already won" a hard fact; `scrubActive`
+  // (written by the crosshair, read by the scroll pan) is the mirror image.
+  const scrollActive = useSharedValue(false);
+
   const crosshair = useCrosshairSeries(
     engine,
     effectivePadding,
@@ -415,6 +423,7 @@ function useLiveChartSeriesController({
     scrubHoldMs,
     onGestureStart,
     onGestureEnd,
+    scrollActive,
   );
 
   // Capture only the shared value in the worklets below. Referencing
@@ -458,6 +467,10 @@ function useLiveChartSeriesController({
     minTime: scrollMinTime,
     enabled: timeScrollEnabled,
     mode: scrollGestureMode,
+    scrollActive,
+    // Once a scrub is engaged the chart is locked: scrolling goes inert so the
+    // finger only moves the price indicator across a fixed window.
+    scrubActive: crosshairScrubActive,
     onScrollStart: () => {
       "worklet";
       crosshairScrubActive.set(false);

--- a/packages/react-native-livechart/src/hooks/delayedPanGuard.ts
+++ b/packages/react-native-livechart/src/hooks/delayedPanGuard.ts
@@ -1,22 +1,95 @@
 import type { SharedValue } from "react-native-reanimated";
 
 type BooleanSharedValue = Pick<SharedValue<boolean>, "get" | "set">;
+type NumberSharedValue = Pick<SharedValue<number>, "get" | "set">;
+
+type TouchPoint = { x: number; y: number };
 
 type TouchCountEvent = {
   numberOfTouches: number;
+};
+
+type TouchesEvent = TouchCountEvent & {
+  changedTouches: TouchPoint[];
+  allTouches: TouchPoint[];
 };
 
 type GestureStateManager = {
   fail: () => void;
 };
 
-/** Mark the first pointer of a delayed pan as down. Zero-delay pans are inert. */
+/**
+ * A pending hold-to-scrub pan must stay within this radius of its touch-down
+ * point to activate. Matches the platform long-press convention (RNGH
+ * LongPress `maxDist` / UIKit `allowableMovement` default 10) with a little
+ * slack for thumbs.
+ */
+export const HOLD_MAX_DRIFT_PX = 12;
+
+/**
+ * An activation earlier than `delayMs - slack` after the current touch went
+ * down cannot be a real hold — it is a stale `activateAfterLongPress` timer
+ * carried over from a previous touch (see `shouldStartDelayedPan`).
+ */
+export const HOLD_TIMER_SLACK_MS = 50;
+
+/** Record the first pointer of a delayed pan going down. Zero-delay pans are inert. */
 export function delayedPanTouchDown(
   delayMs: number,
+  event: TouchesEvent,
   fingerDown: BooleanSharedValue,
+  downX: NumberSharedValue,
+  downY: NumberSharedValue,
+  downAtMs: NumberSharedValue,
+  holdBroken: BooleanSharedValue,
 ): void {
   "worklet";
-  if (delayMs > 0) fingerDown.set(true);
+  if (delayMs <= 0) return;
+  fingerDown.set(true);
+  const t = event.changedTouches[0];
+  if (t) {
+    downX.set(t.x);
+    downY.set(t.y);
+  }
+  downAtMs.set(performance.now());
+  holdBroken.set(false);
+}
+
+/**
+ * Enforce the stationary hold: while the delayed pan is still pending, any
+ * drift beyond HOLD_MAX_DRIFT_PX fails it outright AND latches `holdBroken`.
+ *
+ * `manager.fail()` alone is not enough. It only lands if the recognizer is
+ * still in a state that can fail, and — on iOS — the native
+ * `activateAfterLongPress` timer fires `handleGesture:inState:Active`
+ * unconditionally (RNPanHandler.m), so a timer that survived the fail still
+ * emits ACTIVE. The latch makes "the finger moved before the hold elapsed" a
+ * decision `shouldStartDelayedPan` can re-check at activation time, instead of
+ * trusting the native recognizer to have stayed failed.
+ *
+ * The latch also covers movement that returns to its origin: a finger that
+ * wanders 40px away and comes back is within the slop when the timer fires, but
+ * it was never a stationary hold.
+ */
+export function delayedPanTouchMove(
+  delayMs: number,
+  event: TouchesEvent,
+  manager: GestureStateManager,
+  panActivated: BooleanSharedValue,
+  downX: NumberSharedValue,
+  downY: NumberSharedValue,
+  holdBroken: BooleanSharedValue,
+): void {
+  "worklet";
+  if (delayMs <= 0 || panActivated.get()) return;
+  const t = event.allTouches[0];
+  if (!t) return;
+  const dx = t.x - downX.get();
+  const dy = t.y - downY.get();
+  if (dx * dx + dy * dy > HOLD_MAX_DRIFT_PX * HOLD_MAX_DRIFT_PX) {
+    holdBroken.set(true);
+    manager.fail();
+  }
 }
 
 /**
@@ -49,19 +122,49 @@ export function delayedPanTouchCancelled(
 }
 
 /**
- * Record a real delayed-pan activation, or reject an activation whose timer
- * raced the final pointer-up. The rejected path deliberately keeps
- * `panActivated` false so a missing native FINALIZE cannot poison the next
- * interaction.
+ * Record a real delayed-pan activation, or reject a spurious one. Two spurious
+ * shapes exist, both from RNGH's long-press timer surviving where it shouldn't:
+ *
+ * 1. The timer fires after the final pointer already lifted (`fingerDown`
+ *    false) — the original touch-up race.
+ * 2. The timer fires DURING a later touch: fast successive taps can land a new
+ *    pointer before the failed recognizer's native reset completes, so the
+ *    previous tap's timer fires only `now - downAtMs < delayMs` into the new
+ *    touch. A real hold can never activate early, so reject anything faster
+ *    than `delayMs - HOLD_TIMER_SLACK_MS`.
+ *
+ * 3. The timer fires after the finger already moved off the touch-down point
+ *    (`holdBroken`) — it was a drag, not a hold. See `delayedPanTouchMove`.
+ *
+ * 4. The timer fires after the time-scroll pan already took the touch
+ *    (`scrollActive`) — the chart is mid-drag, so the hold lost the race. The
+ *    two pans are composed with `Gesture.Race`, which in RNGH declares NO
+ *    relation between them (`RaceGestureType = ComposedGestureType`), so
+ *    nothing native stops a losing recognizer from activating later. This latch
+ *    is the arbitration.
+ *
+ * All rejected paths deliberately keep `panActivated` false so a missing
+ * native FINALIZE cannot poison the next interaction.
  */
 export function shouldStartDelayedPan(
   delayMs: number,
   fingerDown: BooleanSharedValue,
   panActivated: BooleanSharedValue,
+  downAtMs: NumberSharedValue,
+  holdBroken: BooleanSharedValue,
+  scrollActive: BooleanSharedValue,
 ): boolean {
   "worklet";
   if (delayMs <= 0) return true;
   if (!fingerDown.get()) {
+    panActivated.set(false);
+    return false;
+  }
+  if (performance.now() - downAtMs.get() < delayMs - HOLD_TIMER_SLACK_MS) {
+    panActivated.set(false);
+    return false;
+  }
+  if (holdBroken.get() || scrollActive.get()) {
     panActivated.set(false);
     return false;
   }
@@ -73,8 +176,10 @@ export function shouldStartDelayedPan(
 export function resetDelayedPanGuard(
   fingerDown: BooleanSharedValue,
   panActivated: BooleanSharedValue,
+  holdBroken: BooleanSharedValue,
 ): void {
   "worklet";
   fingerDown.set(false);
   panActivated.set(false);
+  holdBroken.set(false);
 }

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -40,6 +40,7 @@ import {
 import {
   delayedPanTouchCancelled,
   delayedPanTouchDown,
+  delayedPanTouchMove,
   delayedPanTouchUp,
   resetDelayedPanGuard,
   shouldStartDelayedPan,
@@ -152,6 +153,12 @@ export function useCrosshair(
    * exclusion (the default; scrub covers the whole plot).
    */
   scrubBottomExclude = 0,
+  /**
+   * True while the time-scroll pan owns the touch. The hold-to-scrub pan refuses
+   * to activate while set, so a drag that already started scrolling can never
+   * mature into a scrub (see `delayedPanGuard.shouldStartDelayedPan`).
+   */
+  scrollActive?: SharedValue<boolean>,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -162,6 +169,18 @@ export function useCrosshair(
   // lifecycle helpers are also used by LiveChartSeries and unit-tested directly.
   const fingerDown = useSharedValue(false);
   const panActivated = useSharedValue(false);
+  // Where and when the current touch went down, for the stationary-hold and
+  // stale-timer guards (see delayedPanGuard).
+  const downX = useSharedValue(0);
+  const downY = useSharedValue(0);
+  const downAtMs = useSharedValue(0);
+  // Latched once the finger leaves the hold slop: this touch is a drag, so its
+  // long-press timer must not be honored even if it still fires.
+  const holdBroken = useSharedValue(false);
+  // Inert stand-in so the guard always has a latch to read when the controller
+  // wires no time-scroll (hooks must be created unconditionally).
+  const noScrollActive = useSharedValue(false);
+  const scrollActiveSV = scrollActive ?? noScrollActive;
   // Where the crosshair line should start (canvas Y) so it stops at a top-pinned
   // custom tooltip instead of running through it. -1 = no top tooltip → the line
   // starts at padding.top. Written by CustomTooltipOverlay, read by CrosshairOverlay.
@@ -505,9 +524,33 @@ export function useCrosshair(
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
     .onTouchesDown(
-      /* istanbul ignore next */ () => {
+      /* istanbul ignore next */ (e) => {
         "worklet";
-        delayedPanTouchDown(longPressMs, fingerDown);
+        delayedPanTouchDown(
+          longPressMs,
+          e,
+          fingerDown,
+          downX,
+          downY,
+          downAtMs,
+          holdBroken,
+        );
+      },
+    )
+    // Stationary hold: drift beyond the slop while the long-press is still
+    // pending fails the pan, so a drag can never mature into a scrub.
+    .onTouchesMove(
+      /* istanbul ignore next */ (e, manager) => {
+        "worklet";
+        delayedPanTouchMove(
+          longPressMs,
+          e,
+          manager,
+          panActivated,
+          downX,
+          downY,
+          holdBroken,
+        );
       },
     )
     .onTouchesUp(
@@ -535,7 +578,17 @@ export function useCrosshair(
     .onStart(
       /* istanbul ignore next */ (e) => {
         "worklet";
-        if (!shouldStartDelayedPan(longPressMs, fingerDown, panActivated)) return;
+        if (
+          !shouldStartDelayedPan(
+            longPressMs,
+            fingerDown,
+            panActivated,
+            downAtMs,
+            holdBroken,
+            scrollActiveSV,
+          )
+        )
+          return;
         if (!enabled) return;
         // Scrub-action: once a reticle is placed, drag adjusts it (2D — the Y is
         // the price). The ephemeral live-scrub never engages, so scrubActive
@@ -600,7 +653,7 @@ export function useCrosshair(
     .onFinalize(
       /* istanbul ignore next */ () => {
         "worklet";
-        resetDelayedPanGuard(fingerDown, panActivated);
+        resetDelayedPanGuard(fingerDown, panActivated, holdBroken);
         // A lock-adjust drag leaves the reticle in place (scrubActive was never
         // set); a live-scrub clears its crosshair. Always clear scrubActive so a
         // stray scrub can never linger behind a placed reticle.

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -3,6 +3,7 @@ import {
   useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
+  type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
@@ -24,6 +25,7 @@ import {
 import {
   delayedPanTouchCancelled,
   delayedPanTouchDown,
+  delayedPanTouchMove,
   delayedPanTouchUp,
   resetDelayedPanGuard,
   shouldStartDelayedPan,
@@ -42,6 +44,12 @@ export function useCrosshairSeries(
   panGestureDelay = 0,
   onGestureStart?: () => void,
   onGestureEnd?: () => void,
+  /**
+   * True while the time-scroll pan owns the touch. The hold-to-scrub pan refuses
+   * to activate while set, so a drag that already started scrolling can never
+   * mature into a scrub (see `delayedPanGuard.shouldStartDelayedPan`).
+   */
+  scrollActive?: SharedValue<boolean>,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -52,6 +60,18 @@ export function useCrosshairSeries(
   // the final pointer has already lifted on iOS.
   const fingerDown = useSharedValue(false);
   const panActivated = useSharedValue(false);
+  // Where and when the current touch went down, for the stationary-hold and
+  // stale-timer guards (see delayedPanGuard).
+  const downX = useSharedValue(0);
+  const downY = useSharedValue(0);
+  const downAtMs = useSharedValue(0);
+  // Latched once the finger leaves the hold slop: this touch is a drag, so its
+  // long-press timer must not be honored even if it still fires.
+  const holdBroken = useSharedValue(false);
+  // Inert stand-in so the guard always has a latch to read when the controller
+  // wires no time-scroll (hooks must be created unconditionally).
+  const noScrollActive = useSharedValue(false);
+  const scrollActiveSV = scrollActive ?? noScrollActive;
 
   const scrubTime = useDerivedValue(() =>
     computeScrubTime(
@@ -169,9 +189,33 @@ export function useCrosshairSeries(
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
     .onTouchesDown(
-      /* istanbul ignore next */ () => {
+      /* istanbul ignore next */ (e) => {
         "worklet";
-        delayedPanTouchDown(panGestureDelay, fingerDown);
+        delayedPanTouchDown(
+          panGestureDelay,
+          e,
+          fingerDown,
+          downX,
+          downY,
+          downAtMs,
+          holdBroken,
+        );
+      },
+    )
+    // Stationary hold: drift beyond the slop while the long-press is still
+    // pending fails the pan, so a drag can never mature into a scrub.
+    .onTouchesMove(
+      /* istanbul ignore next */ (e, manager) => {
+        "worklet";
+        delayedPanTouchMove(
+          panGestureDelay,
+          e,
+          manager,
+          panActivated,
+          downX,
+          downY,
+          holdBroken,
+        );
       },
     )
     .onTouchesUp(
@@ -199,7 +243,16 @@ export function useCrosshairSeries(
     .onStart(
       /* istanbul ignore next */ (e) => {
         "worklet";
-        if (!shouldStartDelayedPan(panGestureDelay, fingerDown, panActivated))
+        if (
+          !shouldStartDelayedPan(
+            panGestureDelay,
+            fingerDown,
+            panActivated,
+            downAtMs,
+            holdBroken,
+            scrollActiveSV,
+          )
+        )
           return;
         if (!enabled) return;
         scrubX.set(e.x);
@@ -218,7 +271,7 @@ export function useCrosshairSeries(
     .onFinalize(
       /* istanbul ignore next */ () => {
         "worklet";
-        resetDelayedPanGuard(fingerDown, panActivated);
+        resetDelayedPanGuard(fingerDown, panActivated, holdBroken);
         scrubActive.set(false);
         if (gestureStarted.get()) {
           gestureStarted.set(false);

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -57,6 +57,20 @@ export interface UsePanScrollOptions {
    * a stray scrub doesn't linger behind the pan.
    */
   onScrollStart?: () => void;
+  /**
+   * Set true for as long as this gesture owns the touch, cleared on finalize.
+   * The hold-to-scrub pan reads it and refuses to activate mid-scroll — RNGH's
+   * `Gesture.Race` declares no relation between the two pans, so this latch is
+   * the only thing stopping the scrub's long-press timer from firing while the
+   * chart is already being dragged. See `delayedPanGuard.shouldStartDelayedPan`.
+   */
+  scrollActive?: SharedValue<boolean>;
+  /**
+   * True while the scrub crosshair owns the touch. Scrolling is inert while set,
+   * so an engaged scrub locks the chart in place and the finger only moves the
+   * price indicator. Cleared when the finger lifts (the scrub pan's finalize).
+   */
+  scrubActive?: SharedValue<boolean>;
 }
 
 /**
@@ -134,6 +148,8 @@ export function usePanScroll({
   enabled,
   mode = "holdToScrub",
   onScrollStart,
+  scrollActive,
+  scrubActive,
 }: UsePanScrollOptions): ReturnType<typeof Gesture.Pan> {
   const { viewEnd, liveEdge, displayWindow, canvasWidth, canvasHeight } = engine;
   const padLeft = padding.left;
@@ -150,7 +166,17 @@ export function usePanScroll({
     /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
     () => {
       "worklet";
+      // Stop an in-flight fling FIRST. `withDecay` keeps writing `viewEnd` after
+      // the finger lifts, and `Gesture.Race` declares no relation between the two
+      // pans, so this can run while a scrub is already engaged. Bailing out below
+      // without cancelling left the decay sliding the window underneath the
+      // crosshair — the opposite of the lock the scrub is meant to hold.
       cancelAnimation(viewEnd);
+      // An engaged scrub locks the chart: the finger moves the price indicator
+      // across a fixed window, so a scroll that activates underneath it must do
+      // nothing further (and must not claim the touch via `scrollActive`).
+      if (scrubActive?.get()) return;
+      scrollActive?.set(true);
       // Anchor at the current right edge so the first delta is relative to where
       // the window sits (the live edge when we were following).
       if (viewEnd.get() == null) viewEnd.set(liveEdge.get());
@@ -161,6 +187,7 @@ export function usePanScroll({
     /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
     (e: { changeX: number }) => {
       "worklet";
+      if (scrubActive?.get()) return;
       const win = displayWindow.get();
       const chartW = canvasWidth.get() - padLeft - padRight;
       if (chartW <= 0) return;
@@ -174,6 +201,7 @@ export function usePanScroll({
     /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
     (e: { velocityX: number }) => {
       "worklet";
+      if (scrubActive?.get()) return;
       if (viewEnd.get() == null) return;
       const win = displayWindow.get();
       const chartW = canvasWidth.get() - padLeft - padRight;
@@ -192,6 +220,16 @@ export function usePanScroll({
           }
         }),
       );
+    };
+
+  // Release the touch claim on every terminal state (END, FAIL, CANCEL), not just
+  // onEnd — a scroll that fails its offset clamps never reaches onEnd, and a
+  // stuck `scrollActive` would block scrub for the rest of the session.
+  const onFinalize =
+    /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
+    () => {
+      "worklet";
+      scrollActive?.set(false);
     };
 
   if (mode === "axisDrag") {
@@ -235,7 +273,8 @@ export function usePanScroll({
       )
       .onStart(onStart)
       .onChange(onChange)
-      .onEnd(onEnd);
+      .onEnd(onEnd)
+      .onFinalize(onFinalize);
   }
 
   // holdToScrub (default): a one-finger drag anywhere scrolls. Activate on
@@ -249,5 +288,6 @@ export function usePanScroll({
     .failOffsetY([-HOLD_SCRUB_FAIL_Y_PX, HOLD_SCRUB_FAIL_Y_PX])
     .onStart(onStart)
     .onChange(onChange)
-    .onEnd(onEnd);
+    .onEnd(onEnd)
+    .onFinalize(onFinalize);
 }

--- a/packages/react-native-livechart/tests/hooks/delayedPanGuard.test.ts
+++ b/packages/react-native-livechart/tests/hooks/delayedPanGuard.test.ts
@@ -1,127 +1,435 @@
 import type { SharedValue } from "react-native-reanimated";
 import {
+  HOLD_MAX_DRIFT_PX,
+  HOLD_TIMER_SLACK_MS,
   delayedPanTouchCancelled,
   delayedPanTouchDown,
+  delayedPanTouchMove,
   delayedPanTouchUp,
   resetDelayedPanGuard,
   shouldStartDelayedPan,
 } from "../../src/hooks/delayedPanGuard";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
-function booleanSharedValue(initial: boolean): SharedValue<boolean> {
+function sharedValue<T>(initial: T): SharedValue<T> {
   const result = withSharedValueAccessors({
     shared: { value: initial },
   });
-  return result.shared as unknown as SharedValue<boolean>;
+  return result.shared as unknown as SharedValue<T>;
+}
+
+function makeGuard() {
+  return {
+    fingerDown: sharedValue(false),
+    panActivated: sharedValue(false),
+    downX: sharedValue(0),
+    downY: sharedValue(0),
+    downAtMs: sharedValue(0),
+    holdBroken: sharedValue(false),
+    scrollActive: sharedValue(false),
+  };
+}
+
+function touchEvent(x: number, y: number, numberOfTouches = 1) {
+  return {
+    numberOfTouches,
+    changedTouches: [{ x, y }],
+    allTouches: [{ x, y }],
+  };
+}
+
+/** Rewind `downAtMs` so the guard sees a fully elapsed hold. */
+function elapseHold(g: ReturnType<typeof makeGuard>, delayMs: number) {
+  g.downAtMs.set(performance.now() - delayMs);
 }
 
 describe("delayed pan guard", () => {
   it("fails a pending delayed pan when its final pointer lifts", () => {
-    const fingerDown = booleanSharedValue(false);
-    const panActivated = booleanSharedValue(false);
+    const g = makeGuard();
     const manager = { fail: jest.fn() };
 
-    delayedPanTouchDown(400, fingerDown);
-    expect(fingerDown.get()).toBe(true);
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    expect(g.fingerDown.get()).toBe(true);
+    expect(g.downX.get()).toBe(50);
+    expect(g.downY.get()).toBe(60);
 
     delayedPanTouchUp(
       400,
       { numberOfTouches: 0 },
       manager,
-      fingerDown,
-      panActivated,
+      g.fingerDown,
+      g.panActivated,
     );
 
-    expect(fingerDown.get()).toBe(false);
+    expect(g.fingerDown.get()).toBe(false);
     expect(manager.fail).toHaveBeenCalledTimes(1);
   });
 
   it("waits for the final pointer before failing a pending pan", () => {
-    const fingerDown = booleanSharedValue(true);
-    const panActivated = booleanSharedValue(false);
+    const g = makeGuard();
+    g.fingerDown.set(true);
     const manager = { fail: jest.fn() };
 
     delayedPanTouchUp(
       400,
       { numberOfTouches: 1 },
       manager,
-      fingerDown,
-      panActivated,
+      g.fingerDown,
+      g.panActivated,
     );
 
-    expect(fingerDown.get()).toBe(true);
+    expect(g.fingerDown.get()).toBe(true);
     expect(manager.fail).not.toHaveBeenCalled();
   });
 
   it("allows a real hold activation and lets the active pan finish normally", () => {
-    const fingerDown = booleanSharedValue(false);
-    const panActivated = booleanSharedValue(false);
+    const g = makeGuard();
     const manager = { fail: jest.fn() };
 
-    delayedPanTouchDown(400, fingerDown);
-    expect(shouldStartDelayedPan(400, fingerDown, panActivated)).toBe(true);
-    expect(panActivated.get()).toBe(true);
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    elapseHold(g, 400);
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(true);
+    expect(g.panActivated.get()).toBe(true);
 
     delayedPanTouchUp(
       400,
       { numberOfTouches: 0 },
       manager,
-      fingerDown,
-      panActivated,
+      g.fingerDown,
+      g.panActivated,
     );
     expect(manager.fail).not.toHaveBeenCalled();
 
-    resetDelayedPanGuard(fingerDown, panActivated);
-    expect(fingerDown.get()).toBe(false);
-    expect(panActivated.get()).toBe(false);
+    resetDelayedPanGuard(g.fingerDown, g.panActivated, g.holdBroken);
+    expect(g.fingerDown.get()).toBe(false);
+    expect(g.panActivated.get()).toBe(false);
+    expect(g.holdBroken.get()).toBe(false);
   });
 
   it("rejects a post-lift activation without leaving stale activated state", () => {
-    const fingerDown = booleanSharedValue(false);
-    const panActivated = booleanSharedValue(false);
+    const g = makeGuard();
     const manager = { fail: jest.fn() };
 
-    delayedPanTouchDown(400, fingerDown);
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
     delayedPanTouchUp(
       400,
       { numberOfTouches: 0 },
       manager,
-      fingerDown,
-      panActivated,
+      g.fingerDown,
+      g.panActivated,
     );
 
-    expect(shouldStartDelayedPan(400, fingerDown, panActivated)).toBe(false);
-    expect(panActivated.get()).toBe(false);
+    elapseHold(g, 400);
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(false);
+    expect(g.panActivated.get()).toBe(false);
 
-    delayedPanTouchDown(400, fingerDown);
-    expect(shouldStartDelayedPan(400, fingerDown, panActivated)).toBe(true);
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    elapseHold(g, 400);
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(true);
   });
 
   it("leaves zero-delay pan behavior untouched", () => {
-    const fingerDown = booleanSharedValue(false);
-    const panActivated = booleanSharedValue(false);
+    const g = makeGuard();
     const manager = { fail: jest.fn() };
 
-    delayedPanTouchDown(0, fingerDown);
+    delayedPanTouchDown(
+      0,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    delayedPanTouchMove(
+      0,
+      touchEvent(500, 600),
+      manager,
+      g.panActivated,
+      g.downX,
+      g.downY,
+      g.holdBroken,
+    );
     delayedPanTouchUp(
       0,
       { numberOfTouches: 0 },
       manager,
-      fingerDown,
-      panActivated,
+      g.fingerDown,
+      g.panActivated,
     );
 
-    expect(shouldStartDelayedPan(0, fingerDown, panActivated)).toBe(true);
-    expect(fingerDown.get()).toBe(false);
-    expect(panActivated.get()).toBe(false);
+    expect(
+      shouldStartDelayedPan(
+        0,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(true);
+    expect(g.fingerDown.get()).toBe(false);
+    expect(g.panActivated.get()).toBe(false);
     expect(manager.fail).not.toHaveBeenCalled();
   });
 
   it("clears delayed pointer state on cancellation", () => {
-    const fingerDown = booleanSharedValue(true);
+    const g = makeGuard();
+    g.fingerDown.set(true);
 
-    delayedPanTouchCancelled(400, fingerDown);
+    delayedPanTouchCancelled(400, g.fingerDown);
 
-    expect(fingerDown.get()).toBe(false);
+    expect(g.fingerDown.get()).toBe(false);
+  });
+
+  it("fails the pending pan once the finger drifts beyond the hold slop", () => {
+    const g = makeGuard();
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    delayedPanTouchMove(
+      400,
+      touchEvent(50 + HOLD_MAX_DRIFT_PX + 1, 60),
+      manager,
+      g.panActivated,
+      g.downX,
+      g.downY,
+      g.holdBroken,
+    );
+
+    expect(g.holdBroken.get()).toBe(true);
+    expect(manager.fail).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates drift within the hold slop", () => {
+    const g = makeGuard();
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    delayedPanTouchMove(
+      400,
+      touchEvent(50 + HOLD_MAX_DRIFT_PX - 1, 60),
+      manager,
+      g.panActivated,
+      g.downX,
+      g.downY,
+      g.holdBroken,
+    );
+
+    expect(g.holdBroken.get()).toBe(false);
+    expect(manager.fail).not.toHaveBeenCalled();
+  });
+
+  it("ignores movement once the pan is already activated", () => {
+    const g = makeGuard();
+    const manager = { fail: jest.fn() };
+    g.panActivated.set(true);
+
+    delayedPanTouchMove(
+      400,
+      touchEvent(500, 600),
+      manager,
+      g.panActivated,
+      g.downX,
+      g.downY,
+      g.holdBroken,
+    );
+
+    expect(g.holdBroken.get()).toBe(false);
+    expect(manager.fail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an activation whose hold was broken, even after native fail was lost", () => {
+    const g = makeGuard();
+    const manager = { fail: jest.fn() };
+
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    delayedPanTouchMove(
+      400,
+      touchEvent(200, 60),
+      manager,
+      g.panActivated,
+      g.downX,
+      g.downY,
+      g.holdBroken,
+    );
+
+    // iOS `activateAfterLongPress` fires ACTIVE unconditionally — the latch is
+    // what rejects it.
+    elapseHold(g, 400);
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(false);
+    expect(g.panActivated.get()).toBe(false);
+  });
+
+  it("rejects a stale timer firing early into a new touch", () => {
+    const g = makeGuard();
+
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    // Fast successive taps: the previous touch's timer fires only ~100ms into
+    // this touch — far less than delayMs - HOLD_TIMER_SLACK_MS.
+    g.downAtMs.set(performance.now() - 100);
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(false);
+    expect(g.panActivated.get()).toBe(false);
+  });
+
+  it("accepts a timer within the slack window of the full delay", () => {
+    const g = makeGuard();
+
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    g.downAtMs.set(performance.now() - (400 - HOLD_TIMER_SLACK_MS));
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an activation while the time-scroll pan owns the touch", () => {
+    const g = makeGuard();
+
+    delayedPanTouchDown(
+      400,
+      touchEvent(50, 60),
+      g.fingerDown,
+      g.downX,
+      g.downY,
+      g.downAtMs,
+      g.holdBroken,
+    );
+    g.scrollActive.set(true);
+    elapseHold(g, 400);
+    expect(
+      shouldStartDelayedPan(
+        400,
+        g.fingerDown,
+        g.panActivated,
+        g.downAtMs,
+        g.holdBroken,
+        g.scrollActive,
+      ),
+    ).toBe(false);
+    expect(g.panActivated.get()).toBe(false);
   });
 });


### PR DESCRIPTION
## What happens

- Enable `timeScroll` with the default `holdToScrub` gesture.
- Drag to scroll and keep the finger down: the hold timer fires mid-drag and a crosshair appears on top of the scroll.
- Engage a scrub, then move: the window can keep sliding underneath the reticle, including a leftover fling.

## Why

- The two pans are composed with `Gesture.Race`.
- In RNGH, `Race` adds **no relation** between its children — both recognizers run independently, so both can activate on the same touch.
- On iOS, the native `activateAfterLongPress` timer fires ACTIVE unconditionally, even after the recognizer was failed.

## Fix

One arbitration layer, shared by `LiveChart` and `LiveChartSeries`:

- `scrollActive` latch: while the scroll pan owns the touch, the scrub refuses to activate.
- `scrubActive` mirror: while a scrub is engaged, scrolling goes inert and any in-flight fling is cancelled.
- Stationary hold: drifting more than 12 px (`HOLD_MAX_DRIFT_PX`) before the hold elapses fails the pending scrub outright.
- Stale-timer guard: an activation that fires implausibly early for the current touch (a timer left over from a previous tap) is rejected.

These pieces only work together, so they ship as one PR.

## Tests

- `delayedPanGuard.test.ts` extended: drift beyond/within the slop, movement after activation, broken-hold rejection, stale-timer rejection, slack-window acceptance, and scroll-owns-the-touch rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
