### PR TITLE
Add market detail tooltips to LiveChartSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`LiveChartSeries` can render Morfi-style per-series scrub tooltips.**
+  Enable `scrub.seriesTooltip` for a dashed guide, clamped time-range pill,
+  per-series colour/value pills and intersection dots. Pills flip at the right
+  edge, stack to avoid collisions, omit hidden series, and can stay pinned to
+  live endpoints with `alwaysShow`. Formatting and pill styling remain on the
+  UI thread, and the existing guide-only multi-series default is unchanged.
+  Includes controls in the multi-series demo. ([#228](https://github.com/brandtnewlabs/react-native-livechart/issues/228))
+
 ### Fixed
 
 - **The live-dot pulse no longer freezes when `nowOverride` is pinned.** The pulse

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -50,7 +50,7 @@ const SECTIONS: DemoSection[] = [
       {
         href: "/demo/multi-series",
         title: "Multi-series",
-        blurb: "LiveChartSeries: per-series style, legend, dots, scrub.",
+        blurb: "LiveChartSeries: legend, dots, and Morfi-style scrub tooltip pills.",
       },
       {
         href: "/demo/sparklines",

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -122,6 +122,9 @@ export default function MultiSeriesScreen() {
   const [exaggerate, setExaggerate] = useState(false);
   const [degen, setDegen] = useState(false);
   const [scrubDim, setScrubDim] = useState(0.3);
+  const [seriesTooltip, setSeriesTooltip] = useState(true);
+  const [tooltipAlwaysShow, setTooltipAlwaysShow] = useState(false);
+  const [styledTooltip, setStyledTooltip] = useState(false);
   const [theme, setTheme] = useState<"dark" | "light">(APP_THEME);
   // Keep this on by default: it is the visual QA case for a custom left-pinned
   // reference tag. Its dashed connector must start at the native tag's right
@@ -274,7 +277,36 @@ export default function MultiSeriesScreen() {
             emptyText="No series"
             dot={dotConfig}
             legend={legendConfig}
-            scrub={{ dimOpacity: scrubDim }}
+            scrub={{
+              dimOpacity: scrubDim,
+              seriesTooltip: seriesTooltip
+                ? {
+                    alwaysShow: tooltipAlwaysShow,
+                    formatSeriesValue: (value) => {
+                      "worklet";
+                      return `${value.toFixed(2)}%`;
+                    },
+                    formatTimeRange: (from, to) => {
+                      "worklet";
+                      return `${formatTime(from)} – ${formatTime(to)}`;
+                    },
+                    ...(styledTooltip
+                      ? {
+                          guideColor: "#f59e0b",
+                          guideDashPattern: [2, 4],
+                          timePillBackground: "#1e293b",
+                          timePillColor: "#fbbf24",
+                          timePillBorderColor: "#f59e0b",
+                          seriesPillBackground: "#1e293b",
+                          seriesPillLabelColor: "#94a3b8",
+                          seriesPillValueColor: "#f8fafc",
+                          seriesPillBorderColor: "#334155",
+                          seriesPillRadius: 10,
+                        }
+                      : null),
+                  }
+                : false,
+            }}
             onSeriesToggle={
               empty
                 ? undefined
@@ -378,6 +410,24 @@ export default function MultiSeriesScreen() {
         value={scrubDim}
         onChange={setScrubDim}
       />
+
+      <ControlRow label="Series scrub tooltip">
+        <ToggleChip
+          label="Pills"
+          value={seriesTooltip}
+          onChange={setSeriesTooltip}
+        />
+        <ToggleChip
+          label="Pin while idle"
+          value={tooltipAlwaysShow}
+          onChange={setTooltipAlwaysShow}
+        />
+        <ToggleChip
+          label="Styled"
+          value={styledTooltip}
+          onChange={setStyledTooltip}
+        />
+      </ControlRow>
 
       <ControlRow label="Playback & theme">
         <ToggleChip

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -97,14 +97,22 @@ default off.
 
 <ParamField body="scrub" type="boolean | ScrubConfig" default="true">
   Crosshair scrubbing on drag. **As of v2 this defaults to `true`** (it previously
-  defaulted to `false`); pass `scrub={false}` to disable.
+  defaulted to `false`); pass `scrub={false}` to disable. The existing default is
+  a guide/dim layer. Omitting `seriesTooltip` (or setting it to `false`) preserves
+  that behavior. Set `scrub.seriesTooltip` to opt into the Morfi-style
+  time-range pill, one colour/value pill and intersection dot per visible series,
+  collision stacking, and edge flipping. `seriesTooltip.alwaysShow` keeps value
+  pills pinned to the visible endpoints while idle without showing the guide or
+  time pill. The existing `scrub.tooltip={false}` switch remains the master
+  tooltip control and also suppresses the per-series pills. See
+  [Multi-series tooltips](/guides/multi-series#per-series-scrub-tooltip).
 </ParamField>
 
 <ParamField body="selectionDot" type="boolean | SelectionDotConfig" default="false">
   Dot drawn at the scrub intersection while scrubbing. **Hidden by default on
   `LiveChartSeries`** (unlike `LiveChart`): with multiple lines the dot can only
-  track the leading series, so the crosshair + per-series tooltips mark the
-  scrub point instead. Pass `true` to opt in (it anchors to the leading series),
+  track the leading series, so the crosshair and the opt-in tooltip's per-series
+  intersection dots mark the scrub point instead. Pass `true` to opt in (it anchors to the leading series),
   a config to set `size` / `color` / `ring`, or `{ component }` for a fully
   custom Skia dot. See [Scrubbing](/guides/scrubbing#selection-dot).
 </ParamField>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -345,7 +345,10 @@ interface ValueLineConfig { strokeWidth?: number; intervals?: [number, number]; 
 // Shared styling for a straight line (the connector, valueLine, …). Omit `intervals` for solid.
 interface LineStyleConfig { color?: string; strokeWidth?: number; intervals?: [number, number] }
 interface ScrubConfig {
-  tooltip?: boolean;
+  tooltip?: boolean; // existing master tooltip switch; false also suppresses seriesTooltip
+  // LiveChartSeries only: opt-in Morfi-style time + per-series value pills.
+  // false/omitted preserves the existing guide-only default.
+  seriesTooltip?: boolean | PerSeriesTooltipConfig;
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
@@ -356,6 +359,30 @@ interface ScrubConfig {
   tooltipShowValue?: boolean; tooltipShowTime?: boolean; // default both true; drop a row (e.g. date-only)
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0
   hideOverlaysOnScrub?: boolean; // fade markers + reference lines out while scrubbing; default false
+}
+interface PerSeriesTooltipConfig {
+  alwaysShow?: boolean;      // pin value pills to visible endpoints while idle; default false
+  bucketSeconds?: number;    // omit to infer from the first visible series
+  formatSeriesValue?: (value: number, seriesId: string) => string; // UI-thread worklet
+  formatTimeRange?: (from: number, to: number) => string;          // UI-thread worklet
+  maxLabelChars?: number;    // ellipsis truncation; default 14
+
+  guideColor?: string;
+  guideWidth?: number;       // default 1
+  guideDashPattern?: boolean | number[]; // default [3,3]; false = solid
+
+  timePillBackground?: string; timePillColor?: string; timePillBorderColor?: string;
+  timePillRadius?: number; timePillPaddingX?: number; timePillPaddingY?: number;
+
+  seriesPillBackground?: string;
+  seriesPillLabelColor?: string;
+  seriesPillValueColor?: string;
+  seriesPillBorderColor?: string;
+  seriesPillRadius?: number;
+  seriesPillPaddingX?: number; seriesPillPaddingY?: number;
+  seriesPillDotSize?: number; seriesPillDotGap?: number;
+  seriesPillLabelValueGap?: number;
+  intersectionDotSize?: number;
 }
 // Order-ticket mode (scrubAction). Opt-in — default off.
 interface ScrubActionConfig {
@@ -374,7 +401,7 @@ interface SelectionDotRingConfig {
   width?: number; // ring thickness past the dot, default 2
 }
 // The scrub-intersection dot (selectionDot). Default ON for LiveChart,
-// OFF for LiveChartSeries (the crosshair + tooltips mark the scrub point there).
+// OFF for LiveChartSeries (the crosshair + opt-in per-series tooltip dots mark it).
 interface SelectionDotConfig {
   size?: number; // dot radius, default 4
   color?: string; // dot color, defaults to the line / leading-series color

--- a/docs/guides/multi-series.mdx
+++ b/docs/guides/multi-series.mdx
@@ -96,3 +96,83 @@ Tune or turn off the halo, hide the dots, or override the fill color:
 ```
 
 See the full prop list in the [`LiveChartSeries` reference](/api-reference/livechart-series).
+
+## Per-series scrub tooltip
+
+`LiveChartSeries` keeps its historical guide-only scrub by default. Opt into the
+Morfi market-detail readout with `scrub.seriesTooltip`: a dashed vertical guide,
+a top-centred bucket range, and one pill plus intersection dot for every visible
+series. Close values stack instead of overlapping, wide pills flip to the
+guide's left near the right edge, and hidden legend series are omitted.
+
+<Note>
+  This feature is opt-in and backward compatible. `scrub={true}`,
+  `scrub={{}}`, and `scrub={{ seriesTooltip: false }}` all keep the existing
+  guide-only multi-series behavior. The existing `scrub.tooltip` property is
+  still the master switch; setting it to `false` also suppresses the per-series
+  pills.
+</Note>
+
+Enable the default tooltip treatment with:
+
+```tsx
+<LiveChartSeries
+  series={series}
+  scrub={{ seriesTooltip: true }}
+/>
+```
+
+Pass an object instead of `true` to customize formatting and appearance:
+
+```tsx
+<LiveChartSeries
+  series={series}
+  scrub={{
+    seriesTooltip: {
+      formatSeriesValue: (value, seriesId) => {
+        "worklet";
+        return seriesId.startsWith("probability")
+          ? `${(value * 100).toFixed(1)}%`
+          : `$${value.toFixed(2)}`;
+      },
+      formatTimeRange: (from, to) => {
+        "worklet";
+        return `${formatTime(from)} – ${formatTime(to)}`;
+      },
+      maxLabelChars: 14,
+    },
+  }}
+/>
+```
+
+`formatSeriesValue` and `formatTimeRange` run on the UI thread; keep them
+worklet-safe, just like the chart's `formatValue` and `formatTime`. Omit
+`bucketSeconds` to infer the range width from the first visible series. The
+range end is always clamped to the chart's current-time anchor, so an
+in-progress live bucket never displays a future end time.
+
+Set `alwaysShow` to keep the value pills at the visible endpoints while the
+user is not touching the chart. Idle mode deliberately hides the guide and
+time pill; scrubbing restores the full readout.
+
+```tsx
+<LiveChartSeries
+  series={series}
+  scrub={{
+    seriesTooltip: {
+      alwaysShow: true,
+      guideColor: "#f59e0b",
+      guideDashPattern: [3, 3],
+      timePillBackground: "#1e293b",
+      seriesPillBackground: "#1e293b",
+      seriesPillLabelColor: "#94a3b8",
+      seriesPillValueColor: "#f8fafc",
+      seriesPillRadius: 10,
+      intersectionDotSize: 8,
+    },
+  }}
+/>
+```
+
+The [multi-series demo](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/demo/multi-series.tsx)
+has live toggles for the pills, pinned mode, and styling.

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -238,7 +238,8 @@ through to the parent gesture, while a deliberate hold begins scrubbing.
 A dot is drawn at the scrub intersection — where the crosshair meets the line. On `LiveChart` it's
 **on by default**, so you get it for free with `scrub`. On `LiveChartSeries` it's **off by
 default** — with multiple lines the dot can only track the leading series, so the crosshair +
-per-series tooltips mark the scrub point instead; pass `selectionDot` explicitly to opt in.
+the opt-in per-series tooltip dots mark the scrub point instead; pass `selectionDot` explicitly
+to opt in.
 
 Turn it off, or tweak its look, with the `boolean | SelectionDotConfig` `selectionDot` prop:
 

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -23,6 +23,7 @@ export function CrosshairLine({
   dimOpacity = 0.3,
   liveDotExtent = 0,
   crosshairLineColor,
+  crosshairLineWidth = 1,
   crosshairDash,
   crosshairDimColor,
   opaqueCanvas = false,
@@ -50,6 +51,8 @@ export function CrosshairLine({
    *  the gutter reserves beyond them bright. Default 0. */
   liveDotExtent?: number;
   crosshairLineColor?: string;
+  /** Vertical guide stroke width in px. Default 1. */
+  crosshairLineWidth?: number;
   /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
   crosshairDash?: number[];
   crosshairDimColor?: string;
@@ -138,7 +141,7 @@ export function CrosshairLine({
           p1={p1}
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
-          strokeWidth={1}
+          strokeWidth={crosshairLineWidth}
         >
           {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
         </Line>

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -100,6 +100,7 @@ import { MultiSeriesDots } from "./MultiSeriesDots";
 import { MultiSeriesStroke } from "./MultiSeriesStroke";
 import { MultiSeriesValueLabels } from "./MultiSeriesValueLabels";
 import { MultiSeriesValueLines } from "./MultiSeriesValueLines";
+import { PerSeriesTooltipOverlay } from "./PerSeriesTooltipOverlay";
 import { ReferenceLineOverlay } from "./ReferenceLineOverlay";
 import { SeriesToggleChips } from "./SeriesToggleChips";
 import { XAxisOverlay } from "./XAxisOverlay";
@@ -196,6 +197,10 @@ function useLiveChartSeriesController({
   const bottomLabelCfg = resolveAxisLabel(bottomLabel);
   const scrubCfg = resolveScrub(scrub);
   const scrubEnabled = scrubCfg !== null;
+  // Opt-in and subordinate to the existing master `tooltip` switch. Keeping
+  // this null by default preserves LiveChartSeries' historical guide-only scrub.
+  const seriesTooltipCfg =
+    scrubCfg?.tooltip === true ? scrubCfg.seriesTooltip : null;
 
   // Time-scroll + pinch-zoom (mirrors LiveChart). LiveChartSeries has no static
   // mode, so these gate on the props alone. `holdToScrub` requires the scrub
@@ -222,8 +227,8 @@ function useLiveChartSeriesController({
 
   // Multi-series defaults the scrub selection dot OFF: it can only track one
   // line (the leading series), which reads as a bug next to the other series.
-  // The crosshair line + per-series tooltip stack already mark the scrub point.
-  // Passing `selectionDot` explicitly (true / config) still opts it in.
+  // The crosshair line (and the opt-in tooltip's per-series intersection dots)
+  // mark the scrub point. Passing `selectionDot` explicitly still opts it in.
   const selectionDotCfg = resolveSelectionDot(selectionDot ?? false);
   const gridStyleCfg = resolveGridStyle(gridStyle);
   const dotCfg = resolveMultiSeriesDot(dotProp);
@@ -432,6 +437,12 @@ function useLiveChartSeriesController({
   // long-press guard) makes "the scroll already won" a hard fact; `scrubActive`
   // (written by the crosshair, read by the scroll pan) is the mirror image.
   const scrollActive = useSharedValue(false);
+  // `liveEdge` includes the optional right breathing-room buffer. The time pill
+  // must clamp against the real "now" anchor so its live bucket never ends in
+  // that future buffer.
+  const tooltipMaxTime = useDerivedValue(
+    () => engine.liveEdge.get() - windowBuffer * timeWindow,
+  );
 
   const crosshair = useCrosshairSeries(
     engine,
@@ -442,6 +453,16 @@ function useLiveChartSeriesController({
     onGestureStart,
     onGestureEnd,
     scrollActive,
+    seriesTooltipCfg
+      ? {
+          config: seriesTooltipCfg,
+          formatValue,
+          formatTime,
+          font: skiaFont,
+          colors: lineColors,
+          maxTime: tooltipMaxTime,
+        }
+      : undefined,
   );
 
   // Capture only the shared value in the worklets below. Referencing
@@ -566,6 +587,7 @@ function useLiveChartSeriesController({
     yAxisCfg,
     xAxisCfg,
     scrubCfg,
+    seriesTooltipCfg,
     gridStyleCfg,
     dotCfg,
     dotOuterRadius,
@@ -915,6 +937,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     effectivePadding,
     engine,
     scrubCfg,
+    seriesTooltipCfg,
     crosshair,
     palette,
     dotCfg,
@@ -939,6 +962,8 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     refLineCustomTagWidths,
     overlayScrubFade,
     canvasMode,
+    activeSeriesCount,
+    skiaFont,
   } = model;
 
   // Mirror the Skia overlay fade onto the RN custom-marker sibling so
@@ -1036,8 +1061,16 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 selectionColor={selectionColor}
                 dimOpacity={scrubCfg.dimOpacity}
                 liveDotExtent={liveDotExtent}
-                crosshairLineColor={scrubCfg.crosshairLineColor}
-                crosshairDash={scrubCfg.crosshairDash}
+                crosshairLineColor={
+                  seriesTooltipCfg?.guideColor ??
+                  scrubCfg.crosshairLineColor
+                }
+                crosshairLineWidth={seriesTooltipCfg?.guideWidth}
+                crosshairDash={
+                  seriesTooltipCfg
+                    ? seriesTooltipCfg.guideDashPattern
+                    : scrubCfg.crosshairDash
+                }
                 crosshairDimColor={scrubCfg.crosshairDimColor}
                 opaqueCanvas={canvasMode === "opaque"}
               />
@@ -1046,6 +1079,19 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
             {/* Per-series value labels on top of the scrub dim so the dim never
                 clips them (they track each series' live value, not the scrub). */}
             <SeriesValueLabelLayer model={model} />
+
+            {seriesTooltipCfg && (
+              <PerSeriesTooltipOverlay
+                layout={crosshair.tooltipLayout}
+                font={skiaFont}
+                palette={palette}
+                config={seriesTooltipCfg}
+                seriesCount={activeSeriesCount}
+                tooltipBackground={scrubCfg?.tooltipBackground}
+                tooltipColor={scrubCfg?.tooltipColor}
+                tooltipBorderColor={scrubCfg?.tooltipBorderColor}
+              />
+            )}
           </Canvas>
 
           {/* RN labels floated over the canvas (sibling of <Canvas>, an RN

--- a/packages/react-native-livechart/src/components/PerSeriesTooltipOverlay.tsx
+++ b/packages/react-native-livechart/src/components/PerSeriesTooltipOverlay.tsx
@@ -1,0 +1,287 @@
+import {
+  Circle,
+  Group,
+  RoundedRect,
+  Text as SkiaText,
+  type SkFont,
+} from "@shopify/react-native-skia";
+import {
+  useDerivedValue,
+  type DerivedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+import type { ResolvedPerSeriesTooltipConfig } from "../core/resolveConfig";
+import type { TooltipLayout } from "../hooks/crosshairShared";
+import type { LiveChartPalette } from "../types";
+
+type TooltipLayoutValue =
+  | SharedValue<TooltipLayout>
+  | DerivedValue<TooltipLayout>;
+
+function TimePill({
+  layout,
+  font,
+  palette,
+  config,
+  background,
+  color,
+  borderColor,
+}: {
+  layout: TooltipLayoutValue;
+  font: SkFont;
+  palette: LiveChartPalette;
+  config: ResolvedPerSeriesTooltipConfig;
+  background?: string;
+  color?: string;
+  borderColor?: string;
+}) {
+  const opacity = useDerivedValue(() =>
+    layout.value.perSeries?.timePill ? 1 : 0,
+  );
+  const x = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.x ?? -400,
+  );
+  const y = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.y ?? 0,
+  );
+  const w = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.w ?? 0,
+  );
+  const h = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.h ?? 0,
+  );
+  const text = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.text ?? "",
+  );
+  const textX = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.textX ?? -400,
+  );
+  const baselineY = useDerivedValue(
+    () => layout.value.perSeries?.timePill?.baselineY ?? 0,
+  );
+  const clip = useDerivedValue(() => ({
+    x: layout.value.perSeries?.timePill?.x ?? -400,
+    y: layout.value.perSeries?.timePill?.y ?? 0,
+    width: layout.value.perSeries?.timePill?.w ?? 0,
+    height: layout.value.perSeries?.timePill?.h ?? 0,
+  }));
+
+  return (
+    <Group opacity={opacity}>
+      <RoundedRect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        r={config.timePillRadius}
+        color={background ?? palette.tooltipBg}
+      />
+      <RoundedRect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        r={config.timePillRadius}
+        color={borderColor ?? palette.tooltipBorder}
+        style="stroke"
+        strokeWidth={1}
+      />
+      <Group clip={clip}>
+        <SkiaText
+          x={textX}
+          y={baselineY}
+          text={text}
+          font={font}
+          color={color ?? palette.tooltipText}
+        />
+      </Group>
+    </Group>
+  );
+}
+
+function SeriesPill({
+  index,
+  layout,
+  font,
+  palette,
+  config,
+  background,
+  labelColor,
+  valueColor,
+  borderColor,
+}: {
+  index: number;
+  layout: TooltipLayoutValue;
+  font: SkFont;
+  palette: LiveChartPalette;
+  config: ResolvedPerSeriesTooltipConfig;
+  background?: string;
+  labelColor?: string;
+  valueColor?: string;
+  borderColor?: string;
+}) {
+  const opacity = useDerivedValue(() => {
+    const pills = layout.value.perSeries?.pills;
+    return pills && index < pills.length ? 1 : 0;
+  });
+  const x = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.x ?? -400,
+  );
+  const y = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.y ?? 0,
+  );
+  const w = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.w ?? 0,
+  );
+  const h = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.h ?? 0,
+  );
+  const anchorX = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.anchorX ?? -400,
+  );
+  const anchorY = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.anchorY ?? -400,
+  );
+  const dotX = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.dotX ?? -400,
+  );
+  const dotY = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.dotY ?? -400,
+  );
+  const dotColor = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.color ?? palette.tooltipText,
+  );
+  const label = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.label ?? "",
+  );
+  const labelX = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.labelX ?? -400,
+  );
+  const value = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.value ?? "",
+  );
+  const valueX = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.valueX ?? -400,
+  );
+  const baselineY = useDerivedValue(
+    () => layout.value.perSeries?.pills[index]?.baselineY ?? 0,
+  );
+  const clip = useDerivedValue(() => ({
+    x: layout.value.perSeries?.pills[index]?.x ?? -400,
+    y: layout.value.perSeries?.pills[index]?.y ?? 0,
+    width: layout.value.perSeries?.pills[index]?.w ?? 0,
+    height: layout.value.perSeries?.pills[index]?.h ?? 0,
+  }));
+
+  return (
+    <Group opacity={opacity}>
+      <Circle
+        cx={anchorX}
+        cy={anchorY}
+        r={config.intersectionDotSize / 2}
+        color={dotColor}
+      />
+      <RoundedRect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        r={config.seriesPillRadius}
+        color={background ?? palette.tooltipBg}
+      />
+      <RoundedRect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        r={config.seriesPillRadius}
+        color={borderColor ?? palette.tooltipBorder}
+        style="stroke"
+        strokeWidth={1}
+      />
+      <Group clip={clip}>
+        <Circle
+          cx={dotX}
+          cy={dotY}
+          r={config.seriesPillDotSize / 2}
+          color={dotColor}
+        />
+        <SkiaText
+          x={labelX}
+          y={baselineY}
+          text={label}
+          font={font}
+          color={labelColor ?? palette.tooltipText}
+        />
+        <SkiaText
+          x={valueX}
+          y={baselineY}
+          text={value}
+          font={font}
+          color={valueColor ?? labelColor ?? palette.tooltipText}
+        />
+      </Group>
+    </Group>
+  );
+}
+
+/** Skia-only per-series tooltip renderer; every position is SharedValue-driven. */
+export function PerSeriesTooltipOverlay({
+  layout,
+  font,
+  palette,
+  config,
+  seriesCount,
+  tooltipBackground,
+  tooltipColor,
+  tooltipBorderColor,
+}: {
+  layout: TooltipLayoutValue;
+  font: SkFont;
+  palette: LiveChartPalette;
+  config: ResolvedPerSeriesTooltipConfig;
+  seriesCount: number;
+  tooltipBackground?: string;
+  tooltipColor?: string;
+  tooltipBorderColor?: string;
+}) {
+  const timeBackground =
+    config.timePillBackground ?? tooltipBackground;
+  const timeColor = config.timePillColor ?? tooltipColor;
+  const timeBorder =
+    config.timePillBorderColor ?? tooltipBorderColor;
+  const seriesBackground =
+    config.seriesPillBackground ?? tooltipBackground;
+  const seriesLabelColor =
+    config.seriesPillLabelColor ?? tooltipColor;
+  const seriesBorder =
+    config.seriesPillBorderColor ?? tooltipBorderColor;
+
+  return (
+    <Group>
+      <TimePill
+        layout={layout}
+        font={font}
+        palette={palette}
+        config={config}
+        background={timeBackground}
+        color={timeColor}
+        borderColor={timeBorder}
+      />
+      {Array.from({ length: seriesCount }, (_, index) => (
+        <SeriesPill
+          key={index}
+          index={index}
+          layout={layout}
+          font={font}
+          palette={palette}
+          config={config}
+          background={seriesBackground}
+          labelColor={seriesLabelColor}
+          valueColor={config.seriesPillValueColor}
+          borderColor={seriesBorder}
+        />
+      ))}
+    </Group>
+  );
+}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -24,6 +24,7 @@ import type {
   ReferenceLine,
   ScrubActionConfig,
   ScrubConfig,
+  PerSeriesTooltipConfig,
   SelectionDotConfig,
   SelectionDotProps,
   SelectionDotRingConfig,
@@ -144,6 +145,8 @@ export interface ResolvedXAxisConfig {
 
 export interface ResolvedScrubConfig {
   tooltip: boolean;
+  /** Opt-in per-series pill tooltip for LiveChartSeries; null keeps guide-only behavior. */
+  seriesTooltip: ResolvedPerSeriesTooltipConfig | null;
   /** Opacity of content right of the crosshair while scrubbing (dstOut fade). */
   dimOpacity: number;
   /** undefined → palette.crosshairLine */
@@ -172,6 +175,36 @@ export interface ResolvedScrubConfig {
   panGestureDelay: number;
   /** Fade markers + reference lines out while scrubbing. */
   hideOverlaysOnScrub: boolean;
+}
+
+export interface ResolvedPerSeriesTooltipConfig {
+  alwaysShow: boolean;
+  bucketSeconds: number | undefined;
+  formatSeriesValue:
+    | ((value: number, seriesId: string) => string)
+    | undefined;
+  formatTimeRange: ((from: number, to: number) => string) | undefined;
+  maxLabelChars: number;
+  guideColor: string | undefined;
+  guideWidth: number;
+  guideDashPattern: number[] | undefined;
+  timePillBackground: string | undefined;
+  timePillColor: string | undefined;
+  timePillBorderColor: string | undefined;
+  timePillRadius: number;
+  timePillPaddingX: number;
+  timePillPaddingY: number;
+  seriesPillBackground: string | undefined;
+  seriesPillLabelColor: string | undefined;
+  seriesPillValueColor: string | undefined;
+  seriesPillBorderColor: string | undefined;
+  seriesPillRadius: number;
+  seriesPillPaddingX: number;
+  seriesPillPaddingY: number;
+  seriesPillDotSize: number;
+  seriesPillDotGap: number;
+  seriesPillLabelValueGap: number;
+  intersectionDotSize: number;
 }
 
 export interface ResolvedScrubActionConfig {
@@ -628,6 +661,7 @@ export function resolveXAxis(
 
 const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltip: true,
+  seriesTooltip: null,
   dimOpacity: 0.3,
   crosshairLineColor: undefined,
   crosshairDash: undefined,
@@ -644,6 +678,55 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   hideOverlaysOnScrub: false,
 };
 
+const PER_SERIES_TOOLTIP_DEFAULTS: ResolvedPerSeriesTooltipConfig = {
+  alwaysShow: false,
+  bucketSeconds: undefined,
+  formatSeriesValue: undefined,
+  formatTimeRange: undefined,
+  maxLabelChars: 14,
+  guideColor: undefined,
+  guideWidth: 1,
+  guideDashPattern: [3, 3],
+  timePillBackground: undefined,
+  timePillColor: undefined,
+  timePillBorderColor: undefined,
+  timePillRadius: 6,
+  timePillPaddingX: 8,
+  timePillPaddingY: 4,
+  seriesPillBackground: undefined,
+  seriesPillLabelColor: undefined,
+  seriesPillValueColor: undefined,
+  seriesPillBorderColor: undefined,
+  seriesPillRadius: 6,
+  seriesPillPaddingX: 8,
+  seriesPillPaddingY: 4,
+  seriesPillDotSize: 8,
+  seriesPillDotGap: 6,
+  seriesPillLabelValueGap: 6,
+  intersectionDotSize: 8,
+};
+
+function resolvePerSeriesTooltip(
+  prop: boolean | PerSeriesTooltipConfig | undefined,
+): ResolvedPerSeriesTooltipConfig | null {
+  const resolved = resolveToggle(
+    prop,
+    PER_SERIES_TOOLTIP_DEFAULTS,
+    false,
+  );
+  if (!resolved) return null;
+  const dash = typeof prop === "object" ? prop.guideDashPattern : undefined;
+  if (dash !== undefined) {
+    resolved.guideDashPattern = dash === true ? [3, 3] : dash || undefined;
+  }
+  resolved.maxLabelChars = Math.max(1, Math.floor(resolved.maxLabelChars));
+  resolved.bucketSeconds =
+    resolved.bucketSeconds !== undefined && resolved.bucketSeconds > 0
+      ? resolved.bucketSeconds
+      : undefined;
+  return resolved;
+}
+
 /**
  * Resolves `scrub` prop to a fully-typed config or null (disabled).
  * `true` → defaults, object → merged with defaults, falsy → null.
@@ -657,6 +740,9 @@ export function resolveScrub(
     // through, anything falsy → solid (undefined).
     const dash = typeof prop === "object" ? prop.crosshairDash : undefined;
     resolved.crosshairDash = dash === true ? [4, 4] : dash || undefined;
+    const seriesTooltip =
+      typeof prop === "object" ? prop.seriesTooltip : undefined;
+    resolved.seriesTooltip = resolvePerSeriesTooltip(seriesTooltip);
   }
   return resolved;
 }

--- a/packages/react-native-livechart/src/hooks/crosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairSeries.ts
@@ -1,12 +1,23 @@
 import { type SkFont } from "@shopify/react-native-skia";
+import type { ResolvedPerSeriesTooltipConfig } from "../core/resolveConfig";
 import { type ChartPadding } from "../draw/line";
+import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { interpolateAtTime } from "../math/interpolate";
 import type { ScrubSeriesValue, SeriesConfig } from "../types";
 import {
-  computeTooltipLayoutMulti,
   HIDDEN_TOOLTIP,
   type TooltipLayout,
 } from "./crosshairShared";
+
+const TOOLTIP_EDGE_GAP = 4;
+const TOOLTIP_SIDE_GAP = 8;
+const TOOLTIP_STACK_GAP = 4;
+const TOOLTIP_TOP_GAP = 4;
+
+function valueAtTime(series: SeriesConfig, time: number): number | null {
+  "worklet";
+  return interpolateAtTime(series.data, time);
+}
 
 export function interpolateSeriesAtTime(
   series: SeriesConfig[],
@@ -17,7 +28,7 @@ export function interpolateSeriesAtTime(
   let primary: number | null = null;
   for (let i = 0; i < series.length; i++) {
     if (series[i].visible === false) continue;
-    const v = interpolateAtTime(series[i].data, time);
+    const v = valueAtTime(series[i], time);
     if (v === null) continue;
     seriesValues.push({
       id: series[i].id,
@@ -29,6 +40,259 @@ export function interpolateSeriesAtTime(
   return { primary, seriesValues };
 }
 
+/** Infer a bucket width from the latest positive interval in a visible series. */
+export function estimateSeriesBucketSeconds(series: SeriesConfig[]): number {
+  "worklet";
+  for (let i = 0; i < series.length; i++) {
+    if (series[i].visible === false) continue;
+    const points = series[i].data;
+    for (let j = points.length - 1; j > 0; j--) {
+      const delta = points[j].time - points[j - 1].time;
+      if (delta > 0) return delta;
+    }
+  }
+  return 0;
+}
+
+/** Truncate a series label with the same ellipsis treatment as Morfi web. */
+export function truncateSeriesTooltipLabel(
+  label: string,
+  maxChars: number,
+): string {
+  "worklet";
+  if (label.length <= maxChars) return label;
+  return `${label.slice(0, Math.max(1, maxChars - 1))}…`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  "worklet";
+  if (max < min) return min;
+  return value < min ? min : value > max ? max : value;
+}
+
+/**
+ * Morfi-style per-series scrub tooltip geometry. Pure/worklet-safe so the
+ * entire readout can be recomputed on the UI thread without React renders.
+ */
+export function computePerSeriesTooltipLayout(
+  scrubActive: boolean,
+  scrubX: number,
+  scrubTime: number,
+  series: SeriesConfig[],
+  displaySeriesValues: number[],
+  colors: string[],
+  displayMin: number,
+  displayMax: number,
+  padding: ChartPadding,
+  canvasWidth: number,
+  canvasHeight: number,
+  maxTime: number,
+  formatValue: (value: number) => string,
+  formatTime: (time: number) => string,
+  font: SkFont,
+  config: ResolvedPerSeriesTooltipConfig,
+): TooltipLayout {
+  "worklet";
+  const pinned = !scrubActive && config.alwaysShow;
+  if ((!scrubActive && !pinned) || canvasWidth <= 0 || canvasHeight <= 0) {
+    return HIDDEN_TOOLTIP;
+  }
+
+  const plotLeft = padding.left;
+  const plotRight = canvasWidth - padding.right;
+  const plotTop = padding.top;
+  const plotBottom = canvasHeight - padding.bottom;
+  if (plotRight <= plotLeft || plotBottom <= plotTop) return HIDDEN_TOOLTIP;
+
+  const anchorX = pinned
+    ? plotRight
+    : clamp(scrubX, plotLeft, plotRight);
+  const activeTime = Math.min(scrubTime, maxTime);
+  if (!pinned && activeTime < 0) return HIDDEN_TOOLTIP;
+
+  const fm = font.getMetrics();
+  const lineH = Math.max(1, -fm.ascent + fm.descent);
+  const seriesPillH = lineH + config.seriesPillPaddingY * 2;
+  const maxPillW = Math.max(1, plotRight - plotLeft - TOOLTIP_EDGE_GAP * 2);
+  const valueFormatter = config.formatSeriesValue;
+
+  const pills: NonNullable<
+    NonNullable<TooltipLayout["perSeries"]>["pills"]
+  > = [];
+  const preferredY: number[] = [];
+  for (let i = 0; i < series.length; i++) {
+    const item = series[i];
+    if (item.visible === false || item.data.length === 0) continue;
+    const value = pinned
+      ? (displaySeriesValues[i] ?? item.value)
+      : valueAtTime(item, activeTime);
+    if (value === null || !Number.isFinite(value)) continue;
+
+    const label = truncateSeriesTooltipLabel(
+      item.label ?? item.id,
+      config.maxLabelChars,
+    );
+    const valueText = valueFormatter
+      ? valueFormatter(value, item.id)
+      : formatValue(value);
+    const labelW = measureFontTextWidth(font, label);
+    const valueW = measureFontTextWidth(font, valueText);
+    const labelGap = label.length > 0 ? config.seriesPillLabelValueGap : 0;
+    const rawPillW =
+      config.seriesPillPaddingX * 2 +
+      config.seriesPillDotSize +
+      config.seriesPillDotGap +
+      labelW +
+      labelGap +
+      valueW;
+    const pillW = Math.min(rawPillW, maxPillW);
+    let pillX = anchorX + TOOLTIP_SIDE_GAP;
+    if (pillX + pillW > plotRight - TOOLTIP_EDGE_GAP) {
+      pillX = anchorX - pillW - TOOLTIP_SIDE_GAP;
+    }
+    pillX = clamp(
+      pillX,
+      plotLeft + TOOLTIP_EDGE_GAP,
+      plotRight - TOOLTIP_EDGE_GAP - pillW,
+    );
+
+    const chartH = plotBottom - plotTop;
+    const valRange = displayMax - displayMin;
+    const anchorY =
+      valRange === 0
+        ? plotTop + chartH / 2
+        : clamp(
+            plotTop + ((displayMax - value) / valRange) * chartH,
+            plotTop,
+            plotBottom,
+          );
+    const dotX =
+      pillX + config.seriesPillPaddingX + config.seriesPillDotSize / 2;
+    const dotY = anchorY;
+    const labelX =
+      dotX + config.seriesPillDotSize / 2 + config.seriesPillDotGap;
+    const valueX = labelX + labelW + labelGap;
+    pills.push({
+      id: item.id,
+      color: colors[i] ?? item.color ?? "#ffffff",
+      anchorX,
+      anchorY,
+      x: pillX,
+      y: anchorY - seriesPillH / 2,
+      w: pillW,
+      h: seriesPillH,
+      dotX,
+      dotY,
+      label,
+      labelX,
+      value: valueText,
+      valueX,
+      baselineY: 0,
+    });
+    preferredY.push(anchorY - seriesPillH / 2);
+  }
+  if (pills.length === 0) return HIDDEN_TOOLTIP;
+
+  let timePill: NonNullable<
+    NonNullable<TooltipLayout["perSeries"]>["timePill"]
+  > | undefined;
+  if (!pinned) {
+    const bucketSeconds =
+      config.bucketSeconds ?? estimateSeriesBucketSeconds(series);
+    const from = activeTime;
+    const to = Math.max(from, Math.min(from + bucketSeconds, maxTime));
+    const timeText = config.formatTimeRange
+      ? config.formatTimeRange(from, to)
+      : bucketSeconds > 0
+        ? `${formatTime(from)} – ${formatTime(to)}`
+        : formatTime(from);
+    const timeW = Math.min(
+      measureFontTextWidth(font, timeText) + config.timePillPaddingX * 2,
+      maxPillW,
+    );
+    const timeH = lineH + config.timePillPaddingY * 2;
+    const timeX = clamp(
+      anchorX - timeW / 2,
+      plotLeft + TOOLTIP_EDGE_GAP,
+      plotRight - TOOLTIP_EDGE_GAP - timeW,
+    );
+    const timeY = plotTop + TOOLTIP_TOP_GAP;
+    timePill = {
+      x: timeX,
+      y: timeY,
+      w: timeW,
+      h: timeH,
+      text: timeText,
+      textX: timeX + config.timePillPaddingX,
+      baselineY: timeY + config.timePillPaddingY - fm.ascent,
+    };
+  }
+
+  // Collision avoidance: sort by preferred position, push down, then pull the
+  // stack back up from the bottom. If the plot is extremely short, compress the
+  // inter-pill gap to zero before accepting overlap as the unavoidable fallback.
+  const topBound = Math.min(
+    plotBottom - seriesPillH,
+    timePill
+      ? Math.max(plotTop, timePill.y + timePill.h + TOOLTIP_STACK_GAP)
+      : plotTop,
+  );
+  const bottomBound = plotBottom;
+  const order = pills.map((_, index) => index);
+  order.sort((a, b) => preferredY[a] - preferredY[b]);
+
+  let stackGap = TOOLTIP_STACK_GAP;
+  const availableH = Math.max(0, bottomBound - topBound);
+  const requiredWithoutGaps = pills.length * seriesPillH;
+  if (pills.length > 1 && requiredWithoutGaps + stackGap * (pills.length - 1) > availableH) {
+    stackGap = Math.max(
+      0,
+      (availableH - requiredWithoutGaps) / (pills.length - 1),
+    );
+  }
+
+  let cursor = topBound;
+  for (let i = 0; i < order.length; i++) {
+    const index = order[i];
+    const y = clamp(
+      Math.max(preferredY[index], cursor),
+      topBound,
+      Math.max(topBound, bottomBound - seriesPillH),
+    );
+    pills[index].y = y;
+    cursor = y + seriesPillH + stackGap;
+  }
+  for (let i = order.length - 2; i >= 0; i--) {
+    const index = order[i];
+    const next = pills[order[i + 1]];
+    pills[index].y = Math.max(
+      topBound,
+      Math.min(pills[index].y, next.y - seriesPillH - stackGap),
+    );
+  }
+  for (let i = 0; i < pills.length; i++) {
+    pills[i].dotY = pills[i].y + pills[i].h / 2;
+    pills[i].baselineY =
+      pills[i].y + config.seriesPillPaddingY - fm.ascent;
+  }
+
+  const firstRect = timePill ?? pills[0];
+  return {
+    x: firstRect.x,
+    y: firstRect.y,
+    w: firstRect.w,
+    h: firstRect.h,
+    valueStr: "",
+    timeStr: "",
+    valueTextX: -400,
+    timeTextX: -400,
+    line1Y: 0,
+    line2Y: 0,
+    stackedLines: undefined,
+    perSeries: { pinned, timePill, pills },
+  };
+}
+
 /** Series-chart scrub primary value at window time — extracted for tests. */
 export function deriveScrubValueSeries(
   scrubActive: boolean,
@@ -38,41 +302,4 @@ export function deriveScrubValueSeries(
   "worklet";
   if (!scrubActive || scrubTime < 0) return null;
   return interpolateSeriesAtTime(series, scrubTime).primary;
-}
-
-/** Series-chart stacked tooltip at scrub time — extracted for tests. */
-export function computeSeriesScrubTooltipLayout(
-  scrubActive: boolean,
-  scrubX: number,
-  scrubTime: number,
-  series: SeriesConfig[],
-  padding: ChartPadding,
-  canvasWidth: number,
-  formatValue: (v: number) => string,
-  formatTime: (t: number) => string,
-  font: SkFont,
-): TooltipLayout {
-  "worklet";
-  if (!scrubActive || scrubTime < 0) return HIDDEN_TOOLTIP;
-  const r = interpolateSeriesAtTime(series, scrubTime);
-  if (r.primary === null) return HIDDEN_TOOLTIP;
-  const lineObjs: { text: string; dim: boolean }[] = [
-    { text: formatTime(scrubTime), dim: true },
-  ];
-  for (let k = 0; k < r.seriesValues.length; k++) {
-    const sv = r.seriesValues[k];
-    const label = sv.label ?? sv.id;
-    lineObjs.push({
-      text: `${label}: ${formatValue(sv.value)}`,
-      dim: false,
-    });
-  }
-  return computeTooltipLayoutMulti(
-    scrubActive,
-    scrubX,
-    lineObjs,
-    padding,
-    canvasWidth,
-    font,
-  );
 }

--- a/packages/react-native-livechart/src/hooks/crosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairSeries.ts
@@ -1,4 +1,5 @@
 import { type SkFont } from "@shopify/react-native-skia";
+import { MAX_MULTI_SERIES } from "../constants";
 import type { ResolvedPerSeriesTooltipConfig } from "../core/resolveConfig";
 import { type ChartPadding } from "../draw/line";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
@@ -120,7 +121,8 @@ export function computePerSeriesTooltipLayout(
     NonNullable<TooltipLayout["perSeries"]>["pills"]
   > = [];
   const preferredY: number[] = [];
-  for (let i = 0; i < series.length; i++) {
+  const renderedSeriesCount = Math.min(series.length, MAX_MULTI_SERIES);
+  for (let i = 0; i < renderedSeriesCount; i++) {
     const item = series[i];
     if (item.visible === false || item.data.length === 0) continue;
     const value = pinned

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -1,6 +1,6 @@
 import { type SkFont } from "@shopify/react-native-skia";
 import { type Gesture } from "react-native-gesture-handler";
-import type { SharedValue } from "react-native-reanimated";
+import type { DerivedValue, SharedValue } from "react-native-reanimated";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { type ChartPadding } from "../draw/line";
 import { interpolateAtTime } from "../math/interpolate";
@@ -48,6 +48,37 @@ export interface TooltipLayout {
     baselineY: number;
     dim: boolean;
   }[];
+  /** LiveChartSeries' opt-in Morfi-style time pill + per-series value pills. */
+  perSeries?: {
+    /** Idle endpoint mode: value pills only, with no guide or time pill. */
+    pinned: boolean;
+    timePill?: {
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+      text: string;
+      textX: number;
+      baselineY: number;
+    };
+    pills: {
+      id: string;
+      color: string;
+      anchorX: number;
+      anchorY: number;
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+      dotX: number;
+      dotY: number;
+      label: string;
+      labelX: number;
+      value: string;
+      valueX: number;
+      baselineY: number;
+    }[];
+  };
 }
 
 export const HIDDEN_TOOLTIP: TooltipLayout = {
@@ -62,6 +93,7 @@ export const HIDDEN_TOOLTIP: TooltipLayout = {
   line1Y: 0,
   line2Y: 0,
   stackedLines: undefined,
+  perSeries: undefined,
 };
 
 export interface CrosshairState {
@@ -70,7 +102,9 @@ export interface CrosshairState {
   scrubTime: SharedValue<number>;
   scrubValue: SharedValue<number | null>;
   crosshairOpacity: SharedValue<number>;
-  tooltipLayout: SharedValue<TooltipLayout>;
+  tooltipLayout:
+    | SharedValue<TooltipLayout>
+    | DerivedValue<TooltipLayout>;
   /** Scrub intersection Y in canvas px; -1 when there's no dot to draw
    *  (inactive / no value / degenerate range). See {@link computeScrubDotY}. */
   scrubDotY: SharedValue<number>;

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -1,15 +1,19 @@
+import type { SkFont } from "@shopify/react-native-skia";
 import { Gesture } from "react-native-gesture-handler";
 import {
   useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
+  type DerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
+import type { ResolvedPerSeriesTooltipConfig } from "../core/resolveConfig";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 import { type ChartPadding } from "../draw/line";
 import type { ScrubPointMulti } from "../types";
 import {
+  computePerSeriesTooltipLayout,
   deriveScrubValueSeries,
   interpolateSeriesAtTime,
 } from "./crosshairSeries";
@@ -32,9 +36,19 @@ import {
 } from "./delayedPanGuard";
 
 /**
- * LiveChartSeries crosshair + scrub. No tooltip — data is delivered via
- * `onScrub` worklet callback on the UI thread.
+ * LiveChartSeries crosshair + scrub. The optional per-series tooltip is
+ * calculated on the UI thread alongside the callback payload.
  */
+interface CrosshairSeriesTooltipOptions {
+  config: ResolvedPerSeriesTooltipConfig;
+  formatValue: (value: number) => string;
+  formatTime: (time: number) => string;
+  font: SkFont;
+  colors: string[];
+  /** Current-time anchor used to clamp the live bucket's range end. */
+  maxTime: SharedValue<number> | DerivedValue<number>;
+}
+
 export function useCrosshairSeries(
   engine: MultiEngineState,
   padding: ChartPadding,
@@ -50,6 +64,7 @@ export function useCrosshairSeries(
    * mature into a scrub (see `delayedPanGuard.shouldStartDelayedPan`).
    */
   scrollActive?: SharedValue<boolean>,
+  tooltip?: CrosshairSeriesTooltipOptions,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -114,7 +129,27 @@ export function useCrosshairSeries(
     ),
   );
 
-  const tooltipLayout = useSharedValue(HIDDEN_TOOLTIP);
+  const tooltipLayout = useDerivedValue(() => {
+    if (!tooltip) return HIDDEN_TOOLTIP;
+    return computePerSeriesTooltipLayout(
+      scrubActive.get(),
+      scrubX.get(),
+      scrubTime.get(),
+      engine.series.get(),
+      engine.displaySeriesValues.get(),
+      tooltip.colors,
+      engine.displayMin.get(),
+      engine.displayMax.get(),
+      padding,
+      engine.canvasWidth.get(),
+      engine.canvasHeight.get(),
+      tooltip.maxTime.get(),
+      tooltip.formatValue,
+      tooltip.formatTime,
+      tooltip.font,
+      tooltip.config,
+    );
+  });
 
   /* istanbul ignore next */
   function handleGestureStart() {

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -77,6 +77,7 @@ export type {
   MomentumConfig,
   MotionMetrics,
   MultiSeriesDotConfig,
+  PerSeriesTooltipConfig,
   PulseConfig,
   ReferenceLine,
   ReferenceLineBadgeConfig,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -725,10 +725,102 @@ export interface XAxisConfig {
   minGap?: number;
 }
 
+/**
+ * Morfi-style on-canvas tooltip for {@link LiveChartSeries}: a time-range pill
+ * above the guide plus one value pill at every visible series intersection.
+ *
+ * Enable it with `scrub={{ seriesTooltip: true }}` or pass this object to style
+ * and format the readout. It is ignored by the single-series {@link LiveChart}.
+ */
+export interface PerSeriesTooltipConfig {
+  /**
+   * Keep the value pills pinned to the visible series endpoints while idle.
+   * The guide and time pill remain hidden until a scrub starts. Default `false`.
+   */
+  alwaysShow?: boolean;
+  /**
+   * Bucket width used by the time-range pill, in seconds. Omit to infer it from
+   * the latest positive interval in the first visible series.
+   */
+  bucketSeconds?: number;
+  /**
+   * Format a value pill. The second argument identifies the series so one chart
+   * can dispatch to different unit formatters. Defaults to the chart's
+   * `formatValue`.
+   *
+   * Runs on the UI thread and must be worklet-safe.
+   */
+  formatSeriesValue?: (value: number, seriesId: string) => string;
+  /**
+   * Format the time pill from the bucket's start/end unix seconds. The end is
+   * clamped to the chart's current-time anchor, so the live bucket never claims
+   * to end in the future. Defaults to two chart `formatTime` labels joined by
+   * an en dash.
+   *
+   * Runs on the UI thread and must be worklet-safe.
+   */
+  formatTimeRange?: (from: number, to: number) => string;
+  /** Truncate labels longer than this many characters with `…`. Default `14`. */
+  maxLabelChars?: number;
+
+  /** Guide color. Omit to use `scrub.crosshairLineColor`, then the theme. */
+  guideColor?: string;
+  /** Guide stroke width in px. Default `1`. */
+  guideWidth?: number;
+  /**
+   * Guide dash pattern. `true` uses `[3, 3]`; an array supplies explicit Skia
+   * dash intervals; `false` draws a solid guide. Default `[3, 3]`.
+   */
+  guideDashPattern?: boolean | number[];
+
+  /** Time-pill background. Omit to use `scrub.tooltipBackground`, then the theme. */
+  timePillBackground?: string;
+  /** Time-pill text color. Omit to use `scrub.tooltipColor`, then the theme. */
+  timePillColor?: string;
+  /** Time-pill border color. Omit to use `scrub.tooltipBorderColor`, then the theme. */
+  timePillBorderColor?: string;
+  /** Time-pill corner radius in px. Default `6`. */
+  timePillRadius?: number;
+  /** Time-pill horizontal padding in px. Default `8`. */
+  timePillPaddingX?: number;
+  /** Time-pill vertical padding in px. Default `4`. */
+  timePillPaddingY?: number;
+
+  /** Series-pill background. Omit to use `scrub.tooltipBackground`, then the theme. */
+  seriesPillBackground?: string;
+  /** Series label color. Omit to use the theme tooltip text. */
+  seriesPillLabelColor?: string;
+  /** Formatted series value color. Omit to use `seriesPillLabelColor`. */
+  seriesPillValueColor?: string;
+  /** Series-pill border color. Omit to use `scrub.tooltipBorderColor`, then the theme. */
+  seriesPillBorderColor?: string;
+  /** Series-pill corner radius in px. Default `6`. */
+  seriesPillRadius?: number;
+  /** Series-pill horizontal padding in px. Default `8`. */
+  seriesPillPaddingX?: number;
+  /** Series-pill vertical padding in px. Default `4`. */
+  seriesPillPaddingY?: number;
+  /** Diameter of the series-colour dot inside each pill, in px. Default `8`. */
+  seriesPillDotSize?: number;
+  /** Gap between the colour dot and label, in px. Default `6`. */
+  seriesPillDotGap?: number;
+  /** Gap between the label and formatted value, in px. Default `6`. */
+  seriesPillLabelValueGap?: number;
+  /** Diameter of the dot drawn at each line/guide intersection. Default `8`. */
+  intersectionDotSize?: number;
+}
+
 /** Crosshair scrub configuration. */
 export interface ScrubConfig {
   /** Show the value/time tooltip pill while scrubbing. Default `true`. */
   tooltip?: boolean;
+  /**
+   * Opt into the Morfi-style per-series pill tooltip on `LiveChartSeries`.
+   * `true` uses defaults; an object enables and configures it; `false`/omitted
+   * preserves the existing guide-only multi-series scrub. Ignored by
+   * single-series `LiveChart`. Default `false`.
+   */
+  seriesTooltip?: boolean | PerSeriesTooltipConfig;
   /**
    * Opacity of the chart content to the *right* of the crosshair (the "future")
    * while scrubbing — `0` fully fades it out, `1` disables the dim. Implemented
@@ -2027,8 +2119,9 @@ export interface LiveChartCoreProps {
    *
    * Defaults differ per chart: `LiveChart` shows it (`true`); `LiveChartSeries`
    * hides it (`false`) — with multiple lines the dot can only track the leading
-   * series, so the crosshair + per-series tooltips mark the scrub point instead.
-   * Pass `true` / a config to opt a multi-series chart in.
+   * series. The crosshair — and, when enabled, the per-series tooltip's own
+   * intersection dots — mark the scrub point instead. Pass `true` / a config to
+   * opt a multi-series chart in.
    */
   selectionDot?: boolean | SelectionDotConfig;
   /** Called once when the user starts scrubbing/panning the chart. */

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -5,6 +5,7 @@ import { useSharedValue } from "react-native-reanimated";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
+import { PerSeriesTooltipOverlay } from "../src/components/PerSeriesTooltipOverlay";
 import { ReferenceLineOverlay } from "../src/components/ReferenceLineOverlay";
 import { DefaultSelectionDot } from "../src/components/SelectionDot";
 import type { ChartOverlayContext, SeriesConfig } from "../src/types";
@@ -118,6 +119,37 @@ describe("LiveChartSeries", () => {
     fireEvent(layoutView, "layout", {
       nativeEvent: { layout: { width: 400, height: 300 } },
     });
+  });
+
+  it("mounts the opt-in per-series tooltip and respects the master tooltip switch", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H({ tooltip = true }: { tooltip?: boolean }) {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          scrub={{ tooltip, seriesTooltip: { alwaysShow: true } }}
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    expect(screen.UNSAFE_getAllByType(PerSeriesTooltipOverlay)).toHaveLength(1);
+
+    screen.rerender(<H tooltip={false} />);
+    expect(screen.UNSAFE_queryAllByType(PerSeriesTooltipOverlay)).toHaveLength(0);
   });
 
   it("renders custom reference-line tags with per-line built-in fallback", async () => {

--- a/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
@@ -2,10 +2,17 @@ import { type SkFont } from "@shopify/react-native-skia";
 import { renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import type { MultiEngineState } from "../../src/core/useLiveChartEngine";
+import { resolveScrub } from "../../src/core/resolveConfig";
+import type {
+  PerSeriesTooltipConfig,
+  SeriesConfig,
+} from "../../src/types";
 import {
-  computeSeriesScrubTooltipLayout,
+  computePerSeriesTooltipLayout,
   deriveScrubValueSeries,
+  estimateSeriesBucketSeconds,
   interpolateSeriesAtTime,
+  truncateSeriesTooltipLabel,
 } from "../../src/hooks/crosshairSeries";
 import { useCrosshairSeries } from "../../src/hooks/useCrosshairSeries";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
@@ -44,6 +51,12 @@ const padding = { top: 12, right: 80, bottom: 28, left: 12 };
 const formatValue = (v: number) => v.toFixed(2);
 const formatTime = (t: number) =>
   new Date(t * 1000).toISOString().slice(11, 19);
+
+function tooltipConfig(
+  overrides: true | PerSeriesTooltipConfig = true,
+) {
+  return resolveScrub({ seriesTooltip: overrides })!.seriesTooltip!;
+}
 
 function makeEngine(
   overrides: Partial<Record<keyof MultiEngineState, { value: unknown }>> = {},
@@ -87,103 +100,232 @@ describe("deriveScrubValueSeries", () => {
   });
 });
 
-describe("computeSeriesScrubTooltipLayout", () => {
-  it("returns hidden when scrub is inactive", () => {
-    const layout = computeSeriesScrubTooltipLayout(
+describe("computePerSeriesTooltipLayout", () => {
+  const visibleSeries = [
+    {
+      id: "alpha",
+      label: "Alpha outcome with a long label",
+      data: [
+        { time: 900, value: 10 },
+        { time: 960, value: 30 },
+      ],
+      value: 30,
+      color: "#2563eb",
+    },
+    {
+      id: "beta",
+      label: "Beta",
+      data: [
+        { time: 900, value: 11 },
+        { time: 960, value: 31 },
+      ],
+      value: 31,
+      color: "#dc2626",
+    },
+    {
+      id: "hidden",
+      label: "Hidden",
+      visible: false,
+      data: [
+        { time: 900, value: 80 },
+        { time: 960, value: 90 },
+      ],
+      value: 90,
+      color: "#16a34a",
+    },
+  ] satisfies SeriesConfig[];
+
+  it("stays hidden until scrub or alwaysShow is active", () => {
+    const layout = computePerSeriesTooltipLayout(
       false,
-      50,
-      985,
-      [
-        {
-          id: "a",
-          data: [{ time: 970, value: 1 }],
-          value: 1,
-          color: "#00f",
-        },
-      ],
+      -1,
+      -1,
+      visibleSeries,
+      [30, 31, 90],
+      ["#2563eb", "#dc2626", "#16a34a"],
+      0,
+      100,
       padding,
       400,
-      formatValue,
-      formatTime,
-      font,
-    );
-    expect(layout.x).toBeLessThan(0);
-  });
-
-  it("returns hidden when no primary value", () => {
-    const layout = computeSeriesScrubTooltipLayout(
-      true,
-      50,
+      300,
       1000,
-      [
-        {
-          id: "a",
-          visible: false,
-          data: [{ time: 1000, value: 1 }],
-          value: 1,
-          color: "#00f",
-        },
-      ],
-      padding,
-      400,
       formatValue,
       formatTime,
       font,
+      tooltipConfig(),
     );
     expect(layout.x).toBeLessThan(0);
+    expect(layout.perSeries).toBeUndefined();
   });
 
-  it("builds stacked tooltip rows for visible series", () => {
-    const layout = computeSeriesScrubTooltipLayout(
+  it("formats and clamps the time range, truncates labels, filters hidden series, and flips left", () => {
+    const formatSeriesValue = jest.fn((value: number, id: string) =>
+      `${id}=${value.toFixed(1)}`,
+    );
+    const formatTimeRange = jest.fn(
+      (from: number, to: number) => `${from}-${to}`,
+    );
+    const layout = computePerSeriesTooltipLayout(
       true,
-      50,
-      985,
-      [
-        {
-          id: "a",
-          label: "A",
-          data: [
-            { time: 970, value: 10 },
-            { time: 1000, value: 30 },
-          ],
-          value: 30,
-          color: "#00f",
-        },
-      ],
+      315,
+      990,
+      visibleSeries,
+      [30, 31, 90],
+      ["#2563eb", "#dc2626", "#16a34a"],
+      0,
+      100,
       padding,
       400,
+      300,
+      1000,
       formatValue,
       formatTime,
       font,
+      tooltipConfig({
+        bucketSeconds: 60,
+        maxLabelChars: 5,
+        formatSeriesValue,
+        formatTimeRange,
+      }),
     );
-    expect(layout.stackedLines?.length).toBeGreaterThanOrEqual(2);
+
+    expect(layout.perSeries?.pills.map((pill) => pill.id)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    expect(layout.perSeries?.pills[0].label).toBe("Alph…");
+    expect(layout.perSeries?.pills[0].value).toBe("alpha=30.0");
+    expect(layout.perSeries?.pills.every((pill) => pill.x < 315)).toBe(true);
+    expect(layout.perSeries?.timePill?.text).toBe("990-1000");
+    expect(formatTimeRange).toHaveBeenCalledWith(990, 1000);
+    expect(formatSeriesValue).toHaveBeenCalledTimes(2);
+  });
+
+  it("stacks near-identical values without overlap and keeps pills inside a short plot", () => {
+    const clustered = visibleSeries.slice(0, 2).map((item, index) => ({
+      ...item,
+      data: [
+        { time: 900, value: 50 + index * 0.01 },
+        { time: 960, value: 50 + index * 0.01 },
+      ],
+    }));
+    const layout = computePerSeriesTooltipLayout(
+      true,
+      160,
+      930,
+      clustered,
+      [50, 50.01],
+      ["#2563eb", "#dc2626"],
+      0,
+      100,
+      padding,
+      240,
+      110,
+      1000,
+      formatValue,
+      formatTime,
+      font,
+      tooltipConfig({ bucketSeconds: 60 }),
+    );
+    const pills = [...(layout.perSeries?.pills ?? [])].sort(
+      (a, b) => a.y - b.y,
+    );
+    expect(pills).toHaveLength(2);
+    expect(pills[1].y).toBeGreaterThanOrEqual(pills[0].y + pills[0].h);
+    expect(pills.every((pill) => pill.y >= padding.top)).toBe(true);
+    expect(
+      pills.every((pill) => pill.y + pill.h <= 110 - padding.bottom),
+    ).toBe(true);
+  });
+
+  it("pins only value pills to live endpoints while idle", () => {
+    const layout = computePerSeriesTooltipLayout(
+      false,
+      -1,
+      -1,
+      visibleSeries,
+      [42, 43, 90],
+      ["#2563eb", "#dc2626", "#16a34a"],
+      0,
+      100,
+      padding,
+      400,
+      300,
+      1000,
+      formatValue,
+      formatTime,
+      font,
+      tooltipConfig({ alwaysShow: true }),
+    );
+
+    expect(layout.perSeries?.pinned).toBe(true);
+    expect(layout.perSeries?.timePill).toBeUndefined();
+    expect(layout.perSeries?.pills.map((pill) => pill.value)).toEqual([
+      "42.00",
+      "43.00",
+    ]);
+    expect(
+      layout.perSeries?.pills.every(
+        (pill) => pill.anchorX === 400 - padding.right,
+      ),
+    ).toBe(true);
+  });
+
+  it("clips oversized pill geometry into both horizontal plot edges", () => {
+    const layout = computePerSeriesTooltipLayout(
+      true,
+      padding.left,
+      930,
+      [visibleSeries[0]],
+      [30],
+      ["#2563eb"],
+      0,
+      100,
+      padding,
+      125,
+      100,
+      1000,
+      () => "a very long formatted value",
+      formatTime,
+      font,
+      tooltipConfig({ maxLabelChars: 40 }),
+    );
+    const pill = layout.perSeries!.pills[0];
+    expect(pill.x).toBeGreaterThanOrEqual(padding.left + 4);
+    expect(pill.x + pill.w).toBeLessThanOrEqual(125 - padding.right - 4);
   });
 });
 
-describe("series scrub tooltip layout vs single path", () => {
-  it("produces stacked lines for series scrub tooltip", () => {
-    const layout = computeSeriesScrubTooltipLayout(
-      true,
-      50,
-      985,
-      [
+describe("per-series tooltip helpers", () => {
+  it("infers the latest positive bucket interval from visible series", () => {
+    expect(
+      estimateSeriesBucketSeconds([
         {
-          id: "a",
+          id: "hidden",
+          visible: false,
           data: [
-            { time: 970, value: 10 },
-            { time: 1000, value: 30 },
+            { time: 0, value: 0 },
+            { time: 100, value: 1 },
           ],
-          value: 30,
-          color: "#00f",
+          value: 1,
         },
-      ],
-      padding,
-      400,
-      formatValue,
-      formatTime,
-      font,
-    );
-    expect(layout.stackedLines?.length).toBeGreaterThan(0);
+        {
+          id: "shown",
+          data: [
+            { time: 0, value: 0 },
+            { time: 30, value: 1 },
+            { time: 90, value: 2 },
+          ],
+          value: 2,
+        },
+      ]),
+    ).toBe(60);
+    expect(estimateSeriesBucketSeconds([])).toBe(0);
+  });
+
+  it("truncates only labels over the configured limit", () => {
+    expect(truncateSeriesTooltipLabel("Beta", 5)).toBe("Beta");
+    expect(truncateSeriesTooltipLabel("Outcome", 5)).toBe("Outc…");
   });
 });
 

--- a/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
@@ -1,6 +1,7 @@
 import { type SkFont } from "@shopify/react-native-skia";
 import { renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
+import { MAX_MULTI_SERIES } from "../../src/constants";
 import type { MultiEngineState } from "../../src/core/useLiveChartEngine";
 import { resolveScrub } from "../../src/core/resolveConfig";
 import type {
@@ -293,6 +294,51 @@ describe("computePerSeriesTooltipLayout", () => {
     const pill = layout.perSeries!.pills[0];
     expect(pill.x).toBeGreaterThanOrEqual(padding.left + 4);
     expect(pill.x + pill.w).toBeLessThanOrEqual(125 - padding.right - 4);
+  });
+
+  it("only lays out pills for series slots the chart can render", () => {
+    const overLimit = Array.from(
+      { length: MAX_MULTI_SERIES + 1 },
+      (_, index): SeriesConfig => ({
+        id: `series-${index}`,
+        label: `Series ${index}`,
+        visible: index !== 0,
+        data: [
+          { time: 900, value: index + 1 },
+          { time: 960, value: index + 2 },
+        ],
+        value: index + 2,
+        color: `hsl(${index * 20}, 80%, 50%)`,
+      }),
+    );
+    const layout = computePerSeriesTooltipLayout(
+      true,
+      160,
+      930,
+      overLimit,
+      overLimit.map((item) => item.value),
+      overLimit.map((item) => item.color!),
+      0,
+      100,
+      padding,
+      400,
+      600,
+      1000,
+      formatValue,
+      formatTime,
+      font,
+      tooltipConfig(),
+    );
+
+    expect(layout.perSeries?.pills.map((pill) => pill.id)).toEqual(
+      Array.from(
+        { length: MAX_MULTI_SERIES - 1 },
+        (_, index) => `series-${index + 1}`,
+      ),
+    );
+    expect(layout.perSeries?.pills).not.toContainEqual(
+      expect.objectContaining({ id: `series-${MAX_MULTI_SERIES}` }),
+    );
   });
 });
 

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -522,6 +522,7 @@ describe("resolveScrub", () => {
   it("returns defaults for true", () => {
     expect(resolveScrub(true)).toEqual({
       tooltip: true,
+      seriesTooltip: null,
       dimOpacity: 0.3,
       tooltipBorderRadius: 5,
       tooltipPlacement: "side",
@@ -536,6 +537,7 @@ describe("resolveScrub", () => {
   it("merges partial config with defaults", () => {
     expect(resolveScrub({ tooltip: false })).toEqual({
       tooltip: false,
+      seriesTooltip: null,
       dimOpacity: 0.3,
       tooltipBorderRadius: 5,
       tooltipPlacement: "side",
@@ -550,6 +552,7 @@ describe("resolveScrub", () => {
   it("accepts a custom dimOpacity", () => {
     expect(resolveScrub({ dimOpacity: 0.5 })).toEqual({
       tooltip: true,
+      seriesTooltip: null,
       dimOpacity: 0.5,
       tooltipBorderRadius: 5,
       tooltipPlacement: "side",
@@ -574,6 +577,7 @@ describe("resolveScrub", () => {
   it("carries a custom panGestureDelay (press-and-hold to scrub)", () => {
     expect(resolveScrub({ panGestureDelay: 300 })).toEqual({
       tooltip: true,
+      seriesTooltip: null,
       dimOpacity: 0.3,
       tooltipBorderRadius: 5,
       tooltipPlacement: "side",
@@ -617,6 +621,45 @@ describe("resolveScrub", () => {
     expect(resolveScrub({ tooltipShowValue: false })).toMatchObject({
       tooltipShowValue: false,
       tooltipShowTime: true,
+    });
+  });
+
+  it("resolves the opt-in per-series tooltip and normalizes its inputs", () => {
+    const resolved = resolveScrub({
+      seriesTooltip: {
+        alwaysShow: true,
+        bucketSeconds: -10,
+        maxLabelChars: 4.9,
+        guideDashPattern: false,
+        seriesPillRadius: 12,
+      },
+    })?.seriesTooltip;
+
+    expect(resolved).toMatchObject({
+      alwaysShow: true,
+      bucketSeconds: undefined,
+      maxLabelChars: 4,
+      guideDashPattern: undefined,
+      guideWidth: 1,
+      timePillRadius: 6,
+      seriesPillRadius: 12,
+      intersectionDotSize: 8,
+    });
+  });
+
+  it("enables per-series tooltip defaults and normalizes dash shorthand", () => {
+    expect(resolveScrub({ seriesTooltip: true })?.seriesTooltip).toMatchObject({
+      alwaysShow: false,
+      maxLabelChars: 14,
+      guideDashPattern: [3, 3],
+    });
+    expect(
+      resolveScrub({
+        seriesTooltip: { guideDashPattern: true, bucketSeconds: 60 },
+      })?.seriesTooltip,
+    ).toMatchObject({
+      guideDashPattern: [3, 3],
+      bucketSeconds: 60,
     });
   });
 });


### PR DESCRIPTION
## Summary

- add an opt-in `scrub.seriesTooltip` API for Morfi-style market-detail tooltips on `LiveChartSeries`
- render the time range, per-series value pills, guide, and intersection dots on the UI thread with collision stacking and edge flipping
- support idle endpoint pinning, formatters, label truncation, and tooltip styling while preserving the existing guide-only default
- add multi-series demo controls, API documentation, guide examples, changelog notes, and regression coverage

## Backward compatibility

The feature is opt-in. Existing `scrub={true}` behavior is unchanged, and omitting `seriesTooltip` or setting it to `false` retains the guide-only multi-series scrub. The existing `scrub.tooltip` property remains the master tooltip switch.

## Validation

- `npm run verify` — typecheck, lint, 97 test suites; 1,394 passed and 5 skipped
- full coverage gate passed
- library build passed
- React Doctor: 100/100
- agent-device QA on an iPhone 17 simulator covering idle-hidden behavior, live scrub pills, formatting, collision stacking, intersection dots, and right-edge flipping

Closes #228