### PR TITLE
[codex] Add configurable Y-axis label spacing and align reference lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Right-anchored Y-axis label columns.** `yAxis.labelRightMargin` pins a
+  shared left-aligned column to a fixed canvas-edge margin; `yAxis.gridEndGap`
+  leaves a deterministic gap between grid lines and the widest label. Omitting
+  `labelRightMargin` preserves the centered-gutter layout.
+
 ## [4.12.0] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Right-anchored Y-axis label columns.** `yAxis.labelRightMargin` pins a
   shared left-aligned column to a fixed canvas-edge margin; `yAxis.gridEndGap`
-  leaves a deterministic gap between grid lines and the widest label. Omitting
-  `labelRightMargin` preserves the centered-gutter layout.
+  leaves a deterministic gap between grid/plain reference lines and the widest
+  label. Omitting `labelRightMargin` preserves the centered-gutter layout;
+  `fullWidth` reference lines and bands keep their existing extents.
 
 ## [4.12.0] - 2026-07-28
 

--- a/app/demo/axes-and-grid.tsx
+++ b/app/demo/axes-and-grid.tsx
@@ -10,7 +10,7 @@ import {
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
-import { ACCENT } from "../../demo-lib/shared";
+import { ACCENT, formatWholeValue } from "../../demo-lib/shared";
 import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
@@ -22,6 +22,7 @@ type AxisVis = "both" | "noY" | "noX" | "none";
 type GapPreset = "default" | "wide";
 type YCountPreset = "auto" | "3" | "5" | "7";
 type GridLineStyle = "default" | "dotted" | "solid" | "blue";
+type YAxisColumnPreset = "off" | "tight" | "wide";
 
 const CHART_OPTIONS: { value: ChartKind; label: string }[] = [
   { value: "single", label: "LiveChart" },
@@ -54,6 +55,15 @@ const GRID_OPTIONS: { value: GridLineStyle; label: string }[] = [
   { value: "blue", label: "Blue solid" },
 ];
 
+const Y_AXIS_COLUMN_OPTIONS: {
+  value: YAxisColumnPreset;
+  label: string;
+}[] = [
+  { value: "off", label: "Legacy" },
+  { value: "tight", label: "8 / 4 px" },
+  { value: "wide", label: "20 / 12 px" },
+];
+
 // `gridStyle` is a GridStyleConfig: `intervals: [1, 3]` dashes the lines,
 // `intervals: []` forces solid; `color` / `opacity` recolor them. `undefined`
 // keeps the chart's built-in dotted default.
@@ -74,6 +84,7 @@ export default function AxesGridScreen() {
   const [flushBottom, setFlushBottom] = useState(false);
   const [gridLine, setGridLine] = useState<GridLineStyle>("default");
   const [edgeFade, setEdgeFade] = useState(false);
+  const [yAxisColumn, setYAxisColumn] = useState<YAxisColumnPreset>("wide");
 
   const gridStyle = GRID_STYLES[gridLine];
   // A wider-than-default fade band (default is 40px) makes the soft left erase
@@ -89,6 +100,10 @@ export default function AxesGridScreen() {
   const yAxisCfg: YAxisConfig = {};
   if (gap === "wide") yAxisCfg.minGap = 72;
   if (yCountVal > 0) yAxisCfg.count = yCountVal;
+  if (yAxisColumn !== "off") {
+    yAxisCfg.labelRightMargin = yAxisColumn === "tight" ? 8 : 20;
+    yAxisCfg.gridEndGap = yAxisColumn === "tight" ? 4 : 12;
+  }
   const yAxis = !yOn
     ? false
     : Object.keys(yAxisCfg).length > 0
@@ -144,6 +159,7 @@ export default function AxesGridScreen() {
             scrub
             topLabel={topLabel}
             bottomLabel={bottomLabel}
+            formatValue={formatWholeValue}
           />
         ) : (
           <LiveChartSeries
@@ -158,6 +174,7 @@ export default function AxesGridScreen() {
             scrub
             topLabel={topLabel}
             bottomLabel={bottomLabel}
+            formatValue={formatWholeValue}
           />
         )
       }
@@ -185,6 +202,12 @@ export default function AxesGridScreen() {
         options={Y_COUNT_OPTIONS}
         value={yCount}
         onChange={setYCount}
+      />
+      <ChipRow
+        label="Y label column (right margin / grid gap)"
+        options={Y_AXIS_COLUMN_OPTIONS}
+        value={yAxisColumn}
+        onChange={setYAxisColumn}
       />
       <ChipRow
         label="Grid lines (gridStyle)"

--- a/app/demo/axes-and-grid.tsx
+++ b/app/demo/axes-and-grid.tsx
@@ -61,7 +61,7 @@ const Y_AXIS_COLUMN_OPTIONS: {
 }[] = [
   { value: "off", label: "Legacy" },
   { value: "tight", label: "8 / 4 px" },
-  { value: "wide", label: "20 / 12 px" },
+  { value: "wide", label: "24 / 12 px" },
 ];
 
 // `gridStyle` is a GridStyleConfig: `intervals: [1, 3]` dashes the lines,
@@ -101,7 +101,7 @@ export default function AxesGridScreen() {
   if (gap === "wide") yAxisCfg.minGap = 72;
   if (yCountVal > 0) yAxisCfg.count = yCountVal;
   if (yAxisColumn !== "off") {
-    yAxisCfg.labelRightMargin = yAxisColumn === "tight" ? 8 : 20;
+    yAxisCfg.labelRightMargin = yAxisColumn === "tight" ? 8 : 24;
     yAxisCfg.gridEndGap = yAxisColumn === "tight" ? 4 : 12;
   }
   const yAxis = !yOn

--- a/app/demo/reference-lines-and-bands.tsx
+++ b/app/demo/reference-lines-and-bands.tsx
@@ -146,7 +146,7 @@ export default function ReferenceLinesScreen() {
   }
 
   const yAxis = alignedYAxis
-    ? { labelRightMargin: 20, gridEndGap: 12 }
+    ? { labelRightMargin: 24, gridEndGap: 12 }
     : true;
 
   return (
@@ -190,7 +190,7 @@ export default function ReferenceLinesScreen() {
       />
       <ControlRow label="Contribution preview">
         <ToggleChip
-          label="Aligned Y column (20 / 12 px)"
+          label="Aligned Y column (24 / 12 px)"
           value={alignedYAxis}
           onChange={setAlignedYAxis}
         />

--- a/app/demo/reference-lines-and-bands.tsx
+++ b/app/demo/reference-lines-and-bands.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
-import { LiveChart, type ReferenceLine } from "react-native-livechart";
+import {
+  LiveChart,
+  LiveChartSeries,
+  type ReferenceLine,
+} from "react-native-livechart";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
-import { ACCENT } from "../../demo-lib/shared";
+import { ACCENT, formatWholeValue } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
@@ -11,7 +15,15 @@ export const options = { title: "Reference lines & bands" };
 
 const START = 100;
 
+type ChartKind = "single" | "multi";
+
+const CHART_OPTIONS: { value: ChartKind; label: string }[] = [
+  { value: "single", label: "LiveChart" },
+  { value: "multi", label: "LiveChartSeries" },
+];
+
 export default function ReferenceLinesScreen() {
+  const [chartKind, setChartKind] = useState<ChartKind>("single");
   const [lines, setLines] = useState(true);
   const [valueBand, setValueBand] = useState(false);
   const [timeBand, setTimeBand] = useState(false);
@@ -29,9 +41,11 @@ export default function ReferenceLinesScreen() {
   >("left");
   // text:false → icon-only pill (just the chevron glyph, no label/value text).
   const [badgeIconOnly, setBadgeIconOnly] = useState(false);
+  const [alignedYAxis, setAlignedYAxis] = useState(true);
+  const referenceCenter = chartKind === "multi" ? 33.3 : START;
 
-  const { data, value } = useSimulatedChartData({
-    multiSeries: false,
+  const { data, value, series } = useSimulatedChartData({
+    multiSeries: chartKind === "multi",
     candleAggregation: false,
     tradeStream: false,
     startValue: START,
@@ -62,13 +76,13 @@ export default function ReferenceLinesScreen() {
   const referenceLines: ReferenceLine[] = [];
   if (lines) {
     referenceLines.push({
-      value: START * 1.05,
+      value: referenceCenter * 1.05,
       label: "+5%",
       color: "#34d399",
       fullWidth,
     });
     referenceLines.push({
-      value: START * 0.95,
+      value: referenceCenter * 0.95,
       label: "-5%",
       color: "#f87171",
       strokeWidth: 2,
@@ -78,8 +92,8 @@ export default function ReferenceLinesScreen() {
   }
   if (valueBand) {
     referenceLines.push({
-      valueFrom: START * 0.98,
-      valueTo: START * 1.02,
+      valueFrom: referenceCenter * 0.98,
+      valueTo: referenceCenter * 1.02,
       color: "#fbbf24",
       label: "±2% band",
       // strokeWidth adds a dashed border; fillOpacity tunes the fill alpha.
@@ -101,7 +115,7 @@ export default function ReferenceLinesScreen() {
   }
   if (offAxis) {
     referenceLines.push({
-      value: START * 1.5,
+      value: referenceCenter * 1.5,
       label: "Target",
       excludeFromRange: true,
       color: "#a855f7",
@@ -131,23 +145,56 @@ export default function ReferenceLinesScreen() {
     });
   }
 
+  const yAxis = alignedYAxis
+    ? { labelRightMargin: 20, gridEndGap: 12 }
+    : true;
+
   return (
     <DemoScreen
       title="Reference lines & bands"
       docs="guides/reference-lines-and-bands"
       description="referenceLines array — lines, value bands, time bands, off-axis badge"
       chart={
-        <LiveChart
-          data={data}
-          value={value}
-          accentColor={ACCENT}
-          theme={APP_THEME}
-          referenceLines={referenceLines}
-          valueLine={valueLine}
-          scrub={false}
-        />
+        chartKind === "single" ? (
+          <LiveChart
+            data={data}
+            value={value}
+            accentColor={ACCENT}
+            theme={APP_THEME}
+            referenceLines={referenceLines}
+            valueLine={valueLine}
+            scrub={false}
+            yAxis={yAxis}
+            formatValue={formatWholeValue}
+          />
+        ) : (
+          <LiveChartSeries
+            series={series}
+            accentColor={ACCENT}
+            theme={APP_THEME}
+            referenceLines={referenceLines}
+            dot={{ valueLine }}
+            legend={false}
+            scrub={false}
+            yAxis={yAxis}
+            formatValue={formatWholeValue}
+          />
+        )
       }
     >
+      <ChipRow
+        label="Chart"
+        options={CHART_OPTIONS}
+        value={chartKind}
+        onChange={setChartKind}
+      />
+      <ControlRow label="Contribution preview">
+        <ToggleChip
+          label="Aligned Y column (20 / 12 px)"
+          value={alignedYAxis}
+          onChange={setAlignedYAxis}
+        />
+      </ControlRow>
       <ControlRow label="Reference forms">
         <ToggleChip label="Lines (±5%)" value={lines} onChange={setLines} />
         <ToggleChip

--- a/demo-lib/shared.ts
+++ b/demo-lib/shared.ts
@@ -2,6 +2,12 @@ import type { VolatilityMode } from "../sim/generators";
 
 export const ACCENT = "#3323E6";
 
+/** Uneven widths make shared Y-axis label columns easy to inspect. */
+export function formatWholeValue(v: number): string {
+  "worklet";
+  return String(Math.round(v));
+}
+
 export const TIME_WINDOWS: { label: string; secs: number }[] = [
   { label: "30s", secs: 30 },
   { label: "1m", secs: 60 },

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -366,7 +366,9 @@ provided; everything else has a default.
 
 <ParamField body="yAxis" type="boolean | YAxisConfig" default="true">
   Value-axis grid + labels. Pass `{ count }` for a fixed number of evenly-spaced
-  prices instead of the dynamic nice-interval grid.
+  prices instead of the dynamic nice-interval grid. Use `{ labelRightMargin,
+  gridEndGap }` for a fixed right-anchored label column and deterministic gap
+  between labels and grid lines.
 </ParamField>
 
 <ParamField body="topLabel" type="boolean | AxisLabelConfig" default="false">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -368,7 +368,7 @@ provided; everything else has a default.
   Value-axis grid + labels. Pass `{ count }` for a fixed number of evenly-spaced
   prices instead of the dynamic nice-interval grid. Use `{ labelRightMargin,
   gridEndGap }` for a fixed right-anchored label column and deterministic gap
-  between labels and grid lines.
+  between labels and grid/plain reference lines.
 </ParamField>
 
 <ParamField body="topLabel" type="boolean | AxisLabelConfig" default="false">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -415,6 +415,12 @@ interface YAxisConfig {
   // instead of the dynamic nice-interval grid. Values track the live range each
   // frame. `minGap` still floors the spacing; clamped to at most 15. Default 0.
   count?: number;
+  // Place labels in a shared left-aligned column whose right edge sits this
+  // many px from the canvas edge. Omit for the centered-gutter placement.
+  labelRightMargin?: number;
+  // Gap between each grid-line end and the shared label column. Only
+  // applies with labelRightMargin. Default 0.
+  gridEndGap?: number;
   // Float the price axis over a full-width plot instead of reserving a right
   // gutter — the line/candles run to the edge and the labels float on top.
   // Pairs with `timeScroll` (see the Time-scroll guide). Default false. @experimental

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -418,8 +418,8 @@ interface YAxisConfig {
   // Place labels in a shared left-aligned column whose right edge sits this
   // many px from the canvas edge. Omit for the centered-gutter placement.
   labelRightMargin?: number;
-  // Gap between each grid-line end and the shared label column. Only
-  // applies with labelRightMargin. Default 0.
+  // Gap between the shared label column and each grid/plain-reference-line end.
+  // Only applies with labelRightMargin. Default 0.
   gridEndGap?: number;
   // Float the price axis over a full-width plot instead of reserving a right
   // gutter — the line/candles run to the edge and the labels float on top.

--- a/docs/guides/axes-and-grid.mdx
+++ b/docs/guides/axes-and-grid.mdx
@@ -43,6 +43,24 @@ the values track the live range each frame (they aren't rounded to nice numbers)
 `minGap` still acts as a floor: if `count` labels won't fit at least `minGap` px apart, the count
 drops to what fits. The count is clamped to at most 15.
 
+## Right-anchored price label column
+
+Set `labelRightMargin` to place every Y-axis label at the same left X in a column whose right edge
+is measured from the canvas edge. Add `gridEndGap` to keep a fixed gap between the grid-line end
+and that column:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  yAxis={{ labelRightMargin: 8, gridEndGap: 6 }}
+/>
+```
+
+Without `labelRightMargin`, labels keep their default centered-gutter placement and `gridEndGap`
+has no effect. When combined with `yAxis.float`, `labelRightMargin` overrides the floating axis's
+default edge margin.
+
 ## Axis edge labels
 
 `topLabel` and `bottomLabel` float a value at the top / bottom edge of the plot — the

--- a/docs/guides/axes-and-grid.mdx
+++ b/docs/guides/axes-and-grid.mdx
@@ -61,6 +61,9 @@ Without `labelRightMargin`, labels keep their default centered-gutter placement 
 has no effect. When combined with `yAxis.float`, `labelRightMargin` overrides the floating axis's
 default edge margin.
 
+Plain horizontal `referenceLines` stop at the same X as the grid, keeping the gap consistent.
+`fullWidth` reference lines and value/time bands keep their existing extents.
+
 ## Axis edge labels
 
 `topLabel` and `bottomLabel` float a value at the top / bottom edge of the plot — the

--- a/docs/guides/reference-lines-and-bands.mdx
+++ b/docs/guides/reference-lines-and-bands.mdx
@@ -45,6 +45,10 @@ By default a line/band stops at the plot's right edge. Set `fullWidth: true` to 
 (like a price tag). Only the line/band extends — any `label` or `badge` stays anchored inside
 the plot. For a Form-A line with a `badge`, the full-width line replaces the dashed connector.
 
+When `yAxis.labelRightMargin` is set, a plain non-`fullWidth` line stops at the same X as the grid,
+honoring `yAxis.gridEndGap`. Badge/label anchors, `fullWidth` lines, and value/time bands are
+unchanged.
+
 ```tsx
 referenceLines={[
   { value: 142.5, label: "Avg entry", fullWidth: true }, // runs through the gutter

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1849,6 +1849,9 @@ function ChartStack({
             fontProp={fontProp}
             dragValues={dragValues}
             index={i}
+            yAxisEntries={yAxisEntries}
+            labelRightMargin={yAxisCfg?.labelRightMargin}
+            gridEndGap={yAxisCfg?.gridEndGap}
           />
         ))}
       </Group>
@@ -2288,6 +2291,8 @@ function ChartRefBadgeLayer({
     formatValue,
     skiaFont,
     fontProp,
+    yAxisCfg,
+    yAxisEntries,
     overlayScrubFade,
   } = model;
   if (allRefLines.length === 0) return null;
@@ -2310,6 +2315,9 @@ function ChartRefBadgeLayer({
           suppressTagWhenOffAxis={refLineOffAxisCustom[i]}
           customTagWidths={refLineCustomTagWidths}
           groupHidden={refGroupingActive ? groupHidden : undefined}
+          yAxisEntries={yAxisEntries}
+          labelRightMargin={yAxisCfg?.labelRightMargin}
+          gridEndGap={yAxisCfg?.gridEndGap}
         />
       ))}
       {/* Collapsed count handles for grouped (near-value) lines. */}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1495,6 +1495,7 @@ function ChartYAxisLayer({
     metricsCfg,
     gridStyleCfg,
     yAxisFloat,
+    yAxisCfg,
     liveBadgeOpacity,
   } = model;
   return (
@@ -1515,6 +1516,8 @@ function ChartYAxisLayer({
         badgeOffsetY={badgeCfg?.offsetY ?? 0}
         badgeOpacity={badgeUsesRightGutter ? liveBadgeOpacity : undefined}
         gridStyle={gridStyleCfg}
+        labelRightMargin={yAxisCfg?.labelRightMargin}
+        gridEndGap={yAxisCfg?.gridEndGap}
       />
     </Group>
   );

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -2268,9 +2268,11 @@ function ChartBadgeLayer({
 function ChartRefBadgeLayer({
   model,
   degen,
+  yAxisEntries,
 }: {
   model: LiveChartModel;
   degen: DegenState | null;
+  yAxisEntries: YAxisEntries | null;
 }) {
   const {
     allRefLines,
@@ -2292,7 +2294,6 @@ function ChartRefBadgeLayer({
     skiaFont,
     fontProp,
     yAxisCfg,
-    yAxisEntries,
     overlayScrubFade,
   } = model;
   if (allRefLines.length === 0) return null;
@@ -2558,7 +2559,11 @@ function ChartView({
           )}
 
           {/* Reference-line badges + labels above the fade so they stay crisp. */}
-          <ChartRefBadgeLayer model={model} degen={degen} />
+          <ChartRefBadgeLayer
+            model={model}
+            degen={degen}
+            yAxisEntries={yAxisEntries}
+          />
 
           <ChartValueOverlay model={model} degen={degen} />
 

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -712,6 +712,8 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
             badge={false}
             seriesLabelInset={seriesLabelInset}
             gridStyle={gridStyleCfg}
+            labelRightMargin={yAxisCfg.labelRightMargin}
+            gridEndGap={yAxisCfg.gridEndGap}
           />
         </Group>
       )}

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -730,6 +730,9 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
             palette={palette}
             formatValue={formatValue}
             font={skiaFont}
+            yAxisEntries={yAxisEntries}
+            labelRightMargin={yAxisCfg?.labelRightMargin}
+            gridEndGap={yAxisCfg?.gridEndGap}
           />
         ))}
       </Group>
@@ -890,6 +893,8 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
     palette,
     formatValue,
     skiaFont,
+    yAxisCfg,
+    yAxisEntries,
     degenShakeTransform,
     overlayScrubFade,
   } = model;
@@ -909,6 +914,9 @@ function SeriesRefBadgeLayer({ model }: { model: LiveChartSeriesModel }) {
           suppressTag={refLineCustom[i]}
           suppressTagWhenOffAxis={refLineOffAxisCustom[i]}
           customTagWidths={refLineCustomTagWidths}
+          yAxisEntries={yAxisEntries}
+          labelRightMargin={yAxisCfg?.labelRightMargin}
+          gridEndGap={yAxisCfg?.gridEndGap}
         />
       ))}
     </Group>

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -9,6 +9,7 @@ import {
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { YAxisEntry } from "../draw/grid";
 import type { ChartPadding } from "../draw/line";
 import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
 import { usePathBuilder } from "../hooks/usePathBuilder";
@@ -85,6 +86,12 @@ type ReferenceLineOverlayProps = {
   dragValues?: SharedValue<number[]>;
   /** This line's index into {@link dragValues}. */
   index?: number;
+  /** Y-axis entries used to match a right-anchored grid endpoint. */
+  yAxisEntries?: SharedValue<YAxisEntry[]>;
+  /** Enables clipping to the right-anchored Y-axis label column. */
+  labelRightMargin?: number;
+  /** Gap between the drawn line endpoint and the label column. */
+  gridEndGap?: number;
 };
 
 export function ReferenceLineOverlay({
@@ -102,6 +109,9 @@ export function ReferenceLineOverlay({
   groupHidden,
   dragValues,
   index = 0,
+  yAxisEntries,
+  labelRightMargin,
+  gridEndGap,
 }: ReferenceLineOverlayProps) {
   const form = referenceLineForm(line);
   const isBand = form === "value-band" || form === "time-band";
@@ -141,6 +151,10 @@ export function ReferenceLineOverlay({
     badgeFont,
     dragValues,
     index,
+    yAxisEntries,
+    labelRightMargin,
+    gridEndGap,
+    font,
   );
 
   const labelColor =

--- a/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ReferenceLineOverlay.tsx
@@ -87,7 +87,7 @@ type ReferenceLineOverlayProps = {
   /** This line's index into {@link dragValues}. */
   index?: number;
   /** Y-axis entries used to match a right-anchored grid endpoint. */
-  yAxisEntries?: SharedValue<YAxisEntry[]>;
+  yAxisEntries?: SharedValue<YAxisEntry[]> | null;
   /** Enables clipping to the right-anchored Y-axis label column. */
   labelRightMargin?: number;
   /** Gap between the drawn line endpoint and the label column. */
@@ -151,7 +151,7 @@ export function ReferenceLineOverlay({
     badgeFont,
     dragValues,
     index,
-    yAxisEntries,
+    yAxisEntries ?? undefined,
     labelRightMargin,
     gridEndGap,
     font,

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -57,6 +57,8 @@ export function YAxisOverlay({
   gridStyle,
   variant = "all",
   float = false,
+  labelRightMargin,
+  gridEndGap = 0,
 }: {
   entries: SharedValue<YAxisEntry[]>;
   engine: ChartEngineLayout;
@@ -92,6 +94,10 @@ export function YAxisOverlay({
    * plot) instead of centering them in a reserved gutter. See {@link YAxisConfig.float}.
    */
   float?: boolean;
+  /** Fixed canvas-edge margin for a shared left-aligned label column. */
+  labelRightMargin?: number;
+  /** Gap between the grid-line end and the shared label column. */
+  gridEndGap?: number;
 }) {
   const gridColor = gridStyle?.color ?? palette.gridLine;
   const gridWidth = gridStyle?.strokeWidth ?? 1;
@@ -99,14 +105,33 @@ export function YAxisOverlay({
   const gridOpacity = gridStyle?.opacity ?? 1;
   const gridBuilder = usePathBuilder();
 
+  const rightAnchoredColumn = useDerivedValue(() => {
+    if (labelRightMargin === undefined) return null;
+    const items = entries.get();
+    let maxTextW = 0;
+    for (let i = 0; i < items.length; i++) {
+      maxTextW = Math.max(
+        maxTextW,
+        measureFontTextWidth(font, items[i].label),
+      );
+    }
+    const rightX = engine.canvasWidth.get() - labelRightMargin;
+    const labelX = rightX - maxTextW;
+    return {
+      labelX,
+      gridEndX: labelX - gridEndGap,
+    };
+  });
+
   const gridLinesPath = useDerivedValue(() => {
     const b = gridBuilder.value;
     if (variant === "labels") return b.detach();
     const items = entries.get();
     const w = engine.canvasWidth.get();
+    const lineX2 = rightAnchoredColumn.get()?.gridEndX ?? w - padding.right;
     for (let i = 0; i < items.length; i++) {
       b.moveTo(padding.left, items[i].y);
-      b.lineTo(w - padding.right, items[i].y);
+      b.lineTo(lineX2, items[i].y);
     }
     return b.detach();
   });
@@ -120,6 +145,7 @@ export function YAxisOverlay({
     const w = engine.canvasWidth.get();
     const fm = font.getMetrics();
     const baselineOffset = (fm.ascent + fm.descent) / 2;
+    const columnX = rightAnchoredColumn.get()?.labelX;
     const labelHeight = fm.descent - fm.ascent;
     const badgeIsVisible = badgeOpacity === undefined || badgeOpacity.get() > 0;
     const resolvedBadgeCenterY = badgeCenterY && badgeIsVisible
@@ -133,13 +159,16 @@ export function YAxisOverlay({
     for (let i = 0; i < items.length; i++) {
       const e = items[i];
       const textW = measureFontTextWidth(font, e.label);
-      const x = float
-        ? gutterRightAlignedTextLeftX(w, textW, FLOAT_LABEL_RIGHT_MARGIN)
-        : badge
-          ? pillTextLeftX(w, padding.right, leftInset, textW, badgeMetrics)
-          : seriesLabelInset > 0
-            ? gutterRightAlignedTextLeftX(w, textW)
-            : gutterCenteredTextLeftX(w, padding.right, textW);
+      const x =
+        columnX !== undefined
+          ? columnX
+          : float
+            ? gutterRightAlignedTextLeftX(w, textW, FLOAT_LABEL_RIGHT_MARGIN)
+            : badge
+              ? pillTextLeftX(w, padding.right, leftInset, textW, badgeMetrics)
+              : seriesLabelInset > 0
+                ? gutterRightAlignedTextLeftX(w, textW)
+                : gutterCenteredTextLeftX(w, padding.right, textW);
       result.push({
         x,
         y: e.y - baselineOffset,

--- a/packages/react-native-livechart/src/components/YAxisOverlay.tsx
+++ b/packages/react-native-livechart/src/components/YAxisOverlay.tsx
@@ -7,7 +7,10 @@ import {
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { BADGE_METRICS_DEFAULTS, MAX_Y_LABELS } from "../constants";
 import type { ResolvedGridStyleConfig } from "../core/resolveConfig";
-import type { YAxisEntry } from "../draw/grid";
+import {
+  rightAnchoredYAxisColumnLayout,
+  type YAxisEntry,
+} from "../draw/grid";
 import {
   badgeTailAndCap,
   gutterCenteredTextLeftX,
@@ -107,20 +110,13 @@ export function YAxisOverlay({
 
   const rightAnchoredColumn = useDerivedValue(() => {
     if (labelRightMargin === undefined) return null;
-    const items = entries.get();
-    let maxTextW = 0;
-    for (let i = 0; i < items.length; i++) {
-      maxTextW = Math.max(
-        maxTextW,
-        measureFontTextWidth(font, items[i].label),
-      );
-    }
-    const rightX = engine.canvasWidth.get() - labelRightMargin;
-    const labelX = rightX - maxTextW;
-    return {
-      labelX,
-      gridEndX: labelX - gridEndGap,
-    };
+    return rightAnchoredYAxisColumnLayout(
+      engine.canvasWidth.get(),
+      entries.get(),
+      font,
+      labelRightMargin,
+      gridEndGap,
+    );
   });
 
   const gridLinesPath = useDerivedValue(() => {

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -89,6 +89,10 @@ export interface ResolvedYAxisConfig {
   minGap: number;
   /** Fixed label count (≥ 2), or 0 for the dynamic nice-interval grid. */
   count: number;
+  /** undefined → keep the default centered-gutter label placement. */
+  labelRightMargin: number | undefined;
+  /** undefined → no gap; inert unless labelRightMargin is set. */
+  gridEndGap: number | undefined;
   /** Float the axis over a full-width plot (no reserved right gutter). */
   float: boolean;
 }
@@ -465,6 +469,8 @@ export function resolveBadge(
 const Y_AXIS_DEFAULTS: ResolvedYAxisConfig = {
   minGap: 36,
   count: 0,
+  labelRightMargin: undefined,
+  gridEndGap: undefined,
   float: false,
 };
 

--- a/packages/react-native-livechart/src/draw/grid.ts
+++ b/packages/react-native-livechart/src/draw/grid.ts
@@ -1,4 +1,6 @@
 import { GRID_METRICS_DEFAULTS, MAX_Y_LABELS } from "../constants";
+import type { SkFont } from "@shopify/react-native-skia";
+import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { lerp } from "../math/lerp";
 import type { GridMetrics } from "../types";
 
@@ -6,6 +8,37 @@ export interface YAxisEntry {
   y: number;
   label: string;
   alpha: number;
+}
+
+export interface RightAnchoredYAxisColumnLayout {
+  /** Shared left X for every label in the column. */
+  labelX: number;
+  /** Grid/reference-line end X immediately before the column gap. */
+  gridEndX: number;
+}
+
+/**
+ * Measure the widest Y-axis label and anchor the shared left-aligned column to
+ * a fixed canvas-edge margin. Shared by the axis and reference-line worklets so
+ * their right edges cannot drift apart.
+ */
+export function rightAnchoredYAxisColumnLayout(
+  canvasWidth: number,
+  entries: readonly YAxisEntry[],
+  font: SkFont,
+  labelRightMargin: number,
+  gridEndGap = 0,
+): RightAnchoredYAxisColumnLayout {
+  "worklet";
+  let maxTextW = 0;
+  for (let i = 0; i < entries.length; i++) {
+    maxTextW = Math.max(
+      maxTextW,
+      measureFontTextWidth(font, entries[i].label),
+    );
+  }
+  const labelX = canvasWidth - labelRightMargin - maxTextW;
+  return { labelX, gridEndX: labelX - gridEndGap };
 }
 
 /**

--- a/packages/react-native-livechart/src/hooks/useReferenceLine.ts
+++ b/packages/react-native-livechart/src/hooks/useReferenceLine.ts
@@ -2,6 +2,10 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 
 import type { SkFont } from "@shopify/react-native-skia";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import {
+  rightAnchoredYAxisColumnLayout,
+  type YAxisEntry,
+} from "../draw/grid";
 import type { ChartPadding } from "../draw/line";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import {
@@ -293,6 +297,14 @@ export function useReferenceLine(
    */
   dragValues?: SharedValue<number[]>,
   index = 0,
+  /** Y-axis labels used to match the right-anchored grid endpoint. */
+  yAxisEntries?: SharedValue<YAxisEntry[]>,
+  /** Enables clipping when set; matches {@link YAxisConfig.labelRightMargin}. */
+  labelRightMargin?: number,
+  /** Gap before the label column; matches {@link YAxisConfig.gridEndGap}. */
+  gridEndGap = 0,
+  /** Font used by the Y-axis labels; badge font overrides must not move the line. */
+  yAxisFont: SkFont = font,
 ): SharedValue<ReferenceLineLayout> {
   const form = line ? referenceLineForm(line) : "none";
   // Badge presentation depends only on the (stable) line props — resolve once.
@@ -314,7 +326,20 @@ export function useReferenceLine(
     // the badge/label anchor (x1/x2) stays at the plot edges either way.
     const fullWidth = line.fullWidth ?? false;
     const lineX1 = fullWidth ? 0 : x1;
-    const lineX2 = fullWidth ? w : x2;
+    const yAxisColumn =
+      form === "line" &&
+      !fullWidth &&
+      yAxisEntries !== undefined &&
+      labelRightMargin !== undefined
+        ? rightAnchoredYAxisColumnLayout(
+            w,
+            yAxisEntries.value,
+            yAxisFont,
+            labelRightMargin,
+            gridEndGap,
+          )
+        : null;
+    const lineX2 = fullWidth ? w : (yAxisColumn?.gridEndX ?? x2);
 
     const fm = font.getMetrics();
     const baselineOffset = (fm.ascent + fm.descent) / 2;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -648,6 +648,17 @@ export interface YAxisConfig {
    */
   count?: number;
   /**
+   * Place price labels in a shared left-aligned column whose right edge sits
+   * this many pixels from the canvas edge. When omitted, labels keep the
+   * default centered-gutter placement.
+   */
+  labelRightMargin?: number;
+  /**
+   * Gap (px) between the end of each grid line and the shared price-label
+   * column. Only applies when {@link labelRightMargin} is set. Default `0`.
+   */
+  gridEndGap?: number;
+  /**
    * Float the price axis over a full-width plot instead of reserving a right
    * gutter for it. The line/candles run all the way to the right edge, and the
    * price labels (and the live-value badge) float on top — so the chart isn't

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -654,8 +654,9 @@ export interface YAxisConfig {
    */
   labelRightMargin?: number;
   /**
-   * Gap (px) between the end of each grid line and the shared price-label
-   * column. Only applies when {@link labelRightMargin} is set. Default `0`.
+   * Gap (px) between the shared price-label column and the end of each grid or
+   * plain reference line. Only applies when {@link labelRightMargin} is set.
+   * Default `0`.
    */
   gridEndGap?: number;
   /**

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -554,7 +554,7 @@ describe("LiveChart", () => {
     render(
       <Harness
         badge={{ variant: "minimal", tail: false }}
-        yAxis={{ minGap: 48 }}
+        yAxis={{ minGap: 48, labelRightMargin: 8, gridEndGap: 6 }}
         scrub={{ tooltip: false }}
         valueLine={{ strokeWidth: 2, intervals: [6, 3] }}
       />,

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -105,6 +105,7 @@ describe("LiveChartSeries", () => {
         <LiveChartSeries
           series={series}
           scrub={{ tooltip: true }}
+          yAxis={{ labelRightMargin: 8, gridEndGap: 6 }}
           referenceLines={[{ value: 11 }]}
           legend={{ compact: true }}
           onSeriesToggle={jest.fn()}

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -24,6 +24,7 @@ import {
   resolveSelectionDot,
 } from "../../src/core/resolveConfig";
 import { resolveTheme } from "../../src/theme";
+import { View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
@@ -116,6 +117,9 @@ describe("YAxisOverlay", () => {
   });
 
   it("renders grid lines and labels", () => {
+    const makeBuilder = Skia.PathBuilder.Make as jest.Mock;
+    const resultIndex = makeBuilder.mock.results.length;
+
     function Fixture() {
       const entries = useSharedValue([{ y: 40, label: "10", alpha: 1 }]);
       return (
@@ -129,6 +133,48 @@ describe("YAxisOverlay", () => {
       );
     }
     render(<Fixture />);
+
+    const builder = makeBuilder.mock.results[resultIndex].value;
+    expect(builder.lineTo).toHaveBeenCalledWith(388, 40);
+  });
+
+  it("ends grid lines before the right-anchored label column", () => {
+    const makeBuilder = Skia.PathBuilder.Make as jest.Mock;
+    const resultIndex = makeBuilder.mock.results.length;
+
+    function Fixture() {
+      const entries = useSharedValue([
+        { y: 40, label: "10", alpha: 1 },
+        { y: 80, label: "100000", alpha: 1 },
+      ]);
+      return (
+        <YAxisOverlay
+          entries={entries}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          labelRightMargin={8}
+          gridEndGap={6}
+        />
+      );
+    }
+
+    const screen = render(<Fixture />);
+
+    // 400 canvas - 8 edge margin - 42 widest label - 6 grid gap = 344.
+    const builder = makeBuilder.mock.results[resultIndex].value;
+    expect(builder.lineTo).toHaveBeenNthCalledWith(1, 344, 40);
+    expect(builder.lineTo).toHaveBeenNthCalledWith(2, 344, 80);
+
+    const labels = screen
+      .UNSAFE_getAllByType(View)
+      .filter(
+        (view) =>
+          view.props.text?.value === "10" ||
+          view.props.text?.value === "100000",
+      );
+    expect(labels.map((view) => view.props.x.value)).toEqual([350, 350]);
   });
 
   it("renders with live-badge collision suppression enabled", () => {

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -1025,6 +1025,36 @@ describe("ReferenceLineOverlay", () => {
     renderLine({ value: 5, label: "mid" });
   });
 
+  it("clips a plain line to the right-anchored Y-axis column", () => {
+    const makeBuilder = Skia.PathBuilder.Make as jest.Mock;
+    const resultIndex = makeBuilder.mock.results.length;
+
+    function Fixture() {
+      const yAxisEntries = useSharedValue([
+        { y: 40, label: "10", alpha: 1 },
+        { y: 80, label: "100000", alpha: 1 },
+      ]);
+      return (
+        <ReferenceLineOverlay
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          line={{ value: 5, label: "mid" }}
+          palette={palette}
+          formatValue={fmt}
+          font={font}
+          yAxisEntries={yAxisEntries}
+          labelRightMargin={8}
+          gridEndGap={6}
+        />
+      );
+    }
+
+    render(<Fixture />);
+
+    const lineBuilder = makeBuilder.mock.results[resultIndex].value;
+    expect(lineBuilder.lineTo).toHaveBeenCalledWith(344, 142);
+  });
+
   it("renders a full-width Form-A line (edge to edge through the gutter)", () => {
     renderLine({ value: 5, label: "mid", fullWidth: true });
   });

--- a/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useReferenceLine.test.tsx
@@ -1,6 +1,8 @@
 import { DEFAULT_PADDING } from "../../src/draw/line";
 import type { EngineState } from "../../src/core/useLiveChartEngine";
+import type { YAxisEntry } from "../../src/draw/grid";
 import { renderHook } from "@testing-library/react-native";
+import type { SharedValue } from "react-native-reanimated";
 import {
   computeReferenceBadgeRect,
   useReferenceLine,
@@ -12,9 +14,21 @@ const font = {
   getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
 } as never;
 
+const widerYAxisFont = {
+  getSize: () => 12,
+  measureText: (s: string) => ({ x: 0, y: 0, width: s.length * 10, height: 12 }),
+  getMetrics: () => ({ ascent: -9.6, descent: 2.4, leading: 0 }),
+} as never;
+
 // padding: top=12, right=80, bottom=28, left=12 → chartH = 300-12-28 = 260
 const PADDING = { top: 12, right: 80, bottom: 28, left: 12 };
 const fmt = (v: number) => v.toFixed(2);
+const rightAnchoredYAxisEntries = {
+  value: [
+    { y: 40, label: "10", alpha: 1 },
+    { y: 80, label: "100000", alpha: 1 },
+  ],
+} as SharedValue<YAxisEntry[]>;
 
 function engine(
   partial: Partial<{
@@ -132,6 +146,89 @@ describe("useReferenceLine", () => {
     expect(l.drawLine).toBe(true);
     expect(l.lineX1).toBe(PADDING.left);
     expect(l.lineX2).toBe(400 - PADDING.right);
+  });
+
+  it("clips a plain line before the right-anchored Y-axis label column", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50 },
+        fmt,
+        font,
+        undefined,
+        0,
+        rightAnchoredYAxisEntries,
+        8,
+        6,
+      ),
+    );
+    const l = result.current.value;
+
+    // 400 canvas - 8 edge margin - 42 widest label - 6 grid gap = 344.
+    expect(l.lineX2).toBe(344);
+    // Badge/label anchors remain at the plot edge.
+    expect(l.x2).toBe(320);
+    expect(l.labelX).toBe(324);
+  });
+
+  it("uses the Y-axis font when the reference badge font differs", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50 },
+        fmt,
+        font,
+        undefined,
+        0,
+        rightAnchoredYAxisEntries,
+        8,
+        6,
+        widerYAxisFont,
+      ),
+    );
+
+    // 400 canvas - 8 edge margin - 60 widest Y label - 6 grid gap = 326.
+    expect(result.current.value.lineX2).toBe(326);
+  });
+
+  it("does not clip a full-width line to the Y-axis column", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { value: 50, fullWidth: true },
+        fmt,
+        font,
+        undefined,
+        0,
+        rightAnchoredYAxisEntries,
+        8,
+        6,
+      ),
+    );
+
+    expect(result.current.value.lineX2).toBe(400);
+  });
+
+  it("does not clip a value band to the Y-axis column", () => {
+    const { result } = renderHook(() =>
+      useReferenceLine(
+        engine(),
+        PADDING,
+        { valueFrom: 20, valueTo: 60 },
+        fmt,
+        font,
+        undefined,
+        0,
+        rightAnchoredYAxisEntries,
+        8,
+        6,
+      ),
+    );
+
+    expect(result.current.value.lineX2).toBe(320);
   });
 
   it("extends the line edge-to-edge through the gutter when fullWidth", () => {

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -196,7 +196,13 @@ describe("resolveYAxis", () => {
   });
 
   it("returns defaults for true", () => {
-    expect(resolveYAxis(true)).toEqual({ minGap: 36, count: 0, float: false });
+    expect(resolveYAxis(true)).toEqual({
+      minGap: 36,
+      count: 0,
+      float: false,
+      labelRightMargin: undefined,
+      gridEndGap: undefined,
+    });
   });
 
   it("merges partial config with defaults", () => {
@@ -204,6 +210,8 @@ describe("resolveYAxis", () => {
       minGap: 48,
       count: 0,
       float: false,
+      labelRightMargin: undefined,
+      gridEndGap: undefined,
     });
   });
 
@@ -212,6 +220,8 @@ describe("resolveYAxis", () => {
       minGap: 36,
       count: 0,
       float: true,
+      labelRightMargin: undefined,
+      gridEndGap: undefined,
     });
   });
 
@@ -220,6 +230,18 @@ describe("resolveYAxis", () => {
       minGap: 36,
       count: 5,
       float: false,
+      labelRightMargin: undefined,
+      gridEndGap: undefined,
+    });
+  });
+
+  it("carries through right-anchored label spacing", () => {
+    expect(resolveYAxis({ labelRightMargin: 8, gridEndGap: 6 })).toEqual({
+      minGap: 36,
+      count: 0,
+      float: false,
+      labelRightMargin: 8,
+      gridEndGap: 6,
     });
   });
 


### PR DESCRIPTION
## Summary

Adds configurable Y-axis label-column spacing and aligns plain horizontal
reference lines with the shortened grid in both `LiveChart` and
`LiveChartSeries`.

## Public API

Adds two optional `YAxisConfig` fields:

- `labelRightMargin?: number` keeps the label column's right edge at a fixed
  distance from the canvas edge.
- `gridEndGap?: number` controls the gap between the grid endpoint and the
  label column.

```tsx
<LiveChart
  yAxis={{
    labelRightMargin: 24,
    gridEndGap: 12,
  }}
/>
```

Both fields are optional. Omitting `labelRightMargin` preserves the existing
centered-gutter layout.

## Behavior

When `labelRightMargin` is configured:

- the widest visible Y-axis label determines the shared column width;
- visible labels remain left-aligned within that column;
- the column stays the requested distance from the canvas edge;
- grid lines stop `gridEndGap` pixels before the column;
- plain, non-`fullWidth` horizontal reference lines stop at the same X as the
  grid.

Only the reference-line stroke endpoint changes. Badge and label anchors remain
at the plot edges. `fullWidth` reference lines, value bands, and time bands keep
their existing geometry.

Axis-font measurements remain the source of truth for the endpoint, so a custom
reference-line badge font cannot shift the grid alignment.

## Demo and documentation

- Adds legacy and configured spacing demos, including the `24 / 12 px` preset.
- Covers both single- and multi-series charts.
- Demonstrates plain lines, `fullWidth` lines, value bands, and time bands.
- Updates `YAxisConfig` JSDoc, API docs, axes/grid docs, reference-line docs, and
  the changelog.

## Validation

- Typecheck passed.
- Lint passed.
- Jest: 97 suites passed; 1,402 tests passed; 5 skipped.
- Library build passed.
- React Doctor: library 100/100.
