### PR TITLE
Live dot and value line mark an off-screen price while scrolled back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   permanent `NaN`, so every body and wick drew at `NaN` width. `lerp` now snaps straight to
   the target at `speed >= 1`.
 
+- **The live dot and value line no longer mark an off-screen price while scrolled back.**
+  With `timeScroll`, panning back through history froze the window behind the live edge, but
+  the live dot stayed pinned to the plot's right edge at the live value's Y — a price not in
+  the visible window — and the dashed value line drew at that same Y. Both are now hidden
+  while scrolled back and reappear on return to the live edge. `badge.followViewEdge` keeps
+  its behavior (there the dot tracks the visible edge price, which is in view). Opt out with
+  the new `timeScroll.hideLiveOnScrollBack: false`.
+
 ### Documentation
 
 - Added an end-to-end guide and runnable example for loading older REST history while time-scrolling,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the visible window — and the dashed value line drew at that same Y. Both are now hidden
   while scrolled back and reappear on return to the live edge. `badge.followViewEdge` keeps
   its behavior (there the dot tracks the visible edge price, which is in view). Opt out with
-  the new `timeScroll.hideLiveOnScrollBack: false`.
+  the new `timeScroll.hideLiveOnScrollBack: false`. In line mode, the plotted series now
+  always ends at the historical window's visible-edge value instead of extending to the
+  off-screen live price; badge and indicator options no longer alter line geometry.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,15 +50,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   permanent `NaN`, so every body and wick drew at `NaN` width. `lerp` now snaps straight to
   the target at `speed >= 1`.
 
-- **The live dot and value line no longer mark an off-screen price while scrolled back.**
+- **Live indicators no longer mark an off-screen price while scrolled back.**
   With `timeScroll`, panning back through history froze the window behind the live edge, but
   the live dot stayed pinned to the plot's right edge at the live value's Y — a price not in
-  the visible window — and the dashed value line drew at that same Y. Both are now hidden
-  while scrolled back and reappear on return to the live edge. `badge.followViewEdge` keeps
-  its behavior (there the dot tracks the visible edge price, which is in view). Opt out with
+  the visible window — the dashed value line drew at that same Y, and the badge stayed pinned
+  to the off-screen live value. The badge, dot, and value line are now hidden together while
+  scrolled back and reappear on return to the live edge. `badge.followViewEdge` keeps its
+  behavior (there the group tracks the visible edge price, which is in view). Opt out with
   the new `timeScroll.hideLiveOnScrollBack: false`. In line mode, the plotted series now
   always ends at the historical window's visible-edge value instead of extending to the
-  off-screen live price; badge and indicator options no longer alter line geometry.
+  off-screen live price; badge and indicator options no longer alter line geometry. A
+  follow-edge badge's momentum color is also derived at that historical edge, so incoming
+  live ticks no longer recolor a stationary historical badge.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   always ends at the historical window's visible-edge value instead of extending to the
   off-screen live price; badge and indicator options no longer alter line geometry. A
   follow-edge badge's momentum color is also derived at that historical edge, so incoming
