### PR TITLE
Make crosshair fade distance and line cap configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Configurable scrub crosshair geometry and edge fade.** `ScrubConfig` now
   accepts `crosshairStrokeWidth` (default `1`), `crosshairOvershoot` (default
-  `0`; negative values clamp to `0`), and `crosshairFade` (default `true`) on
-  `LiveChart` and `LiveChartSeries`. Disabling the crosshair fade keeps the line,
-  selection dot, and tooltip opaque near the live edge without changing the
-  trailing-content dim fade.
+  `0`; negative values clamp to `0`), `crosshairFade` (default `true`),
+  `crosshairFadeDistance` (default `4`; negative values clamp to `0`), and
+  `crosshairLineCap` (`"butt" | "round" | "square"`) on `LiveChart` and
+  `LiveChartSeries`. The distance applies to the visible line, selection dot,
+  and tooltip without changing the trailing-content dim fade; omitting the cap
+  preserves existing rendering.
 
 - **Optional plot-bound scrub gestures.** `ScrubConfig.clampToPlot` (default
   `false`) makes plain scrub ignore gestures that start in the Y-axis gutter or

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -39,6 +39,8 @@ const SCRUB_OPTIONS: { value: ScrubMode; label: string }[] = [
 ];
 
 type TooltipPlacement = NonNullable<ScrubConfig["tooltipPlacement"]>;
+type CrosshairLineCap = NonNullable<ScrubConfig["crosshairLineCap"]>;
+type CrosshairLineCapChoice = "default" | CrosshairLineCap;
 
 // Placement applies to BOTH the built-in pill and a custom `renderTooltip` —
 // the chart positions either one on the UI thread per `tooltipPlacement`.
@@ -55,6 +57,22 @@ const MARGIN_OPTIONS: { value: number; label: string }[] = [
   { value: 8, label: "8" },
   { value: 24, label: "24" },
   { value: 48, label: "48" },
+];
+
+const FADE_DISTANCE_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: "0px" },
+  { value: 4, label: "4px (default)" },
+  { value: 12, label: "12px" },
+];
+
+const LINE_CAP_OPTIONS: {
+  value: CrosshairLineCapChoice;
+  label: string;
+}[] = [
+  { value: "default", label: "Default" },
+  { value: "butt", label: "Butt" },
+  { value: "round", label: "Round" },
+  { value: "square", label: "Square" },
 ];
 
 type DisplayMode = "line" | "candle";
