### PR TITLE
[codex] Configure scrub crosshair geometry and edge fade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Configurable scrub crosshair geometry and edge fade.** `ScrubConfig` now
   accepts `crosshairStrokeWidth` (default `1`), `crosshairOvershoot` (default
-  `0`), and `crosshairFade` (default `true`) on `LiveChart` and
-  `LiveChartSeries`. Disabling the crosshair fade keeps the line, selection dot,
-  and tooltip opaque near the live edge without changing the trailing-content
-  dim fade.
+  `0`; negative values clamp to `0`), and `crosshairFade` (default `true`) on
+  `LiveChart` and `LiveChartSeries`. Disabling the crosshair fade keeps the line,
+  selection dot, and tooltip opaque near the live edge without changing the
+  trailing-content dim fade.
 
 ## [4.12.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable scrub crosshair geometry and edge fade.** `ScrubConfig` now
+  accepts `crosshairStrokeWidth` (default `1`), `crosshairOvershoot` (default
+  `0`), and `crosshairFade` (default `true`) on `LiveChart` and
+  `LiveChartSeries`. Disabling the crosshair fade keeps the line, selection dot,
+  and tooltip opaque near the live edge without changing the trailing-content
+  dim fade.
+
 ## [4.12.0] - 2026-07-28
 
 ### Added

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -158,6 +158,10 @@ export default function ScrubbingScreen() {
   const [timeRow, setTimeRow] = useState(true);
   const [roundedTip, setRoundedTip] = useState(false);
   const [crosshairDash, setCrosshairDash] = useState(false);
+  const [thickCrosshair, setThickCrosshair] = useState(false);
+  const [crosshairOvershootEnabled, setCrosshairOvershootEnabled] =
+    useState(false);
+  const [crosshairFade, setCrosshairFade] = useState(true);
   const [dimOpacity, setDimOpacity] = useState(0.3);
   const [dotMode, setDotMode] = useState<DotMode>("default");
   const [holdToScrub, setHoldToScrub] = useState(false);
@@ -247,6 +251,9 @@ export default function ScrubbingScreen() {
           // `true` → default [4,4] dash; pass explicit [on, off] intervals for
           // finer control. Omit / `false` → solid.
           crosshairDash: crosshairDash ? [3, 4] : false,
+          crosshairStrokeWidth: thickCrosshair ? 3 : 1,
+          crosshairOvershoot: crosshairOvershootEnabled ? 6 : 0,
+          crosshairFade,
           // The "Styled" toggle recolors the built-in pill + crosshair line.
           ...(styledTooltip
             ? {
@@ -385,11 +392,26 @@ export default function ScrubbingScreen() {
         onChange={setDotMode}
       />
       <ControlRow label="Crosshair">
-        {/* Dashed line via `scrub.crosshairDash` ([3,4] intervals here). */}
+        {/* Geometry and edge-fade controls live together for visual QA. */}
         <ToggleChip
           label="Dashed"
           value={crosshairDash}
           onChange={setCrosshairDash}
+        />
+        <ToggleChip
+          label="3px wide"
+          value={thickCrosshair}
+          onChange={setThickCrosshair}
+        />
+        <ToggleChip
+          label="6px overshoot"
+          value={crosshairOvershootEnabled}
+          onChange={setCrosshairOvershootEnabled}
+        />
+        <ToggleChip
+          label="Edge fade"
+          value={crosshairFade}
+          onChange={setCrosshairFade}
         />
       </ControlRow>
       <ControlRow label="Gesture">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -352,7 +352,7 @@ interface ScrubConfig {
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
   crosshairStrokeWidth?: number; // line width in px; default 1
-  crosshairOvershoot?: number; // extend past each vertical plot edge in px; default 0
+  crosshairOvershoot?: number; // extend past each vertical plot edge in px; negatives clamp to 0; default 0
   crosshairFade?: boolean; // fade near the live edge; default true
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -351,6 +351,9 @@ interface ScrubConfig {
   seriesTooltip?: boolean | PerSeriesTooltipConfig;
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
+  crosshairStrokeWidth?: number; // line width in px; default 1
+  crosshairOvershoot?: number; // extend past each vertical plot edge in px; default 0
+  crosshairFade?: boolean; // fade near the live edge; default true
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;
   tooltipBorderRadius?: number; // pill corner radius; default 5

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -352,7 +352,7 @@ interface ScrubConfig {
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
   crosshairStrokeWidth?: number; // line width in px; default 1
-  crosshairOvershoot?: number; // extend past the plot's top/bottom edges in px; negatives clamp to 0; default 0
+  crosshairOvershoot?: number; // extend past top/bottom in px; preserves a custom top-tooltip stop; negatives clamp to 0; default 0
   crosshairFade?: boolean; // fade near the live edge; default true
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -352,7 +352,7 @@ interface ScrubConfig {
   dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
   crosshairStrokeWidth?: number; // line width in px; default 1
-  crosshairOvershoot?: number; // extend past each vertical plot edge in px; negatives clamp to 0; default 0
+  crosshairOvershoot?: number; // extend past the plot's top/bottom edges in px; negatives clamp to 0; default 0
   crosshairFade?: boolean; // fade near the live edge; default true
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -221,7 +221,8 @@ Pairs with `crosshairLineColor` for the stroke color, and works on `LiveChartSer
 ## Crosshair width, overshoot, and edge fade
 
 Use `crosshairStrokeWidth` to change the line width and `crosshairOvershoot` to extend it past both
-vertical plot edges. Both values are pixels; their defaults are `1` and `0`.
+vertical plot edges. Both values are pixels; their defaults are `1` and `0`. Negative overshoot
+values are clamped to `0`.
 
 The crosshair fades as it approaches the live edge by default. Set `crosshairFade: false` when the
 chart has no live dot or the crosshair should remain fully visible. This only affects the line,

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -222,7 +222,8 @@ Pairs with `crosshairLineColor` for the stroke color, and works on `LiveChartSer
 
 Use `crosshairStrokeWidth` to change the line width and `crosshairOvershoot` to extend it past the
 plot's top and bottom edges. Both values are pixels; their defaults are `1` and `0`. Negative
-overshoot values are clamped to `0`.
+overshoot values are clamped to `0`. A custom top tooltip's measured line stop is preserved so
+overshoot never draws the crosshair through the tooltip.
 
 The crosshair fades as it approaches the live edge by default. Set `crosshairFade: false` when the
 chart has no live dot or the crosshair should remain fully visible. This only affects the line,

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -218,6 +218,29 @@ finer control. Omitting it (or `false`) keeps the solid line.
 
 Pairs with `crosshairLineColor` for the stroke color, and works on `LiveChartSeries` too.
 
+## Crosshair width, overshoot, and edge fade
+
+Use `crosshairStrokeWidth` to change the line width and `crosshairOvershoot` to extend it past both
+vertical plot edges. Both values are pixels; their defaults are `1` and `0`.
+
+The crosshair fades as it approaches the live edge by default. Set `crosshairFade: false` when the
+chart has no live dot or the crosshair should remain fully visible. This only affects the line,
+selection dot, and tooltip; the trailing-content dim keeps its own fade.
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  scrub={{
+    crosshairStrokeWidth: 2,
+    crosshairOvershoot: 6,
+    crosshairFade: false,
+  }}
+/>
+```
+
+These options also work on `LiveChartSeries`.
+
 ## Press-and-hold to scrub (`panGestureDelay`)
 
 By default scrubbing starts the moment the user drags. When the chart sits inside a horizontally

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -220,9 +220,9 @@ Pairs with `crosshairLineColor` for the stroke color, and works on `LiveChartSer
 
 ## Crosshair width, overshoot, and edge fade
 
-Use `crosshairStrokeWidth` to change the line width and `crosshairOvershoot` to extend it past both
-vertical plot edges. Both values are pixels; their defaults are `1` and `0`. Negative overshoot
-values are clamped to `0`.
+Use `crosshairStrokeWidth` to change the line width and `crosshairOvershoot` to extend it past the
+plot's top and bottom edges. Both values are pixels; their defaults are `1` and `0`. Negative
+overshoot values are clamped to `0`.
 
 The crosshair fades as it approaches the live edge by default. Set `crosshairFade: false` when the
 chart has no live dot or the crosshair should remain fully visible. This only affects the line,

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -42,7 +42,7 @@ export function CrosshairLine({
   /** Scrub intersection Y in canvas px (the value the dot marks); -1 hides it. */
   selectionY?: SharedValue<number>;
   /** Whether scrubbing is active (passed through to a custom dot). */
-  scrubActive?: SharedValue<number> | SharedValue<boolean>;
+  scrubActive: SharedValue<number> | SharedValue<boolean>;
   /** Fallback selection-dot color (leading-series color), used when the config's
    *  own `color` is unset. */
   selectionColor?: string;
@@ -56,7 +56,7 @@ export function CrosshairLine({
   crosshairLineColor?: string;
   /** Vertical crosshair line width in px. Default 1. */
   crosshairStrokeWidth?: number;
-  /** Extension past each vertical plot edge in px. Default 0. */
+  /** Resolved extension past each vertical plot edge in px. Default 0. */
   crosshairOvershoot?: number;
   /** Fade the crosshair near the live edge. Default true. */
   crosshairFade?: boolean;

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -56,7 +56,7 @@ export function CrosshairLine({
   crosshairLineColor?: string;
   /** Vertical crosshair line width in px. Default 1. */
   crosshairStrokeWidth?: number;
-  /** Resolved extension past each vertical plot edge in px. Default 0. */
+  /** Resolved extension past the top and bottom plot edges in px. Default 0. */
   crosshairOvershoot?: number;
   /** Fade the crosshair near the live edge. Default true. */
   crosshairFade?: boolean;

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -4,6 +4,7 @@ import { type ChartPadding } from "../draw/line";
 import type { LiveChartPalette } from "../types";
 import type { ResolvedSelectionDotConfig } from "../core/resolveConfig";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import { useCrosshairVisibleOpacity } from "../hooks/useCrosshairVisibleOpacity";
 import { SelectionDotSlot } from "./SelectionDot";
 
 /**
@@ -23,7 +24,9 @@ export function CrosshairLine({
   dimOpacity = 0.3,
   liveDotExtent = 0,
   crosshairLineColor,
-  crosshairLineWidth = 1,
+  crosshairStrokeWidth = 1,
+  crosshairOvershoot = 0,
+  crosshairFade = true,
   crosshairDash,
   crosshairDimColor,
   opaqueCanvas = false,
@@ -51,8 +54,12 @@ export function CrosshairLine({
    *  the gutter reserves beyond them bright. Default 0. */
   liveDotExtent?: number;
   crosshairLineColor?: string;
-  /** Vertical guide stroke width in px. Default 1. */
-  crosshairLineWidth?: number;
+  /** Vertical crosshair line width in px. Default 1. */
+  crosshairStrokeWidth?: number;
+  /** Extension past each vertical plot edge in px. Default 0. */
+  crosshairOvershoot?: number;
+  /** Fade the crosshair near the live edge. Default true. */
+  crosshairFade?: boolean;
   /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
   crosshairDash?: number[];
   crosshairDimColor?: string;
@@ -68,16 +75,19 @@ export function CrosshairLine({
   const p1 = useDerivedValue(
     () => ({
       x: scrubX.value,
-      y: padding.top,
+      y: padding.top - crosshairOvershoot,
     }),
-    [scrubX, padding.top],
+    [scrubX, padding.top, crosshairOvershoot],
   );
   const p2 = useDerivedValue(
     () => ({
       x: scrubX.value,
-      y: engine.canvasHeight.value - padding.bottom,
+      y:
+        engine.canvasHeight.value -
+        padding.bottom +
+        crosshairOvershoot,
     }),
-    [scrubX, engine.canvasHeight, padding.bottom],
+    [scrubX, engine.canvasHeight, padding.bottom, crosshairOvershoot],
   );
 
   const dimWidth = useDerivedValue(() => {
@@ -100,6 +110,13 @@ export function CrosshairLine({
     [dimOpacity, crosshairOpacity],
   );
   const backgroundColor = `rgb(${palette.bgRgb[0]},${palette.bgRgb[1]},${palette.bgRgb[2]})`;
+
+  // The trailing dim deliberately keeps the original edge fade.
+  const visibleOpacity = useCrosshairVisibleOpacity(
+    crosshairOpacity,
+    scrubActive,
+    crosshairFade,
+  );
 
   return (
     <>
@@ -136,12 +153,12 @@ export function CrosshairLine({
         </Group>
       ) : null}
 
-      <Group opacity={crosshairOpacity}>
+      <Group opacity={visibleOpacity}>
         <Line
           p1={p1}
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
-          strokeWidth={crosshairLineWidth}
+          strokeWidth={crosshairStrokeWidth}
         >
           {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
         </Line>
@@ -153,7 +170,7 @@ export function CrosshairLine({
           x={scrubX}
           y={selectionY}
           active={scrubActive}
-          opacity={crosshairOpacity}
+          opacity={visibleOpacity}
           color={selectionColor ?? palette.line}
         />
       </Group>

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -74,7 +74,7 @@ export function CrosshairOverlay({
   /** Scrub intersection Y in canvas px (the value the dot marks); -1 hides it. */
   selectionY?: SharedValue<number>;
   /** Whether scrubbing is active (passed through to a custom dot). */
-  scrubActive?: SharedValue<number> | SharedValue<boolean>;
+  scrubActive: SharedValue<number> | SharedValue<boolean>;
   /** Fallback selection-dot color (accent / leading-series color), used when the
    *  config's own `color` is unset. */
   selectionColor?: string;
@@ -89,7 +89,7 @@ export function CrosshairOverlay({
   crosshairLineColor?: string;
   /** Vertical crosshair line width in px. Default 1. */
   crosshairStrokeWidth?: number;
-  /** Extension past each vertical plot edge in px. Default 0. */
+  /** Resolved extension past each vertical plot edge in px. Default 0. */
   crosshairOvershoot?: number;
   /** Fade the crosshair near the live edge. Default true. */
   crosshairFade?: boolean;

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -89,7 +89,7 @@ export function CrosshairOverlay({
   crosshairLineColor?: string;
   /** Vertical crosshair line width in px. Default 1. */
   crosshairStrokeWidth?: number;
-  /** Resolved extension past each vertical plot edge in px. Default 0. */
+  /** Resolved extension past the top and bottom plot edges in px. Default 0. */
   crosshairOvershoot?: number;
   /** Fade the crosshair near the live edge. Default true. */
   crosshairFade?: boolean;

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from "react";
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { type ChartPadding } from "../draw/line";
 import { type TooltipLayout } from "../hooks/crosshairShared";
+import { useCrosshairVisibleOpacity } from "../hooks/useCrosshairVisibleOpacity";
 import type { LiveChartPalette } from "../types";
 import type { ResolvedSelectionDotConfig } from "../core/resolveConfig";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
@@ -35,6 +36,9 @@ export function CrosshairOverlay({
   dimOpacity = 0.3,
   liveDotExtent = 0,
   crosshairLineColor,
+  crosshairStrokeWidth = 1,
+  crosshairOvershoot = 0,
+  crosshairFade = true,
   crosshairDash,
   crosshairDimColor,
   tooltipBackground,
@@ -83,6 +87,12 @@ export function CrosshairOverlay({
    *  reserves beyond it. Default 0. */
   liveDotExtent?: number;
   crosshairLineColor?: string;
+  /** Vertical crosshair line width in px. Default 1. */
+  crosshairStrokeWidth?: number;
+  /** Extension past each vertical plot edge in px. Default 0. */
+  crosshairOvershoot?: number;
+  /** Fade the crosshair near the live edge. Default true. */
+  crosshairFade?: boolean;
   /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
   crosshairDash?: number[];
   crosshairDimColor?: string;
@@ -104,21 +114,27 @@ export function CrosshairOverlay({
   // React's "final argument changed size between renders" error. Listing the
   // captured plain values keeps the dependency array a constant size. SharedValue
   // reads stay reactive regardless of this list.
-  const p1 = useDerivedValue(() => {
-    // A top-pinned custom tooltip pushes the line's start down to its measured
-    // bottom (lineTop) so the line stops at the label; -1 → no top tooltip.
-    const lt = lineTop?.value ?? -1;
-    return {
-      x: scrubX.value,
-      y: lt >= 0 ? lt : padding.top,
-    };
-  }, [scrubX, padding.top, lineTop]);
+  const p1 = useDerivedValue(
+    () => {
+      // A top-pinned custom tooltip pushes the line's start down to its measured
+      // bottom (lineTop) so the line stops at the label; -1 → no top tooltip.
+      const lt = lineTop?.value ?? -1;
+      return {
+        x: scrubX.value,
+        y: lt >= 0 ? lt : padding.top - crosshairOvershoot,
+      };
+    },
+    [scrubX, padding.top, lineTop, crosshairOvershoot],
+  );
   const p2 = useDerivedValue(
     () => ({
       x: scrubX.value,
-      y: engine.canvasHeight.value - padding.bottom,
+      y:
+        engine.canvasHeight.value -
+        padding.bottom +
+        crosshairOvershoot,
     }),
-    [scrubX, engine.canvasHeight, padding.bottom],
+    [scrubX, engine.canvasHeight, padding.bottom, crosshairOvershoot],
   );
 
   const dimWidth = useDerivedValue(() => {
@@ -159,6 +175,14 @@ export function CrosshairOverlay({
   );
   const backgroundColor = `rgb(${palette.bgRgb[0]},${palette.bgRgb[1]},${palette.bgRgb[2]})`;
 
+  // Keep the trailing dim on its original edge fade. Only the visible
+  // crosshair group (line, dot, tooltip) opts out when crosshairFade is false.
+  const visibleOpacity = useCrosshairVisibleOpacity(
+    crosshairOpacity,
+    scrubActive,
+    crosshairFade,
+  );
+
   return (
     <>
       {crosshairDimColor !== undefined ? (
@@ -195,12 +219,12 @@ export function CrosshairOverlay({
         </Group>
       ) : null}
 
-      <Group opacity={crosshairOpacity}>
+      <Group opacity={visibleOpacity}>
         <Line
           p1={p1}
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
-          strokeWidth={1}
+          strokeWidth={crosshairStrokeWidth}
         >
           {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
         </Line>
@@ -212,7 +236,7 @@ export function CrosshairOverlay({
           x={scrubX}
           y={selectionY}
           active={scrubActive}
-          opacity={crosshairOpacity}
+          opacity={visibleOpacity}
           color={selectionColor ?? palette.line}
         />
 

--- a/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
@@ -47,6 +47,7 @@ export function CustomTooltipOverlay({
   padding,
   placement,
   margin = 8,
+  crosshairFade = true,
   lineTop,
   scrubDotY,
 }: {
@@ -64,6 +65,8 @@ export function CustomTooltipOverlay({
   placement: "side" | "top" | "bottom" | "point";
   /** Gap (px) between the pill and the plot edge it's pinned to. Default 8. */
   margin?: number;
+  /** Fade the tooltip near the live edge. Default true. */
+  crosshairFade?: boolean;
   /** When `placement` is `"top"`, the overlay publishes the label's bottom edge
    *  (canvas Y) here so {@link CrosshairOverlay} can stop the crosshair line at
    *  the label instead of running through it; -1 when not top-pinned/active. */
@@ -154,7 +157,7 @@ export function CustomTooltipOverlay({
     }
 
     return {
-      opacity: active ? crosshairOpacity.get() : 0,
+      opacity: active ? (crosshairFade ? crosshairOpacity.get() : 1) : 0,
       transform: [{ translateX: x }, { translateY: y }],
     };
   });

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -2119,6 +2119,9 @@ function ChartScrubLayer({
           dimOpacity={scrubCfg.dimOpacity}
           liveDotExtent={liveDotExtent}
           crosshairLineColor={scrubCfg.crosshairLineColor}
+          crosshairStrokeWidth={scrubCfg.crosshairStrokeWidth}
+          crosshairOvershoot={scrubCfg.crosshairOvershoot}
+          crosshairFade={scrubCfg.crosshairFade}
           crosshairDash={scrubCfg.crosshairDash}
           crosshairDimColor={scrubCfg.crosshairDimColor}
           tooltipBackground={scrubCfg.tooltipBackground}
@@ -2607,6 +2610,7 @@ function ChartView({
             padding={effectivePadding}
             placement={scrubCfg.tooltipPlacement}
             margin={scrubCfg.tooltipMargin}
+            crosshairFade={scrubCfg.crosshairFade}
             lineTop={crosshair.tooltipLineTop}
             scrubDotY={crosshair.scrubDotY}
           />

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -1065,7 +1065,12 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                   seriesTooltipCfg?.guideColor ??
                   scrubCfg.crosshairLineColor
                 }
-                crosshairLineWidth={seriesTooltipCfg?.guideWidth}
+                crosshairStrokeWidth={
+                  seriesTooltipCfg?.guideWidth ??
+                  scrubCfg.crosshairStrokeWidth
+                }
+                crosshairOvershoot={scrubCfg.crosshairOvershoot}
+                crosshairFade={scrubCfg.crosshairFade}
                 crosshairDash={
                   seriesTooltipCfg
                     ? seriesTooltipCfg.guideDashPattern

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -752,6 +752,7 @@ export function resolveScrub(
     const seriesTooltip =
       typeof prop === "object" ? prop.seriesTooltip : undefined;
     resolved.seriesTooltip = resolvePerSeriesTooltip(seriesTooltip);
+    resolved.crosshairOvershoot = Math.max(0, resolved.crosshairOvershoot);
   }
   return resolved;
 }

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -151,6 +151,12 @@ export interface ResolvedScrubConfig {
   dimOpacity: number;
   /** undefined → palette.crosshairLine */
   crosshairLineColor: string | undefined;
+  /** Vertical crosshair line width in px. */
+  crosshairStrokeWidth: number;
+  /** Extension past each vertical plot edge in px. */
+  crosshairOvershoot: number;
+  /** Fade the crosshair near the live edge. */
+  crosshairFade: boolean;
   /** Dash intervals `[on, off, …]` for the crosshair line; undefined → solid. */
   crosshairDash: number[] | undefined;
   /** undefined → palette.crosshairDim */
@@ -664,6 +670,9 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   seriesTooltip: null,
   dimOpacity: 0.3,
   crosshairLineColor: undefined,
+  crosshairStrokeWidth: 1,
+  crosshairOvershoot: 0,
+  crosshairFade: true,
   crosshairDash: undefined,
   crosshairDimColor: undefined,
   tooltipBackground: undefined,

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -153,7 +153,7 @@ export interface ResolvedScrubConfig {
   crosshairLineColor: string | undefined;
   /** Vertical crosshair line width in px. */
   crosshairStrokeWidth: number;
-  /** Extension past each vertical plot edge in px. */
+  /** Extension past the plot's top and bottom edges in px. */
   crosshairOvershoot: number;
   /** Fade the crosshair near the live edge. */
   crosshairFade: boolean;

--- a/packages/react-native-livechart/src/hooks/useCrosshairVisibleOpacity.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairVisibleOpacity.ts
@@ -1,0 +1,23 @@
+import {
+  useDerivedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+
+/**
+ * Opacity for the visible crosshair UI. The trailing-content dim keeps using
+ * the edge-faded opacity directly, independent of this setting.
+ */
+export function useCrosshairVisibleOpacity(
+  edgeOpacity: SharedValue<number>,
+  active: SharedValue<number> | SharedValue<boolean> | undefined,
+  fade: boolean,
+) {
+  return useDerivedValue(
+    () => {
+      if (fade) return edgeOpacity.get();
+      if (active === undefined) return edgeOpacity.get() > 0 ? 1 : 0;
+      return active.get() ? 1 : 0;
+    },
+    [fade, edgeOpacity, active],
+  );
+}

--- a/packages/react-native-livechart/src/hooks/useCrosshairVisibleOpacity.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairVisibleOpacity.ts
@@ -9,15 +9,26 @@ import {
  */
 export function useCrosshairVisibleOpacity(
   edgeOpacity: SharedValue<number>,
-  active: SharedValue<number> | SharedValue<boolean> | undefined,
+  active: SharedValue<number> | SharedValue<boolean>,
   fade: boolean,
 ) {
   return useDerivedValue(
-    () => {
-      if (fade) return edgeOpacity.get();
-      if (active === undefined) return edgeOpacity.get() > 0 ? 1 : 0;
-      return active.get() ? 1 : 0;
-    },
+    () =>
+      resolveCrosshairVisibleOpacity(
+        edgeOpacity.get(),
+        Boolean(active.get()),
+        fade,
+      ),
     [fade, edgeOpacity, active],
   );
+}
+
+export function resolveCrosshairVisibleOpacity(
+  edgeOpacity: number,
+  active: boolean,
+  fade: boolean,
+): number {
+  "worklet";
+  if (fade) return edgeOpacity;
+  return active ? 1 : 0;
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -835,7 +835,9 @@ export interface ScrubConfig {
   crosshairStrokeWidth?: number;
   /**
    * Extend the vertical crosshair line past the plot's top and bottom edges by
-   * this many px. Negative values are clamped to `0`. Default `0`.
+   * this many px. A measured top custom-tooltip stop remains unchanged so the
+   * line does not draw through the tooltip. Negative values are clamped to `0`.
+   * Default `0`.
    */
   crosshairOvershoot?: number;
   /**

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -831,6 +831,19 @@ export interface ScrubConfig {
   dimOpacity?: number;
   /** Vertical crosshair line stroke. Omit to use theme `crosshairLine`. */
   crosshairLineColor?: string;
+  /** Vertical crosshair line width in px. Default `1`. */
+  crosshairStrokeWidth?: number;
+  /**
+   * Extend the vertical crosshair line past the plot's top and bottom edges by
+   * this many px. Default `0`.
+   */
+  crosshairOvershoot?: number;
+  /**
+   * Fade the crosshair as it approaches the live edge. Set `false` to keep the
+   * line, selection dot, and tooltip fully opaque while scrubbing. The trailing
+   * content dim keeps its own edge fade. Default `true`.
+   */
+  crosshairFade?: boolean;
   /**
    * Dash the vertical crosshair line. `true` → a default `[4, 4]` dash; an array
    * sets explicit Skia dash intervals `[on, off, …]` in px. Omit / `false` → a

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -835,7 +835,7 @@ export interface ScrubConfig {
   crosshairStrokeWidth?: number;
   /**
    * Extend the vertical crosshair line past the plot's top and bottom edges by
-   * this many px. Default `0`.
+   * this many px. Negative values are clamped to `0`. Default `0`.
    */
   crosshairOvershoot?: number;
   /**

--- a/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
@@ -42,18 +42,22 @@ function Fixture({
   candle,
   captureLineTop,
   scrubDotY,
+  crosshairFade,
+  crosshairOpacityValue = 1,
 }: {
   renderTooltip: (ctx: TooltipRenderProps) => React.ReactElement | null | undefined;
   placement?: "side" | "top" | "bottom" | "point";
   candle?: CandlePoint | null;
   captureLineTop?: (lineTop: SharedValue<number>) => void;
   scrubDotY?: number;
+  crosshairFade?: boolean;
+  crosshairOpacityValue?: number;
 }) {
   const scrubX = useSharedValue(100);
   const scrubValue = useSharedValue<number | null>(42);
   const scrubTime = useSharedValue(985);
   const scrubActive = useSharedValue(true);
-  const crosshairOpacity = useSharedValue(1);
+  const crosshairOpacity = useSharedValue(crosshairOpacityValue);
   const tooltipLayout = useSharedValue<TooltipLayout>(LAYOUT);
   const scrubCandle = useSharedValue<CandlePoint | null>(candle ?? null);
   const lineTop = useSharedValue(-1);
@@ -74,6 +78,7 @@ function Fixture({
       engine={engine()}
       padding={DEFAULT_PADDING}
       placement={placement}
+      crosshairFade={crosshairFade}
       lineTop={lineTop}
       scrubDotY={scrubDotYSV}
     />
@@ -86,6 +91,17 @@ describe("CustomTooltipOverlay", () => {
       <Fixture renderTooltip={() => <Text testID="custom-tip">tip</Text>} />,
     );
     expect(getByTestId("custom-tip")).toBeTruthy();
+  });
+
+  it("keeps the custom tooltip opaque when edge fade is disabled", () => {
+    const { toJSON } = render(
+      <Fixture
+        crosshairFade={false}
+        crosshairOpacityValue={0.25}
+        renderTooltip={() => <Text testID="custom-tip">tip</Text>}
+      />,
+    );
+    expect(JSON.stringify(toJSON())).toContain('"opacity":1');
   });
 
   it("measures the element via onLayout without throwing", () => {

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -56,6 +56,17 @@ function engine(): EngineState {
   }) as unknown as EngineState;
 }
 
+function expectConfiguredCrosshair(tree: unknown) {
+  const serialized = JSON.stringify(tree);
+  expect(serialized).toContain('"strokeWidth":3');
+  expect(serialized).toContain(`\\"y\\":${DEFAULT_PADDING.top - 6}`);
+  expect(serialized).toContain(
+    `\\"y\\":${300 - DEFAULT_PADDING.bottom + 6}`,
+  );
+  expect(serialized).toContain('"opacity":"1"');
+  expect(serialized).toContain("rgba(0,0,0,0.175)");
+}
+
 describe("AnimatedLabel", () => {
   it("renders off-screen when index missing", () => {
     function Fixture() {
@@ -454,6 +465,59 @@ describe("CrosshairOverlay", () => {
     render(<Fixture />);
   });
 
+  it("applies crosshair stroke width, overshoot, and disabled edge fade", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(0.25);
+      const scrubActive = useSharedValue(true);
+      const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          scrubActive={scrubActive}
+          crosshairStrokeWidth={3}
+          crosshairOvershoot={6}
+          crosshairFade={false}
+        />
+      );
+    }
+    const { toJSON } = render(<Fixture />);
+    expectConfiguredCrosshair(toJSON());
+  });
+
+  it("keeps a custom top-tooltip line stop when overshoot is set", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
+      const lineTop = useSharedValue(48);
+      const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          scrubActive={scrubActive}
+          lineTop={lineTop}
+          crosshairOvershoot={6}
+        />
+      );
+    }
+    const tree = JSON.stringify(render(<Fixture />).toJSON());
+    expect(tree).toContain('\\"y\\":48');
+    expect(tree).not.toContain('\\"y\\":42');
+  });
+
   it("renders tooltip pill when showTooltip=true", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
@@ -813,6 +877,26 @@ describe("CrosshairOverlay", () => {
 });
 
 describe("CrosshairLine", () => {
+  it("stays visible without scrubActive when edge opacity is positive", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(0.25);
+      return (
+        <CrosshairLine
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          crosshairFade={false}
+        />
+      );
+    }
+    expect(JSON.stringify(render(<Fixture />).toJSON())).toContain(
+      '"opacity":"1"',
+    );
+  });
+
   it("renders the built-in selection dot for the default config", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
@@ -923,6 +1007,32 @@ describe("CrosshairLine", () => {
       );
     }
     render(<Fixture />);
+  });
+
+  it("applies crosshair stroke width, overshoot, and disabled edge fade", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(0.25);
+      const scrubActive = useSharedValue(true);
+      const selectionY = useSharedValue(140);
+      return (
+        <CrosshairLine
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          selectionDot={resolveSelectionDot(true)}
+          selectionY={selectionY}
+          scrubActive={scrubActive}
+          crosshairStrokeWidth={3}
+          crosshairOvershoot={6}
+          crosshairFade={false}
+        />
+      );
+    }
+    const { toJSON } = render(<Fixture />);
+    expectConfiguredCrosshair(toJSON());
   });
 });
 

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -428,6 +428,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
       return (
         <CrosshairOverlay
@@ -438,6 +439,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
         />
       );
     }
@@ -448,6 +450,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
       return (
         <CrosshairOverlay
@@ -458,6 +461,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           crosshairDash={[4, 4]}
         />
       );
@@ -522,6 +526,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>({
         x: 110,
         y: 20,
@@ -544,6 +549,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           showTooltip
         />
       );
@@ -555,6 +561,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>({
         x: 110,
         y: 20,
@@ -577,6 +584,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           showTooltip
           tooltipShowValue={false}
           tooltipBorderRadius={9}
@@ -633,6 +641,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>({
         x: 110,
         y: 20,
@@ -658,6 +667,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           showTooltip
         >
           <MultiSeriesTooltipStack
@@ -675,6 +685,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(0.5);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
       return (
         <CrosshairOverlay
@@ -685,6 +696,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           showTooltip={false}
         />
       );
@@ -857,6 +869,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
       return (
         <CrosshairOverlay
@@ -867,6 +880,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           showTooltip
           renderTooltip={() => <Circle cx={1} cy={2} r={3} color="#fff" />}
         />
@@ -877,10 +891,11 @@ describe("CrosshairOverlay", () => {
 });
 
 describe("CrosshairLine", () => {
-  it("stays visible without scrubActive when edge opacity is positive", () => {
+  it("stays visible at zero edge opacity when fade is disabled", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
-      const crosshairOpacity = useSharedValue(0.25);
+      const crosshairOpacity = useSharedValue(0);
+      const scrubActive = useSharedValue(true);
       return (
         <CrosshairLine
           scrubX={scrubX}
@@ -888,6 +903,7 @@ describe("CrosshairLine", () => {
           engine={engine()}
           padding={DEFAULT_PADDING}
           palette={palette}
+          scrubActive={scrubActive}
           crosshairFade={false}
         />
       );
@@ -942,10 +958,11 @@ describe("CrosshairLine", () => {
     render(<Fixture />);
   });
 
-  it("renders nothing for the dot when scrubActive is absent (early return)", () => {
+  it("renders nothing for the dot when selectionY is absent", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       return (
         <CrosshairLine
           scrubX={scrubX}
@@ -954,6 +971,7 @@ describe("CrosshairLine", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           selectionDot={resolveSelectionDot(true)}
+          scrubActive={scrubActive}
         />
       );
     }

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -603,6 +603,7 @@ describe("CrosshairOverlay", () => {
     function Fixture() {
       const scrubX = useSharedValue(100);
       const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
       const tooltipLayout = useSharedValue<TooltipLayout>({
         x: 110,
         y: 20,
@@ -625,6 +626,7 @@ describe("CrosshairOverlay", () => {
           padding={DEFAULT_PADDING}
           palette={palette}
           font={font}
+          scrubActive={scrubActive}
           showTooltip
           tooltipShowValue={false}
           tooltipShowTime={false}

--- a/packages/react-native-livechart/tests/hooks/useCrosshairVisibleOpacity.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairVisibleOpacity.test.ts
@@ -1,0 +1,15 @@
+import { resolveCrosshairVisibleOpacity } from "../../src/hooks/useCrosshairVisibleOpacity";
+
+describe("resolveCrosshairVisibleOpacity", () => {
+  it("stays visible at the exact live edge when fade is disabled", () => {
+    expect(resolveCrosshairVisibleOpacity(0, true, false)).toBe(1);
+  });
+
+  it("stays hidden when scrub is inactive", () => {
+    expect(resolveCrosshairVisibleOpacity(0, false, false)).toBe(0);
+  });
+
+  it("preserves edge opacity when fade is enabled", () => {
+    expect(resolveCrosshairVisibleOpacity(0.25, true, true)).toBe(0.25);
+  });
+});

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -511,6 +511,28 @@ describe("resolveAxisLabel", () => {
 // ─── resolveScrub ─────────────────────────────────────────────────────────────
 
 describe("resolveScrub", () => {
+  const DEFAULTS = {
+    tooltip: true,
+    seriesTooltip: null,
+    dimOpacity: 0.3,
+    crosshairLineColor: undefined,
+    crosshairStrokeWidth: 1,
+    crosshairOvershoot: 0,
+    crosshairFade: true,
+    crosshairDash: undefined,
+    crosshairDimColor: undefined,
+    tooltipBackground: undefined,
+    tooltipColor: undefined,
+    tooltipBorderColor: undefined,
+    tooltipBorderRadius: 5,
+    tooltipPlacement: "side",
+    tooltipMargin: 8,
+    tooltipShowValue: true,
+    tooltipShowTime: true,
+    panGestureDelay: 0,
+    hideOverlaysOnScrub: false,
+  };
+
   it("returns null for undefined", () => {
     expect(resolveScrub(undefined)).toBeNull();
   });
@@ -520,47 +542,20 @@ describe("resolveScrub", () => {
   });
 
   it("returns defaults for true", () => {
-    expect(resolveScrub(true)).toEqual({
-      tooltip: true,
-      seriesTooltip: null,
-      dimOpacity: 0.3,
-      tooltipBorderRadius: 5,
-      tooltipPlacement: "side",
-      tooltipMargin: 8,
-      tooltipShowValue: true,
-      tooltipShowTime: true,
-      panGestureDelay: 0,
-      hideOverlaysOnScrub: false,
-    });
+    expect(resolveScrub(true)).toEqual(DEFAULTS);
   });
 
   it("merges partial config with defaults", () => {
     expect(resolveScrub({ tooltip: false })).toEqual({
+      ...DEFAULTS,
       tooltip: false,
-      seriesTooltip: null,
-      dimOpacity: 0.3,
-      tooltipBorderRadius: 5,
-      tooltipPlacement: "side",
-      tooltipMargin: 8,
-      tooltipShowValue: true,
-      tooltipShowTime: true,
-      panGestureDelay: 0,
-      hideOverlaysOnScrub: false,
     });
   });
 
   it("accepts a custom dimOpacity", () => {
     expect(resolveScrub({ dimOpacity: 0.5 })).toEqual({
-      tooltip: true,
-      seriesTooltip: null,
+      ...DEFAULTS,
       dimOpacity: 0.5,
-      tooltipBorderRadius: 5,
-      tooltipPlacement: "side",
-      tooltipMargin: 8,
-      tooltipShowValue: true,
-      tooltipShowTime: true,
-      panGestureDelay: 0,
-      hideOverlaysOnScrub: false,
     });
   });
 
@@ -576,16 +571,8 @@ describe("resolveScrub", () => {
 
   it("carries a custom panGestureDelay (press-and-hold to scrub)", () => {
     expect(resolveScrub({ panGestureDelay: 300 })).toEqual({
-      tooltip: true,
-      seriesTooltip: null,
-      dimOpacity: 0.3,
-      tooltipBorderRadius: 5,
-      tooltipPlacement: "side",
-      tooltipMargin: 8,
-      tooltipShowValue: true,
-      tooltipShowTime: true,
+      ...DEFAULTS,
       panGestureDelay: 300,
-      hideOverlaysOnScrub: false,
     });
   });
 
@@ -594,6 +581,20 @@ describe("resolveScrub", () => {
     expect(
       resolveScrub({ hideOverlaysOnScrub: true })?.hideOverlaysOnScrub,
     ).toBe(true);
+  });
+
+  it("carries crosshair stroke, overshoot, and fade overrides", () => {
+    expect(
+      resolveScrub({
+        crosshairStrokeWidth: 3,
+        crosshairOvershoot: 6,
+        crosshairFade: false,
+      }),
+    ).toMatchObject({
+      crosshairStrokeWidth: 3,
+      crosshairOvershoot: 6,
+      crosshairFade: false,
+    });
   });
 
   it("carries a custom tooltipBorderRadius", () => {

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -597,6 +597,10 @@ describe("resolveScrub", () => {
     });
   });
 
+  it("clamps negative crosshair overshoot to zero", () => {
+    expect(resolveScrub({ crosshairOvershoot: -6 })?.crosshairOvershoot).toBe(0);
+  });
+
   it("carries a custom tooltipBorderRadius", () => {
     expect(resolveScrub({ tooltipBorderRadius: 12 })).toMatchObject({
       tooltipBorderRadius: 12,


### PR DESCRIPTION
## Summary

Adds three optional `ScrubConfig` controls to `LiveChart` and
`LiveChartSeries`:

- `crosshairStrokeWidth` — line width in pixels; default `1`.
- `crosshairOvershoot` — extension beyond the top/bottom plot edges; default `0`.
- `crosshairFade` — live-edge fade; default `true`.

## Why

The crosshair previously used a fixed 1px stroke, stopped exactly at the plot
bounds, and always faded near the live edge. That prevented matching designs
that require a wider line, slight endpoint coverage, or a persistent crosshair
on charts without a live dot.

## Behavior and compatibility

Defaults preserve existing output:

```ts
crosshairStrokeWidth: 1
crosshairOvershoot: 0
crosshairFade: true
```

`crosshairFade: false` keeps the line, selection dot, and tooltip opaque only
while scrubbing. The trailing-content dim/erase overlay retains its independent
edge fade.

Overshoot extends both vertical endpoints without moving a measured
top-tooltip line stop. Negative overshoot values normalize to `0`.

## Documentation and tests

- Adds demo controls for width, overshoot, and fade.
- Updates `ScrubConfig` JSDoc, API reference, guide, and changelog.
- Covers defaults, geometry, custom-tooltip bounds, active/inactive opacity,
  exact-edge behavior, and backwards-compatible rendering.

## Validation

- Typecheck passed.
- Lint passed.
- Jest: 98 suites passed; 1,405 tests passed; 5 skipped.
- Library build passed.
- React Doctor: library 100/100.
