### PR TITLE
[codex] Clamp plain scrub gestures to plot bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Optional plot-bound scrub gestures.** `ScrubConfig.clampToPlot` (default
-  `false`) ignores gestures that start in the Y-axis gutter or beyond either
-  horizontal plot edge, then clamps an active crosshair to the left and right
-  plot edges. Supported by `LiveChart` and `LiveChartSeries`.
+  `false`) makes plain scrub ignore gestures that start in the Y-axis gutter or
+  beyond either horizontal plot edge, then clamps an active crosshair to the
+  left and right plot edges. Supported by `LiveChart` and `LiveChartSeries`.
 
 ## [4.12.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Optional plot-bound scrub gestures.** `ScrubConfig.clampToPlot` (default
+  `false`) ignores gestures that start in the Y-axis gutter or beyond either
+  horizontal plot edge, then clamps an active crosshair to the left and right
+  plot edges. Supported by `LiveChart` and `LiveChartSeries`.
+
 ## [4.12.0] - 2026-07-28
 
 ### Added

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -161,6 +161,7 @@ export default function ScrubbingScreen() {
   const [dimOpacity, setDimOpacity] = useState(0.3);
   const [dotMode, setDotMode] = useState<DotMode>("default");
   const [holdToScrub, setHoldToScrub] = useState(false);
+  const [clampToPlot, setClampToPlot] = useState(true);
   // Fade markers + reference lines out while scrubbing (scrub.hideOverlaysOnScrub).
   const [hideOverlays, setHideOverlays] = useState(true);
   // onGestureStart/onGestureEnd are JS-thread callbacks, so plain React state
@@ -234,6 +235,7 @@ export default function ScrubbingScreen() {
           tooltip: scrubMode !== "noTooltip",
           dimOpacity,
           panGestureDelay,
+          clampToPlot,
           hideOverlaysOnScrub: hideOverlays,
           // Tooltip layout knobs — apply to the built-in pill and the custom
           // render alike (placement + margin position either one).
@@ -397,6 +399,11 @@ export default function ScrubbingScreen() {
           label="Hold to scrub (250ms)"
           value={holdToScrub}
           onChange={setHoldToScrub}
+        />
+        <ToggleChip
+          label="Clamp to plot"
+          value={clampToPlot}
+          onChange={setClampToPlot}
         />
       </ControlRow>
       <ControlRow label="Overlays">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -358,7 +358,7 @@ interface ScrubConfig {
   tooltipMargin?: number; // gap (px) to the pinned plot edge (top for side/top, bottom for bottom); default 8
   tooltipShowValue?: boolean; tooltipShowTime?: boolean; // default both true; drop a row (e.g. date-only)
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0
-  clampToPlot?: boolean; // ignore starts beyond the plot's X bounds; clamp active drags to them; default false
+  clampToPlot?: boolean; // plain scrub: ignore starts beyond the plot's X bounds and clamp active drags; default false
   hideOverlaysOnScrub?: boolean; // fade markers + reference lines out while scrubbing; default false
 }
 interface PerSeriesTooltipConfig {

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -358,6 +358,7 @@ interface ScrubConfig {
   tooltipMargin?: number; // gap (px) to the pinned plot edge (top for side/top, bottom for bottom); default 8
   tooltipShowValue?: boolean; tooltipShowTime?: boolean; // default both true; drop a row (e.g. date-only)
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0
+  clampToPlot?: boolean; // ignore starts beyond the plot's X bounds; clamp active drags to them; default false
   hideOverlaysOnScrub?: boolean; // fade markers + reference lines out while scrubbing; default false
 }
 interface PerSeriesTooltipConfig {

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -44,12 +44,13 @@ horizontal padding:
 />
 ```
 
-A gesture that starts left or right of the plot is rejected before activation,
-remains available to competing or parent gestures, and does not fire
-`onGestureStart`. A gesture that starts within its horizontal bounds stays
+A plain-scrub gesture that starts left or right of the plot is rejected before
+activation, remains available to competing or parent gestures, and does not
+fire `onGestureStart`. A gesture that starts within its horizontal bounds stays
 active when the pointer moves beyond either edge; its crosshair remains clamped
-to the nearest plot edge. The option works on `LiveChart` and `LiveChartSeries`
-and defaults to `false` for backwards compatibility.
+to the nearest plot edge. Scrub-action gestures retain their existing behavior.
+The option works on `LiveChart` and `LiveChartSeries` and defaults to `false`
+for backwards compatibility.
 
 ## Customizing the tooltip
 

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -44,11 +44,12 @@ horizontal padding:
 />
 ```
 
-A gesture that starts left or right of the plot is ignored and does not fire
+A gesture that starts left or right of the plot is rejected before activation,
+remains available to competing or parent gestures, and does not fire
 `onGestureStart`. A gesture that starts within its horizontal bounds stays
 active when the pointer moves beyond either edge; its crosshair remains clamped
-to the nearest plot edge. The option works on `LiveChart` and
-`LiveChartSeries` and defaults to `false` for backwards compatibility.
+to the nearest plot edge. The option works on `LiveChart` and `LiveChartSeries`
+and defaults to `false` for backwards compatibility.
 
 ## Customizing the tooltip
 

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -31,6 +31,25 @@ Disable it with `scrub={false}`, or configure the crosshair and tooltip:
 />
 ```
 
+## Keeping scrubs inside the plot
+
+Set `clampToPlot` to keep the crosshair out of the Y-axis gutter and other
+horizontal padding:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  scrub={{ clampToPlot: true }}
+/>
+```
+
+A gesture that starts left or right of the plot is ignored and does not fire
+`onGestureStart`. A gesture that starts within its horizontal bounds stays
+active when the pointer moves beyond either edge; its crosshair remains clamped
+to the nearest plot edge. The option works on `LiveChart` and
+`LiveChartSeries` and defaults to `false` for backwards compatibility.
+
 ## Customizing the tooltip
 
 The default pill shows the value on the first row and the time on the second, offset to the side of

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1066,6 +1066,7 @@ function useLiveChartController({
       ? Math.max(effectivePadding.bottom, AXIS_GRAB_MIN_PX)
       : 0,
     scrollActive,
+    scrubCfg?.clampToPlot ?? false,
   );
 
   // Capture only the shared value in the worklets below. Referencing

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -463,6 +463,7 @@ function useLiveChartSeriesController({
           maxTime: tooltipMaxTime,
         }
       : undefined,
+    scrubCfg?.clampToPlot ?? false,
   );
 
   // Capture only the shared value in the worklets below. Referencing

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -175,6 +175,8 @@ export interface ResolvedScrubConfig {
   panGestureDelay: number;
   /** Fade markers + reference lines out while scrubbing. */
   hideOverlaysOnScrub: boolean;
+  /** Reject horizontally outside starts and clamp active scrub X to the plot. */
+  clampToPlot: boolean;
 }
 
 export interface ResolvedPerSeriesTooltipConfig {
@@ -676,6 +678,7 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltipShowTime: true,
   panGestureDelay: 0,
   hideOverlaysOnScrub: false,
+  clampToPlot: false,
 };
 
 const PER_SERIES_TOOLTIP_DEFAULTS: ResolvedPerSeriesTooltipConfig = {

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -175,7 +175,7 @@ export interface ResolvedScrubConfig {
   panGestureDelay: number;
   /** Fade markers + reference lines out while scrubbing. */
   hideOverlaysOnScrub: boolean;
-  /** Reject horizontally outside starts and clamp active scrub X to the plot. */
+  /** Reject outside plain-scrub starts and clamp active scrub X to the plot. */
   clampToPlot: boolean;
 }
 

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -30,12 +30,33 @@ export function clampPlotX(
   return Math.min(canvasWidth - padRight, Math.max(padLeft, x));
 }
 
+export interface ScrubHitSlop {
+  left?: number;
+  right?: number;
+  bottom?: number;
+}
+
+/** Build touch-down bounds for a scrub recognizer. */
+export function resolveScrubHitSlop(
+  padding: ChartPadding,
+  clampToPlot: boolean,
+  bottomExclude = 0,
+): ScrubHitSlop | undefined {
+  if (!clampToPlot && bottomExclude <= 0) return undefined;
+  return {
+    ...(clampToPlot
+      ? { left: -padding.left, right: -padding.right }
+      : {}),
+    ...(bottomExclude > 0 ? { bottom: -bottomExclude } : {}),
+  };
+}
+
 interface ScrubGestureValue<T> {
   get(): T;
   set(value: T): void;
 }
 
-/** Start plain scrubbing, rejecting a horizontally outside press when clamped. */
+/** Start plain scrubbing; the recognizer gates out-of-plot touch origins. */
 export function startPlainScrub(
   x: number,
   padding: ChartPadding,
@@ -47,8 +68,6 @@ export function startPlainScrub(
 ): boolean {
   "worklet";
   if (clampToPlot) {
-    const plotRight = canvasWidth - padding.right;
-    if (x < padding.left || x > plotRight) return false;
     scrubX.set(clampPlotX(x, padding.left, canvasWidth, padding.right));
   } else {
     scrubX.set(x);
@@ -58,7 +77,7 @@ export function startPlainScrub(
   return true;
 }
 
-/** Track plain scrubbing, clamping only gestures that were accepted in-plot. */
+/** Track plain scrubbing, clamping gestures accepted by the recognizer. */
 export function updatePlainScrub(
   x: number,
   padding: ChartPadding,
@@ -69,7 +88,6 @@ export function updatePlainScrub(
 ): void {
   "worklet";
   if (clampToPlot) {
-    // RNGH may still send updates after an outside start was rejected.
     if (!scrubActive.get()) return;
     scrubX.set(clampPlotX(x, padding.left, canvasWidth, padding.right));
   } else {

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -65,7 +65,7 @@ export function startPlainScrub(
   scrubX: ScrubGestureValue<number>,
   scrubActive: ScrubGestureValue<boolean>,
   gestureStarted: ScrubGestureValue<boolean>,
-): boolean {
+): void {
   "worklet";
   if (clampToPlot) {
     scrubX.set(clampPlotX(x, padding.left, canvasWidth, padding.right));
@@ -74,7 +74,6 @@ export function startPlainScrub(
   }
   scrubActive.set(true);
   gestureStarted.set(true);
-  return true;
 }
 
 /** Track plain scrubbing, clamping gestures accepted by the recognizer. */

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -19,6 +19,64 @@ export const SCRUB_ACTIVATE_X_PX = 20;
 /** Vertical travel that fails a plain scrub so a parent scroll gesture can win. */
 export const SCRUB_FAIL_Y_PX = 10;
 
+/** Clamp an X pixel to the plot's horizontal bounds. */
+export function clampPlotX(
+  x: number,
+  padLeft: number,
+  canvasWidth: number,
+  padRight: number,
+): number {
+  "worklet";
+  return Math.min(canvasWidth - padRight, Math.max(padLeft, x));
+}
+
+interface ScrubGestureValue<T> {
+  get(): T;
+  set(value: T): void;
+}
+
+/** Start plain scrubbing, rejecting a horizontally outside press when clamped. */
+export function startPlainScrub(
+  x: number,
+  padding: ChartPadding,
+  canvasWidth: number,
+  clampToPlot: boolean,
+  scrubX: ScrubGestureValue<number>,
+  scrubActive: ScrubGestureValue<boolean>,
+  gestureStarted: ScrubGestureValue<boolean>,
+): boolean {
+  "worklet";
+  if (clampToPlot) {
+    const plotRight = canvasWidth - padding.right;
+    if (x < padding.left || x > plotRight) return false;
+    scrubX.set(clampPlotX(x, padding.left, canvasWidth, padding.right));
+  } else {
+    scrubX.set(x);
+  }
+  scrubActive.set(true);
+  gestureStarted.set(true);
+  return true;
+}
+
+/** Track plain scrubbing, clamping only gestures that were accepted in-plot. */
+export function updatePlainScrub(
+  x: number,
+  padding: ChartPadding,
+  canvasWidth: number,
+  clampToPlot: boolean,
+  scrubX: ScrubGestureValue<number>,
+  scrubActive: ScrubGestureValue<boolean>,
+): void {
+  "worklet";
+  if (clampToPlot) {
+    // RNGH may still send updates after an outside start was rejected.
+    if (!scrubActive.get()) return;
+    scrubX.set(clampPlotX(x, padding.left, canvasWidth, padding.right));
+  } else {
+    scrubX.set(x);
+  }
+}
+
 /** Measure rendered text so the pill and its content share the same centre. */
 function measureTooltipTextWidth(
   font: SkFont,

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -193,6 +193,7 @@ export function useCrosshair(
   // tracks the price as the axis rescales instead of drifting under a fixed pixel.
   const lockPriceValue = useSharedValue<number | null>(null);
   const hasScrubAction = scrubAction != null;
+  const clampPlainScrubToPlot = clampToPlot && !hasScrubAction;
   const hasOnScrubAction = onScrubAction != null;
   const dismissOnTapOutside = scrubAction?.dismissOnTapOutside ?? false;
   const dismissOnAction = scrubAction?.dismissOnAction ?? false;
@@ -620,7 +621,7 @@ export function useCrosshair(
           e.x,
           padding,
           engine.canvasWidth.get(),
-          clampToPlot,
+          clampPlainScrubToPlot,
           scrubX,
           scrubActive,
           gestureStarted,
@@ -655,7 +656,7 @@ export function useCrosshair(
           e.x,
           padding,
           engine.canvasWidth.get(),
-          clampToPlot,
+          clampPlainScrubToPlot,
           scrubX,
           scrubActive,
         );
@@ -702,7 +703,7 @@ export function useCrosshair(
   // `shouldCancelWhenOutside(false)` keeps tracking beyond these bounds.
   const scrubHitSlop = resolveScrubHitSlop(
     padding,
-    clampToPlot && !hasScrubAction,
+    clampPlainScrubToPlot,
     scrubBottomExclude,
   );
   if (scrubHitSlop) gesture = gesture.hitSlop(scrubHitSlop);

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -152,8 +152,9 @@ export function useCrosshair(
    */
   scrollActive?: SharedValue<boolean>,
   /**
-   * Reject scrub starts beyond either horizontal plot edge and clamp active
-   * drags to those bounds. Default `false`.
+   * Reject plain-scrub starts beyond either horizontal plot edge and clamp
+   * active drags to those bounds. Scrub-action behavior is unchanged.
+   * Default `false`.
    */
   clampToPlot = false,
 ): CrosshairState {
@@ -615,7 +616,7 @@ export function useCrosshair(
         // also keeps a follow-on drag from showing a crosshair — no `onUpdate`
         // guard needed. (Plain-scrub counterpart of the scrub-action tap defer.)
         if (deferTapHit !== undefined && deferTapHit(e.x, e.y)) return;
-        const didStart = startPlainScrub(
+        startPlainScrub(
           e.x,
           padding,
           engine.canvasWidth.get(),
@@ -624,7 +625,6 @@ export function useCrosshair(
           scrubActive,
           gestureStarted,
         );
-        if (!didStart) return;
         if (hasOnGestureStart) scheduleOnRN(handleGestureStart);
       },
     )
@@ -702,7 +702,7 @@ export function useCrosshair(
   // `shouldCancelWhenOutside(false)` keeps tracking beyond these bounds.
   const scrubHitSlop = resolveScrubHitSlop(
     padding,
-    clampToPlot,
+    clampToPlot && !hasScrubAction,
     scrubBottomExclude,
   );
   if (scrubHitSlop) gesture = gesture.hitSlop(scrubHitSlop);

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -20,6 +20,7 @@ import type {
   ScrubPoint,
 } from "../types";
 import {
+  clampPlotX,
   computeActionBadgeLayout,
   computeCandleTooltipLayout,
   computeCrosshairOpacity,
@@ -35,7 +36,9 @@ import {
   SCRUB_ACTIVATE_X_PX,
   SCRUB_FAIL_Y_PX,
   snapPrice,
+  startPlainScrub,
   type CrosshairState,
+  updatePlainScrub,
 } from "./crosshairShared";
 import {
   delayedPanTouchCancelled,
@@ -63,18 +66,6 @@ const SCRUB_ACTION_TAP_SLOP = 10;
  * it. Overridden by an explicit `scrub.panGestureDelay`.
  */
 const SCRUB_ACTION_PRESS_HOLD_MS = 200;
-
-/** Clamp an X pixel to the plot's horizontal bounds. */
-/* istanbul ignore next -- worklet, called only from UI-thread gesture handlers */
-function clampPlotX(
-  x: number,
-  padLeft: number,
-  canvasWidth: number,
-  padRight: number,
-): number {
-  "worklet";
-  return Math.min(canvasWidth - padRight, Math.max(padLeft, x));
-}
 
 /** Clamp a Y pixel to the plot's vertical bounds. */
 /* istanbul ignore next -- worklet, called only from UI-thread gesture handlers */
@@ -159,6 +150,11 @@ export function useCrosshair(
    * mature into a scrub (see `delayedPanGuard.shouldStartDelayedPan`).
    */
   scrollActive?: SharedValue<boolean>,
+  /**
+   * Reject scrub starts beyond either horizontal plot edge and clamp active
+   * drags to those bounds. Default `false`.
+   */
+  clampToPlot = false,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -618,9 +614,16 @@ export function useCrosshair(
         // also keeps a follow-on drag from showing a crosshair — no `onUpdate`
         // guard needed. (Plain-scrub counterpart of the scrub-action tap defer.)
         if (deferTapHit !== undefined && deferTapHit(e.x, e.y)) return;
-        scrubX.set(e.x);
-        scrubActive.set(true);
-        gestureStarted.set(true);
+        const didStart = startPlainScrub(
+          e.x,
+          padding,
+          engine.canvasWidth.get(),
+          clampToPlot,
+          scrubX,
+          scrubActive,
+          gestureStarted,
+        );
+        if (!didStart) return;
         if (hasOnGestureStart) scheduleOnRN(handleGestureStart);
       },
     )
@@ -647,7 +650,14 @@ export function useCrosshair(
           }
           return;
         }
-        scrubX.set(e.x);
+        updatePlainScrub(
+          e.x,
+          padding,
+          engine.canvasWidth.get(),
+          clampToPlot,
+          scrubX,
+          scrubActive,
+        );
       },
     )
     .onFinalize(

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -33,6 +33,7 @@ import {
   HIDDEN_TIME_BADGE,
   HIDDEN_TOOLTIP,
   pointInRect,
+  resolveScrubHitSlop,
   SCRUB_ACTIVATE_X_PX,
   SCRUB_FAIL_Y_PX,
   snapPrice,
@@ -696,13 +697,15 @@ export function useCrosshair(
       .failOffsetY([-SCRUB_FAIL_Y_PX, SCRUB_FAIL_Y_PX]);
   }
 
-  // Axis-drag time-scroll: carve the bottom "time ruler" band out of the scrub's
-  // hit area so a drag starting there scrolls (the pan-scroll gesture owns it)
-  // and never trips the crosshair. `shouldCancelWhenOutside(false)` above keeps a
-  // scrub that *started* in the plot tracking on into the band.
-  if (scrubBottomExclude > 0) {
-    gesture = gesture.hitSlop({ bottom: -scrubBottomExclude });
-  }
+  // Restrict recognition by touch-down position. This rejects before ACTIVE,
+  // leaving outside starts to competing/parent gestures. Once accepted,
+  // `shouldCancelWhenOutside(false)` keeps tracking beyond these bounds.
+  const scrubHitSlop = resolveScrubHitSlop(
+    padding,
+    clampToPlot,
+    scrubBottomExclude,
+  );
+  if (scrubHitSlop) gesture = gesture.hitSlop(scrubHitSlop);
 
   // Tap: place/move the reticle, press the action badge, or dismiss the lock.
   // Composed ahead of the pan by the controller, so a tap is never swallowed.
@@ -777,11 +780,15 @@ export function useCrosshair(
         .maxDistance(SCRUB_ACTION_TAP_SLOP)
         .onEnd(handleActionTap)
     : undefined;
-  // Keep the axis-drag band scroll-only for taps too — a tap there shouldn't
-  // drop an order-ticket reticle.
-  if (tapGesture && scrubBottomExclude > 0) {
-    tapGesture = tapGesture.hitSlop({ bottom: -scrubBottomExclude });
-  }
+  // Keep the bottom axis scroll-only. Do not apply horizontal plot bounds here:
+  // the action badge is intentionally tappable in the right gutter.
+  const tapHitSlop = resolveScrubHitSlop(
+    padding,
+    false,
+    scrubBottomExclude,
+  );
+  if (tapGesture && tapHitSlop)
+    tapGesture = tapGesture.hitSlop(tapHitSlop);
 
   return {
     scrubX,

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -24,7 +24,9 @@ import {
   HIDDEN_TOOLTIP,
   SCRUB_ACTIVATE_X_PX,
   SCRUB_FAIL_Y_PX,
+  startPlainScrub,
   type CrosshairState,
+  updatePlainScrub,
 } from "./crosshairShared";
 import {
   delayedPanTouchCancelled,
@@ -65,6 +67,11 @@ export function useCrosshairSeries(
    */
   scrollActive?: SharedValue<boolean>,
   tooltip?: CrosshairSeriesTooltipOptions,
+  /**
+   * Reject scrub starts beyond either horizontal plot edge and clamp active
+   * drags to those bounds. Default `false`.
+   */
+  clampToPlot = false,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -290,9 +297,16 @@ export function useCrosshairSeries(
         )
           return;
         if (!enabled) return;
-        scrubX.set(e.x);
-        scrubActive.set(true);
-        gestureStarted.set(true);
+        const didStart = startPlainScrub(
+          e.x,
+          padding,
+          engine.canvasWidth.get(),
+          clampToPlot,
+          scrubX,
+          scrubActive,
+          gestureStarted,
+        );
+        if (!didStart) return;
         if (hasOnGestureStart) scheduleOnRN(handleGestureStart);
       },
     )
@@ -300,7 +314,14 @@ export function useCrosshairSeries(
       /* istanbul ignore next */ (e) => {
         "worklet";
         if (!enabled) return;
-        scrubX.set(e.x);
+        updatePlainScrub(
+          e.x,
+          padding,
+          engine.canvasWidth.get(),
+          clampToPlot,
+          scrubX,
+          scrubActive,
+        );
       },
     )
     .onFinalize(

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -22,6 +22,7 @@ import {
   computeScrubDotY,
   computeScrubTime,
   HIDDEN_TOOLTIP,
+  resolveScrubHitSlop,
   SCRUB_ACTIVATE_X_PX,
   SCRUB_FAIL_Y_PX,
   startPlainScrub,
@@ -346,6 +347,12 @@ export function useCrosshairSeries(
   gesture = gesture
     .activeOffsetX([-SCRUB_ACTIVATE_X_PX, SCRUB_ACTIVATE_X_PX])
     .failOffsetY([-SCRUB_FAIL_Y_PX, SCRUB_FAIL_Y_PX]);
+
+  // Gate by touch-down position so outside starts fail before activation and
+  // remain available to competing/parent gestures. Accepted pans keep tracking
+  // outside because `shouldCancelWhenOutside(false)` is set above.
+  const scrubHitSlop = resolveScrubHitSlop(padding, clampToPlot);
+  if (scrubHitSlop) gesture = gesture.hitSlop(scrubHitSlop);
 
   return {
     scrubX,

--- a/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairSeries.ts
@@ -298,7 +298,7 @@ export function useCrosshairSeries(
         )
           return;
         if (!enabled) return;
-        const didStart = startPlainScrub(
+        startPlainScrub(
           e.x,
           padding,
           engine.canvasWidth.get(),
@@ -307,7 +307,6 @@ export function useCrosshairSeries(
           scrubActive,
           gestureStarted,
         );
-        if (!didStart) return;
         if (hasOnGestureStart) scheduleOnRN(handleGestureStart);
       },
     )

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -899,10 +899,11 @@ export interface ScrubConfig {
    */
   hideOverlaysOnScrub?: boolean;
   /**
-   * Keep scrubbing inside the horizontal plot bounds. A gesture that starts in
-   * the Y-axis gutter (or beyond either horizontal edge) is ignored; one that
-   * starts inside remains active and clamps to the nearest plot edge while
-   * dragging. Default `false`.
+   * Keep plain scrubbing inside the horizontal plot bounds. A gesture that
+   * starts in the Y-axis gutter (or beyond either horizontal edge) is ignored;
+   * one that starts inside remains active and clamps to the nearest plot edge
+   * while dragging. Scrub-action gestures retain their existing behavior.
+   * Default `false`.
    */
   clampToPlot?: boolean;
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -898,6 +898,13 @@ export interface ScrubConfig {
    * `false` / omitted keeps the overlays visible while scrubbing (default).
    */
   hideOverlaysOnScrub?: boolean;
+  /**
+   * Keep scrubbing inside the horizontal plot bounds. A gesture that starts in
+   * the Y-axis gutter (or beyond either horizontal edge) is ignored; one that
+   * starts inside remains active and clamps to the nearest plot edge while
+   * dragging. Default `false`.
+   */
+  clampToPlot?: boolean;
 }
 
 /**

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -1175,6 +1175,7 @@ describe("useCrosshair (hook)", () => {
         true,
         8,
         24,
+        undefined,
         true,
       ),
     );

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -1,12 +1,17 @@
 import { type SkFont } from "@shopify/react-native-skia";
-import { renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import { interpolateAtTime } from "../../src/math/interpolate";
 import { resolveTheme } from "../../src/theme";
 import type { SingleEngineState } from "../../src/core/useLiveChartEngine";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 import { resolveScrubAction } from "../../src/core/resolveConfig";
-import { computeScrubDotY } from "../../src/hooks/crosshairShared";
+import {
+  clampPlotX,
+  computeScrubDotY,
+  startPlainScrub,
+  updatePlainScrub,
+} from "../../src/hooks/crosshairShared";
 import {
   computeCandleTooltipLayout,
   computeCrosshairOpacity,
@@ -19,26 +24,52 @@ import {
 } from "../../src/hooks/useCrosshair";
 
 jest.mock("react-native-gesture-handler", () => {
-  const makeGesture = () => {
-    const g: Record<string, unknown> = { config: {} };
+  let lastPanCalls: Record<string, unknown[]>;
+  const makeGesture = (
+    capture?: (calls: Record<string, unknown[]>) => void,
+  ) => {
+    const calls: Record<string, unknown[]> = {};
+    capture?.(calls);
+    const g: Record<string, unknown> = { config: calls };
     const proxy: typeof g = new Proxy(g, {
       get: (target, key) => {
         if (key in target) return target[key as string];
         return (...args: unknown[]) => {
-          (target.config as Record<string, unknown[]>)[String(key)] = args;
+          calls[String(key)] = args;
           return proxy;
         };
       },
     });
     return proxy;
   };
-  return { Gesture: { Pan: makeGesture, Tap: makeGesture } };
+  return {
+    Gesture: {
+      Pan: () => makeGesture((calls) => {
+        lastPanCalls = calls;
+      }),
+      Tap: () => makeGesture(),
+    },
+    __getLastPanCalls: () => lastPanCalls,
+  };
 });
 
 type GestureConfig = Record<string, unknown[]>;
 
 function getGestureConfig(gesture: unknown): GestureConfig {
   return (gesture as { config: GestureConfig }).config;
+}
+
+function getLastPanHandlers() {
+  const calls = (
+    jest.requireMock("react-native-gesture-handler") as {
+      __getLastPanCalls: () => Record<string, unknown[]>;
+    }
+  ).__getLastPanCalls();
+  return (
+    Object.fromEntries(
+      Object.entries(calls).map(([key, args]) => [key, args[0]]),
+    ) as Record<string, (event?: { x: number; y: number }) => void>
+  );
 }
 
 const palette = resolveTheme("#3b82f6", "dark");
@@ -105,6 +136,98 @@ describe("computeScrubTime", () => {
   it("handles scrubX before the left edge (extrapolates)", () => {
     const result = computeScrubTime(true, 0, padding, 400, 1000, 30);
     expect(result).toBeLessThan(970);
+  });
+});
+
+describe("clampPlotX", () => {
+  it("clamps to the left and right plot edges", () => {
+    expect(clampPlotX(-20, padding.left, 400, padding.right)).toBe(padding.left);
+    expect(clampPlotX(390, padding.left, 400, padding.right)).toBe(
+      400 - padding.right,
+    );
+  });
+
+  it("preserves an X inside the plot", () => {
+    expect(clampPlotX(100, padding.left, 400, padding.right)).toBe(100);
+  });
+});
+
+describe("plain scrub gesture bounds", () => {
+  const mutable = <T,>(initial: T) => {
+    let value = initial;
+    return {
+      get: () => value,
+      set: (next: T) => {
+        value = next;
+      },
+    };
+  };
+
+  it("preserves legacy outside coordinates when clamping is disabled", () => {
+    const scrubX = mutable(-1);
+    const scrubActive = mutable(false);
+    const gestureStarted = mutable(false);
+
+    expect(
+      startPlainScrub(
+        0,
+        padding,
+        400,
+        false,
+        scrubX,
+        scrubActive,
+        gestureStarted,
+      ),
+    ).toBe(true);
+    expect(scrubX.get()).toBe(0);
+    expect(scrubActive.get()).toBe(true);
+    expect(gestureStarted.get()).toBe(true);
+  });
+
+  it("rejects outside starts and ignores their follow-on updates", () => {
+    const scrubX = mutable(-1);
+    const scrubActive = mutable(false);
+    const gestureStarted = mutable(false);
+
+    expect(
+      startPlainScrub(
+        390,
+        padding,
+        400,
+        true,
+        scrubX,
+        scrubActive,
+        gestureStarted,
+      ),
+    ).toBe(false);
+    updatePlainScrub(100, padding, 400, true, scrubX, scrubActive);
+
+    expect(scrubX.get()).toBe(-1);
+    expect(scrubActive.get()).toBe(false);
+    expect(gestureStarted.get()).toBe(false);
+  });
+
+  it("clamps a scrub started inside to both plot edges", () => {
+    const scrubX = mutable(-1);
+    const scrubActive = mutable(false);
+    const gestureStarted = mutable(false);
+
+    expect(
+      startPlainScrub(
+        100,
+        padding,
+        400,
+        true,
+        scrubX,
+        scrubActive,
+        gestureStarted,
+      ),
+    ).toBe(true);
+    updatePlainScrub(-20, padding, 400, true, scrubX, scrubActive);
+    expect(scrubX.get()).toBe(padding.left);
+
+    updatePlainScrub(390, padding, 400, true, scrubX, scrubActive);
+    expect(scrubX.get()).toBe(400 - padding.right);
   });
 });
 
@@ -918,6 +1041,42 @@ describe("useCrosshair (hook)", () => {
       });
     },
   );
+
+  it("rejects outside starts when plot clamping is enabled", () => {
+    const onGestureStart = jest.fn();
+    const engine = makeEngine();
+    renderHook(() =>
+      useCrosshair(
+        engine,
+        padding,
+        palette,
+        formatValue,
+        formatTime,
+        font,
+        true,
+        undefined,
+        undefined,
+        0,
+        onGestureStart,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "side",
+        true,
+        true,
+        8,
+        0,
+        undefined,
+        true,
+      ),
+    );
+    const handlers = getLastPanHandlers();
+
+    act(() => handlers.onStart?.({ x: 0, y: 100 }));
+    expect(onGestureStart).not.toHaveBeenCalled();
+  });
 
   it("only configures a long-press modifier for a positive delay", () => {
     const engine = makeEngine();

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -175,17 +175,15 @@ describe("plain scrub gesture bounds", () => {
     const scrubActive = mutable(false);
     const gestureStarted = mutable(false);
 
-    expect(
-      startPlainScrub(
-        0,
-        padding,
-        400,
-        false,
-        scrubX,
-        scrubActive,
-        gestureStarted,
-      ),
-    ).toBe(true);
+    startPlainScrub(
+      0,
+      padding,
+      400,
+      false,
+      scrubX,
+      scrubActive,
+      gestureStarted,
+    );
     expect(scrubX.get()).toBe(0);
     expect(scrubActive.get()).toBe(true);
     expect(gestureStarted.get()).toBe(true);
@@ -196,17 +194,15 @@ describe("plain scrub gesture bounds", () => {
     const scrubActive = mutable(false);
     const gestureStarted = mutable(false);
 
-    expect(
-      startPlainScrub(
-        390,
-        padding,
-        400,
-        true,
-        scrubX,
-        scrubActive,
-        gestureStarted,
-      ),
-    ).toBe(true);
+    startPlainScrub(
+      390,
+      padding,
+      400,
+      true,
+      scrubX,
+      scrubActive,
+      gestureStarted,
+    );
     expect(scrubX.get()).toBe(400 - padding.right);
     expect(scrubActive.get()).toBe(true);
     expect(gestureStarted.get()).toBe(true);
@@ -217,17 +213,15 @@ describe("plain scrub gesture bounds", () => {
     const scrubActive = mutable(false);
     const gestureStarted = mutable(false);
 
-    expect(
-      startPlainScrub(
-        100,
-        padding,
-        400,
-        true,
-        scrubX,
-        scrubActive,
-        gestureStarted,
-      ),
-    ).toBe(true);
+    startPlainScrub(
+      100,
+      padding,
+      400,
+      true,
+      scrubX,
+      scrubActive,
+      gestureStarted,
+    );
     updatePlainScrub(-20, padding, 400, true, scrubX, scrubActive);
     expect(scrubX.get()).toBe(padding.left);
 
@@ -1156,7 +1150,7 @@ describe("useCrosshair (hook)", () => {
     expect(onScrubAction).not.toHaveBeenCalled();
   });
 
-  it("keeps the action gutter tappable while excluding the bottom band", () => {
+  it("keeps action Pan and Tap gutter-accessible while excluding the bottom band", () => {
     const engine = makeEngine();
     renderHook(() =>
       useCrosshair(
@@ -1185,6 +1179,7 @@ describe("useCrosshair (hook)", () => {
       ),
     );
 
+    expect(getLastPanCalls().hitSlop?.[0]).toEqual({ bottom: -24 });
     expect(getLastTapCalls().hitSlop?.[0]).toEqual({ bottom: -24 });
   });
 });

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -1,5 +1,5 @@
 import { type SkFont } from "@shopify/react-native-skia";
-import { act, renderHook } from "@testing-library/react-native";
+import { renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import { interpolateAtTime } from "../../src/math/interpolate";
 import { resolveTheme } from "../../src/theme";
@@ -25,6 +25,7 @@ import {
 
 jest.mock("react-native-gesture-handler", () => {
   let lastPanCalls: Record<string, unknown[]>;
+  let lastTapCalls: Record<string, unknown[]>;
   const makeGesture = (
     capture?: (calls: Record<string, unknown[]>) => void,
   ) => {
@@ -47,9 +48,12 @@ jest.mock("react-native-gesture-handler", () => {
       Pan: () => makeGesture((calls) => {
         lastPanCalls = calls;
       }),
-      Tap: () => makeGesture(),
+      Tap: () => makeGesture((calls) => {
+        lastTapCalls = calls;
+      }),
     },
     __getLastPanCalls: () => lastPanCalls,
+    __getLastTapCalls: () => lastTapCalls,
   };
 });
 
@@ -59,17 +63,20 @@ function getGestureConfig(gesture: unknown): GestureConfig {
   return (gesture as { config: GestureConfig }).config;
 }
 
-function getLastPanHandlers() {
-  const calls = (
+function getLastPanCalls() {
+  return (
     jest.requireMock("react-native-gesture-handler") as {
       __getLastPanCalls: () => Record<string, unknown[]>;
     }
   ).__getLastPanCalls();
+}
+
+function getLastTapCalls() {
   return (
-    Object.fromEntries(
-      Object.entries(calls).map(([key, args]) => [key, args[0]]),
-    ) as Record<string, (event?: { x: number; y: number }) => void>
-  );
+    jest.requireMock("react-native-gesture-handler") as {
+      __getLastTapCalls: () => Record<string, unknown[]>;
+    }
+  ).__getLastTapCalls();
 }
 
 const palette = resolveTheme("#3b82f6", "dark");
@@ -184,7 +191,7 @@ describe("plain scrub gesture bounds", () => {
     expect(gestureStarted.get()).toBe(true);
   });
 
-  it("rejects outside starts and ignores their follow-on updates", () => {
+  it("clamps an activation outside after its touch-down was accepted", () => {
     const scrubX = mutable(-1);
     const scrubActive = mutable(false);
     const gestureStarted = mutable(false);
@@ -199,12 +206,10 @@ describe("plain scrub gesture bounds", () => {
         scrubActive,
         gestureStarted,
       ),
-    ).toBe(false);
-    updatePlainScrub(100, padding, 400, true, scrubX, scrubActive);
-
-    expect(scrubX.get()).toBe(-1);
-    expect(scrubActive.get()).toBe(false);
-    expect(gestureStarted.get()).toBe(false);
+    ).toBe(true);
+    expect(scrubX.get()).toBe(400 - padding.right);
+    expect(scrubActive.get()).toBe(true);
+    expect(gestureStarted.get()).toBe(true);
   });
 
   it("clamps a scrub started inside to both plot edges", () => {
@@ -1042,8 +1047,7 @@ describe("useCrosshair (hook)", () => {
     },
   );
 
-  it("rejects outside starts when plot clamping is enabled", () => {
-    const onGestureStart = jest.fn();
+  it("combines horizontal plot and bottom-band recognition bounds", () => {
     const engine = makeEngine();
     renderHook(() =>
       useCrosshair(
@@ -1057,7 +1061,7 @@ describe("useCrosshair (hook)", () => {
         undefined,
         undefined,
         0,
-        onGestureStart,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1067,15 +1071,17 @@ describe("useCrosshair (hook)", () => {
         true,
         true,
         8,
-        0,
+        24,
         undefined,
         true,
       ),
     );
-    const handlers = getLastPanHandlers();
 
-    act(() => handlers.onStart?.({ x: 0, y: 100 }));
-    expect(onGestureStart).not.toHaveBeenCalled();
+    expect(getLastPanCalls().hitSlop?.[0]).toEqual({
+      left: -padding.left,
+      right: -padding.right,
+      bottom: -24,
+    });
   });
 
   it("only configures a long-press modifier for a positive delay", () => {
@@ -1148,6 +1154,38 @@ describe("useCrosshair (hook)", () => {
     expect(config.failOffsetY).toBeUndefined();
     // The callback fires only from the UI-thread tap worklet (istanbul-ignored).
     expect(onScrubAction).not.toHaveBeenCalled();
+  });
+
+  it("keeps the action gutter tappable while excluding the bottom band", () => {
+    const engine = makeEngine();
+    renderHook(() =>
+      useCrosshair(
+        engine,
+        padding,
+        palette,
+        formatValue,
+        formatTime,
+        font,
+        true,
+        undefined,
+        undefined,
+        0,
+        undefined,
+        undefined,
+        resolveScrubAction(true),
+        undefined,
+        undefined,
+        undefined,
+        "side",
+        true,
+        true,
+        8,
+        24,
+        true,
+      ),
+    );
+
+    expect(getLastTapCalls().hitSlop?.[0]).toEqual({ bottom: -24 });
   });
 });
 

--- a/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
@@ -1,5 +1,5 @@
 import { type SkFont } from "@shopify/react-native-skia";
-import { renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import { MAX_MULTI_SERIES } from "../../src/constants";
 import type { MultiEngineState } from "../../src/core/useLiveChartEngine";
@@ -19,26 +19,45 @@ import { useCrosshairSeries } from "../../src/hooks/useCrosshairSeries";
 import { withSharedValueAccessors } from "../support/sharedValueMock";
 
 jest.mock("react-native-gesture-handler", () => {
+  let lastPanCalls: Record<string, unknown[]>;
   const makeGesture = () => {
-    const g: Record<string, unknown> = { config: {} };
+    const calls: Record<string, unknown[]> = {};
+    lastPanCalls = calls;
+    const g: Record<string, unknown> = { config: calls };
     const proxy: typeof g = new Proxy(g, {
       get: (target, key) => {
         if (key in target) return target[key as string];
         return (...args: unknown[]) => {
-          (target.config as Record<string, unknown[]>)[String(key)] = args;
+          calls[String(key)] = args;
           return proxy;
         };
       },
     });
     return proxy;
   };
-  return { Gesture: { Pan: makeGesture } };
+  return {
+    Gesture: { Pan: makeGesture },
+    __getLastPanCalls: () => lastPanCalls,
+  };
 });
 
 type GestureConfig = Record<string, unknown[]>;
 
 function getGestureConfig(gesture: unknown): GestureConfig {
   return (gesture as { config: GestureConfig }).config;
+}
+
+function getLastPanHandlers() {
+  const calls = (
+    jest.requireMock("react-native-gesture-handler") as {
+      __getLastPanCalls: () => Record<string, unknown[]>;
+    }
+  ).__getLastPanCalls();
+  return (
+    Object.fromEntries(
+      Object.entries(calls).map(([key, args]) => [key, args[0]]),
+    ) as Record<string, (event?: { x: number; y: number }) => void>
+  );
 }
 
 const font = {
@@ -593,6 +612,29 @@ describe("useCrosshairSeries (hook)", () => {
       });
     },
   );
+
+  it("rejects outside starts when plot clamping is enabled", () => {
+    const onGestureStart = jest.fn();
+    const engine = makeEngine();
+    renderHook(() =>
+      useCrosshairSeries(
+        engine,
+        padding,
+        true,
+        undefined,
+        0,
+        onGestureStart,
+        undefined,
+        undefined,
+        undefined,
+        true,
+      ),
+    );
+    const handlers = getLastPanHandlers();
+
+    act(() => handlers.onStart?.({ x: 390, y: 100 }));
+    expect(onGestureStart).not.toHaveBeenCalled();
+  });
 
   it("only configures a long-press modifier for a positive delay", () => {
     const engine = makeEngine({

--- a/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairSeries.test.ts
@@ -1,5 +1,5 @@
 import { type SkFont } from "@shopify/react-native-skia";
-import { act, renderHook } from "@testing-library/react-native";
+import { renderHook } from "@testing-library/react-native";
 import { Platform } from "react-native";
 import { MAX_MULTI_SERIES } from "../../src/constants";
 import type { MultiEngineState } from "../../src/core/useLiveChartEngine";
@@ -47,17 +47,12 @@ function getGestureConfig(gesture: unknown): GestureConfig {
   return (gesture as { config: GestureConfig }).config;
 }
 
-function getLastPanHandlers() {
-  const calls = (
+function getLastPanCalls() {
+  return (
     jest.requireMock("react-native-gesture-handler") as {
       __getLastPanCalls: () => Record<string, unknown[]>;
     }
   ).__getLastPanCalls();
-  return (
-    Object.fromEntries(
-      Object.entries(calls).map(([key, args]) => [key, args[0]]),
-    ) as Record<string, (event?: { x: number; y: number }) => void>
-  );
 }
 
 const font = {
@@ -613,8 +608,7 @@ describe("useCrosshairSeries (hook)", () => {
     },
   );
 
-  it("rejects outside starts when plot clamping is enabled", () => {
-    const onGestureStart = jest.fn();
+  it("restricts scrub recognition to horizontal plot bounds", () => {
     const engine = makeEngine();
     renderHook(() =>
       useCrosshairSeries(
@@ -623,17 +617,18 @@ describe("useCrosshairSeries (hook)", () => {
         true,
         undefined,
         0,
-        onGestureStart,
+        undefined,
         undefined,
         undefined,
         undefined,
         true,
       ),
     );
-    const handlers = getLastPanHandlers();
 
-    act(() => handlers.onStart?.({ x: 390, y: 100 }));
-    expect(onGestureStart).not.toHaveBeenCalled();
+    expect(getLastPanCalls().hitSlop?.[0]).toEqual({
+      left: -padding.left,
+      right: -padding.right,
+    });
   });
 
   it("only configures a long-press modifier for a positive delay", () => {

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -531,6 +531,7 @@ describe("resolveScrub", () => {
       tooltipShowTime: true,
       panGestureDelay: 0,
       hideOverlaysOnScrub: false,
+      clampToPlot: false,
     });
   });
 
@@ -546,6 +547,7 @@ describe("resolveScrub", () => {
       tooltipShowTime: true,
       panGestureDelay: 0,
       hideOverlaysOnScrub: false,
+      clampToPlot: false,
     });
   });
 
@@ -561,6 +563,7 @@ describe("resolveScrub", () => {
       tooltipShowTime: true,
       panGestureDelay: 0,
       hideOverlaysOnScrub: false,
+      clampToPlot: false,
     });
   });
 
@@ -586,6 +589,7 @@ describe("resolveScrub", () => {
       tooltipShowTime: true,
       panGestureDelay: 300,
       hideOverlaysOnScrub: false,
+      clampToPlot: false,
     });
   });
 
@@ -594,6 +598,11 @@ describe("resolveScrub", () => {
     expect(
       resolveScrub({ hideOverlaysOnScrub: true })?.hideOverlaysOnScrub,
     ).toBe(true);
+  });
+
+  it("defaults clampToPlot to false and carries it when set", () => {
+    expect(resolveScrub(true)?.clampToPlot).toBe(false);
+    expect(resolveScrub({ clampToPlot: true })?.clampToPlot).toBe(true);
   });
 
   it("carries a custom tooltipBorderRadius", () => {


### PR DESCRIPTION
## Summary

Adds opt-in `ScrubConfig.clampToPlot` support to `LiveChart` and
`LiveChartSeries`.

With `clampToPlot: true`:

- Touches that begin left or right of the plot fail before the scrub activates.
- Outside starts remain available to competing or parent gestures.
- `scrubActive` and `onGestureStart` are not triggered for rejected starts.
- A scrub accepted inside remains active beyond either edge and its crosshair
  clamps to the nearest plot boundary.

The option defaults to `false`, preserving existing behavior.

## Why

Plain scrubbing stored the raw touch X. A gutter press could therefore place the
crosshair over Y-axis labels and fire scrub callbacks, unlike the already
clamped scrub-action path.

## Gesture details

The plain-scrub Pan recognizer limits the touch-down region before activation,
including when a press delay is configured. Once accepted,
`shouldCancelWhenOutside(false)` keeps the gesture tracking across the edges.
The horizontal bounds compose with the existing bottom-axis exclusion.

Scrub-action Pan and Tap gestures retain their existing horizontal behavior,
including access to the right-gutter action badge; the existing bottom-axis
exclusion still applies.

## Documentation and tests

- Adds a demo toggle.
- Updates `ScrubConfig` JSDoc, API reference, guide, and changelog.
- Covers defaults, single- and multi-series bounds, edge clamping, recognizer
  bounds, bottom-axis composition, and action-badge access.

## Validation

- Typecheck passed.
- Lint passed.
- Jest: 97 suites passed; 1,404 tests passed; 5 skipped.
- Library build passed.
- React Doctor: library 100/100.
