### PR TITLE
Add renderOffAxisReferenceLine, stable reference line ids, and renderOverlay for LiveChartSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Custom off-axis reference tags no longer suppress the normal in-range tag.**
+  `renderOffAxisReferenceLine` on `LiveChart` and `LiveChartSeries` swaps only the
+  edge-pinned tag, keeps the built-in tag in range, and retains a left- or
+  right-pinned native connector from the measured custom badge edge.
+  ([#227](https://github.com/brandtnewlabs/react-native-livechart/issues/227))
+
+- **`LiveChartSeries` now exposes the layout-aware `renderOverlay` bridge.**
+  Custom off-axis reference-line tags and connectors can read the live resolved
+  plot bounds, preserving the chart's actual axis inset instead of guessing at a
+  full-width overlay. ([#227](https://github.com/brandtnewlabs/react-native-livechart/issues/227))
+
+- **Custom reference-line badges retain their dashed connector.** `LiveChart`
+  and `LiveChartSeries` now measure a custom `renderReferenceLine` tag and start
+  the left- or right-pinned connector at its outer edge. ([#227](https://github.com/brandtnewlabs/react-native-livechart/issues/227))
+
+- **Reference lines accept stable `id`s.** Reordering `referenceLines` now keeps
+  each rendered line's identity; existing lines fall back to a deterministic
+  visual-config key.
+
 ### Documentation
 
 - Added an end-to-end guide and runnable example for loading older REST history while time-scrolling,

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native-livechart";
 import Animated, {
   useAnimatedProps,
+  useAnimatedStyle,
   useSharedValue,
 } from "react-native-reanimated";
 import { ACCENT, TIME_WINDOWS } from "../../demo-lib/shared";
@@ -21,14 +22,18 @@ import { Chip, ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME } from "../../demo-lib/theme";
 
-export const options = { title: "Multi-series" };
-
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 function CustomTargetTag({ ctx }: { ctx: ReferenceLineRenderProps }) {
+  const caretStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: ctx.edge.get() === "below" ? "180deg" : "0deg" }],
+  }));
+
   return (
     <View style={styles.targetTag}>
-      <Ionicons name="arrow-up-circle" size={14} color="#86efac" />
+      <Animated.View style={caretStyle}>
+        <Ionicons name="arrow-up-circle" size={14} color="#86efac" />
+      </Animated.View>
       <Text style={styles.targetTagText}>
         {ctx.line.label}: {ctx.line.value?.toFixed(1)}%
       </Text>
@@ -96,6 +101,14 @@ const CURVE_OPTIONS: { value: "monotone" | "linear"; label: string }[] = [
   { value: "linear", label: "Linear" },
 ];
 
+// Values straddling the simulated data range (~33–34). This lets the QA demo
+// exercise the same reference line above the plot, within it, and below it.
+const QA_REFERENCE_EDGE_OPTIONS: { value: number; label: string }[] = [
+  { value: 66.7, label: "Above" },
+  { value: 33.8, label: "In range" },
+  { value: 0, label: "Below" },
+];
+
 export default function MultiSeriesScreen() {
   const seriesVisibilityRef = useRef<Record<string, boolean>>({});
   const emptySeries = useSharedValue<SeriesConfig[]>([]);
@@ -110,7 +123,11 @@ export default function MultiSeriesScreen() {
   const [degen, setDegen] = useState(false);
   const [scrubDim, setScrubDim] = useState(0.3);
   const [theme, setTheme] = useState<"dark" | "light">(APP_THEME);
-  const [showRef, setShowRef] = useState(false);
+  // Keep this on by default: it is the visual QA case for a custom left-pinned
+  // reference tag. Its dashed connector must start at the native tag's right
+  // edge and continue across the plot.
+  const [showRef, setShowRef] = useState(true);
+  const [qaReferenceValue, setQaReferenceValue] = useState(66.7);
   const [axisVis, setAxisVis] = useState<"both" | "noY" | "noX" | "none">(
     "both",
   );
@@ -202,7 +219,7 @@ export default function MultiSeriesScreen() {
     <DemoScreen
       title="Multi-series"
       docs="guides/multi-series"
-      description="series, onSeriesToggle, scrub, axis visibility. Chart stays empty until at least one series has ≥2 points (toggle No series for shell)."
+      description="series, onSeriesToggle, scrub, axis visibility. Use the QA reference buttons to move one line above, into, or below the plot: the custom tag takes over only off-axis, its caret flips with the edge, and its dashed connector continues right from the badge edge. Chart stays empty until at least one series has ≥2 points (toggle No series for shell)."
       chartWrapperStyle={{ height: 360 }}
       chart={
         <>
@@ -229,32 +246,25 @@ export default function MultiSeriesScreen() {
               showRef
                 ? [
                     {
-                      value: 33.3,
-                      label: "Target",
-                      excludeFromRange: true,
-                      badge: { position: "right" },
-                    },
-                    {
-                      value: 35,
-                      label: "Built-in fallback",
-                      excludeFromRange: true,
-                      badge: { position: "center" },
-                    },
-                    {
-                      value: 110,
-                      label: "Above range",
-                      excludeFromRange: true,
+                      // The controls below move this one line through all three
+                      // states so QA can observe the off-axis tag hand back to
+                      // the native, in-range tag.
+                      id: "qa-custom-connector",
+                      value: qaReferenceValue,
+                      label: "QA custom",
+                      color: "#22c55e",
                       badge: { position: "left" },
+                      excludeFromRange: true,
                     },
                   ]
                 : undefined
             }
-            renderReferenceLine={
+            renderOffAxisReferenceLine={
               showRef
                 ? (ctx) =>
-                    ctx.line.label === "Built-in fallback" ? null : (
+                    ctx.line.label === "QA custom" ? (
                       <CustomTargetTag ctx={ctx} />
-                    )
+                    ) : null
                 : undefined
             }
             yAxis={yOn}
@@ -395,7 +405,7 @@ export default function MultiSeriesScreen() {
           }}
         />
         <ToggleChip
-          label="Ref line"
+          label="QA connector"
           value={showRef}
           onChange={() => setShowRef((r) => !r)}
         />
@@ -405,6 +415,12 @@ export default function MultiSeriesScreen() {
           onChange={() => setPanZoom((p) => !p)}
         />
       </ControlRow>
+      <ChipRow
+        label="QA reference edge"
+        options={QA_REFERENCE_EDGE_OPTIONS}
+        value={qaReferenceValue}
+        onChange={setQaReferenceValue}
+      />
       <ChipRow options={THEME_OPTIONS} value={theme} onChange={setTheme} />
 
       <ChipRow

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -18,6 +18,16 @@ On Android, the shared experimental `canvasMode="opaque"` option selects an opaq
 paints the palette background inside the canvas. See
 [Android surface rendering](/guides/android-surface-rendering) for constraints and profiling guidance.
 
+## Custom overlays
+
+<ParamField body="renderOverlay" type="(ctx: ChartOverlayContext) => ReactElement | null">
+  Render a full-bleed custom React Native overlay with the live price↔pixel /
+  time↔pixel bridge. [`ChartOverlayContext`](/api-reference/types#chartoverlaycontext)
+  includes the resolved plot rectangle, so custom off-axis tags and connectors can
+  stop at the same axis inset as the chart. Return `null` or `undefined` for no
+  overlay. See [Overlay bridge](/guides/overlay-bridge).
+</ParamField>
+
 ## Reference-line tags
 
 <ParamField body="renderReferenceLine" type="(ctx: ReferenceLineRenderProps) => ReactElement | null">
@@ -25,8 +35,19 @@ paints the palette background inside the canvas. See
   React Native element. Return `null` or `undefined` for per-line fallback to the
   built-in tag. The custom view tracks the line's live Y position, pins to the
   nearest plot edge when off-axis, and respects left, center, and right badge
-  positions. The reference-line stroke remains visible. See
+  positions. A left- or right-pinned badge keeps its dashed connector, beginning
+  after the measured custom view. The reference-line stroke remains visible. See
   [Reference lines and bands](/guides/reference-lines-and-bands#custom-tags-renderreferenceline).
+</ParamField>
+
+<ParamField body="renderOffAxisReferenceLine" type="(ctx: ReferenceLineRenderProps) => ReactElement | null">
+  Replace only an off-axis Form-A tag. The standard Skia tag or gutter label stays
+  in range, while the custom React Native view takes over when the line is pinned
+  above or below the plot. A left- or right-pinned `badge` (or legacy
+  `offAxisBadge`) retains its dashed connector from the custom view's measured
+  edge. Return `null` for lines that opt out, and use `ctx.edge` inside the
+  returned component for a directional caret. See
+  [Reference lines and bands](/guides/reference-lines-and-bands#off-axis-only-custom-tags-renderoffaxisreferenceline).
 </ParamField>
 
 ## Series data

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -210,8 +210,8 @@ provided; everything else has a default.
   in the worklet, then feed the snapshot to the mappings.) Return any RN view tree
   (order / avg-entry / liquidation price tags, custom level lines); return
   `null`/`undefined` for no overlay. The tree mounts full-bleed with
-  `pointerEvents="box-none"` so empty areas still scrub. **Single-series only.** See
-  [Overlay bridge](/guides/overlay-bridge).
+  `pointerEvents="box-none"` so empty areas still scrub. Available on both
+  `LiveChart` and `LiveChartSeries`. See [Overlay bridge](/guides/overlay-bridge).
 </ParamField>
 
 <ParamField body="referenceLines" type="ReferenceLine[]">
@@ -229,7 +229,18 @@ provided; everything else has a default.
   [`ReferenceLineRenderProps`](/api-reference/types#annotations)), so it tracks the
   rescaling axis and any drag without JS re-renders. Called per Form-A line; return
   `null` to keep that line's built-in tag (works with `badge: false` too).
-  Single-series only.
+  A left- or right-pinned badge keeps its built-in dashed connector, which starts
+  after the measured custom view. Single-series only.
+</ParamField>
+
+<ParamField body="renderOffAxisReferenceLine" type="(ctx: ReferenceLineRenderProps) => ReactElement | null">
+  Replace only a Form-A line's **off-axis** tag with a React Native element. The
+  standard Skia tag or gutter label remains visible in range; the custom view takes
+  over only when the value is pinned above or below the plot. A left- or
+  right-pinned `badge` (or legacy `offAxisBadge`) keeps its native dashed connector,
+  beginning after the measured custom view. Return `null` for lines that opt out;
+  use `ctx.edge` inside the returned component to animate a directional caret. See
+  [Reference lines](/guides/reference-lines-and-bands#off-axis-only-custom-tags-renderoffaxisreferenceline).
 </ParamField>
 
 <ParamField body="referenceLineGrouping" type="boolean | ReferenceLineGroupingConfig" default="false">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -135,6 +135,7 @@ interface TradeEvent {
 }
 
 interface ReferenceLine {
+  id?: string;                   // stable identity; supply when lines may reorder
   // Form A — horizontal line:
   value?: number;
   // Form B — horizontal band:
@@ -201,6 +202,9 @@ interface ReferenceLineRenderProps {
   edge: SharedValue<"above" | "in" | "below">; // for a directional off-axis chevron
   dragging: SharedValue<boolean>; // whether this line is currently being dragged
 }
+
+// `renderReferenceLine` replaces a tag in every state. `renderOffAxisReferenceLine`
+// keeps the built-in in-range tag and shows the custom element only for edge !== "in".
 
 interface ReferenceLineGroupingConfig {
   radius?: number;             // collapse lines whose value-Y are within this many px; default 18
@@ -541,8 +545,9 @@ interface TooltipRenderProps {
 ## ChartOverlayContext
 
 The price↔pixel / time↔pixel bridge passed to a custom
-[`renderOverlay`](/api-reference/livechart#renderoverlay). It hands you a single
-per-frame `scale` `SharedValue` plus pure mapping worklets.
+[`renderOverlay`](/api-reference/livechart#renderoverlay) on `LiveChart` or
+`LiveChartSeries`. It hands you a single per-frame `scale` `SharedValue` plus pure
+mapping worklets.
 
 ```ts
 interface ChartOverlayContext {

--- a/docs/guides/overlay-bridge.mdx
+++ b/docs/guides/overlay-bridge.mdx
@@ -21,7 +21,8 @@ plain React Native that stays glued to the auto-rescaling axis.
 
 The callback receives a [`ChartOverlayContext`](/api-reference/types#chartoverlaycontext).
 The returned tree mounts full-bleed over the canvas with `pointerEvents="box-none"`,
-so empty areas still scrub.
+so empty areas still scrub. `renderOverlay` is available on both `LiveChart` and
+`LiveChartSeries`; the same context reports each chart's resolved plot rectangle.
 
 ## The easy path — `usePriceY` / `useTimeX`
 
@@ -76,4 +77,7 @@ function PriceTag({ ctx, price }) {
 
 These are the same projections the engine uses internally for the live dot, the
 scrub crosshair, and the [order-ticket drag](/guides/order-ticket)
-— so a custom overlay lines up pixel-for-pixel with the chart. Single-series only.
+— so a custom overlay lines up pixel-for-pixel with the chart. On a multi-series
+chart, use `s.plot.left` / `s.plot.right` for a custom off-axis badge or connector:
+those values already account for the chart's actual Y-axis gutter and any `insets`
+override.

--- a/docs/guides/reference-lines-and-bands.mdx
+++ b/docs/guides/reference-lines-and-bands.mdx
@@ -35,6 +35,8 @@ description: "Draw horizontal lines, value/time bands, pill badges, and draggabl
 
 Lines support labels, dashes (`intervals`), and excluding their value from the axis range
 (`excludeFromRange`). See the [types reference](/api-reference/types) for every field.
+When the array can reorder (for example, a dynamic order book), give each line a unique `id`
+so its rendered identity follows that line instead of its array position.
 
 ## Full-width lines (`fullWidth`)
 
@@ -132,6 +134,9 @@ renderReferenceLine={(ctx) =>
 
 `ctx` ([`ReferenceLineRenderProps`](/api-reference/types#annotations)) also carries `y`, `inRange`,
 `edge` (`"above"` / `"in"` / `"below"`, for a directional chevron), and `dragging` as SharedValues.
+For a left- or right-pinned `badge`, the built-in dashed connector stays in place
+behind the native tag and starts after the tag's measured edge; a center badge has
+no connector by design.
 
 For example, a multi-series market chart can use the app's native icon and localized target copy
 while leaving any other line on the built-in renderer:
@@ -154,8 +159,41 @@ while leaving any other line on the built-in renderer:
 />
 ```
 
-The custom target owns only its tag: its dashed line still draws, while the midpoint keeps its
+The custom target owns only its tag: its dashed connector still draws from the
+native tag's measured edge to the plot boundary, while the midpoint keeps its
 built-in badge. The React Native tag is layered above the left-edge fade and scrub overlay.
+
+## Off-axis-only custom tags (`renderOffAxisReferenceLine`)
+
+Use `renderOffAxisReferenceLine` when the regular label should remain in range but an
+edge-pinned target needs custom chrome. The chart switches the two tags on the UI thread:
+the built-in tag remains in range, and the custom element appears only above or below the
+plot. Give the line a left- or right-pinned `badge` (or legacy `offAxisBadge`) to retain
+the native dashed connector; it begins after the custom tag's measured edge.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  referenceLines={[
+    {
+      id: "take-profit",
+      value: 142.5,
+      label: "Target",
+      excludeFromRange: true,
+      badge: { position: "left" },
+    },
+  ]}
+  renderOffAxisReferenceLine={({ line, edge }) => (
+    <OffAxisTargetTag label={line.label} edge={edge} />
+  )}
+/>
+```
+
+`OffAxisTargetTag` stays mounted so it can read the live `edge` SharedValue in an animated
+style and flip its caret between `"above"` and `"below"`. Return `null` from the callback
+only to opt a static `line` / `index` out; do not branch on `edge.get()` while rendering the
+callback itself. `renderReferenceLine` takes precedence if both callbacks handle one line.
 
 ## Grouping near-value lines (`referenceLineGrouping`)
 
@@ -175,8 +213,8 @@ referenceLineGrouping={{
 
 The clustered lines' individual tags are suppressed and replaced by one "count" pill at the
 cluster's center; the lines themselves still draw. Lines you render with `renderReferenceLine`
-are excluded from grouping (their custom tag draws itself), so the count reflects only collapsed
-built-in tags. The count pill takes the same style/shape config as a per-line badge
+or `renderOffAxisReferenceLine` are excluded from grouping (their custom tag draws itself), so
+the count reflects only collapsed built-in tags. The count pill takes the same style/shape config as a per-line badge
 ([`ReferenceLineBadgeConfig`](/api-reference/types#annotations)) via `badge`, plus a `format` fn
 for the count label.
 

--- a/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomReferenceLineOverlay.tsx
@@ -12,6 +12,7 @@ import { computeScrubDotY } from "../hooks/crosshairShared";
 import {
   classifyReferenceEdge,
   referenceLineForm,
+  referenceLineReactKeys,
   resolveReferenceBadge,
 } from "../math/referenceLines";
 import type { ReferenceLine, ReferenceLineRenderProps } from "../types";
@@ -39,20 +40,24 @@ function stub<T>(v: T): SharedValue<T> {
   return { value: v, get: () => v } as unknown as SharedValue<T>;
 }
 
+/** Whether a custom tag owns every state or only an off-axis tag. */
+export type CustomReferenceLineMode = "always" | "off-axis";
+
 /**
- * Which Form-A reference lines a `renderReferenceLine` returns an element for —
- * the set whose built-in Skia tag is suppressed (so there's no double-draw). The
- * render fn is probed with placeholder SharedValues; it must decide null-ness from
- * `line` / `index`, not from live values (mirrors how `renderMarker` is probed for
- * the marker-atlas exclusion set). Index-aligned with `lines`.
+ * Which Form-A reference lines a custom renderer returns an element for. This
+ * initial probe determines a line's static eligibility only; `"off-axis"` still
+ * switches the built-in tag and the RN tag on the UI thread as the edge changes.
+ * Index-aligned with `lines`.
  */
 export function customReferenceLineFlags(
   lines: ReferenceLine[],
   render?: (
     ctx: ReferenceLineRenderProps,
   ) => React.ReactElement | null | undefined,
+  mode: CustomReferenceLineMode = "always",
 ): boolean[] {
   if (!render) return lines.map(() => false);
+  const offAxisOnly = mode === "off-axis";
   return lines.map((line, index) => {
     if (referenceLineForm(line) !== "line") return false;
     return (
@@ -62,8 +67,10 @@ export function customReferenceLineFlags(
         value: stub(line.value ?? 0),
         valueStr: stub(""),
         y: stub(-1),
-        inRange: stub(true),
-        edge: stub<"above" | "in" | "below">("in"),
+        inRange: stub(!offAxisOnly),
+        edge: stub<"above" | "in" | "below">(
+          offAxisOnly ? "above" : "in",
+        ),
         dragging: stub(false),
       }) != null
     );
@@ -88,6 +95,8 @@ function CustomReferenceLineView({
   formatValue,
   dragValues,
   dragActive,
+  tagWidths,
+  offAxisOnly,
 }: {
   line: ReferenceLine;
   index: number;
@@ -101,6 +110,10 @@ function CustomReferenceLineView({
   dragValues?: SharedValue<number[]>;
   /** Optional drag state used by draggable single-series lines. */
   dragActive?: SharedValue<boolean[]>;
+  /** Measured custom-tag widths, index-aligned for the Skia connector. */
+  tagWidths?: SharedValue<number[]>;
+  /** Show this custom tag only while its line is pinned above or below the plot. */
+  offAxisOnly: boolean;
 }) {
   const staticValue = line.value ?? 0;
 
@@ -147,7 +160,14 @@ function CustomReferenceLineView({
   const size = useSharedValue({ width: 0, height: 0 });
   const onLayout = (e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
-    size.value = { width, height };
+    size.set({ width, height });
+    if (tagWidths) {
+      const previous = tagWidths.get();
+      if (previous[index] === width) return;
+      const widths = previous.slice();
+      widths[index] = width;
+      tagWidths.set(widths);
+    }
   };
 
   const anchor = resolveAnchor(line);
@@ -155,7 +175,7 @@ function CustomReferenceLineView({
     const yy = y.get();
     const s = size.get();
     const w = engine.canvasWidth.get();
-    const visible = yy >= 0 && w > 0;
+    const visible = yy >= 0 && w > 0 && (!offAxisOnly || edge.get() !== "in");
     const x1 = padding.left;
     const x2 = w - padding.right;
     let tx: number;
@@ -195,9 +215,9 @@ function CustomReferenceLineView({
  * React Native overlay (NOT Skia) that floats `renderReferenceLine` elements over
  * the canvas, one per Form-A line the consumer customizes. Rendered as a sibling
  * of `<Canvas>` (like {@link CustomMarkerOverlay}) so the tags can be any RN view
- * and stay crisp at native resolution. Lines whose render returns an element have
- * their built-in Skia tag suppressed upstream (see {@link customReferenceLineFlags}),
- * so there's no double-draw.
+ * and stay crisp at native resolution. Lines whose render returns an element hide
+ * their built-in pill / label upstream (see {@link customReferenceLineFlags}); a
+ * badged line's Skia connector remains, measured against the native tag's width.
  */
 export function CustomReferenceLineOverlay({
   lines,
@@ -208,6 +228,8 @@ export function CustomReferenceLineOverlay({
   formatValue,
   dragValues,
   dragActive,
+  tagWidths,
+  offAxisOnly = false,
 }: {
   lines: ReferenceLine[];
   renderReferenceLine: (
@@ -226,13 +248,18 @@ export function CustomReferenceLineOverlay({
   dragValues?: SharedValue<number[]>;
   /** Optional drag state used by draggable single-series lines. */
   dragActive?: SharedValue<boolean[]>;
+  /** Measured custom-tag widths, index-aligned for the Skia connector. */
+  tagWidths?: SharedValue<number[]>;
+  /** Keep the built-in in-range tag and show this RN tag only off-axis. */
+  offAxisOnly?: boolean;
 }) {
   const children: React.ReactElement[] = [];
+  const lineKeys = referenceLineReactKeys(lines);
   for (let i = 0; i < lines.length; i++) {
     if (!custom[i]) continue;
     children.push(
       <CustomReferenceLineView
-        key={i}
+        key={lineKeys[i]}
         line={lines[i]}
         index={i}
         render={renderReferenceLine}
@@ -241,6 +268,8 @@ export function CustomReferenceLineOverlay({
         formatValue={formatValue}
         dragValues={dragValues}
         dragActive={dragActive}
+        tagWidths={tagWidths}
+        offAxisOnly={offAxisOnly}
       />,
     );
   }

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -58,7 +58,7 @@ import {
   resolveYAxis,
 } from "../core/resolveConfig";
 import type { ResolvedThresholdConfig } from "../core/resolveConfig";
-import { resolveSegment } from "../core/resolveSegment";
+import { resolveSegment, type ResolvedSegment } from "../core/resolveSegment";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
 import { pulseRadialOutset } from "../draw/line";
 import { resolveChartLayout } from "../hooks/resolveChartLayout";
@@ -105,6 +105,7 @@ import {
 import {
   collectReferenceValues,
   referenceLineForm,
+  referenceLineReactKeys,
   resolveReferenceGroupBadge,
 } from "../math/referenceLines";
 import {
@@ -311,6 +312,7 @@ function useLiveChartController({
   renderTooltip,
   renderOverlay,
   renderReferenceLine,
+  renderOffAxisReferenceLine,
   referenceLineGrouping,
   leftEdgeFade = true,
 
@@ -387,18 +389,18 @@ function useLiveChartController({
   const seededRef = useRef<(number | undefined)[]>([]);
   const refValueSig = allRefLines.map((l) => l.value ?? "_").join(",");
   useEffect(() => {
-    const active = dragActive.value;
-    const cur = dragValues.value;
+    const active = dragActive.get();
+    const cur = dragValues.get();
     const seeded = seededRef.current;
-    dragValues.value = allRefLines.map((l, i) => {
+    dragValues.set(allRefLines.map((l, i) => {
       const prop = l.value ?? 0;
       if (active[i]) return cur[i] ?? prop; // mid-drag → keep the dragged value
       if (l.value !== seeded[i]) return prop; // prop changed → adopt (controlled)
       return cur[i] ?? prop; // unchanged → keep current (uncontrolled persist)
-    });
+    }));
     seededRef.current = allRefLines.map((l) => l.value);
-    if (dragActive.value.length !== allRefLines.length) {
-      dragActive.value = allRefLines.map((_, i) => active[i] ?? false);
+    if (dragActive.get().length !== allRefLines.length) {
+      dragActive.set(allRefLines.map((_, i) => active[i] ?? false));
     }
     // allRefLines is rebuilt every render; key off the value signature + length.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -410,6 +412,17 @@ function useLiveChartController({
     allRefLines,
     renderReferenceLine,
   );
+  // An off-axis renderer replaces only the edge-pinned tag. A full custom tag
+  // takes precedence for the same line to avoid mounting two native tags.
+  const refLineOffAxisCustom = customReferenceLineFlags(
+    allRefLines,
+    renderOffAxisReferenceLine,
+    "off-axis",
+  ).map((custom, index) => custom && !refLineCustom[index]);
+  const refLineKeys = referenceLineReactKeys(allRefLines);
+  // RN custom tags report their measured widths here so the Skia connector can
+  // start after the native badge instead of the hidden built-in pill.
+  const refLineCustomTagWidths = useSharedValue<number[]>([]);
 
   // Live Y values of the *draggable* Form-A lines, folded into the engine's
   // axis-range fit so dragging a line toward / past the visible edge expands the
@@ -421,13 +434,17 @@ function useLiveChartController({
   // contributes its live value; a series contributes its window min/max
   // (respecting `extendToNow`), so an off-range break-even expands the axis and
   // stays on-plot like a reference line would.
-  const draggableRefIdx = allRefLines
-    .map((l, i) =>
-      l.draggable && !l.excludeFromRange && referenceLineForm(l) === "line"
-        ? i
-        : -1,
-    )
-    .filter((i) => i >= 0);
+  const draggableRefIdx: number[] = [];
+  for (let i = 0; i < allRefLines.length; i++) {
+    const line = allRefLines[i];
+    if (
+      line.draggable &&
+      !line.excludeFromRange &&
+      referenceLineForm(line) === "line"
+    ) {
+      draggableRefIdx.push(i);
+    }
+  }
   const thresholdInRange = thresholdCfg?.includeInRange === true;
   // Constant benchmark → its live value rides this channel. A series threshold
   // is folded inside the engine tick instead (`thresholdRangePoints`), which
@@ -572,6 +589,7 @@ function useLiveChartController({
   // react-doctor-disable-next-line react-doctor/no-derived-state-effect -- Reanimated: must read the SharedValue off the render path
   useLayoutEffect(() => {
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- Reanimated: seeding from a SharedValue off render is the warning-free path
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Reanimated: seed from the SharedValue outside render to avoid strict-mode access warnings
     setValueLayoutSample(value.get());
   }, [value]);
 
@@ -721,7 +739,7 @@ function useLiveChartController({
       if (
         referenceLineForm(l) !== "line" ||
         l.value === undefined ||
-        refLineCustom[i]
+        refLineCustom[i] || refLineOffAxisCustom[i]
       ) {
         ys.push(-1);
         continue;
@@ -1235,10 +1253,14 @@ function useLiveChartController({
     leftEdgeFadeCfg,
     metricsCfg,
     allRefLines,
+    refLineKeys,
     refLineCustom,
+    refLineOffAxisCustom,
+    refLineCustomTagWidths,
     dragValues,
     dragActive,
     renderReferenceLine,
+    renderOffAxisReferenceLine,
     refGroupingActive: refGroupingRadius != null,
     refGroupResult,
     groupHidden,
@@ -1672,6 +1694,7 @@ function ChartStack({
     valueLineCfg,
     dotY,
     allRefLines,
+    refLineKeys,
     dragValues,
     resolvedSegments,
     hasRecolorSegments,
@@ -1722,9 +1745,9 @@ function ChartStack({
     <Group transform={degen?.shakeTransform}>
       {/* Segment dividers + labels (behind the line). The scrub-focus emphasis is
           painted on the line stroke itself, below — this overlay draws no fill. */}
-      {resolvedSegments.map((seg, i) => (
+      {resolvedSegments.map((seg) => (
         <SegmentDividerOverlay
-          key={`seg-${seg.from ?? "start"}-${seg.to ?? "end"}-${i}`}
+          key={segmentReactKey(seg)}
           engine={engine}
           padding={effectivePadding}
           segment={seg}
@@ -1746,14 +1769,12 @@ function ChartStack({
         </Group>
       )}
 
-      {/* Index keys: reference lines are a positional array and two may share
-          value + label (e.g. duplicate working orders at the same price), which a
-          content-derived key would collapse to one. Wrapped in a fade group so
-          `scrub.hideOverlaysOnScrub` can ease the lines out while scrubbing. */}
+      {/* Wrapped in a fade group so `scrub.hideOverlaysOnScrub` can ease lines
+          out while scrubbing. Explicit ids keep lines stable when reordered. */}
       <Group opacity={overlayScrubFade}>
         {allRefLines.map((rl, i) => (
           <ReferenceLineOverlay
-            key={i}
+            key={refLineKeys[i]}
             engine={engine}
             padding={effectivePadding}
             line={rl}
@@ -2064,6 +2085,19 @@ function ChartScrubLayer({
   );
 }
 
+/** A segment's time range and presentation uniquely identify its divider view. */
+function segmentReactKey(segment: ResolvedSegment): string {
+  return [
+    "seg",
+    segment.from ?? "start",
+    segment.to ?? "end",
+    segment.divider,
+    segment.dividerColor,
+    segment.label ?? "",
+    segment.labelPosition,
+  ].join(":");
+}
+
 /** Live-value text drawn as its own canvas layer, above both the area gradient
  *  and the left-edge fade, so the large number stays crisp at the left edge
  *  instead of being washed out by the fade's `dstOut` blend. */
@@ -2173,7 +2207,10 @@ function ChartRefBadgeLayer({
 }) {
   const {
     allRefLines,
+    refLineKeys,
     refLineCustom,
+    refLineOffAxisCustom,
+    refLineCustomTagWidths,
     dragValues,
     groupHidden,
     refGroupResult,
@@ -2194,7 +2231,7 @@ function ChartRefBadgeLayer({
     <Group transform={degen?.shakeTransform} opacity={overlayScrubFade}>
       {allRefLines.map((rl, i) => (
         <ReferenceLineOverlay
-          key={i}
+          key={refLineKeys[i]}
           engine={engine}
           padding={effectivePadding}
           line={rl}
@@ -2206,6 +2243,8 @@ function ChartRefBadgeLayer({
           dragValues={dragValues}
           index={i}
           suppressTag={refLineCustom[i]}
+          suppressTagWhenOffAxis={refLineOffAxisCustom[i]}
+          customTagWidths={refLineCustomTagWidths}
           groupHidden={refGroupingActive ? groupHidden : undefined}
         />
       ))}
@@ -2276,8 +2315,11 @@ function ChartCustomAnnotations({ model }: { model: LiveChartModel }) {
     markerClusterCfg,
     renderMarker,
     renderReferenceLine,
+    renderOffAxisReferenceLine,
     allRefLines,
     refLineCustom,
+    refLineOffAxisCustom,
+    refLineCustomTagWidths,
     dragValues,
     dragActive,
     engine,
@@ -2316,6 +2358,21 @@ function ChartCustomAnnotations({ model }: { model: LiveChartModel }) {
           formatValue={formatValue}
           dragValues={dragValues}
           dragActive={dragActive}
+          tagWidths={refLineCustomTagWidths}
+        />
+      )}
+      {renderOffAxisReferenceLine && allRefLines.length > 0 && (
+        <CustomReferenceLineOverlay
+          lines={allRefLines}
+          renderReferenceLine={renderOffAxisReferenceLine}
+          custom={refLineOffAxisCustom}
+          engine={engine}
+          padding={effectivePadding}
+          formatValue={formatValue}
+          dragValues={dragValues}
+          dragActive={dragActive}
+          tagWidths={refLineCustomTagWidths}
+          offAxisOnly
         />
       )}
     </Animated.View>
@@ -2357,6 +2414,7 @@ function ChartView({
     renderTooltip,
     renderOverlay,
     renderReferenceLine,
+    renderOffAxisReferenceLine,
     allRefLines,
     scrubCfg,
     crosshair,
@@ -2466,7 +2524,8 @@ function ChartView({
             Skia markers (the wrapper is full-bleed; children keep their own
             absolute positions). */}
         {((markersActive && renderMarker) ||
-          (renderReferenceLine && allRefLines.length > 0)) && (
+          ((renderReferenceLine || renderOffAxisReferenceLine) &&
+            allRefLines.length > 0)) && (
           <ChartCustomAnnotations model={model} />
         )}
 

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -28,7 +28,6 @@ import {
   lineStyleSignatureFromArray,
   resolveMultiSeriesLineColorsSnapshot,
   resolveMultiSeriesLineStylesSnapshot,
-  type SeriesLineStyle,
 } from "../core/multiSeriesLayout";
 import {
   resolveAxisLabel,
@@ -53,6 +52,7 @@ import { pulseRadialOutset } from "../draw/line";
 import { resolveChartLayout } from "../hooks/resolveChartLayout";
 import { useCanvasLayout } from "../hooks/useCanvasLayout";
 import { useChartReveal } from "../hooks/useChartReveal";
+import { useChartOverlayContext } from "../hooks/useChartOverlayContext";
 import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
 import { useCrosshairSeries } from "../hooks/useCrosshairSeries";
 import { useMarkers } from "../hooks/useMarkers";
@@ -70,7 +70,10 @@ import {
 } from "../lib/format";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
-import { collectReferenceValues } from "../math/referenceLines";
+import {
+  collectReferenceValues,
+  referenceLineReactKeys,
+} from "../math/referenceLines";
 import {
   applyPaletteOverride,
   leftEdgeFadeColorsFromBgRgb,
@@ -78,6 +81,7 @@ import {
 } from "../theme";
 import type { LiveChartSeriesProps, Marker, SeriesConfig } from "../types";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
+import { ChartOverlayLayer } from "./ChartOverlayLayer";
 import {
   ExtremaConnectorOverlay,
   labelConnector,
@@ -177,7 +181,9 @@ function useLiveChartSeriesController({
   markerHitRadius = 16,
   markerCluster,
   renderMarker,
+  renderOverlay,
   renderReferenceLine,
+  renderOffAxisReferenceLine,
   leftEdgeFade = true,
 }: LiveChartSeriesProps) {
   const emptyMarkers = useSharedValue<Marker[]>([]);
@@ -237,6 +243,17 @@ function useLiveChartSeriesController({
     allRefLines,
     renderReferenceLine,
   );
+  // A full custom tag owns both states, so it takes precedence over an
+  // off-axis-only renderer for the same line.
+  const refLineOffAxisCustom = customReferenceLineFlags(
+    allRefLines,
+    renderOffAxisReferenceLine,
+    "off-axis",
+  ).map((custom, index) => custom && !refLineCustom[index]);
+  const refLineKeys = referenceLineReactKeys(allRefLines);
+  // RN custom tags report their measured widths here so the Skia connector can
+  // start after the native badge instead of the hidden built-in pill.
+  const refLineCustomTagWidths = useSharedValue<number[]>([]);
 
   const palette = applyPaletteOverride(
     resolveTheme(accentColor, theme),
@@ -266,6 +283,7 @@ function useLiveChartSeriesController({
     // render scope for memoization, which trips Reanimated's strict-mode warning;
     // it leaves the `.get()` method call inside the effect.
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- Reanimated: seeding from a SharedValue off render is the warning-free path
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Reanimated: seed from the SharedValue outside render to avoid strict-mode access warnings
     setSeriesSnapshot(series.get().slice());
   }, [series]);
 
@@ -542,7 +560,10 @@ function useLiveChartSeriesController({
     degenCfg,
     metricsCfg,
     allRefLines,
+    refLineKeys,
     refLineCustom,
+    refLineOffAxisCustom,
+    refLineCustomTagWidths,
     leftEdgeFadeCfg,
     // theme / layout / fonts
     palette,
@@ -580,7 +601,9 @@ function useLiveChartSeriesController({
     markerGroupOpacity,
     overlayScrubFade,
     renderMarker,
+    renderOverlay,
     renderReferenceLine,
+    renderOffAxisReferenceLine,
     // selection dot: resolved config + fallback color (the leading series' color)
     selectionDot: selectionDotCfg,
     selectionColor: lineColors[0],
@@ -638,6 +661,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     loadingSpeed,
     canvasMode,
     activeSeriesCount,
+    refLineKeys,
   } = model;
 
   return (
@@ -657,15 +681,12 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         </Group>
       )}
 
-      {/* Reference lines are index-addressed throughout the drag/press API, and
-          duplicate working orders may share all visible content. Positional keys
-          keep both orders mounted without collapsing them to one React child.
-          Fade group lets `scrub.hideOverlaysOnScrub` ease the lines out. */}
+      {/* Fade group lets `scrub.hideOverlaysOnScrub` ease the lines out. Explicit
+          ids keep each reference line mounted when the caller reorders it. */}
       <Group opacity={overlayScrubFade}>
         {allRefLines.map((rl, i) => (
-          /* react-doctor-disable-next-line react-doctor/no-array-index-as-key */
           <ReferenceLineOverlay
-            key={i}
+            key={refLineKeys[i]}
             engine={engine}
             padding={effectivePadding}
             line={rl}
@@ -823,7 +844,10 @@ function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
 function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
   const {
     allRefLines,
+    refLineKeys,
     refLineCustom,
+    refLineOffAxisCustom,
+    refLineCustomTagWidths,
     engine,
     effectivePadding,
     palette,
@@ -831,15 +855,13 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
     skiaFont,
     degenShakeTransform,
     overlayScrubFade,
-    canvasMode,
   } = model;
   if (allRefLines.length === 0) return null;
   return (
     <Group transform={degenShakeTransform} opacity={overlayScrubFade}>
       {allRefLines.map((rl, i) => (
-        /* react-doctor-disable-next-line react-doctor/no-array-index-as-key */
         <ReferenceLineOverlay
-          key={i}
+          key={refLineKeys[i]}
           engine={engine}
           padding={effectivePadding}
           line={rl}
@@ -848,10 +870,19 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
           font={skiaFont}
           badgeLayer
           suppressTag={refLineCustom[i]}
+          suppressTagWhenOffAxis={refLineOffAxisCustom[i]}
+          customTagWidths={refLineCustomTagWidths}
         />
       ))}
     </Group>
   );
+}
+
+/** Owns the price/time projection worklets for the multi-series custom overlay. */
+function SeriesCustomConsumerOverlay({ model }: { model: LiveChartSeriesModel }) {
+  const { engine, effectivePadding, renderOverlay } = model;
+  const overlayContext = useChartOverlayContext(engine, effectivePadding);
+  return <ChartOverlayLayer render={renderOverlay!} context={overlayContext} />;
 }
 
 export function LiveChartSeries(props: LiveChartSeriesProps) {
@@ -886,9 +917,13 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     markersSV,
     markerClusterCfg,
     renderMarker,
+    renderOverlay,
     renderReferenceLine,
+    renderOffAxisReferenceLine,
     allRefLines,
     refLineCustom,
+    refLineOffAxisCustom,
+    refLineCustomTagWidths,
     overlayScrubFade,
     canvasMode,
   } = model;
@@ -1017,7 +1052,8 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
               above the left-edge fade and scrub overlay. The box-none fade wrapper
               keeps `scrub.hideOverlaysOnScrub` behavior aligned with Skia. */}
           {((markersActive && renderMarker) ||
-            (renderReferenceLine && allRefLines.length > 0)) && (
+            ((renderReferenceLine || renderOffAxisReferenceLine) &&
+              allRefLines.length > 0)) && (
             <Animated.View
               pointerEvents="box-none"
               style={[StyleSheet.absoluteFill, overlayFadeStyle]}
@@ -1040,10 +1076,27 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                   engine={engine}
                   padding={effectivePadding}
                   formatValue={formatValue}
+                  tagWidths={refLineCustomTagWidths}
+                />
+              )}
+              {renderOffAxisReferenceLine && allRefLines.length > 0 && (
+                <CustomReferenceLineOverlay
+                  lines={allRefLines}
+                  renderReferenceLine={renderOffAxisReferenceLine}
+                  custom={refLineOffAxisCustom}
+                  engine={engine}
+                  padding={effectivePadding}
+                  formatValue={formatValue}
+                  tagWidths={refLineCustomTagWidths}
+                  offAxisOnly
                 />
               )}
             </Animated.View>
           )}
+
+          {/* Custom consumer overlay — topmost RN sibling with the live plot
+              rect, including this multi-series chart's resolved axis inset. */}
+          {renderOverlay && <SeriesCustomConsumerOverlay model={model} />}
         </View>
       </GestureDetector>
       {legendCfg.position === "bottom" ? legend : null}

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -12,7 +12,10 @@ import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
 import { usePathBuilder } from "../hooks/usePathBuilder";
-import { useReferenceLine } from "../hooks/useReferenceLine";
+import {
+  useReferenceLine,
+  type ReferenceLineLayout,
+} from "../hooks/useReferenceLine";
 import { MONO_FONT_FAMILY } from "../lib/monoFontFamily";
 import { referenceLineForm, resolveReferenceBadge } from "../math/referenceLines";
 import type { FontConfig, LiveChartPalette, ReferenceLine } from "../types";
@@ -23,6 +26,10 @@ const BAND_FILL_OPACITY = 0.16;
 /** Vertical padding inside the badge pill, in px (kept in sync with the layout). */
 const BADGE_PILL_PAD_Y = 3;
 const BADGE_PILL_RADIUS = 5;
+/** Gap between a badge's outer edge and its dashed connector, in px. */
+const CONNECTOR_GAP = 4;
+/** Badge inset from its plot edge, in px (matches useReferenceLine). */
+const BADGE_EDGE_INSET = 2;
 
 /**
  * Renders one reference line or band into the chart canvas. Handles all three
@@ -30,20 +37,7 @@ const BADGE_PILL_RADIUS = 5;
  * band) plus the Form-A pill badge (in-range tag + off-screen chevron pin).
  * Self-contained so callers can `.map()` over a variable-length array.
  */
-export function ReferenceLineOverlay({
-  engine,
-  padding,
-  line,
-  palette,
-  formatValue,
-  font,
-  fontProp,
-  badgeLayer = false,
-  suppressTag = false,
-  groupHidden,
-  dragValues,
-  index = 0,
-}: {
+type ReferenceLineOverlayProps = {
   engine: ChartEngineLayout;
   padding: ChartPadding;
   line: ReferenceLine;
@@ -64,11 +58,23 @@ export function ReferenceLineOverlay({
    */
   badgeLayer?: boolean;
   /**
-   * Suppress the built-in tag (badge pill + connector + chevron + icon + gutter
-   * label) for this line — used when a custom `renderReferenceLine` element owns
-   * the tag. The line / band stroke still draws. No effect on the base pass.
-   */
+   * Suppress the built-in tag (badge pill + chevron + icon + gutter label) for
+   * this line — used when a custom `renderReferenceLine` element owns the tag.
+   * The line / band stroke and a badged line's dashed connector still draw. No
+   * effect on the base pass.
+  */
   suppressTag?: boolean;
+  /**
+   * Suppress the built-in tag only while the line is off-axis. Used by
+   * `renderOffAxisReferenceLine`, so the normal in-range tag remains intact.
+   */
+  suppressTagWhenOffAxis?: boolean;
+  /**
+   * Measured widths of custom reference-line tags, index-aligned with their
+   * `referenceLines`. When present for a suppressed badged tag, the built-in
+   * connector begins after the custom element instead of the hidden Skia pill.
+   */
+  customTagWidths?: SharedValue<number[]>;
   /**
    * Per-frame grouping flags (index-aligned): when this line's slot is `true` it's
    * collapsed into a group count handle, so its tag is suppressed (the line / band
@@ -79,7 +85,24 @@ export function ReferenceLineOverlay({
   dragValues?: SharedValue<number[]>;
   /** This line's index into {@link dragValues}. */
   index?: number;
-}) {
+};
+
+export function ReferenceLineOverlay({
+  engine,
+  padding,
+  line,
+  palette,
+  formatValue,
+  font,
+  fontProp,
+  badgeLayer = false,
+  suppressTag = false,
+  suppressTagWhenOffAxis = false,
+  customTagWidths,
+  groupHidden,
+  dragValues,
+  index = 0,
+}: ReferenceLineOverlayProps) {
   const form = referenceLineForm(line);
   const isBand = form === "value-band" || form === "time-band";
 
@@ -141,24 +164,78 @@ export function ReferenceLineOverlay({
       ? [{ translateX: badgeOffsetX }, { translateY: badgeOffsetY }]
       : undefined;
 
+  if (!badgeLayer) {
+    return (
+      <ReferenceLineBasePass
+        layout={layout}
+        color={color}
+        strokeWidth={strokeWidth}
+        intervals={intervals}
+        isBand={isBand}
+        isTimeBand={form === "time-band"}
+        bandFillOpacity={bandFillOpacity}
+        hasBandBorder={hasBandBorder}
+      />
+    );
+  }
+
+  return (
+    <ReferenceLineBadgePass
+      layout={layout}
+      color={color}
+      strokeWidth={strokeWidth}
+      intervals={intervals}
+      badgeFont={badgeFont}
+      badgePosition={badge?.position}
+      labelColor={labelColor}
+      badgeBackground={badgeBackground}
+      badgeBorderColor={badgeBorderColor}
+      badgeBorderWidth={badgeBorderWidth}
+      badgeRadius={badgeRadius}
+      badgeOffsetX={badgeOffsetX}
+      badgeOffsetY={badgeOffsetY}
+      suppressTag={suppressTag}
+      suppressTagWhenOffAxis={suppressTagWhenOffAxis}
+      customTagWidths={customTagWidths}
+      groupHidden={groupHidden}
+      index={index}
+    />
+  );
+}
+
+/** Base stroke / band pass, kept behind the chart content. */
+function ReferenceLineBasePass({
+  layout,
+  color,
+  strokeWidth,
+  intervals,
+  isBand,
+  isTimeBand,
+  bandFillOpacity,
+  hasBandBorder,
+}: {
+  layout: SharedValue<ReferenceLineLayout>;
+  color: string;
+  strokeWidth: number;
+  intervals: [number, number];
+  isBand: boolean;
+  isTimeBand: boolean;
+  bandFillOpacity: number;
+  hasBandBorder: boolean;
+}) {
   const lineBuilder = usePathBuilder();
   const bandBuilder = usePathBuilder();
   const borderBuilder = usePathBuilder();
-  const connBuilder = usePathBuilder();
-  const chevBuilder = usePathBuilder();
 
   const linePath = useDerivedValue(() => {
     const b = lineBuilder.value;
     const l = layout.get();
-    // A plain horizontal line, drawn at the line extent (full-width when opted in).
-    // A non-full-width badge instead draws a pill + connector to the edge, below.
     if (l.visible && l.drawLine && !isBand) {
       b.moveTo(l.lineX1, l.y);
       b.lineTo(l.lineX2, l.y);
     }
     return b.detach();
   });
-
   const bandPath = useDerivedValue(() => {
     const b = bandBuilder.value;
     const l = layout.get();
@@ -171,19 +248,16 @@ export function ReferenceLineOverlay({
     }
     return b.detach();
   });
-
   const bandBorderPath = useDerivedValue(() => {
     const b = borderBuilder.value;
     const l = layout.get();
     if (l.visible && hasBandBorder) {
-      if (form === "time-band") {
-        // Vertical edges at the band's left / right.
+      if (isTimeBand) {
         b.moveTo(l.lineX1, l.y);
         b.lineTo(l.lineX1, l.yBottom);
         b.moveTo(l.lineX2, l.y);
         b.lineTo(l.lineX2, l.yBottom);
       } else {
-        // Horizontal edges at the band's top / bottom.
         b.moveTo(l.lineX1, l.y);
         b.lineTo(l.lineX2, l.y);
         b.moveTo(l.lineX1, l.yBottom);
@@ -192,18 +266,125 @@ export function ReferenceLineOverlay({
     }
     return b.detach();
   });
+  const lineOpacity = useDerivedValue(() => {
+    const l = layout.get();
+    return l.visible && l.drawLine && !isBand ? 1 : 0;
+  });
+  const bandOpacity = useDerivedValue(() =>
+    layout.get().visible && isBand ? bandFillOpacity : 0,
+  );
+  const bandBorderOpacity = useDerivedValue(() =>
+    layout.get().visible && hasBandBorder ? 1 : 0,
+  );
 
-  // Badge connector — the dashed line from the pill out to the opposite edge.
+  return (
+    <Group>
+      {isBand && (
+        <Group opacity={bandOpacity}>
+          <Path path={bandPath} style="fill" color={color} />
+        </Group>
+      )}
+      {hasBandBorder && (
+        <Group opacity={bandBorderOpacity}>
+          <Path
+            path={bandBorderPath}
+            style="stroke"
+            strokeWidth={strokeWidth}
+            color={color}
+          >
+            <DashPathEffect intervals={intervals} />
+          </Path>
+        </Group>
+      )}
+      {!isBand && (
+        <Group opacity={lineOpacity}>
+          <Path
+            path={linePath}
+            style="stroke"
+            strokeWidth={strokeWidth}
+            color={color}
+          >
+            <DashPathEffect intervals={intervals} />
+          </Path>
+        </Group>
+      )}
+    </Group>
+  );
+}
+
+/** Badge, connector, and label pass, painted above the chart's left-edge fade. */
+function ReferenceLineBadgePass({
+  layout,
+  color,
+  strokeWidth,
+  intervals,
+  badgeFont,
+  badgePosition,
+  labelColor,
+  badgeBackground,
+  badgeBorderColor,
+  badgeBorderWidth,
+  badgeRadius,
+  badgeOffsetX,
+  badgeOffsetY,
+  suppressTag,
+  suppressTagWhenOffAxis,
+  customTagWidths,
+  groupHidden,
+  index,
+}: {
+  layout: SharedValue<ReferenceLineLayout>;
+  color: string;
+  strokeWidth: number;
+  intervals: [number, number];
+  badgeFont: SkFont;
+  badgePosition: "left" | "center" | "right" | undefined;
+  labelColor: string;
+  badgeBackground: string;
+  badgeBorderColor: string;
+  badgeBorderWidth: number;
+  badgeRadius: number;
+  badgeOffsetX: number;
+  badgeOffsetY: number;
+  suppressTag: boolean;
+  suppressTagWhenOffAxis: boolean;
+  customTagWidths?: SharedValue<number[]>;
+  groupHidden?: SharedValue<boolean[]>;
+  index: number;
+}) {
+  const connBuilder = usePathBuilder();
+  const chevBuilder = usePathBuilder();
+  const badgeTransform =
+    badgeOffsetX !== 0 || badgeOffsetY !== 0
+      ? [{ translateX: badgeOffsetX }, { translateY: badgeOffsetY }]
+      : undefined;
   const connPath = useDerivedValue(() => {
     const b = connBuilder.value;
     const l = layout.get();
     if (l.visible && l.badge && l.connStart >= 0) {
-      b.moveTo(l.connStart, l.y);
-      b.lineTo(l.connEnd, l.y);
+      let start = l.connStart;
+      let end = l.connEnd;
+      const customTagActive =
+        suppressTag || (suppressTagWhenOffAxis && l.offAxis);
+      const customWidth = customTagActive
+        ? customTagWidths?.get()[index] ?? 0
+        : 0;
+      if (customWidth > 0) {
+        if (badgePosition === "left") {
+          start = l.x1 + BADGE_EDGE_INSET + customWidth + CONNECTOR_GAP;
+          end = l.x2;
+        } else if (badgePosition === "right") {
+          start = l.x1;
+          end = l.x2 - BADGE_EDGE_INSET - customWidth - CONNECTOR_GAP;
+        }
+      }
+      if (end > start) {
+        b.moveTo(start, l.y);
+        b.lineTo(end, l.y);
+      }
     }
     return b.detach();
   });
-
   const chevronPath = useDerivedValue(() => {
     const b = chevBuilder.value;
     const l = layout.get();
@@ -223,41 +404,34 @@ export function ReferenceLineOverlay({
     }
     return b.detach();
   });
-
-  const lineOpacity = useDerivedValue(() => {
-    const l = layout.get();
-    return l.visible && l.drawLine && !isBand ? 1 : 0;
-  });
-  const bandOpacity = useDerivedValue(() =>
-    layout.get().visible && isBand ? bandFillOpacity : 0,
-  );
-  const bandBorderOpacity = useDerivedValue(() =>
-    layout.get().visible && hasBandBorder ? 1 : 0,
-  );
   const badgeOpacity = useDerivedValue(() => {
     const l = layout.get();
     const grouped = groupHidden ? groupHidden.get()[index] === true : false;
-    return !suppressTag && !grouped && l.visible && l.badge ? 1 : 0;
+    const customTagActive =
+      suppressTag || (suppressTagWhenOffAxis && l.offAxis);
+    return !customTagActive && !grouped && l.visible && l.badge ? 1 : 0;
   });
-  // Text + icon ride in the badge pass too, so they stay crisp above the fade.
+  const connectorOpacity = useDerivedValue(() => {
+    const l = layout.get();
+    const grouped = groupHidden ? groupHidden.get()[index] === true : false;
+    return !grouped && l.visible && l.badge && l.connStart >= 0 ? 1 : 0;
+  });
   const labelOpacity = useDerivedValue(() => {
     const l = layout.get();
     const grouped = groupHidden ? groupHidden.get()[index] === true : false;
-    return !suppressTag && !grouped && l.visible && l.label.length > 0 ? 1 : 0;
+    const customTagActive =
+      suppressTag || (suppressTagWhenOffAxis && l.offAxis);
+    return !customTagActive && !grouped && l.visible && l.label.length > 0 ? 1 : 0;
   });
   const iconOpacity = useDerivedValue(() => {
     const l = layout.get();
     return l.visible && l.icon.length > 0 ? 1 : 0;
   });
-
   const labelX = useDerivedValue(() => layout.get().labelX);
   const labelY = useDerivedValue(() => layout.get().labelY);
   const labelText = useDerivedValue(() => layout.get().label);
   const iconX = useDerivedValue(() => layout.get().iconX);
   const iconText = useDerivedValue(() => layout.get().icon);
-
-  // Font metrics depend only on the (stable) font, so read them once instead of
-  // on every frame inside the pill worklet (`getMetrics` allocates + crosses JSI).
   const { ascent: fontAscent, height: pillH } = (() => {
     const fm = badgeFont.getMetrics();
     return {
@@ -265,8 +439,6 @@ export function ReferenceLineOverlay({
       height: fm.descent - fm.ascent + BADGE_PILL_PAD_Y * 2,
     };
   })();
-
-  // Pill rect — position/size from the layout; vertically centered on the line.
   const pillX = useDerivedValue(() => layout.get().pillX);
   const pillW = useDerivedValue(() => layout.get().pillW);
   const pillY = useDerivedValue(
@@ -275,101 +447,62 @@ export function ReferenceLineOverlay({
 
   return (
     <Group>
-      {/* Base pass — bands + lines, drawn behind the chart content (and faded at
-          the left edge like the rest of the content). */}
-      {!badgeLayer && isBand && (
-        <Group opacity={bandOpacity}>
-          <Path path={bandPath} style="fill" color={color} />
-        </Group>
-      )}
-
-      {!badgeLayer && hasBandBorder && (
-        <Group opacity={bandBorderOpacity}>
-          <Path
-            path={bandBorderPath}
-            style="stroke"
-            strokeWidth={strokeWidth}
-            color={color}
-          >
-            <DashPathEffect intervals={intervals} />
-          </Path>
-        </Group>
-      )}
-
-      {!badgeLayer && !isBand && (
-        <Group opacity={lineOpacity}>
-          <Path
-            path={linePath}
-            style="stroke"
-            strokeWidth={strokeWidth}
-            color={color}
-          >
-            <DashPathEffect intervals={intervals} />
-          </Path>
-        </Group>
-      )}
-
-      {/* Badge pass — connector + pill + chevron + icon, above the left-edge fade. */}
-      {badgeLayer && (
-        <Group opacity={badgeOpacity} transform={badgeTransform}>
-          <Path
-            path={connPath}
-            style="stroke"
-            strokeWidth={strokeWidth}
-            color={color}
-          >
-            <DashPathEffect intervals={intervals} />
-          </Path>
-          <RoundedRect
-            x={pillX}
-            y={pillY}
-            width={pillW}
-            height={pillH}
-            r={badgeRadius}
-            color={badgeBackground}
-          />
-          <RoundedRect
-            x={pillX}
-            y={pillY}
-            width={pillW}
-            height={pillH}
-            r={badgeRadius}
-            color={badgeBorderColor}
-            style="stroke"
-            strokeWidth={badgeBorderWidth}
-          />
-          <Path
-            path={chevronPath}
-            style="stroke"
-            strokeWidth={1.5}
-            color={color}
-            strokeCap="round"
-            strokeJoin="round"
-          />
-          <Group opacity={iconOpacity}>
-            <SkiaText
-              x={iconX}
-              y={labelY}
-              text={iconText}
-              font={badgeFont}
-              color={labelColor}
-            />
-          </Group>
-        </Group>
-      )}
-
-      {/* Labels ride in the badge pass too, so they stay crisp above the fade. */}
-      {badgeLayer && (
-        <Group opacity={labelOpacity} transform={badgeTransform}>
+      <Group opacity={connectorOpacity} transform={badgeTransform}>
+        <Path
+          path={connPath}
+          style="stroke"
+          strokeWidth={strokeWidth}
+          color={color}
+        >
+          <DashPathEffect intervals={intervals} />
+        </Path>
+      </Group>
+      <Group opacity={badgeOpacity} transform={badgeTransform}>
+        <RoundedRect
+          x={pillX}
+          y={pillY}
+          width={pillW}
+          height={pillH}
+          r={badgeRadius}
+          color={badgeBackground}
+        />
+        <RoundedRect
+          x={pillX}
+          y={pillY}
+          width={pillW}
+          height={pillH}
+          r={badgeRadius}
+          color={badgeBorderColor}
+          style="stroke"
+          strokeWidth={badgeBorderWidth}
+        />
+        <Path
+          path={chevronPath}
+          style="stroke"
+          strokeWidth={1.5}
+          color={color}
+          strokeCap="round"
+          strokeJoin="round"
+        />
+        <Group opacity={iconOpacity}>
           <SkiaText
-            x={labelX}
+            x={iconX}
             y={labelY}
-            text={labelText}
+            text={iconText}
             font={badgeFont}
             color={labelColor}
           />
         </Group>
-      )}
+      </Group>
+      <Group opacity={labelOpacity} transform={badgeTransform}>
+        <SkiaText
+          x={labelX}
+          y={labelY}
+          text={labelText}
+          font={badgeFont}
+          color={labelColor}
+        />
+      </Group>
     </Group>
   );
 }

--- a/packages/react-native-livechart/src/math/referenceLines.ts
+++ b/packages/react-native-livechart/src/math/referenceLines.ts
@@ -45,6 +45,44 @@ export function collectReferenceValues(lines: ReferenceLine[]): number[] {
 }
 
 /**
+ * Stable React keys for an ordered reference-line list. A caller-supplied `id`
+ * keeps the key stable across reordering; the visual config is a deterministic
+ * fallback for legacy lines. Equal fallback signatures receive a suffix so they
+ * remain distinct siblings.
+ */
+export function referenceLineReactKeys(
+  lines: readonly ReferenceLine[],
+): string[] {
+  const occurrences = new Map<string, number>();
+  const keys: string[] = [];
+  for (const line of lines) {
+    const base = line.id ?? stableReferenceLineSignature(line);
+    const occurrence = occurrences.get(base) ?? 0;
+    occurrences.set(base, occurrence + 1);
+    keys.push(`${base}:${occurrence}`);
+  }
+  return keys;
+}
+
+/** Serializes render-relevant config without callback identity churn. */
+function stableReferenceLineSignature(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableReferenceLineSignature).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const entries: string[] = [];
+    for (const key of Object.keys(record).sort()) {
+      const entry = record[key];
+      if (typeof entry === "function" || entry === undefined) continue;
+      entries.push(`${key}:${stableReferenceLineSignature(entry)}`);
+    }
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+/**
  * Fully-resolved badge **style/shape** + anchor — the resolved counterpart of
  * {@link BadgeStyleConfig} (`position` / `icon` / `showText` plus the style knobs).
  * Shared by the reference-line badge ({@link ResolvedReferenceBadge}) and the

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -63,6 +63,11 @@ export type BadgeVariant = "default" | "minimal";
  * - **Form C** — vertical time band between `from` and `to` (unix seconds).
  */
 export interface ReferenceLine {
+  /**
+   * Stable identifier for this line. Supply a unique value when `referenceLines`
+   * may be reordered so the chart preserves the line's rendered identity.
+   */
+  id?: string;
   /** Form A — the Y-axis value where the horizontal line is drawn. */
   value?: number;
   /** Form B — horizontal band lower Y bound (paired with `valueTo`). */
@@ -254,14 +259,16 @@ export interface ReferenceLineBadgeConfig extends BadgeStyleConfig {
 
 /**
  * Context passed to a custom {@link LiveChartProps.renderReferenceLine} or
- * {@link LiveChartSeriesProps.renderReferenceLine}. The chart floats the element
- * you return over the canvas and pins it to the line's value on
- * the UI thread (vertically centered on the line, horizontally at the badge /
- * label position) — so it tracks the rescaling axis and any drag smoothly without
- * JS re-renders, just like {@link TooltipRenderProps}. Replaces the built-in pill
- * badge / gutter label for that line; return `null`/`undefined` to keep the
- * built-in. Bind the SharedValues to animated text (e.g. an animated `TextInput`)
- * for the value to update on the UI thread too.
+ * {@link LiveChartProps.renderOffAxisReferenceLine} (and their
+ * `LiveChartSeries` counterparts). The chart floats the element you return over
+ * the canvas and pins it to the line's value on the UI thread (vertically centered
+ * on the line, horizontally at the badge / label position) — so it tracks the
+ * rescaling axis and any drag smoothly without JS re-renders, just like
+ * {@link TooltipRenderProps}. `renderReferenceLine` replaces the built-in pill /
+ * gutter label in every state; `renderOffAxisReferenceLine` replaces it only while
+ * the value is pinned above or below the visible plot. Bind the SharedValues to
+ * animated text (e.g. an animated `TextInput`) for the value to update on the UI
+ * thread too.
  */
 export interface ReferenceLineRenderProps {
   /** The reference line being rendered. */
@@ -965,7 +972,8 @@ export interface ChartScale {
 
 /**
  * The price↔pixel / time↔pixel bridge handed to a custom
- * {@link LiveChartProps.renderOverlay}.
+ * {@link LiveChartProps.renderOverlay} or
+ * {@link LiveChartSeriesProps.renderOverlay}.
  *
  * **Easiest path — the `usePriceY` / `useTimeX` hooks.** They project a price / time
  * to a `SharedValue<number>` that tracks the live axis for you; just read it in
@@ -2161,9 +2169,25 @@ export interface LiveChartProps extends LiveChartCoreProps {
    * pins it to the line's value on the UI thread (see {@link ReferenceLineRenderProps}),
    * so it tracks the rescaling axis and any drag without JS re-renders. Called per
    * Form-A line; return `null`/`undefined` to keep that line's built-in tag. Works
-   * with `badge: false` too (replace the plain gutter label). Single-series only.
+   * with `badge: false` too (replace the plain gutter label). For a left- or
+   * right-pinned `badge`, the chart retains the dashed connector and measures the
+   * custom tag so the connector starts at its outer edge. Single-series only.
    */
   renderReferenceLine?: (
+    ctx: ReferenceLineRenderProps,
+  ) => ReactElement | null | undefined;
+  /**
+   * Render only a Form-A line's **off-axis** tag as a custom React Native element.
+   * The chart keeps the standard Skia tag / gutter label while the value is in
+   * range, then switches to this element when it pins above or below the plot.
+   * With a left- or right-pinned `badge` (or legacy `offAxisBadge`), its dashed
+   * connector stays native and begins after the measured custom tag. Return
+   * `null`/`undefined` to opt a line out based on its static `line` / `index`;
+   * use the `edge` SharedValue inside the returned element to animate a caret.
+   * `renderReferenceLine` takes precedence if both callbacks handle one line.
+   * Single-series only.
+   */
+  renderOffAxisReferenceLine?: (
     ctx: ReferenceLineRenderProps,
   ) => ReactElement | null | undefined;
   /**
@@ -2171,9 +2195,10 @@ export interface LiveChartProps extends LiveChartCoreProps {
    * single count handle (e.g. a stack of working orders at adjacent prices reads
    * as one "×3" tag). `true` = defaults, `false`/omitted = off, or pass a
    * {@link ReferenceLineGroupingConfig} to tune the proximity radius. Lines a
-   * {@link LiveChartProps.renderReferenceLine} owns are excluded (their custom tag
-   * draws itself), so the count reflects only collapsed built-in tags. Single-series
-   * only. Default off.
+   * {@link LiveChartProps.renderReferenceLine} or
+   * {@link LiveChartProps.renderOffAxisReferenceLine} owns are excluded (their
+   * custom tag draws itself), so the count reflects only collapsed built-in tags.
+   * Single-series only. Default off.
    */
   referenceLineGrouping?: boolean | ReferenceLineGroupingConfig;
   /**
@@ -2196,15 +2221,36 @@ export interface LiveChartSeriesProps extends LiveChartCoreProps {
   /** Array of series definitions. Must be a SharedValue for UI-thread reads. */
   series: SharedValue<SeriesConfig[]>;
   /**
+   * Render a custom overlay floated over the canvas, handed the live
+   * price↔pixel / time↔pixel {@link ChartOverlayContext}. Use its `scale` snapshot
+   * and mapping worklets to position React Native UI against this chart's resolved
+   * plot bounds (including any axis or explicit inset). The tree mounts full-bleed
+   * with `pointerEvents="box-none"`; return `null`/`undefined` for no overlay.
+   */
+  renderOverlay?: (ctx: ChartOverlayContext) => ReactElement | null | undefined;
+  /**
    * Render a Form-A reference line's tag as a custom **React Native** element
    * instead of the built-in Skia pill / gutter label. The chart pins the returned
    * element to the line's live Y position on the UI thread (see
    * {@link ReferenceLineRenderProps}), including off-axis edge pinning. Return
    * `null`/`undefined` to keep that line's built-in tag. The line stroke always
-   * remains visible, and `badge.position` / `labelPosition` controls the custom
-   * tag's left, center, or right anchor.
+   * remains visible; a left- or right-pinned badge also keeps its dashed connector,
+   * starting after the measured custom tag. `badge.position` / `labelPosition`
+   * controls the custom tag's left, center, or right anchor.
    */
   renderReferenceLine?: (
+    ctx: ReferenceLineRenderProps,
+  ) => ReactElement | null | undefined;
+  /**
+   * Render only a Form-A line's **off-axis** tag as a custom React Native element.
+   * The normal in-range Skia tag / gutter label stays visible, while an edge-pinned
+   * custom tag replaces it above or below the plot. A left- or right-pinned
+   * `badge` (or legacy `offAxisBadge`) retains its native dashed connector, measured
+   * against the custom tag. Return `null`/`undefined` to opt a static `line` /
+   * `index` out; use the `edge` SharedValue inside the returned element to animate
+   * its caret. `renderReferenceLine` takes precedence for the same line.
+   */
+  renderOffAxisReferenceLine?: (
     ctx: ReferenceLineRenderProps,
   ) => ReactElement | null | undefined;
   /** Called when a series toggle chip is tapped. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { View } from "react-native";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import { LiveChart } from "../src/components/LiveChart";
+import { ReferenceLineOverlay } from "../src/components/ReferenceLineOverlay";
 import * as badgeHooks from "../src/hooks/useBadge";
 import * as candlePathHooks from "../src/hooks/useCandlePaths";
 import * as chartOverlayHooks from "../src/hooks/useChartOverlayContext";
@@ -418,6 +419,37 @@ describe("LiveChart", () => {
     );
     // The custom-rendered tag is floated as an RN view (built-in tag suppressed).
     expect(screen.queryByTestId("custom-ref")).toBeTruthy();
+  });
+
+  it("replaces only an off-axis reference-line tag", () => {
+    const screen = render(
+      <Harness
+        referenceLines={[
+          {
+            value: 99,
+            label: "Target",
+            excludeFromRange: true,
+            badge: { position: "right" },
+          },
+          { value: 50, label: "Built in", badge: { position: "center" } },
+        ]}
+        renderOffAxisReferenceLine={({ line }) =>
+          line.label === "Target" ? <View testID="off-axis-target" /> : null
+        }
+      />,
+    );
+    expect(screen.getByTestId("off-axis-target")).toBeTruthy();
+
+    const badgePass = screen
+      .UNSAFE_getAllByType(ReferenceLineOverlay)
+      .filter((overlay) => overlay.props.badgeLayer);
+    expect(badgePass.map((overlay) => overlay.props.suppressTag)).toEqual([
+      false,
+      false,
+    ]);
+    expect(
+      badgePass.map((overlay) => overlay.props.suppressTagWhenOffAxis),
+    ).toEqual([true, false]);
   });
 
   it("accepts a boolean referenceLineGrouping and a non-draggable custom line", () => {

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -7,7 +7,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
 import { ReferenceLineOverlay } from "../src/components/ReferenceLineOverlay";
 import { DefaultSelectionDot } from "../src/components/SelectionDot";
-import type { SeriesConfig } from "../src/types";
+import type { ChartOverlayContext, SeriesConfig } from "../src/types";
 
 describe("LiveChartSeries", () => {
   it("opts into an opaque canvas and replaces destination-alpha masks", async () => {
@@ -159,6 +159,100 @@ describe("LiveChartSeries", () => {
       true,
       false,
     ]);
+  });
+
+  it("replaces only an off-axis tag while preserving the in-range fallback", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          referenceLines={[
+            {
+              value: 99,
+              label: "Target",
+              excludeFromRange: true,
+              badge: { position: "left" },
+            },
+            { value: 11, label: "Built in", badge: { position: "center" } },
+          ]}
+          renderOffAxisReferenceLine={({ line }) =>
+            line.label === "Target" ? <View testID="series-off-axis-target" /> : null
+          }
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await waitFor(() =>
+      expect(screen.getByTestId("series-off-axis-target")).toBeTruthy(),
+    );
+
+    const badgePass = screen
+      .UNSAFE_getAllByType(ReferenceLineOverlay)
+      .filter((overlay) => overlay.props.badgeLayer);
+    expect(badgePass.map((overlay) => overlay.props.suppressTag)).toEqual([
+      false,
+      false,
+    ]);
+    expect(
+      badgePass.map((overlay) => overlay.props.suppressTagWhenOffAxis),
+    ).toEqual([true, false]);
+  });
+
+  it("passes a custom overlay the multi-series chart's resolved plot inset", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    let overlayContext: ChartOverlayContext | undefined;
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          insets={{ left: 31, top: 7, right: 53, bottom: 19 }}
+          renderOverlay={(ctx) => {
+            overlayContext = ctx;
+            return <View testID="series-overlay" />;
+          }}
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByTestId("series-overlay")).toBeTruthy());
+    // The canvas is unmeasured in the renderer fixture, but the bridge already
+    // carries the resolved per-side inset. `useChartOverlayContext` separately
+    // verifies the same bridge against a nonzero canvas.
+    expect(overlayContext?.scale.get().plot).toEqual({
+      left: 31,
+      top: 7,
+      right: -53,
+      bottom: -19,
+      width: 0,
+      height: 0,
+    });
   });
 
   it("renders with per-series value lines", async () => {

--- a/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomReferenceLineOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from "@testing-library/react-native";
 import React from "react";
 import { Text, View } from "react-native";
-import { useSharedValue } from "react-native-reanimated";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
 
 import {
   CustomReferenceLineOverlay,
@@ -50,6 +50,16 @@ describe("customReferenceLineFlags", () => {
   it("exposes readable ctx SharedValue stubs to the probe", () => {
     const flags = customReferenceLineFlags([{ value: 42 }], (ctx) =>
       ctx.value.get() === 42 && ctx.edge.get() === "in" ? <Text>ok</Text> : null,
+    );
+    expect(flags).toEqual([true]);
+  });
+
+  it("uses an off-axis sentinel when selecting an off-axis renderer", () => {
+    const flags = customReferenceLineFlags(
+      [{ value: 42 }],
+      (ctx) =>
+        !ctx.inRange.get() && ctx.edge.get() === "above" ? <Text>ok</Text> : null,
+      "off-axis",
     );
     expect(flags).toEqual([true]);
   });
@@ -123,6 +133,33 @@ describe("CustomReferenceLineOverlay", () => {
     expect(queryByTestId("rl-1")).toBeNull();
   });
 
+  it("publishes the measured custom-tag width for the Skia connector", () => {
+    let tagWidths: SharedValue<number[]> | undefined;
+    function WidthFixture() {
+      const widths = useSharedValue<number[]>([]);
+      tagWidths = widths;
+      return (
+        <CustomReferenceLineOverlay
+          lines={[{ value: 30, badge: true }]}
+          renderReferenceLine={({ index }) => (
+            <View testID={`rl-${index}`} style={{ width: 52, height: 16 }} />
+          )}
+          custom={[true]}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          formatValue={fmt}
+          tagWidths={widths}
+        />
+      );
+    }
+
+    const { getByTestId } = render(<WidthFixture />);
+    fireEvent(getByTestId("rl-0").parent!, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 52, height: 16 } },
+    });
+    expect(tagWidths?.get()).toEqual([52]);
+  });
+
   it("uses the static line value when no drag state is provided", () => {
     const { getByText } = render(
       <CustomReferenceLineOverlay
@@ -179,5 +216,22 @@ describe("CustomReferenceLineOverlay", () => {
     );
     // Still mounted (opacity 0), exercising the raw < 0 branch.
     expect(getByTestId("rl-0")).toBeTruthy();
+  });
+
+  it("keeps an off-axis renderer mounted with its live edge context", () => {
+    const { getByText } = render(
+      <CustomReferenceLineOverlay
+        lines={[{ value: 150, badge: true }]}
+        renderReferenceLine={({ edge, inRange }) => (
+          <Text>{`${edge.get()}:${inRange.get()}`}</Text>
+        )}
+        custom={[true]}
+        engine={engine()}
+        padding={DEFAULT_PADDING}
+        formatValue={fmt}
+        offAxisOnly
+      />,
+    );
+    expect(getByText("above:false")).toBeTruthy();
   });
 });

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -8,11 +8,10 @@ import type { EngineState } from "../../src/core/useLiveChartEngine";
 import { LoadingOverlay } from "../../src/components/LoadingOverlay";
 import { MultiSeriesTooltipStack } from "../../src/components/MultiSeriesTooltipStack";
 import React from "react";
-import type { ReferenceLine } from "../../src/types";
+import type { ReferenceLine, SelectionDotProps } from "../../src/types";
 import { ReferenceLineOverlay } from "../../src/components/ReferenceLineOverlay";
 import { Circle, Skia } from "@shopify/react-native-skia";
 import type { TooltipLayout } from "../../src/hooks/crosshairShared";
-import type { SelectionDotProps } from "../../src/types";
 import { ValueLineOverlay } from "../../src/components/ValueLineOverlay";
 import { XAxisOverlay } from "../../src/components/XAxisOverlay";
 import {
@@ -1101,6 +1100,85 @@ describe("ReferenceLineOverlay", () => {
         radius: 6,
       },
     });
+  });
+
+  it("keeps a custom badge's connector and starts it after its measured edge", () => {
+    type MockBuilder = { moveTo: jest.Mock; lineTo: jest.Mock };
+    const make = Skia.PathBuilder.Make as unknown as jest.Mock;
+    make.mockClear();
+    const tagWidth = 80;
+    const y =
+      DEFAULT_PADDING.top +
+      ((10 - 5) / 10) * (300 - DEFAULT_PADDING.top - DEFAULT_PADDING.bottom);
+    function Fixture() {
+      const customTagWidths = useSharedValue([tagWidth]);
+      return (
+        <ReferenceLineOverlay
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          line={{ value: 5, badge: true }}
+          palette={palette}
+          formatValue={fmt}
+          font={font}
+          badgeLayer
+          suppressTag
+          customTagWidths={customTagWidths}
+        />
+      );
+    }
+
+    render(<Fixture />);
+    const builders = make.mock.results.map(
+      ({ value }) => value as unknown as MockBuilder,
+    );
+    const connector = builders.find((builder) =>
+      builder.moveTo.mock.calls.some(
+        ([x, lineY]) =>
+          x === DEFAULT_PADDING.left + 2 + tagWidth + 4 && lineY === y,
+      ),
+    );
+    expect(connector).toBeDefined();
+    expect(connector?.lineTo).toHaveBeenCalledWith(
+      400 - DEFAULT_PADDING.right,
+      y,
+    );
+    make.mockClear();
+  });
+
+  it("uses the custom connector edge only while an off-axis tag is active", () => {
+    type MockBuilder = { moveTo: jest.Mock; lineTo: jest.Mock };
+    const make = Skia.PathBuilder.Make as unknown as jest.Mock;
+    make.mockClear();
+    const tagWidth = 80;
+    function Fixture() {
+      const customTagWidths = useSharedValue([tagWidth]);
+      return (
+        <ReferenceLineOverlay
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          line={{ value: 99, badge: true }}
+          palette={palette}
+          formatValue={fmt}
+          font={font}
+          badgeLayer
+          suppressTagWhenOffAxis
+          customTagWidths={customTagWidths}
+        />
+      );
+    }
+
+    render(<Fixture />);
+    const builders = make.mock.results.map(
+      ({ value }) => value as unknown as MockBuilder,
+    );
+    expect(
+      builders.some((builder) =>
+        builder.moveTo.mock.calls.some(
+          ([x]) => x === DEFAULT_PADDING.left + 2 + tagWidth + 4,
+        ),
+      ),
+    ).toBe(true);
+    make.mockClear();
   });
 
   it("renders a right-pinned, icon-only badge", () => {

--- a/packages/react-native-livechart/tests/math/referenceLines.test.ts
+++ b/packages/react-native-livechart/tests/math/referenceLines.test.ts
@@ -2,6 +2,7 @@ import {
   classifyReferenceEdge,
   collectReferenceValues,
   referenceLineForm,
+  referenceLineReactKeys,
   resolveReferenceBadge,
   resolveReferenceGroupBadge,
 } from "../../src/math/referenceLines";
@@ -236,6 +237,28 @@ describe("collectReferenceValues", () => {
 
   it("returns an empty array for no lines", () => {
     expect(collectReferenceValues([])).toEqual([]);
+  });
+});
+
+describe("referenceLineReactKeys", () => {
+  it("uses an explicit id as a stable key across reordering", () => {
+    const buy = { id: "buy", value: 98, label: "Buy" };
+    const sell = { id: "sell", value: 102, label: "Sell" };
+
+    expect(referenceLineReactKeys([buy, sell])).toEqual(["buy:0", "sell:0"]);
+    expect(referenceLineReactKeys([sell, buy])).toEqual(["sell:0", "buy:0"]);
+  });
+
+  it("derives distinct deterministic fallback keys for legacy lines", () => {
+    expect(
+      referenceLineReactKeys([
+        { value: 10, label: "Target", badge: true },
+        { value: 10, label: "Target", badge: true },
+      ]),
+    ).toEqual([
+      "{badge:true,label:\"Target\",value:10}:0",
+      "{badge:true,label:\"Target\",value:10}:1",
+    ]);
   });
 });
 


### PR DESCRIPTION
Fixes #227.

## Summary

- Add `renderOffAxisReferenceLine` to `LiveChart` and `LiveChartSeries`, keeping the built-in in-range tag intact and swapping only the edge-pinned tag when the line is above or below the plot
- Measure custom reference-line tags and start the left- or right-pinned native dashed connector at the outer edge of the custom badge, with a `CONNECTOR_GAP` between them
- Expose `renderOverlay` on `LiveChartSeries` with a layout-aware bridge that reports the chart's resolved plot rectangle, so custom off-axis tags and connectors respect the actual Y-axis inset
- Add a stable `id` field to `ReferenceLine` and a `referenceLineReactKeys` helper that uses it as a React key, falling back to a deterministic visual-config signature so reordering no longer remounts existing lines
- Split `ReferenceLineOverlay` into `ReferenceLineBasePass` and `ReferenceLineBadgePass`, separating the connector opacity from the badge opacity so the dashed connector remains visible when a custom tag suppresses the built-in pill
- Add `suppressTagWhenOffAxis` and `customTagWidths` props to `ReferenceLineOverlay`; the connector worklet reads the measured custom width and adjusts its start/end only while the custom tag is active
- Update the multi-series QA demo with Above / In range / Below chip controls that move a single reference line through every edge state; the custom caret animates its rotation via `useAnimatedStyle` on `edge`
- Document `renderOffAxisReferenceLine`, the updated `renderReferenceLine` connector behavior, the `id` field, and the `renderOverlay` availability on `LiveChartSeries` across the API reference and guides

## Verification

- `npm run verify` (typecheck, lint, 96 Jest suites: 1,367 passed, 5 skipped)
- React Doctor: 100/100 for both projects in the changed-file scan