### PR TITLE
Fix per-series tooltip layering over custom reference lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   beyond either horizontal plot edge, then clamps an active crosshair to the
   left and right plot edges. Supported by `LiveChart` and `LiveChartSeries`.
 
+### Fixed
+
+- **Per-series scrub tooltips now stay above custom reference-line tags.**
+  `LiveChartSeries` renders the UI-thread tooltip in a transparent top layer so
+  translucent `renderReferenceLine` and `renderOffAxisReferenceLine` views no
+  longer expose a mixed stacking order between the time pill, connector, and
+  badge.
+
 ## [4.12.0] - 2026-07-28
 
 ### Added

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -1095,19 +1095,6 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
             {/* Per-series value labels on top of the scrub dim so the dim never
                 clips them (they track each series' live value, not the scrub). */}
             <SeriesValueLabelLayer model={model} />
-
-            {seriesTooltipCfg && (
-              <PerSeriesTooltipOverlay
-                layout={crosshair.tooltipLayout}
-                font={skiaFont}
-                palette={palette}
-                config={seriesTooltipCfg}
-                seriesCount={activeSeriesCount}
-                tooltipBackground={scrubCfg?.tooltipBackground}
-                tooltipColor={scrubCfg?.tooltipColor}
-                tooltipBorderColor={scrubCfg?.tooltipBorderColor}
-              />
-            )}
           </Canvas>
 
           {/* RN labels floated over the canvas (sibling of <Canvas>, an RN
@@ -1167,6 +1154,31 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 />
               )}
             </Animated.View>
+          )}
+
+          {/* A dedicated transparent Canvas keeps the UI-thread tooltip above
+              custom RN annotations. Rendering it in the primary Canvas would
+              put every post-Canvas `renderReferenceLine` sibling above it and
+              produce mixed stacking through translucent custom tags. */}
+          {seriesTooltipCfg && (
+            <View
+              testID="live-chart-series-tooltip-overlay"
+              pointerEvents="none"
+              style={StyleSheet.absoluteFill}
+            >
+              <Canvas style={StyleSheet.absoluteFill}>
+                <PerSeriesTooltipOverlay
+                  layout={crosshair.tooltipLayout}
+                  font={skiaFont}
+                  palette={palette}
+                  config={seriesTooltipCfg}
+                  seriesCount={activeSeriesCount}
+                  tooltipBackground={scrubCfg?.tooltipBackground}
+                  tooltipColor={scrubCfg?.tooltipColor}
+                  tooltipBorderColor={scrubCfg?.tooltipBorderColor}
+                />
+              </Canvas>
+            </View>
           )}
 
           {/* Custom consumer overlay — topmost RN sibling with the live plot

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -194,6 +194,51 @@ describe("LiveChartSeries", () => {
     ]);
   });
 
+  it("renders the per-series tooltip above custom reference-line tags", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          scrub={{ seriesTooltip: { alwaysShow: true } }}
+          referenceLines={[
+            {
+              value: 99,
+              label: "Target",
+              excludeFromRange: true,
+            },
+          ]}
+          renderReferenceLine={() => <View testID="series-target" />}
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await screen.findByTestId("series-target");
+    const tooltipCanvas = screen.getByTestId(
+      "live-chart-series-tooltip-overlay",
+    );
+    const tree = JSON.stringify(screen.toJSON());
+
+    expect(tree.indexOf("series-target")).toBeLessThan(
+      tree.indexOf("live-chart-series-tooltip-overlay"),
+    );
+    expect(tooltipCanvas.props.pointerEvents).toBe("none");
+    expect(screen.UNSAFE_getAllByType(PerSeriesTooltipOverlay)).toHaveLength(1);
+  });
+
   it("replaces only an off-axis tag while preserving the in-range fallback", async () => {
     const initial: SeriesConfig[] = [
       {


### PR DESCRIPTION
## What

- move the per-series Skia tooltip into a dedicated transparent top canvas
- keep custom reference-line tags below the time/series pills while leaving the consumer `renderOverlay` layer topmost
- make the tooltip layer non-interactive so chart gestures continue through it
- add a regression test for the active per-series tooltip/custom-tag stacking order
- document the fix in the changelog

## Why

`LiveChartSeries` previously drew its tooltip inside the primary canvas. Custom reference-line tags are React Native siblings rendered after that canvas, so translucent tags could reveal a mixed order where the tooltip connector and pills appeared partly behind the tag.

## Impact

The change only affects per-series tooltip composition. Chart paths and live dots remain in the primary canvas below custom reference-line tags, and built-in reference-line rendering is unchanged.

## Verification

- `npm run verify` — 98 suites passed, 1,422 tests passed, 5 skipped
- `npx react-doctor@latest --verbose --diff` — 100/100 for the example app and library
- agent-device QA on iPhone 17 simulator, including the overlapping tooltip/custom-tag state and restored demo state

Fixes #239