@@ -162,6 +180,9 @@ export default function ScrubbingScreen() {
   const [crosshairOvershootEnabled, setCrosshairOvershootEnabled] =
     useState(false);
   const [crosshairFade, setCrosshairFade] = useState(true);
+  const [crosshairFadeDistance, setCrosshairFadeDistance] = useState(4);
+  const [crosshairLineCap, setCrosshairLineCap] =
+    useState<CrosshairLineCapChoice>("default");
   const [dimOpacity, setDimOpacity] = useState(0.3);
   const [dotMode, setDotMode] = useState<DotMode>("default");
   const [holdToScrub, setHoldToScrub] = useState(false);
@@ -256,6 +277,9 @@ export default function ScrubbingScreen() {
           crosshairStrokeWidth: thickCrosshair ? 3 : 1,
           crosshairOvershoot: crosshairOvershootEnabled ? 6 : 0,
           crosshairFade,
+          crosshairFadeDistance,
+          crosshairLineCap:
+            crosshairLineCap === "default" ? undefined : crosshairLineCap,
           // The "Styled" toggle recolors the built-in pill + crosshair line.
           ...(styledTooltip
             ? {
@@ -416,6 +440,18 @@ export default function ScrubbingScreen() {
           onChange={setCrosshairFade}
         />
       </ControlRow>
+      <ChipRow
+        label="Crosshair fade distance"
+        options={FADE_DISTANCE_OPTIONS}
+        value={crosshairFadeDistance}
+        onChange={setCrosshairFadeDistance}
+      />
+      <ChipRow
+        label="Crosshair line cap"
+        options={LINE_CAP_OPTIONS}
+        value={crosshairLineCap}
+        onChange={setCrosshairLineCap}
+      />
       <ControlRow label="Gesture">
         <ToggleChip
           label="Hold to scrub (250ms)"

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -106,6 +106,8 @@ default off.
   time pill. The existing `scrub.tooltip={false}` switch remains the master
   tooltip control and also suppresses the per-series pills. See
   [Multi-series tooltips](/guides/multi-series#per-series-scrub-tooltip).
+  `crosshairFadeDistance` and `crosshairLineCap` style the visible guide,
+  selection dot, and tooltip consistently with `LiveChart`.
 </ParamField>
 
 <ParamField body="selectionDot" type="boolean | SelectionDotConfig" default="false">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -273,7 +273,10 @@ provided; everything else has a default.
 ## Scrubbing
 
 <ParamField body="scrub" type="boolean | ScrubConfig" default="true">
-  Crosshair scrubbing on drag.
+  Crosshair scrubbing on drag. `crosshairFadeDistance` controls the visible
+  line/dot/tooltip fade near the live edge, and `crosshairLineCap` selects a
+  `"butt"`, `"round"`, or `"square"` vertical-line cap. See
+  [Scrubbing](/guides/scrubbing#crosshair-width-line-cap-overshoot-and-edge-fade).
 </ParamField>
 
 <ParamField body="selectionDot" type="boolean | SelectionDotConfig" default="true">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -354,6 +354,8 @@ interface ScrubConfig {
   crosshairStrokeWidth?: number; // line width in px; default 1
   crosshairOvershoot?: number; // extend past top/bottom in px; preserves a custom top-tooltip stop; negatives clamp to 0; default 0
   crosshairFade?: boolean; // fade near the live edge; default true
+  crosshairFadeDistance?: number; // visible line/dot/tooltip fade distance in px; negatives clamp to 0; default 4
+  crosshairLineCap?: "butt" | "round" | "square"; // omit to preserve the existing Skia default
   crosshairDash?: number[] | boolean; // dash the crosshair line; true = [4,4], or explicit [on, off, …] px
   tooltipBackground?: string; tooltipColor?: string; tooltipBorderColor?: string;
   tooltipBorderRadius?: number; // pill corner radius; default 5

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -239,16 +239,21 @@ finer control. Omitting it (or `false`) keeps the solid line.
 
 Pairs with `crosshairLineColor` for the stroke color, and works on `LiveChartSeries` too.
 
-## Crosshair width, overshoot, and edge fade
+## Crosshair width, line cap, overshoot, and edge fade
 
 Use `crosshairStrokeWidth` to change the line width and `crosshairOvershoot` to extend it past the
 plot's top and bottom edges. Both values are pixels; their defaults are `1` and `0`. Negative
 overshoot values are clamped to `0`. A custom top tooltip's measured line stop is preserved so
 overshoot never draws the crosshair through the tooltip.
 
-The crosshair fades as it approaches the live edge by default. Set `crosshairFade: false` when the
-chart has no live dot or the crosshair should remain fully visible. This only affects the line,
-selection dot, and tooltip; the trailing-content dim keeps its own fade.
+Set `crosshairLineCap` to `"butt"`, `"round"`, or `"square"` to control the ends of the vertical
+line. Omitting it preserves the existing Skia default. Caps compose with solid, thick, and dashed
+crosshairs.
+
+The crosshair fades over the final `4` px as it approaches the live edge by default.
+`crosshairFadeDistance` changes that distance for the visible line, selection dot, and tooltip;
+negative values clamp to `0`. Set `crosshairFade: false` to keep that visible group fully opaque
+while scrubbing. Neither option changes the trailing-content dim's existing edge fade.
 
 ```tsx
 <LiveChart
@@ -256,8 +261,9 @@ selection dot, and tooltip; the trailing-content dim keeps its own fade.
   value={value}
   scrub={{
     crosshairStrokeWidth: 2,
+    crosshairLineCap: "round",
     crosshairOvershoot: 6,
-    crosshairFade: false,
+    crosshairFadeDistance: 12,
   }}
 />
 ```

--- a/packages/react-native-livechart/src/components/CrosshairLine.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairLine.tsx
@@ -27,6 +27,8 @@ export function CrosshairLine({
   crosshairStrokeWidth = 1,
   crosshairOvershoot = 0,
   crosshairFade = true,
+  crosshairFadeDistance = 4,
+  crosshairLineCap,
   crosshairDash,
   crosshairDimColor,
   opaqueCanvas = false,
@@ -60,6 +62,10 @@ export function CrosshairLine({
   crosshairOvershoot?: number;
   /** Fade the crosshair near the live edge. Default true. */
   crosshairFade?: boolean;
+  /** Visible-crosshair fade distance near the live edge in px. Default 4. */
+  crosshairFadeDistance?: number;
+  /** Cap style for the vertical crosshair line. */
+  crosshairLineCap?: "butt" | "round" | "square";
   /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
   crosshairDash?: number[];
   crosshairDimColor?: string;
@@ -111,11 +117,15 @@ export function CrosshairLine({
   );
   const backgroundColor = `rgb(${palette.bgRgb[0]},${palette.bgRgb[1]},${palette.bgRgb[2]})`;
 
-  // The trailing dim deliberately keeps the original edge fade.
+  // The trailing dim deliberately keeps the original edge fade while this
+  // visible group uses the configurable distance.
   const visibleOpacity = useCrosshairVisibleOpacity(
-    crosshairOpacity,
+    scrubX,
+    engine.canvasWidth,
+    padding.right,
     scrubActive,
     crosshairFade,
+    crosshairFadeDistance,
   );
 
   return (
@@ -159,6 +169,7 @@ export function CrosshairLine({
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
           strokeWidth={crosshairStrokeWidth}
+          strokeCap={crosshairLineCap}
         >
           {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
         </Line>

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -39,6 +39,8 @@ export function CrosshairOverlay({
   crosshairStrokeWidth = 1,
   crosshairOvershoot = 0,
   crosshairFade = true,
+  crosshairFadeDistance = 4,
+  crosshairLineCap,
   crosshairDash,
   crosshairDimColor,
   tooltipBackground,
@@ -93,6 +95,10 @@ export function CrosshairOverlay({
   crosshairOvershoot?: number;
   /** Fade the crosshair near the live edge. Default true. */
   crosshairFade?: boolean;
+  /** Visible-crosshair fade distance near the live edge in px. Default 4. */
+  crosshairFadeDistance?: number;
+  /** Cap style for the vertical crosshair line. */
+  crosshairLineCap?: "butt" | "round" | "square";
   /** Dash intervals `[on, off, …]` for the crosshair line; omit → solid. */
   crosshairDash?: number[];
   crosshairDimColor?: string;
@@ -176,11 +182,14 @@ export function CrosshairOverlay({
   const backgroundColor = `rgb(${palette.bgRgb[0]},${palette.bgRgb[1]},${palette.bgRgb[2]})`;
 
   // Keep the trailing dim on its original edge fade. Only the visible
-  // crosshair group (line, dot, tooltip) opts out when crosshairFade is false.
+  // crosshair group (line, dot, tooltip) uses the configurable distance.
   const visibleOpacity = useCrosshairVisibleOpacity(
-    crosshairOpacity,
+    scrubX,
+    engine.canvasWidth,
+    padding.right,
     scrubActive,
     crosshairFade,
+    crosshairFadeDistance,
   );
 
   return (
@@ -225,6 +234,7 @@ export function CrosshairOverlay({
           p2={p2}
           color={crosshairLineColor ?? palette.crosshairLine}
           strokeWidth={crosshairStrokeWidth}
+          strokeCap={crosshairLineCap}
         >
           {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
         </Line>

--- a/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomTooltipOverlay.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import type { TooltipLayout } from "../hooks/crosshairShared";
+import { resolveCrosshairVisibleOpacity } from "../hooks/useCrosshairVisibleOpacity";
 import type { CandlePoint, TooltipRenderProps } from "../types";
 
 // Mirror the Skia tooltip's offsets (see crosshairShared.ts) so a custom pill
@@ -41,13 +42,13 @@ export function CustomTooltipOverlay({
   scrubTime,
   scrubActive,
   scrubCandle,
-  crosshairOpacity,
   tooltipLayout,
   engine,
   padding,
   placement,
   margin = 8,
   crosshairFade = true,
+  crosshairFadeDistance = 4,
   lineTop,
   scrubDotY,
 }: {
@@ -58,7 +59,6 @@ export function CustomTooltipOverlay({
   scrubActive: SharedValue<boolean>;
   /** OHLC candle under the crosshair (candle mode); omitted/`null` in line mode. */
   scrubCandle?: SharedValue<CandlePoint | null>;
-  crosshairOpacity: SharedValue<number>;
   tooltipLayout: SharedValue<TooltipLayout>;
   engine: ChartEngineLayout;
   padding: ChartPadding;
@@ -67,6 +67,8 @@ export function CustomTooltipOverlay({
   margin?: number;
   /** Fade the tooltip near the live edge. Default true. */
   crosshairFade?: boolean;
+  /** Tooltip fade distance near the live edge in px. Default 4. */
+  crosshairFadeDistance?: number;
   /** When `placement` is `"top"`, the overlay publishes the label's bottom edge
    *  (canvas Y) here so {@link CrosshairOverlay} can stop the crosshair line at
    *  the label instead of running through it; -1 when not top-pinned/active. */
@@ -157,7 +159,14 @@ export function CustomTooltipOverlay({
     }
 
     return {
-      opacity: active ? (crosshairFade ? crosshairOpacity.get() : 1) : 0,
+      opacity: resolveCrosshairVisibleOpacity(
+        active,
+        sx,
+        cw,
+        padding.right,
+        crosshairFade,
+        crosshairFadeDistance,
+      ),
       transform: [{ translateX: x }, { translateY: y }],
     };
   });

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -2129,6 +2129,8 @@ function ChartScrubLayer({
           crosshairStrokeWidth={scrubCfg.crosshairStrokeWidth}
           crosshairOvershoot={scrubCfg.crosshairOvershoot}
           crosshairFade={scrubCfg.crosshairFade}
+          crosshairFadeDistance={scrubCfg.crosshairFadeDistance}
+          crosshairLineCap={scrubCfg.crosshairLineCap}
           crosshairDash={scrubCfg.crosshairDash}
           crosshairDimColor={scrubCfg.crosshairDimColor}
           tooltipBackground={scrubCfg.tooltipBackground}
@@ -2621,13 +2623,13 @@ function ChartView({
             scrubTime={crosshair.scrubTime}
             scrubActive={crosshair.scrubActive}
             scrubCandle={crosshair.scrubCandle}
-            crosshairOpacity={crosshair.crosshairOpacity}
             tooltipLayout={crosshair.tooltipLayout}
             engine={engine}
             padding={effectivePadding}
             placement={scrubCfg.tooltipPlacement}
             margin={scrubCfg.tooltipMargin}
             crosshairFade={scrubCfg.crosshairFade}
+            crosshairFadeDistance={scrubCfg.crosshairFadeDistance}
             lineTop={crosshair.tooltipLineTop}
             scrubDotY={crosshair.scrubDotY}
           />

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -55,6 +55,7 @@ import { useChartReveal } from "../hooks/useChartReveal";
 import { useChartOverlayContext } from "../hooks/useChartOverlayContext";
 import { useChartSkiaFont } from "../hooks/useChartSkiaFont";
 import { useCrosshairSeries } from "../hooks/useCrosshairSeries";
+import { useCrosshairVisibleOpacity } from "../hooks/useCrosshairVisibleOpacity";
 import { useMarkers } from "../hooks/useMarkers";
 import { useMultiSeriesDegen } from "../hooks/useMultiSeriesDegen";
 import { useMultiSeriesLinePaths } from "../hooks/useMultiSeriesLinePaths";
@@ -931,6 +932,53 @@ function SeriesCustomConsumerOverlay({ model }: { model: LiveChartSeriesModel })
   return <ChartOverlayLayer render={renderOverlay!} context={overlayContext} />;
 }
 
+/** Keeps the extra fade mapper opt-in with the per-series tooltip itself. */
+function SeriesTooltipLayer({
+  model,
+  config,
+}: {
+  model: LiveChartSeriesModel;
+  config: NonNullable<LiveChartSeriesModel["seriesTooltipCfg"]>;
+}) {
+  const {
+    crosshair,
+    engine,
+    effectivePadding,
+    scrubCfg,
+    skiaFont,
+    palette,
+    activeSeriesCount,
+  } = model;
+  const activeOpacity = useCrosshairVisibleOpacity(
+    crosshair.scrubX,
+    engine.canvasWidth,
+    effectivePadding.right,
+    crosshair.scrubActive,
+    scrubCfg?.crosshairFade ?? true,
+    scrubCfg?.crosshairFadeDistance ?? 4,
+  );
+  const scrubActive = crosshair.scrubActive;
+  const alwaysShow = config.alwaysShow;
+  const opacity = useDerivedValue(
+    () => (scrubActive.get() ? activeOpacity.get() : alwaysShow ? 1 : 0),
+    [scrubActive, activeOpacity, alwaysShow],
+  );
+
+  return (
+    <PerSeriesTooltipOverlay
+      layout={crosshair.tooltipLayout}
+      font={skiaFont}
+      palette={palette}
+      config={config}
+      seriesCount={activeSeriesCount}
+      opacity={opacity}
+      tooltipBackground={scrubCfg?.tooltipBackground}
+      tooltipColor={scrubCfg?.tooltipColor}
+      tooltipBorderColor={scrubCfg?.tooltipBorderColor}
+    />
+  );
+}
+
 export function LiveChartSeries(props: LiveChartSeriesProps) {
   const model = useLiveChartSeriesController(props);
   const {
@@ -973,8 +1021,6 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
     refLineCustomTagWidths,
     overlayScrubFade,
     canvasMode,
-    activeSeriesCount,
-    skiaFont,
   } = model;
 
   // Mirror the Skia overlay fade onto the RN custom-marker sibling so
@@ -1082,6 +1128,8 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
                 }
                 crosshairOvershoot={scrubCfg.crosshairOvershoot}
                 crosshairFade={scrubCfg.crosshairFade}
+                crosshairFadeDistance={scrubCfg.crosshairFadeDistance}
+                crosshairLineCap={scrubCfg.crosshairLineCap}
                 crosshairDash={
                   seriesTooltipCfg
                     ? seriesTooltipCfg.guideDashPattern
@@ -1097,16 +1145,7 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
             <SeriesValueLabelLayer model={model} />
 
             {seriesTooltipCfg && (
-              <PerSeriesTooltipOverlay
-                layout={crosshair.tooltipLayout}
-                font={skiaFont}
-                palette={palette}
-                config={seriesTooltipCfg}
-                seriesCount={activeSeriesCount}
-                tooltipBackground={scrubCfg?.tooltipBackground}
-                tooltipColor={scrubCfg?.tooltipColor}
-                tooltipBorderColor={scrubCfg?.tooltipBorderColor}
-              />
+              <SeriesTooltipLayer model={model} config={seriesTooltipCfg} />
             )}
           </Canvas>
 

--- a/packages/react-native-livechart/src/components/PerSeriesTooltipOverlay.tsx
+++ b/packages/react-native-livechart/src/components/PerSeriesTooltipOverlay.tsx
@@ -232,6 +232,7 @@ export function PerSeriesTooltipOverlay({
   palette,
   config,
   seriesCount,
+  opacity,
   tooltipBackground,
   tooltipColor,
   tooltipBorderColor,
@@ -241,6 +242,8 @@ export function PerSeriesTooltipOverlay({
   palette: LiveChartPalette;
   config: ResolvedPerSeriesTooltipConfig;
   seriesCount: number;
+  /** Active crosshair opacity; idle `alwaysShow` pills stay fully visible. */
+  opacity?: SharedValue<number> | DerivedValue<number>;
   tooltipBackground?: string;
   tooltipColor?: string;
   tooltipBorderColor?: string;
@@ -258,7 +261,7 @@ export function PerSeriesTooltipOverlay({
     config.seriesPillBorderColor ?? tooltipBorderColor;
 
   return (
-    <Group>
+    <Group opacity={opacity}>
       <TimePill
         layout={layout}
         font={font}

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -161,6 +161,10 @@ export interface ResolvedScrubConfig {
   crosshairOvershoot: number;
   /** Fade the crosshair near the live edge. */
   crosshairFade: boolean;
+  /** Visible-crosshair fade distance near the live edge in px. */
+  crosshairFadeDistance: number;
+  /** undefined preserves the existing Skia line-cap default. */
+  crosshairLineCap: "butt" | "round" | "square" | undefined;
   /** Dash intervals `[on, off, …]` for the crosshair line; undefined → solid. */
   crosshairDash: number[] | undefined;
   /** undefined → palette.crosshairDim */
@@ -681,6 +685,8 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   crosshairStrokeWidth: 1,
   crosshairOvershoot: 0,
   crosshairFade: true,
+  crosshairFadeDistance: 4,
+  crosshairLineCap: undefined,
   crosshairDash: undefined,
   crosshairDimColor: undefined,
   tooltipBackground: undefined,
@@ -762,6 +768,10 @@ export function resolveScrub(
       typeof prop === "object" ? prop.seriesTooltip : undefined;
     resolved.seriesTooltip = resolvePerSeriesTooltip(seriesTooltip);
     resolved.crosshairOvershoot = Math.max(0, resolved.crosshairOvershoot);
+    resolved.crosshairFadeDistance = Math.max(
+      0,
+      resolved.crosshairFadeDistance,
+    );
   }
   return resolved;
 }

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -12,7 +12,6 @@ const TOOLTIP_LINE_GAP = 4;
 const TOOLTIP_OFFSET_X = 12;
 const TOOLTIP_EDGE_GAP = 4;
 const TOOLTIP_TOP_MARGIN = 8;
-const FADE_ZONE = 4;
 
 /** Horizontal travel required before a plain scrub claims the touch. */
 export const SCRUB_ACTIVATE_X_PX = 20;
@@ -292,20 +291,23 @@ export function computeScrubTime(
 }
 
 /**
- * Crosshair opacity: fades 1→0 over FADE_ZONE px as the crosshair
- * approaches the live dot at the right chart edge.
+ * Crosshair opacity: fades 1→0 over `fadeDistance` px as the crosshair
+ * approaches the live dot at the right chart edge. A zero distance removes
+ * the ramp while keeping the crosshair hidden at and beyond the live edge.
  */
 export function computeCrosshairOpacity(
   scrubActive: boolean,
   scrubX: number,
   canvasWidth: number,
   paddingRight: number,
+  fadeDistance = 4,
 ): number {
   "worklet";
   if (!scrubActive) return 0;
   const dotX = canvasWidth - paddingRight;
   const dist = dotX - scrubX;
-  return Math.min(1, Math.max(0, dist / FADE_ZONE));
+  if (fadeDistance <= 0) return dist > 0 ? 1 : 0;
+  return Math.min(1, Math.max(0, dist / fadeDistance));
 }
 
 /**

--- a/packages/react-native-livechart/src/hooks/useCrosshairVisibleOpacity.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshairVisibleOpacity.ts
@@ -2,33 +2,56 @@ import {
   useDerivedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import { computeCrosshairOpacity } from "./crosshairShared";
 
 /**
  * Opacity for the visible crosshair UI. The trailing-content dim keeps using
  * the edge-faded opacity directly, independent of this setting.
  */
 export function useCrosshairVisibleOpacity(
-  edgeOpacity: SharedValue<number>,
+  scrubX: SharedValue<number>,
+  canvasWidth: SharedValue<number>,
+  paddingRight: number,
   active: SharedValue<number> | SharedValue<boolean>,
   fade: boolean,
+  fadeDistance = 4,
 ) {
   return useDerivedValue(
     () =>
       resolveCrosshairVisibleOpacity(
-        edgeOpacity.get(),
         Boolean(active.get()),
+        scrubX.get(),
+        canvasWidth.get(),
+        paddingRight,
         fade,
+        fadeDistance,
       ),
-    [fade, edgeOpacity, active],
+    [
+      scrubX,
+      canvasWidth,
+      paddingRight,
+      active,
+      fade,
+      fadeDistance,
+    ],
   );
 }
 
 export function resolveCrosshairVisibleOpacity(
-  edgeOpacity: number,
   active: boolean,
+  scrubX: number,
+  canvasWidth: number,
+  paddingRight: number,
   fade: boolean,
+  fadeDistance = 4,
 ): number {
   "worklet";
-  if (fade) return edgeOpacity;
-  return active ? 1 : 0;
+  if (!fade) return active ? 1 : 0;
+  return computeCrosshairOpacity(
+    active,
+    scrubX,
+    canvasWidth,
+    paddingRight,
+    fadeDistance,
+  );
 }

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -859,6 +859,18 @@ export interface ScrubConfig {
    */
   crosshairFade?: boolean;
   /**
+   * Distance in px over which the visible crosshair fades as it approaches the
+   * live edge. Applies to the line, selection dot, and tooltip when
+   * `crosshairFade` is enabled; the trailing-content dim keeps its existing
+   * fade. Negative values are clamped to `0`. Default `4`.
+   */
+  crosshairFadeDistance?: number;
+  /**
+   * Cap style for the vertical crosshair line. Omit to preserve the existing
+   * Skia default.
+   */
+  crosshairLineCap?: "butt" | "round" | "square";
+  /**
    * Dash the vertical crosshair line. `true` → a default `[4, 4]` dash; an array
    * sets explicit Skia dash intervals `[on, off, …]` in px. Omit / `false` → a
    * solid line.

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { View } from "react-native";
 import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import { LiveChart } from "../src/components/LiveChart";
+import { CrosshairOverlay } from "../src/components/CrosshairOverlay";
 import { ReferenceLineOverlay } from "../src/components/ReferenceLineOverlay";
 import * as badgeHooks from "../src/hooks/useBadge";
 import * as candlePathHooks from "../src/hooks/useCandlePaths";
@@ -548,6 +549,17 @@ describe("LiveChart", () => {
     fireEvent(views[0], "layout", {
       nativeEvent: { layout: { width: 400, height: 300 } },
     });
+  });
+
+  it("forwards configurable crosshair fade distance and line cap", () => {
+    const screen = render(
+      <Harness
+        scrub={{ crosshairFadeDistance: 12, crosshairLineCap: "square" }}
+      />,
+    );
+    const crosshair = screen.UNSAFE_getByType(CrosshairOverlay);
+    expect(crosshair.props.crosshairFadeDistance).toBe(12);
+    expect(crosshair.props.crosshairLineCap).toBe("square");
   });
 
   it("accepts config objects for badge, grid, scrub, valueLine", () => {

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -5,6 +5,7 @@ import { useSharedValue } from "react-native-reanimated";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
+import { CrosshairLine } from "../src/components/CrosshairLine";
 import { PerSeriesTooltipOverlay } from "../src/components/PerSeriesTooltipOverlay";
 import { ReferenceLineOverlay } from "../src/components/ReferenceLineOverlay";
 import { DefaultSelectionDot } from "../src/components/SelectionDot";
@@ -55,6 +56,36 @@ describe("LiveChartSeries", () => {
     }
     const screen = render(<H />);
     await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+  });
+
+  it("forwards configurable crosshair fade distance and line cap", async () => {
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          scrub={{ crosshairFadeDistance: 12, crosshairLineCap: "square" }}
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    const crosshair = screen.UNSAFE_getByType(CrosshairLine);
+    expect(crosshair.props.crosshairFadeDistance).toBe(12);
+    expect(crosshair.props.crosshairLineCap).toBe("square");
   });
 
   it("renders with timeScroll + zoom + paging callbacks wired", async () => {
@@ -147,7 +178,11 @@ describe("LiveChartSeries", () => {
 
     const screen = render(<H />);
     await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
-    expect(screen.UNSAFE_getAllByType(PerSeriesTooltipOverlay)).toHaveLength(1);
+    const [seriesTooltip] = screen.UNSAFE_getAllByType(
+      PerSeriesTooltipOverlay,
+    );
+    expect(seriesTooltip).toBeDefined();
+    expect(seriesTooltip.props.opacity.get()).toBe(1);
 
     screen.rerender(<H tooltip={false} />);
     expect(screen.UNSAFE_queryAllByType(PerSeriesTooltipOverlay)).toHaveLength(0);

--- a/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomTooltipOverlay.test.tsx
@@ -43,7 +43,8 @@ function Fixture({
   captureLineTop,
   scrubDotY,
   crosshairFade,
-  crosshairOpacityValue = 1,
+  crosshairFadeDistance,
+  scrubXValue = 100,
 }: {
   renderTooltip: (ctx: TooltipRenderProps) => React.ReactElement | null | undefined;
   placement?: "side" | "top" | "bottom" | "point";
@@ -51,13 +52,13 @@ function Fixture({
   captureLineTop?: (lineTop: SharedValue<number>) => void;
   scrubDotY?: number;
   crosshairFade?: boolean;
-  crosshairOpacityValue?: number;
+  crosshairFadeDistance?: number;
+  scrubXValue?: number;
 }) {
-  const scrubX = useSharedValue(100);
+  const scrubX = useSharedValue(scrubXValue);
   const scrubValue = useSharedValue<number | null>(42);
   const scrubTime = useSharedValue(985);
   const scrubActive = useSharedValue(true);
-  const crosshairOpacity = useSharedValue(crosshairOpacityValue);
   const tooltipLayout = useSharedValue<TooltipLayout>(LAYOUT);
   const scrubCandle = useSharedValue<CandlePoint | null>(candle ?? null);
   const lineTop = useSharedValue(-1);
@@ -73,12 +74,12 @@ function Fixture({
       // Only wire scrubCandle when a candle is supplied, so the line-mode tests
       // also exercise the `?? nullCandle` fallback (candle prop omitted).
       scrubCandle={candle === undefined ? undefined : scrubCandle}
-      crosshairOpacity={crosshairOpacity}
       tooltipLayout={tooltipLayout}
       engine={engine()}
       padding={DEFAULT_PADDING}
       placement={placement}
       crosshairFade={crosshairFade}
+      crosshairFadeDistance={crosshairFadeDistance}
       lineTop={lineTop}
       scrubDotY={scrubDotYSV}
     />
@@ -97,11 +98,22 @@ describe("CustomTooltipOverlay", () => {
     const { toJSON } = render(
       <Fixture
         crosshairFade={false}
-        crosshairOpacityValue={0.25}
+        scrubXValue={400 - DEFAULT_PADDING.right}
         renderTooltip={() => <Text testID="custom-tip">tip</Text>}
       />,
     );
     expect(JSON.stringify(toJSON())).toContain('"opacity":1');
+  });
+
+  it("uses the configured edge-fade distance", () => {
+    const { toJSON } = render(
+      <Fixture
+        crosshairFadeDistance={8}
+        scrubXValue={400 - DEFAULT_PADDING.right - 2}
+        renderTooltip={() => <Text testID="custom-tip">tip</Text>}
+      />,
+    );
+    expect(JSON.stringify(toJSON())).toContain('"opacity":0.25');
   });
 
   it("measures the element via onLayout without throwing", () => {

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -60,6 +60,7 @@ function engine(): EngineState {
 function expectConfiguredCrosshair(tree: unknown) {
   const serialized = JSON.stringify(tree);
   expect(serialized).toContain('"strokeWidth":3');
+  expect(serialized).toContain('"strokeCap":"round"');
   expect(serialized).toContain(`\\"y\\":${DEFAULT_PADDING.top - 6}`);
   expect(serialized).toContain(
     `\\"y\\":${300 - DEFAULT_PADDING.bottom + 6}`,
@@ -534,11 +535,40 @@ describe("CrosshairOverlay", () => {
           crosshairStrokeWidth={3}
           crosshairOvershoot={6}
           crosshairFade={false}
+          crosshairLineCap="round"
         />
       );
     }
     const { toJSON } = render(<Fixture />);
     expectConfiguredCrosshair(toJSON());
+  });
+
+  it("uses the configured visible fade without changing the trailing dim ramp", () => {
+    function Fixture() {
+      const scrubX = useSharedValue(
+        400 - DEFAULT_PADDING.right - 2,
+      );
+      // This stays on the controller's original 4 px fade: 2 / 4 = 0.5.
+      const crosshairOpacity = useSharedValue(0.5);
+      const scrubActive = useSharedValue(true);
+      const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          scrubActive={scrubActive}
+          crosshairFadeDistance={8}
+        />
+      );
+    }
+    const tree = JSON.stringify(render(<Fixture />).toJSON());
+    expect(tree).toContain('"opacity":"0.25"');
+    expect(tree).toContain("rgba(0,0,0,0.35)");
   });
 
   it("keeps a custom top-tooltip line stop when overshoot is set", () => {
@@ -1094,6 +1124,7 @@ describe("CrosshairLine", () => {
           crosshairStrokeWidth={3}
           crosshairOvershoot={6}
           crosshairFade={false}
+          crosshairLineCap="round"
         />
       );
     }

--- a/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshair.test.ts
@@ -272,6 +272,21 @@ describe("computeCrosshairOpacity", () => {
       computeCrosshairOpacity(true, dotX - 4, canvasWidth, paddingRight),
     ).toBeCloseTo(1);
   });
+
+  it("supports a custom fade distance", () => {
+    expect(
+      computeCrosshairOpacity(true, dotX - 2, canvasWidth, paddingRight, 8),
+    ).toBeCloseTo(0.25);
+  });
+
+  it("removes the ramp when the fade distance is zero", () => {
+    expect(
+      computeCrosshairOpacity(true, dotX - 1, canvasWidth, paddingRight, 0),
+    ).toBe(1);
+    expect(
+      computeCrosshairOpacity(true, dotX, canvasWidth, paddingRight, 0),
+    ).toBe(0);
+  });
 });
 
 // ─── computeScrubDotY ────────────────────────────────────────────────────────

--- a/packages/react-native-livechart/tests/hooks/useCrosshairVisibleOpacity.test.ts
+++ b/packages/react-native-livechart/tests/hooks/useCrosshairVisibleOpacity.test.ts
@@ -2,14 +2,25 @@ import { resolveCrosshairVisibleOpacity } from "../../src/hooks/useCrosshairVisi
 
 describe("resolveCrosshairVisibleOpacity", () => {
   it("stays visible at the exact live edge when fade is disabled", () => {
-    expect(resolveCrosshairVisibleOpacity(0, true, false)).toBe(1);
+    expect(resolveCrosshairVisibleOpacity(true, 320, 400, 80, false)).toBe(1);
   });
 
   it("stays hidden when scrub is inactive", () => {
-    expect(resolveCrosshairVisibleOpacity(0, false, false)).toBe(0);
+    expect(resolveCrosshairVisibleOpacity(false, 200, 400, 80, false)).toBe(0);
   });
 
-  it("preserves edge opacity when fade is enabled", () => {
-    expect(resolveCrosshairVisibleOpacity(0.25, true, true)).toBe(0.25);
+  it("uses the configured fade distance when fade is enabled", () => {
+    expect(resolveCrosshairVisibleOpacity(true, 318, 400, 80, true, 8)).toBe(
+      0.25,
+    );
+  });
+
+  it("uses the backwards-compatible 4 px fade by default", () => {
+    expect(resolveCrosshairVisibleOpacity(true, 318, 400, 80, true)).toBe(0.5);
+  });
+
+  it("removes the ramp at zero distance", () => {
+    expect(resolveCrosshairVisibleOpacity(true, 319, 400, 80, true, 0)).toBe(1);
+    expect(resolveCrosshairVisibleOpacity(true, 320, 400, 80, true, 0)).toBe(0);
   });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -541,6 +541,8 @@ describe("resolveScrub", () => {
     crosshairStrokeWidth: 1,
     crosshairOvershoot: 0,
     crosshairFade: true,
+    crosshairFadeDistance: 4,
+    crosshairLineCap: undefined,
     crosshairDash: undefined,
     crosshairDimColor: undefined,
     tooltipBackground: undefined,
@@ -606,22 +608,29 @@ describe("resolveScrub", () => {
     ).toBe(true);
   });
 
-  it("carries crosshair stroke, overshoot, and fade overrides", () => {
+  it("carries crosshair geometry and fade overrides", () => {
     expect(
       resolveScrub({
         crosshairStrokeWidth: 3,
         crosshairOvershoot: 6,
         crosshairFade: false,
+        crosshairFadeDistance: 12,
+        crosshairLineCap: "round",
       }),
     ).toMatchObject({
       crosshairStrokeWidth: 3,
       crosshairOvershoot: 6,
       crosshairFade: false,
+      crosshairFadeDistance: 12,
+      crosshairLineCap: "round",
     });
   });
 
-  it("clamps negative crosshair overshoot to zero", () => {
+  it("clamps negative crosshair distances to zero", () => {
     expect(resolveScrub({ crosshairOvershoot: -6 })?.crosshairOvershoot).toBe(0);
+    expect(
+      resolveScrub({ crosshairFadeDistance: -8 })?.crosshairFadeDistance,
+    ).toBe(0);
   });
 
   it("defaults clampToPlot to false and carries it when set", () => {


### PR DESCRIPTION
## What

- add `scrub.crosshairFadeDistance` with a backwards-compatible `4` px default and clamp negative values to `0`
- add `scrub.crosshairLineCap` for `"butt"`, `"round"`, and `"square"`, while preserving the existing omitted/default rendering
- apply the configurable fade to the visible crosshair line, selection dot, built-in/custom tooltip, and per-series tooltip on both `LiveChart` and `LiveChartSeries`
- keep the trailing-content dim on its existing independent 4 px fade
- add scrubbing-demo controls, public API/JSDoc/guide documentation, and a changelog entry

## Behavior

- `crosshairFade: false` still keeps the visible crosshair group fully opaque
- `crosshairFadeDistance: 0` removes the ramp while retaining the existing hidden state at and beyond the live edge
- line caps compose with solid, thick, and dashed crosshairs
- idle `seriesTooltip.alwaysShow` pills remain fully visible

## Verification

- `npm run verify` — 98 suites passed, 1,429 tests passed, 5 skipped
- targeted config, opacity, overlay, custom-tooltip, `LiveChart`, and `LiveChartSeries` tests — 409 passed
- React Doctor — library 100/100; example app reported no diagnostics
- agent-device QA on iPhone 17 simulator:
  - caught and fixed a UI-thread Worklets serialization issue not visible in Jest
  - exercised `12px` + round and `0px` + square demo configurations
  - verified both Scrubbing and Multi-series screens run without a native error overlay

Fixes #240