-  live ticks no longer recolor a stationary historical badge.
+  live ticks no longer recolor a stationary historical badge. Dragging toward the future
+  while already at the live edge also stays in follow mode throughout the gesture, avoiding
+  a transient floating-axis gutter collapse that drew chart content beneath the Y-axis.
 
 ### Documentation
 

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -143,12 +143,12 @@ export default function TimeScrollScreen() {
     >
       <ControlRow label="Live indicator behavior">
         <ToggleChip
-          label="badge.followViewEdge"
+          label="Follow visible edge"
           value={followViewEdge}
           onChange={setFollowViewEdge}
         />
         <ToggleChip
-          label="hideLiveOnScrollBack"
+          label="Hide on scroll back"
           value={hideLiveOnScrollBack}
           onChange={setHideLiveOnScrollBack}
         />

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -64,6 +64,8 @@ export default function TimeScrollScreen() {
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [holdMs, setHoldMs] = useState(500);
   const [enabled, setEnabled] = useState(true);
+  const [followViewEdge, setFollowViewEdge] = useState(true);
+  const [hideLiveOnScrollBack, setHideLiveOnScrollBack] = useState(true);
   const [returnMode, setReturnMode] = useState<ReturnMode>("glide");
   const [zoomOn, setZoomOn] = useState(true);
   const [scrub, setScrub] = useState(true);
@@ -113,9 +115,12 @@ export default function TimeScrollScreen() {
           theme={APP_THEME}
           timeWindow={WINDOW_SECS}
           yAxis={{ float: floatAxis }}
-          // Pill tracks the last visible price as you scroll back.
-          badge={{ followViewEdge: true }}
-          timeScroll={enabled ? { gesture, scrubHoldMs: holdMs } : false}
+          badge={{ followViewEdge }}
+          timeScroll={
+            enabled
+              ? { gesture, scrubHoldMs: holdMs, hideLiveOnScrollBack }
+              : false
+          }
           returnToLive={RETURN_TO_LIVE[returnMode]}
           zoom={zoomOn}
           // Paging callbacks (Phase 3): log the visible range (~1 Hz) and show an
@@ -136,6 +141,19 @@ export default function TimeScrollScreen() {
         />
       }
     >
+      <ControlRow label="Live indicator behavior">
+        <ToggleChip
+          label="badge.followViewEdge"
+          value={followViewEdge}
+          onChange={setFollowViewEdge}
+        />
+        <ToggleChip
+          label="hideLiveOnScrollBack"
+          value={hideLiveOnScrollBack}
+          onChange={setHideLiveOnScrollBack}
+        />
+      </ControlRow>
+
       <ChipRow
         label="Chart type"
         options={MODE_OPTIONS}

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -323,7 +323,7 @@ provided; everything else has a default.
   press-and-hold scrubs); pass a
   [`TimeScrollConfig`](/api-reference/types#config-objects) to pick `"axisDrag"`
   (drag the x-axis strip), set `scrubHoldMs`, or set
-  `hideLiveOnScrollBack: false` to keep the live dot and value line visible
+  `hideLiveOnScrollBack: false` to keep the live badge, dot, and value line visible
   while scrolled back (hidden by default — they mark the off-screen live price).
   **@experimental.** See [Time-scroll](/guides/time-scroll).
 </ParamField>

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -322,7 +322,9 @@ provided; everything else has a default.
   `true` uses the default drag-to-scroll gesture (`"holdToScrub"` — drag scrolls,
   press-and-hold scrubs); pass a
   [`TimeScrollConfig`](/api-reference/types#config-objects) to pick `"axisDrag"`
-  (drag the x-axis strip) or set `scrubHoldMs`.
+  (drag the x-axis strip), set `scrubHoldMs`, or set
+  `hideLiveOnScrollBack: false` to keep the live dot and value line visible
+  while scrolled back (hidden by default — they mark the off-screen live price).
   **@experimental.** See [Time-scroll](/guides/time-scroll).
 </ParamField>
 

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -334,7 +334,8 @@ interface BadgeConfig {
   offsetX?: number;         // nudge the whole badge horizontally (px); default 0
   offsetY?: number;         // nudge the whole badge vertically (px); default 0
   followViewEdge?: boolean; // while time-scrolled, track the price at the visible
-                            // window's right edge (badge + value line + dot); default false
+                            // window's right edge (badge value/color + value line + dot);
+                            // default false
 }
 interface PulseConfig {
   interval?: number; duration?: number; maxRadius?: number;
@@ -406,7 +407,7 @@ interface VolumeConfig {
 interface TimeScrollConfig {
   gesture?: "holdToScrub" | "axisDrag"; // activation; default "holdToScrub"
   scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
-  hideLiveOnScrollBack?: boolean; // hide live dot + value line while scrolled back (they mark the off-screen live price); default true. Ignored with badge.followViewEdge
+  hideLiveOnScrollBack?: boolean; // hide live badge + dot + value line while scrolled back (they mark the off-screen live price); default true. Ignored with badge.followViewEdge
 }
 // Tunes the return-to-live glide (the `returnToLive` prop). @experimental
 interface ReturnToLiveConfig {

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -406,6 +406,7 @@ interface VolumeConfig {
 interface TimeScrollConfig {
   gesture?: "holdToScrub" | "axisDrag"; // activation; default "holdToScrub"
   scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
+  hideLiveOnScrollBack?: boolean; // hide live dot + value line while scrolled back (they mark the off-screen live price); default true. Ignored with badge.followViewEdge
 }
 // Tunes the return-to-live glide (the `returnToLive` prop). @experimental
 interface ReturnToLiveConfig {

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -161,10 +161,13 @@ candles aren't cut off, and it reverts when you return to live.
 
 ## Track the visible edge (`badge.followViewEdge`)
 
-While scrolled back, the live-price indicators normally stay at the (off-screen, still-advancing)
-live value. Set [`badge.followViewEdge`](/api-reference/types#config-objects) so the **badge, value
+While scrolled back, the live price is off-screen — so the **live dot and value line are hidden**
+by default (they'd mark a price that isn't in view). Set
+[`badge.followViewEdge`](/api-reference/types#config-objects) so the **badge, value
 line, and live dot** instead track the price at the **visible window's right edge** — the last
-price you can see — and snap back to the live value when you return to the live edge.
+price you can see — and snap back to the live value when you return to the live edge. To keep the
+dot and value line pinned at the off-screen live price instead (the pre-4.12 behavior), set
+`timeScroll={{ hideLiveOnScrollBack: false }}`.
 
 ## Notes
 

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -161,13 +161,14 @@ candles aren't cut off, and it reverts when you return to live.
 
 ## Track the visible edge (`badge.followViewEdge`)
 
-While scrolled back, the live price is off-screen — so the **live dot and value line are hidden**
-by default (they'd mark a price that isn't in view). Set
+While scrolled back, the live price is off-screen — so the **live badge, dot, and value line are
+hidden** by default (they'd mark a price that isn't in view). Set
 [`badge.followViewEdge`](/api-reference/types#config-objects) so the **badge, value
 line, and live dot** instead track the price at the **visible window's right edge** — the last
-price you can see — and snap back to the live value when you return to the live edge. To keep the
-dot and value line pinned at the off-screen live price instead (the pre-4.12 behavior), set
-`timeScroll={{ hideLiveOnScrollBack: false }}`.
+price you can see — and snap back to the live value when you return to the live edge. The badge's
+momentum color is calculated at that same historical edge, so new live ticks cannot recolor a
+stationary historical badge. To keep the badge, dot, and value line pinned at the off-screen live
+price instead (the pre-4.12 behavior), set `timeScroll={{ hideLiveOnScrollBack: false }}`.
 
 The plotted line is independent of those overlay settings: while scrolled back, it always ends
 at the visible window's right-edge value and never connects the historical window to the current

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -169,6 +169,10 @@ price you can see — and snap back to the live value when you return to the liv
 dot and value line pinned at the off-screen live price instead (the pre-4.12 behavior), set
 `timeScroll={{ hideLiveOnScrollBack: false }}`.
 
+The plotted line is independent of those overlay settings: while scrolled back, it always ends
+at the visible window's right-edge value and never connects the historical window to the current
+live price.
+
 ## Notes
 
 - **Both charts.** `timeScroll` and `zoom` are wired into `LiveChart` and `LiveChartSeries`. In

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -58,6 +58,10 @@ import {
   resolveYAxis,
 } from "../core/resolveConfig";
 import type { ResolvedThresholdConfig } from "../core/resolveConfig";
+import {
+  liveIndicatorScrollOpacity,
+  resolveHideLiveOnScrollBack,
+} from "../core/liveIndicatorVisibility";
 import { resolveSegment, type ResolvedSegment } from "../core/resolveSegment";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
 import { pulseRadialOutset } from "../draw/line";
@@ -1190,10 +1194,33 @@ function useLiveChartController({
   // point instead — otherwise both dots show at once. Applies on static charts
   // too, now that they're scrubbable.
   const selectionDotDuringScrub = scrubCfg !== null && selectionDotCfg !== null;
+  // While scrolled back the live tip is off-screen but dotX stays pinned to the
+  // plot's right edge, so the dot would mark a price that isn't in view — hide
+  // it (like the pulse). `badge.followViewEdge` opts back in: there the dot
+  // tracks the visible edge price, which IS in view. `hideLiveOnScrollBack:
+  // false` opts out of the hiding entirely.
+  const hideLiveOnScrollBack = resolveHideLiveOnScrollBack(
+    timeScroll,
+    badgeCfg?.followViewEdge ?? false,
+  );
   const liveDotOpacity = useDerivedValue(
     () =>
       reveal.dotOpacity.value *
-      (selectionDotDuringScrub && crosshairScrubActive.value ? 0 : 1),
+      (selectionDotDuringScrub && crosshairScrubActive.value ? 0 : 1) *
+      liveIndicatorScrollOpacity(
+        hideLiveOnScrollBack,
+        engine.viewEnd.value,
+      ),
+  );
+  // Same scrolled-back gating for the value line: it would draw a dashed line
+  // at the live value's Y — a price that isn't in the scrolled-back view.
+  const valueLineOpacity = useDerivedValue(
+    () =>
+      reveal.lineOpacity.value *
+      liveIndicatorScrollOpacity(
+        hideLiveOnScrollBack,
+        engine.viewEnd.value,
+      ),
   );
 
   // Fade the annotation overlays (markers + reference lines) out while scrubbing
@@ -1333,6 +1360,7 @@ function useLiveChartController({
     dotX,
     dotY,
     liveDotOpacity,
+    valueLineOpacity,
     overlayScrubFade,
     markerGroupOpacity,
     momentumSV,
@@ -1692,6 +1720,7 @@ function ChartStack({
     fontProp,
     badgeCfg,
     valueLineCfg,
+    valueLineOpacity,
     dotY,
     allRefLines,
     refLineKeys,
@@ -1757,7 +1786,7 @@ function ChartStack({
 
       {/* Value line + reference line (behind chart line) */}
       {valueLineCfg && (
-        <Group opacity={reveal.lineOpacity}>
+        <Group opacity={valueLineOpacity}>
           <ValueLineOverlay
             dotY={dotY}
             engine={engine}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -82,7 +82,10 @@ import { useMarkers } from "../hooks/useMarkers";
 import { useReferenceDrag } from "../hooks/useReferenceDrag";
 import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
-import { useMomentum } from "../hooks/useMomentum";
+import {
+  resolveMomentumProp,
+  useMomentum,
+} from "../hooks/useMomentum";
 import { AXIS_GRAB_MIN_PX, usePanScroll } from "../hooks/usePanScroll";
 import { usePinchZoom } from "../hooks/usePinchZoom";
 import { useVisibleRange } from "../hooks/useVisibleRange";
@@ -925,6 +928,15 @@ function useLiveChartController({
   );
 
   const momentumSV = useMomentum(engine, momentum);
+  // A follow-edge badge must derive its color from the same historical point
+  // as its value and position. While following live, reuse the normal momentum
+  // result; while scrolled back, detect against the data prefix ending at the
+  // visible right-edge timestamp so incoming live ticks cannot change the pill.
+  const badgeMomentumSV = useDerivedValue(() =>
+    badgeCfg?.followViewEdge && engine.viewEnd.value !== null
+      ? resolveMomentumProp(momentum, engine.data.value, engine.timestamp.value)
+      : momentumSV.value,
+  );
 
   // ── Overlay hooks ─────────────────────────────────────────────────────
   // Scrub/crosshair must see the same stash-backed candles as the engine.
@@ -1204,11 +1216,10 @@ function useLiveChartController({
   // point instead — otherwise both dots show at once. Applies on static charts
   // too, now that they're scrubbable.
   const selectionDotDuringScrub = scrubCfg !== null && selectionDotCfg !== null;
-  // While scrolled back the live tip is off-screen but dotX stays pinned to the
-  // plot's right edge, so the dot would mark a price that isn't in view — hide
-  // it (like the pulse). `badge.followViewEdge` opts back in: there the dot
-  // tracks the visible edge price, which IS in view. `hideLiveOnScrollBack:
-  // false` opts out of the hiding entirely.
+  // While scrolled back, the badge, dot, and value line still point at the live
+  // price even though the window is showing history. Hide that live-priced group
+  // together. `badge.followViewEdge` opts back in because all three then track
+  // the visible edge price; `hideLiveOnScrollBack: false` keeps the legacy group.
   const hideLiveOnScrollBack = resolveHideLiveOnScrollBack(
     timeScroll,
     badgeCfg?.followViewEdge ?? false,
@@ -1227,6 +1238,14 @@ function useLiveChartController({
   const valueLineOpacity = useDerivedValue(
     () =>
       reveal.lineOpacity.value *
+      liveIndicatorScrollOpacity(
+        hideLiveOnScrollBack,
+        engine.viewEnd.value,
+      ),
+  );
+  const liveBadgeOpacity = useDerivedValue(
+    () =>
+      reveal.badgeOpacity.value *
       liveIndicatorScrollOpacity(
         hideLiveOnScrollBack,
         engine.viewEnd.value,
@@ -1371,9 +1390,11 @@ function useLiveChartController({
     dotY,
     liveDotOpacity,
     valueLineOpacity,
+    liveBadgeOpacity,
     overlayScrubFade,
     markerGroupOpacity,
     momentumSV,
+    badgeMomentumSV,
     onDegenShake,
     crosshair,
     rootGesture,
@@ -1474,6 +1495,7 @@ function ChartYAxisLayer({
     metricsCfg,
     gridStyleCfg,
     yAxisFloat,
+    liveBadgeOpacity,
   } = model;
   return (
     <Group opacity={reveal.yAxisOpacity}>
@@ -1491,6 +1513,7 @@ function ChartYAxisLayer({
         badgeCenterY={badgeUsesRightGutter ? dotY : undefined}
         badgeFontSize={badgeUsesRightGutter ? badgeFont.getSize() : undefined}
         badgeOffsetY={badgeCfg?.offsetY ?? 0}
+        badgeOpacity={badgeUsesRightGutter ? liveBadgeOpacity : undefined}
         gridStyle={gridStyleCfg}
       />
     </Group>
@@ -2187,14 +2210,14 @@ function ChartBadgeLayer({
 }) {
   const {
     badgeFont,
-    reveal,
     engine,
     effectivePadding,
     palette,
     formatValue,
-    momentumSV,
+    badgeMomentumSV,
     metricsCfg,
     yAxisFloat,
+    liveBadgeOpacity,
   } = model;
   const badgeCfg = model.badgeCfg!;
   const badgeData = useBadge(
@@ -2205,7 +2228,7 @@ function ChartBadgeLayer({
     badgeFont,
     badgeCfg.variant,
     badgeCfg.tail,
-    momentumSV,
+    badgeMomentumSV,
     badgeCfg.position,
     badgeCfg.background,
     metricsCfg.badge,
@@ -2218,7 +2241,7 @@ function ChartBadgeLayer({
   );
   return (
     <Group transform={degen?.shakeTransform}>
-      <Group opacity={reveal.badgeOpacity}>
+      <Group opacity={liveBadgeOpacity}>
         <BadgeOverlay
           badge={badgeData}
           font={badgeFont}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -888,11 +888,8 @@ function useLiveChartController({
     // polyline passed as the last arg below).
     thresholdCfg?.fill && !thresholdIsSeries ? thresholdGeom.lineY : undefined,
     lineIsLinear,
-    // Tip the line at the view-edge price (not the live value) while scrolled,
-    // matching the live dot — so the right edge doesn't drop to the off-screen
-    // live value when `followViewEdge` tracks the scrolled-back window.
-    engine.edgeValue,
-    badgeCfg?.followViewEdge ?? false,
+    // The plotted line independently selects the visible edge while historical;
+    // badge/live-indicator options affect overlays only.
     // Match the standalone loading squiggle's wave during the reveal morph.
     loadingCfg?.amplitude,
     loadingCfg?.speed,

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -52,6 +52,7 @@ export function YAxisOverlay({
   badgeCenterY,
   badgeFontSize,
   badgeOffsetY = 0,
+  badgeOpacity,
   seriesLabelInset = 0,
   gridStyle,
   variant = "all",
@@ -74,6 +75,8 @@ export function YAxisOverlay({
   badgeFontSize?: number;
   /** Configured live badge Y offset. */
   badgeOffsetY?: number;
+  /** Live badge opacity. A fully hidden badge does not suppress an axis label. */
+  badgeOpacity?: SharedValue<number>;
   /** When > 0, series labels occupy the left portion of the gutter; Y-axis labels right-align. */
   seriesLabelInset?: number;
   /** Grid-line styling overrides. Omit for the legacy solid 1px line. */
@@ -118,7 +121,8 @@ export function YAxisOverlay({
     const fm = font.getMetrics();
     const baselineOffset = (fm.ascent + fm.descent) / 2;
     const labelHeight = fm.descent - fm.ascent;
-    const resolvedBadgeCenterY = badgeCenterY
+    const badgeIsVisible = badgeOpacity === undefined || badgeOpacity.get() > 0;
+    const resolvedBadgeCenterY = badgeCenterY && badgeIsVisible
       ? badgeCenterY.get() + badgeOffsetY
       : null;
     const badgeHeight =

--- a/packages/react-native-livechart/src/core/liveIndicatorVisibility.ts
+++ b/packages/react-native-livechart/src/core/liveIndicatorVisibility.ts
@@ -15,7 +15,7 @@ export function resolveHideLiveOnScrollBack(
   return hide && !followViewEdge;
 }
 
-/** Worklet-safe opacity gate shared by the live dot and dashed value line. */
+/** Worklet-safe opacity gate shared by the live badge, dot, and dashed value line. */
 export function liveIndicatorScrollOpacity(
   hideLiveOnScrollBack: boolean,
   viewEnd: number | null,

--- a/packages/react-native-livechart/src/core/liveIndicatorVisibility.ts
+++ b/packages/react-native-livechart/src/core/liveIndicatorVisibility.ts
@@ -1,0 +1,25 @@
+import type { TimeScrollConfig } from "../types";
+
+/**
+ * Resolve whether historical time-scroll views should suppress indicators that
+ * still point at the live price.
+ */
+export function resolveHideLiveOnScrollBack(
+  timeScroll: boolean | TimeScrollConfig | undefined,
+  followViewEdge: boolean,
+): boolean {
+  const hide =
+    typeof timeScroll === "object"
+      ? (timeScroll.hideLiveOnScrollBack ?? true)
+      : true;
+  return hide && !followViewEdge;
+}
+
+/** Worklet-safe opacity gate shared by the live dot and dashed value line. */
+export function liveIndicatorScrollOpacity(
+  hideLiveOnScrollBack: boolean,
+  viewEnd: number | null,
+): 0 | 1 {
+  "worklet";
+  return hideLiveOnScrollBack && viewEnd != null ? 0 : 1;
+}

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -1,12 +1,27 @@
 import { Skia, type SkPath } from "@shopify/react-native-skia";
 import { useRef } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
-import type { SingleEngineState } from "../core/useLiveChartEngine";
+import type {
+  ChartEngineEdge,
+  ChartEngineScroll,
+  SingleEngineState,
+} from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
 import { drawSpline, makeSplineScratch } from "../math/spline";
 import { sampleThresholdYAt, thresholdSampleSpanX } from "../math/threshold";
 import { blendPtsY, squigglifyPts } from "../math/squiggly";
 import { usePathBuilder } from "./usePathBuilder";
+
+/** Selects the synthetic right-edge line tip without coupling chart geometry
+ * to badge or live-indicator presentation options. */
+export function resolveLineTipValue(
+  displayValue: number,
+  edgeValue: number,
+  viewEnd: number | null,
+): number {
+  "worklet";
+  return viewEnd == null ? displayValue : edgeValue;
+}
 
 /**
  * Builds the `linePath` / `fillPath` with `Skia.PathBuilder`s reused across
@@ -20,7 +35,7 @@ import { usePathBuilder } from "./usePathBuilder";
  * fillPath.
  */
 export function useChartPaths(
-  engine: SingleEngineState,
+  engine: SingleEngineState & ChartEngineScroll & ChartEngineEdge,
   padding: ChartPadding,
   morphT?: SharedValue<number>,
   /** When set, also build `thresholdFillPath` — the band between the line and this
@@ -28,14 +43,6 @@ export function useChartPaths(
   thresholdY?: SharedValue<number>,
   /** Draw the line/fill as a straight polyline instead of the monotone cubic. */
   linear = false,
-  /**
-   * Value at the visible window's right edge (engine `edgeValue`). With
-   * `followViewEdge`, the line's right-edge tip uses this instead of the live
-   * `displayValue` — so while time-scrolled the line ends at the last visible
-   * price rather than dropping to the (off-screen) live value.
-   */
-  edgeValue?: SharedValue<number>,
-  followViewEdge = false,
   /** Loading squiggle wave amplitude (px) for the reveal morph. Default 14. */
   squiggleAmplitude = 14,
   /** Loading squiggle wave speed multiplier for the reveal morph. Default 1. */
@@ -79,11 +86,14 @@ export function useChartPaths(
     const cache = cacheRef.current!;
     cache.ptsTick = !cache.ptsTick;
     const buf = cache.ptsTick ? cache.ptsA : cache.ptsB;
-    // While scrolled back with `followViewEdge`, tip the line at the view-edge
-    // price (engine `edgeValue`) instead of the live value — otherwise the line
-    // drops from the last visible point to the off-screen live value at the edge.
-    const tipValue =
-      followViewEdge && edgeValue ? edgeValue.get() : engine.displayValue.get();
+    // A historical window must end at its own right-edge price. Badge and
+    // live-indicator options affect overlays only; they must not distort the
+    // plotted series by connecting history to the off-screen live value.
+    const tipValue = resolveLineTipValue(
+      engine.displayValue.get(),
+      engine.edgeValue.get(),
+      engine.viewEnd.get(),
+    );
     const realPts = buildLinePoints(
       engine.data.get(),
       tipValue,

--- a/packages/react-native-livechart/src/hooks/useMomentum.ts
+++ b/packages/react-native-livechart/src/hooks/useMomentum.ts
@@ -13,16 +13,23 @@ import type { Momentum, MomentumConfig } from "../types";
 export function resolveMomentumProp(
   prop: boolean | Momentum | MomentumConfig,
   data: readonly { time: number; value: number }[],
+  endTime?: number,
 ): Momentum {
   "worklet";
   if (prop === false) return "flat";
   if (prop === true)
-    return detectMomentum(data as { time: number; value: number }[]);
+    return detectMomentum(
+      data as { time: number; value: number }[],
+      undefined,
+      undefined,
+      endTime,
+    );
   if (typeof prop === "object")
     return detectMomentum(
       data as { time: number; value: number }[],
       prop.lookback,
       prop.threshold,
+      endTime,
     );
   return prop;
 }

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -177,9 +177,10 @@ export function usePanScroll({
       // nothing further (and must not claim the touch via `scrollActive`).
       if (scrubActive?.get()) return;
       scrollActive?.set(true);
-      // Anchor at the current right edge so the first delta is relative to where
-      // the window sits (the live edge when we were following).
-      if (viewEnd.get() == null) viewEnd.set(liveEdge.get());
+      // Keep `null` while following live. `onChange` resolves it to the current
+      // live edge before applying the first delta. Materializing that same edge
+      // here would falsely signal "scrolled back" between start and change,
+      // briefly collapsing the floating-axis gutter on a forward-only overdrag.
       onScrollStart?.();
     };
 

--- a/packages/react-native-livechart/src/math/momentum.ts
+++ b/packages/react-native-livechart/src/math/momentum.ts
@@ -9,15 +9,32 @@ export function detectMomentum(
   points: LiveChartPoint[],
   lookback = 20,
   threshold = 0.12,
+  endTime?: number,
 ): Momentum {
   "worklet";
-  if (points.length < 5) return "flat";
+  // `badge.followViewEdge` needs momentum at the historical window edge rather
+  // than at the live dataset tail. Points are chronological, so find the first
+  // sample after the inclusive cutoff without allocating a sliced array on the
+  // UI thread. With no cutoff, preserve the normal live-tail behavior.
+  let end = points.length;
+  if (endTime !== undefined) {
+    let lo = 0;
+    let hi = points.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (points[mid].time <= endTime) lo = mid + 1;
+      else hi = mid;
+    }
+    end = lo;
+  }
 
-  const start = Math.max(0, points.length - lookback);
+  if (end < 5) return "flat";
+
+  const start = Math.max(0, end - lookback);
 
   let min = Infinity;
   let max = -Infinity;
-  for (let i = start; i < points.length; i++) {
+  for (let i = start; i < end; i++) {
     const v = points[i].value;
     if (v < min) min = v;
     if (v > max) max = v;
@@ -25,9 +42,9 @@ export function detectMomentum(
   const range = max - min;
   if (range === 0) return "flat";
 
-  const tailStart = Math.max(start, points.length - 5);
+  const tailStart = Math.max(start, end - 5);
   const first = points[tailStart].value;
-  const last = points[points.length - 1].value;
+  const last = points[end - 1].value;
   const delta = last - first;
 
   const absThreshold = range * threshold;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -599,7 +599,9 @@ export interface BadgeConfig extends BadgeStyleConfig {
    * When the chart is scrolled back (see `timeScroll`), move the live-price
    * indicators — the badge, the value line, and the live dot — to the price at
    * the visible window's right edge instead of the live price, so they track the
-   * last visible price as you pan. Default `false`.
+   * last visible price as you pan. The badge's momentum color is derived at that
+   * same historical edge, so incoming live ticks do not recolor it. Default
+   * `false`.
    *
    * @experimental
    */
@@ -1629,12 +1631,12 @@ export interface TimeScrollConfig {
    */
   scrubHoldMs?: number;
   /**
-   * Hide the live dot and the dashed value line while scrolled back through
-   * history. Default `true`: both mark the LIVE price, which is off-screen once
-   * the window is frozen behind the live edge, so they'd point at a price that
-   * isn't in view. Set `false` to keep them visible while scrolled back.
-   * Ignored when `badge.followViewEdge` is on — there the dot tracks the visible
-   * edge price, which IS in view.
+   * Hide the live badge, dot, and dashed value line while scrolled back through
+   * history. Default `true`: all three mark the LIVE price, which is off-screen
+   * once the window is frozen behind the live edge, so they'd point at a price
+   * that isn't in view. Set `false` to keep them visible while scrolled back.
+   * Ignored when `badge.followViewEdge` is on — there the group tracks the
+   * visible edge price, which IS in view.
    */
   hideLiveOnScrollBack?: boolean;
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1628,6 +1628,15 @@ export interface TimeScrollConfig {
    * if set, otherwise `500`.
    */
   scrubHoldMs?: number;
+  /**
+   * Hide the live dot and the dashed value line while scrolled back through
+   * history. Default `true`: both mark the LIVE price, which is off-screen once
+   * the window is frozen behind the live edge, so they'd point at a price that
+   * isn't in view. Set `false` to keep them visible while scrolled back.
+   * Ignored when `badge.followViewEdge` is on — there the dot tracks the visible
+   * edge price, which IS in view.
+   */
+  hideLiveOnScrollBack?: boolean;
 }
 
 /**

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -966,6 +966,23 @@ describe("LiveChart", () => {
     });
   });
 
+  it("mounts the live indicators across time-scroll visibility configs", () => {
+    // Behavioral opacity coverage lives in liveIndicatorVisibility.test.ts.
+    // This integration check ensures each public config form wires into the
+    // complete chart without disrupting the mounted dot or value line.
+    for (const props of [
+      { timeScroll: true as const },
+      { timeScroll: { hideLiveOnScrollBack: false } },
+      { timeScroll: true as const, badge: { followViewEdge: true } },
+    ]) {
+      const screen = render(<Harness {...props} valueLine dot />);
+      const views = screen.UNSAFE_getAllByType(View);
+      fireEvent(views[0], "layout", {
+        nativeEvent: { layout: { width: 400, height: 200 } },
+      });
+    }
+  });
+
   it("composes the hold-to-scrub (one-finger drag) gesture", () => {
     // Default hold (no scrubHoldMs) and an explicit override both render cleanly.
     for (const ts of [

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -969,7 +969,7 @@ describe("LiveChart", () => {
   it("mounts the live indicators across time-scroll visibility configs", () => {
     // Behavioral opacity coverage lives in liveIndicatorVisibility.test.ts.
     // This integration check ensures each public config form wires into the
-    // complete chart without disrupting the mounted dot or value line.
+    // complete chart without disrupting the mounted badge, dot, or value line.
     for (const props of [
       { timeScroll: true as const },
       { timeScroll: { hideLiveOnScrollBack: false } },

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -135,6 +135,7 @@ describe("YAxisOverlay", () => {
     function Fixture() {
       const entries = useSharedValue([{ y: 40, label: "10", alpha: 1 }]);
       const badgeCenterY = useSharedValue(40);
+      const badgeOpacity = useSharedValue(0);
       return (
         <YAxisOverlay
           entries={entries}
@@ -146,6 +147,7 @@ describe("YAxisOverlay", () => {
           badgeCenterY={badgeCenterY}
           badgeFontSize={12}
           badgeOffsetY={2}
+          badgeOpacity={badgeOpacity}
         />
       );
     }

--- a/packages/react-native-livechart/tests/core/liveIndicatorVisibility.test.ts
+++ b/packages/react-native-livechart/tests/core/liveIndicatorVisibility.test.ts
@@ -1,0 +1,38 @@
+import {
+  liveIndicatorScrollOpacity,
+  resolveHideLiveOnScrollBack,
+} from "../../src/core/liveIndicatorVisibility";
+
+describe("live indicator visibility while time-scrolling", () => {
+  const historicalViewEnd = 1_700_000_000;
+
+  it("hides the live dot and value line by default while scrolled back", () => {
+    const hide = resolveHideLiveOnScrollBack(true, false);
+
+    expect(hide).toBe(true);
+    expect(liveIndicatorScrollOpacity(hide, historicalViewEnd)).toBe(0);
+  });
+
+  it("keeps both indicators visible at the live edge", () => {
+    const hide = resolveHideLiveOnScrollBack(true, false);
+
+    expect(liveIndicatorScrollOpacity(hide, null)).toBe(1);
+  });
+
+  it("honors the explicit hideLiveOnScrollBack opt-out", () => {
+    const hide = resolveHideLiveOnScrollBack(
+      { hideLiveOnScrollBack: false },
+      false,
+    );
+
+    expect(hide).toBe(false);
+    expect(liveIndicatorScrollOpacity(hide, historicalViewEnd)).toBe(1);
+  });
+
+  it("keeps visible-edge indicators visible while scrolled back", () => {
+    const hide = resolveHideLiveOnScrollBack(true, true);
+
+    expect(hide).toBe(false);
+    expect(liveIndicatorScrollOpacity(hide, historicalViewEnd)).toBe(1);
+  });
+});

--- a/packages/react-native-livechart/tests/core/liveIndicatorVisibility.test.ts
+++ b/packages/react-native-livechart/tests/core/liveIndicatorVisibility.test.ts
@@ -6,14 +6,14 @@ import {
 describe("live indicator visibility while time-scrolling", () => {
   const historicalViewEnd = 1_700_000_000;
 
-  it("hides the live dot and value line by default while scrolled back", () => {
+  it("hides live-priced indicators by default while scrolled back", () => {
     const hide = resolveHideLiveOnScrollBack(true, false);
 
     expect(hide).toBe(true);
     expect(liveIndicatorScrollOpacity(hide, historicalViewEnd)).toBe(0);
   });
 
-  it("keeps both indicators visible at the live edge", () => {
+  it("keeps live indicators visible at the live edge", () => {
     const hide = resolveHideLiveOnScrollBack(true, false);
 
     expect(liveIndicatorScrollOpacity(hide, null)).toBe(1);

--- a/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
@@ -1,17 +1,28 @@
 import { DEFAULT_PADDING } from "../../src/draw/line";
-import type { SingleEngineState } from "../../src/core/useLiveChartEngine";
+import type {
+  ChartEngineEdge,
+  ChartEngineScroll,
+  SingleEngineState,
+} from "../../src/core/useLiveChartEngine";
 import { renderHook } from "@testing-library/react-native";
-import { useChartPaths } from "../../src/hooks/useChartPaths";
+import {
+  resolveLineTipValue,
+  useChartPaths,
+} from "../../src/hooks/useChartPaths";
 import { useSharedValue } from "react-native-reanimated";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
+type ChartPathsEngine = SingleEngineState & ChartEngineScroll & ChartEngineEdge;
+
 function makeEngine(
-  overrides: Partial<SingleEngineState> = {},
-): SingleEngineState {
+  overrides: Partial<ChartPathsEngine> = {},
+): ChartPathsEngine {
   const base = {
     data: { value: [{ time: 1000, value: 1 }] },
     value: { value: 1 },
     displayValue: { value: 1 },
+    edgeValue: { value: 1 },
+    viewEnd: { value: null },
     displayMin: { value: 0 },
     displayMax: { value: 2 },
     displayWindow: { value: 30 },
@@ -22,7 +33,7 @@ function makeEngine(
   return withSharedValueAccessors({
     ...base,
     ...overrides,
-  }) as unknown as SingleEngineState;
+  }) as unknown as ChartPathsEngine;
 }
 
 describe("useChartPaths", () => {
@@ -41,7 +52,7 @@ describe("useChartPaths", () => {
           data: { value: [{ time: 1000, value: 1 }] },
           displayMin: { value: 0 },
           displayMax: { value: 0 },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<ChartPathsEngine>),
         DEFAULT_PADDING,
       ),
     );
@@ -60,7 +71,7 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<ChartPathsEngine>),
         DEFAULT_PADDING,
         undefined,
         thresholdY,
@@ -86,13 +97,11 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<ChartPathsEngine>),
         DEFAULT_PADDING,
         undefined, // morphT
         undefined, // thresholdY (constant) — superseded by the samples below
         false, // linear
-        undefined, // edgeValue
-        false, // followViewEdge
         undefined, // squiggleAmplitude
         undefined, // squiggleSpeed
         thresholdSamples, // time-varying band bottom
@@ -113,7 +122,7 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+        } as unknown as Partial<ChartPathsEngine>),
         DEFAULT_PADDING,
         morphT,
       );
@@ -122,10 +131,17 @@ describe("useChartPaths", () => {
     expect(result.current.fillPath.value).toBeDefined();
   });
 
-  it("tips the line at edgeValue when followViewEdge is on (time-scroll)", () => {
-    // While scrolled back, the right-edge tip should use the view-edge price
-    // (edgeValue), not the live displayValue — so the line doesn't drop to the
-    // off-screen live value.
+  it("tips a live window at displayValue", () => {
+    expect(resolveLineTipValue(9, 4, null)).toBe(9);
+  });
+
+  it("tips a historical window at edgeValue independently of indicator options", () => {
+    // No badge.followViewEdge or hideLiveOnScrollBack input exists here:
+    // presentation flags cannot change the plotted series geometry.
+    expect(resolveLineTipValue(9, 4, 1_000)).toBe(4);
+  });
+
+  it("builds a historical line using the engine edge value", () => {
     const { result } = renderHook(() => {
       const edgeValue = useSharedValue(1.5);
       return useChartPaths(
@@ -137,13 +153,11 @@ describe("useChartPaths", () => {
               { time: 1000, value: 2 },
             ],
           },
-        } as unknown as Partial<SingleEngineState>),
+          displayValue: { value: 999 },
+          edgeValue,
+          viewEnd: { value: 1_000 },
+        } as unknown as Partial<ChartPathsEngine>),
         DEFAULT_PADDING,
-        undefined,
-        undefined,
-        false,
-        edgeValue,
-        true, // followViewEdge → tip uses edgeValue
       );
     });
     expect(result.current.linePath.value).toBeDefined();

--- a/packages/react-native-livechart/tests/hooks/useMomentum.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useMomentum.test.ts
@@ -45,6 +45,15 @@ describe("resolveMomentumProp", () => {
       resolveMomentumProp({ lookback: 5, threshold: 0.5 }, data),
     ).toBeDefined();
   });
+
+  it("auto-detects from the data prefix at a historical edge", () => {
+    const data = makeData([
+      100, 100, 100, 100, 120, 120, 120, 120, 120, 80,
+    ]);
+
+    expect(resolveMomentumProp(true, data)).toBe("down");
+    expect(resolveMomentumProp(true, data, data[4].time)).toBe("up");
+  });
 });
 
 function engineWithData(data: LiveChartPoint[]): SingleEngineState {

--- a/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
@@ -28,6 +28,12 @@ describe("nextViewEnd", () => {
     expect(nextViewEnd(997, -20, 200, 30, 1000, 930)).toBeNull();
   });
 
+  it("keeps a forward overdrag from the live edge in follow mode", () => {
+    // onChange resolves a null viewEnd to the live edge (1000); dragging toward
+    // the future must remain null instead of entering a transient scroll state.
+    expect(nextViewEnd(1000, -20, 200, 30, 1000, 930)).toBeNull();
+  });
+
   it("clamps to the lower bound (oldest history)", () => {
     // 940 - (200/200)*30 = 910, below lo 930 ⇒ 930.
     expect(nextViewEnd(940, 200, 200, 30, 1000, 930)).toBe(930);

--- a/packages/react-native-livechart/tests/math/momentum.test.ts
+++ b/packages/react-native-livechart/tests/math/momentum.test.ts
@@ -62,4 +62,31 @@ describe("detectMomentum", () => {
     }));
     expect(detectMomentum(pts, 100)).toBe("up");
   });
+
+  it("detects momentum at an inclusive historical cutoff", () => {
+    const pts = [
+      { time: 0, value: 100 },
+      { time: 1, value: 100 },
+      { time: 2, value: 100 },
+      { time: 3, value: 100 },
+      { time: 4, value: 120 },
+      { time: 5, value: 120 },
+      { time: 6, value: 120 },
+      { time: 7, value: 120 },
+      { time: 8, value: 120 },
+      { time: 9, value: 80 },
+    ];
+
+    expect(detectMomentum(pts)).toBe("down");
+    expect(detectMomentum(pts, 20, 0.12, 4)).toBe("up");
+  });
+
+  it("returns flat when fewer than five points precede the cutoff", () => {
+    const pts = Array.from({ length: 8 }, (_, time) => ({
+      time,
+      value: time,
+    }));
+
+    expect(detectMomentum(pts, 20, 0.12, 3)).toBe("flat");
+  });
 });


### PR DESCRIPTION
## What happens

- Enable `timeScroll` and drag back through history.
- The live dot stays pinned to the plot's right edge at the **live** price's Y.
- The dashed value line draws at that same Y.
- In line mode, the plotted series can also extend from the historical window to the off-screen live price.
- These indicators and geometry point outside the visible historical window.

## Why

- `dotX` is pinned to the plot's right edge, while `dotY` and the value line follow the live value even when the window is frozen behind the live edge.
- The synthetic right-edge line tip was coupled to `badge.followViewEdge`; with that option off it used the live `displayValue` instead of the historical window's `edgeValue`.

## Fix

- Hide the live dot and dashed value line while scrolled back (`viewEnd != null`); they reappear on return to the live edge.
- `badge.followViewEdge` keeps its overlay behavior — the badge, dot, and value line track the visible edge price, which **is** in view.
- New `timeScroll.hideLiveOnScrollBack` flag (default `true`) opts out for anyone relying on the old live-indicator behavior.
- The plotted line is now independent of both options: live view ends at the current live value; historical view always ends at the visible window's edge value.

## Docs and demo

- `TimeScrollConfig` JSDoc, `types.mdx`, `livechart.mdx`, and the time-scroll guide updated; CHANGELOG entry added.
- The Time Scroll demo exposes human-readable **Follow visible edge** and **Hide on scroll back** toggles for manual QA.

## Tests and profiling

- Behavioral opacity coverage for the default historical state, return to the live edge, explicit opt-out, and `followViewEdge` override.
- Regression coverage proves the line uses `displayValue` live and `edgeValue` historically without consulting indicator options.
- React DevTools profiling with `followViewEdge` off found no follow-specific rerender: with `yAxis.float` off the pan-back/return cycle produced zero React commits. With floating axis on, the JS renders are the intentional gutter-to-floating layout transition (5.3 ms total in the measured development profile).
- Full `npm run verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
