### PR TITLE
fix: keep segment gradient colors/positions equal in length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scrubbing a chart with `segments` no longer crashes the app.** The scrub-focus
+  line gradient handed Skia `colors` and `positions` as two separate derived
+  values, so a frame could pair a fresh `colors` with a stale `positions`. The
+  emitted stop count changes with the visible span count, so a scrub crossing a
+  segment boundary could make the two disagree in length — which Skia's Reanimated
+  recorder raises as a C++ throw on the UI thread inside `recorder.play()`: an
+  unhandled exception that kills the process, not a catchable JS error. Both arrays
+  are now padded to a stop count fixed by the segment list alone, so a torn frame
+  stays equal-length. The padding is inert (base color, at position 1).
+
 ## [4.13.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recorder raises as a C++ throw on the UI thread inside `recorder.play()`: an
   unhandled exception that kills the process, not a catchable JS error. Both arrays
   are now padded to a stop count fixed by the segment list alone, so a torn frame
-  stays equal-length. The padding is inert (base color, at position 1).
+  stays equal-length. If the segment list changes that count at runtime, the
+  gradient remounts both stop arrays together. The padding is inert (base color,
+  at position 1).
 
 ## [4.13.0] - 2026-07-29
 

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -89,7 +89,6 @@ import {
 import { AXIS_GRAB_MIN_PX, usePanScroll } from "../hooks/usePanScroll";
 import { usePinchZoom } from "../hooks/usePinchZoom";
 import { useVisibleRange } from "../hooks/useVisibleRange";
-import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
 import { useSingleChartReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
 import {
   useThreshold,
@@ -162,6 +161,7 @@ import { ReferenceLineGroupOverlay } from "./ReferenceLineGroupOverlay";
 import { ReferenceLineOverlay } from "./ReferenceLineOverlay";
 import { ScrubActionOverlay } from "./ScrubActionOverlay";
 import { SegmentDividerOverlay } from "./SegmentDividerOverlay";
+import { SegmentLineGradient } from "./SegmentLineGradient";
 import { TradeStreamOverlay } from "./TradeStreamOverlay";
 import { ValueLineOverlay } from "./ValueLineOverlay";
 import { XAxisOverlay } from "./XAxisOverlay";
@@ -1200,19 +1200,6 @@ function useLiveChartController({
     effectivePadding,
   );
 
-  // Scrub-focus gradient painted onto the line stroke: uniform at rest, and while
-  // scrubbing (or with an `active` segment) the focused segment stays full while
-  // the others are de-emphasized. Declared after `crosshair` so it can read the
-  // live scrub state.
-  const segmentGradient = useSegmentLineGradient(
-    engine,
-    resolvedSegments,
-    effectivePadding,
-    lineProp?.color ?? palette.line,
-    crosshair.scrubX,
-    crosshair.scrubActive,
-  );
-
   // Hide the live dot while scrubbing when a selection dot is marking the scrub
   // point instead — otherwise both dots show at once. Applies on static charts
   // too, now that they're scrubbable.
@@ -1326,7 +1313,6 @@ function useLiveChartController({
     refGroupFormat,
     resolvedSegments,
     hasRecolorSegments,
-    segmentGradient,
     thresholdCfg,
     thresholdGeom,
     thresholdStrokeColors: thresholdStopColors?.stroke ?? null,
@@ -1764,7 +1750,7 @@ function ChartStack({
     dragValues,
     resolvedSegments,
     hasRecolorSegments,
-    segmentGradient,
+    crosshair,
     thresholdCfg,
     thresholdGeom,
     thresholdStrokeColors,
@@ -1905,11 +1891,13 @@ function ChartStack({
               positions={thresholdGeom.splitPositions}
             />
           ) : hasRecolorSegments ? (
-            <LinearGradient
-              start={vec(0, 0)}
-              end={segmentGradient.gradientEnd}
-              colors={segmentGradient.colors}
-              positions={segmentGradient.positions}
+            <SegmentLineGradient
+              engine={engine}
+              segments={resolvedSegments}
+              padding={effectivePadding}
+              baseColor={lineProp?.color ?? palette.line}
+              scrubX={crosshair.scrubX}
+              scrubActive={crosshair.scrubActive}
             />
           ) : lineProp?.colors?.length ? (
             <LinearGradient

--- a/packages/react-native-livechart/src/components/SegmentLineGradient.tsx
+++ b/packages/react-native-livechart/src/components/SegmentLineGradient.tsx
@@ -1,0 +1,57 @@
+import { LinearGradient, vec } from "@shopify/react-native-skia";
+import type { SharedValue } from "react-native-reanimated";
+
+import type { ResolvedSegment } from "../core/resolveSegment";
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+import { useSegmentLineGradient } from "../hooks/useSegmentLineGradient";
+import { segmentGradientStopCount } from "../math/segments";
+
+interface SegmentLineGradientProps {
+  engine: ChartEngineLayout;
+  segments: ResolvedSegment[];
+  padding: ChartPadding;
+  baseColor: string;
+  scrubX: SharedValue<number>;
+  scrubActive: SharedValue<boolean>;
+}
+
+/**
+ * Keeps the two SharedValues passed to Skia on one stop-count lifecycle.
+ *
+ * Scrubbing can change which stops are visible without changing `stopCount`, so
+ * padding keeps those mapper updates safe. When the segment props themselves
+ * change the count, the keyed child remounts both SharedValues together instead
+ * of letting one retain the previous length for a frame.
+ */
+export function SegmentLineGradient(props: SegmentLineGradientProps) {
+  const stopCount = segmentGradientStopCount(props.segments);
+  return <SegmentLineGradientPaint key={stopCount} {...props} />;
+}
+
+function SegmentLineGradientPaint({
+  engine,
+  segments,
+  padding,
+  baseColor,
+  scrubX,
+  scrubActive,
+}: SegmentLineGradientProps) {
+  const gradient = useSegmentLineGradient(
+    engine,
+    segments,
+    padding,
+    baseColor,
+    scrubX,
+    scrubActive,
+  );
+
+  return (
+    <LinearGradient
+      start={vec(0, 0)}
+      end={gradient.gradientEnd}
+      colors={gradient.colors}
+      positions={gradient.positions}
+    />
+  );
+}

--- a/packages/react-native-livechart/src/hooks/useSegmentLineGradient.ts
+++ b/packages/react-native-livechart/src/hooks/useSegmentLineGradient.ts
@@ -4,7 +4,11 @@ import { vec } from "@shopify/react-native-skia";
 import type { ChartEngineLayout } from "../core/useLiveChartEngine";
 import type { ResolvedSegment } from "../core/resolveSegment";
 import type { ChartPadding } from "../draw/line";
-import { segmentLineGradient } from "../math/segments";
+import {
+  padGradientStops,
+  segmentGradientStopCount,
+  segmentLineGradient,
+} from "../math/segments";
 
 const FALLBACK_POSITIONS = [0, 1];
 
@@ -43,11 +47,15 @@ export function useSegmentLineGradient(
     );
   });
 
-  const colors = useDerivedValue(
-    () => data.value?.colors ?? [baseColor, baseColor],
+  // Fixed stop count: `colors`/`positions` tear independently and Skia treats a
+  // length mismatch as a fatal UI-thread throw.
+  const stopCount = segmentGradientStopCount(segments);
+
+  const colors = useDerivedValue(() =>
+    padGradientStops(data.value?.colors ?? [baseColor, baseColor], stopCount),
   );
-  const positions = useDerivedValue(
-    () => data.value?.positions ?? FALLBACK_POSITIONS,
+  const positions = useDerivedValue(() =>
+    padGradientStops(data.value?.positions ?? FALLBACK_POSITIONS, stopCount),
   );
   const gradientEnd = useDerivedValue(() =>
     vec(Math.max(1, engine.canvasWidth.value), 0),

--- a/packages/react-native-livechart/src/math/segments.ts
+++ b/packages/react-native-livechart/src/math/segments.ts
@@ -171,3 +171,29 @@ export function segmentLineGradient(
 
   return { colors, positions };
 }
+
+/** Stops {@link segmentLineGradient} can emit for `segments` — no per-frame state. */
+export function segmentGradientStopCount(segments: ResolvedSegment[]): number {
+  "worklet";
+  let n = 2;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (!seg.recolorLine) continue;
+    const cols =
+      seg.mutedColors && seg.mutedColors.length >= 2
+        ? seg.mutedColors.length
+        : 2;
+    n += cols + 2;
+  }
+  return n;
+}
+
+/** Resize `stops` to `count` by repeating its last entry. */
+export function padGradientStops<T>(stops: T[], count: number): T[] {
+  "worklet";
+  if (stops.length === count || stops.length === 0) return stops;
+  const out = stops.slice(0, count);
+  const last = stops[stops.length - 1];
+  while (out.length < count) out.push(last);
+  return out;
+}

--- a/packages/react-native-livechart/tests/components/SegmentLineGradient.test.tsx
+++ b/packages/react-native-livechart/tests/components/SegmentLineGradient.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import type { SharedValue } from "react-native-reanimated";
+
+const mockMounts: number[] = [];
+const mockUnmounts: number[] = [];
+let mockNextInstance = 0;
+
+jest.mock("../../src/hooks/useSegmentLineGradient", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+  return {
+    useSegmentLineGradient: () => {
+      const instance = ReactActual.useRef(0);
+      if (instance.current === 0) instance.current = ++mockNextInstance;
+      ReactActual.useEffect(() => {
+        mockMounts.push(instance.current);
+        return () => {
+          mockUnmounts.push(instance.current);
+        };
+      }, [instance]);
+      return {
+        colors: { value: ["#00f", "#00f"] },
+        positions: { value: [0, 1] },
+        gradientEnd: { value: { x: 400, y: 0 } },
+      };
+    },
+  };
+});
+
+import { SegmentLineGradient } from "../../src/components/SegmentLineGradient";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { resolveSegment } from "../../src/core/resolveSegment";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+
+const DEFAULTS = { muted: "#999", divider: "#555", label: "#ccc" };
+const engine = {} as ChartEngineLayout;
+const scrubX = { value: -1 } as SharedValue<number>;
+const scrubActive = { value: false } as SharedValue<boolean>;
+
+const segment = (from: number, to: number) =>
+  resolveSegment({ from, to }, DEFAULTS);
+
+describe("SegmentLineGradient", () => {
+  it("remounts both gradient SharedValues together when the stop count changes", () => {
+    mockMounts.length = 0;
+    mockUnmounts.length = 0;
+    mockNextInstance = 0;
+
+    const firstSegments = [segment(100, 110)];
+    const screen = render(
+      <SegmentLineGradient
+        engine={engine}
+        segments={firstSegments}
+        padding={DEFAULT_PADDING}
+        baseColor="#00f"
+        scrubX={scrubX}
+        scrubActive={scrubActive}
+      />,
+    );
+    expect(mockMounts).toEqual([1]);
+    expect(mockUnmounts).toEqual([]);
+
+    // The segment changed, but its stop count did not: keep the same mapper pair.
+    screen.rerender(
+      <SegmentLineGradient
+        engine={engine}
+        segments={[segment(110, 120)]}
+        padding={DEFAULT_PADDING}
+        baseColor="#00f"
+        scrubX={scrubX}
+        scrubActive={scrubActive}
+      />,
+    );
+    expect(mockMounts).toEqual([1]);
+    expect(mockUnmounts).toEqual([]);
+
+    // A second recoloring segment increases the bound from 6 to 10 stops.
+    screen.rerender(
+      <SegmentLineGradient
+        engine={engine}
+        segments={[segment(110, 120), segment(120, 130)]}
+        padding={DEFAULT_PADDING}
+        baseColor="#00f"
+        scrubX={scrubX}
+        scrubActive={scrubActive}
+      />,
+    );
+    expect(mockMounts).toEqual([1, 2]);
+    expect(mockUnmounts).toEqual([1]);
+  });
+});

--- a/packages/react-native-livechart/tests/hooks/useSegmentLineGradient.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useSegmentLineGradient.test.tsx
@@ -62,8 +62,41 @@ describe("useSegmentLineGradient", () => {
         scrubActive,
       ),
     );
-    expect(result.current.colors.value).toEqual([BASE, BASE]);
-    expect(result.current.positions.value).toEqual([0, 1]);
+    // Padded stops repeat base@1, so this still paints as a flat base line.
+    expect(result.current.colors.value).toEqual(new Array(6).fill(BASE));
+    expect(result.current.positions.value).toEqual([0, 1, 1, 1, 1, 1]);
+  });
+
+  it("pads colors and positions to one stop count across scrub states", () => {
+    const segments = [
+      resolveSegment({ from: 105, to: 115, mutedColor: "#aaa" }, DEFAULTS),
+      resolveSegment({ from: 115, to: 125, mutedColor: "#bbb" }, DEFAULTS),
+    ];
+    const lengths = [
+      scrub(-1, false), // at rest → fallback stops
+      scrub(150, true), // one span dimmed
+      scrub(50, true), // both dimmed
+    ].map(({ scrubX, scrubActive }) => {
+      const { result } = renderHook(() =>
+        useSegmentLineGradient(
+          engine(),
+          segments,
+          PADDING,
+          BASE,
+          scrubX,
+          scrubActive,
+        ),
+      );
+      return [
+        result.current.colors.value.length,
+        result.current.positions.value.length,
+      ];
+    });
+    expect(lengths).toEqual([
+      [10, 10],
+      [10, 10],
+      [10, 10],
+    ]);
   });
 
   it("keeps the gradient end at least 1px wide before layout", () => {

--- a/packages/react-native-livechart/tests/math/segments.test.ts
+++ b/packages/react-native-livechart/tests/math/segments.test.ts
@@ -1,5 +1,10 @@
 import type { ResolvedSegment } from "../../src/core/resolveSegment";
-import { segmentBandX, segmentLineGradient } from "../../src/math/segments";
+import {
+  padGradientStops,
+  segmentBandX,
+  segmentGradientStopCount,
+  segmentLineGradient,
+} from "../../src/math/segments";
 
 // Window [100, 130] (winStart=100, win=30) projected into plot [x1=10, x2=210].
 const WIN_START = 100;
@@ -409,5 +414,68 @@ describe("segmentLineGradient", () => {
     )!;
     expect(g).not.toBeNull();
     expect(nonDecreasing(g.positions)).toBe(true);
+  });
+});
+
+describe("padGradientStops / segmentGradientStopCount", () => {
+  const CW = 220;
+  const PL = 10;
+  const PR = 210;
+  const BASE = "#0000ff";
+  const A = () => mkSeg({ from: 105, to: 115, mutedColor: "#aaaaaa" });
+  const B = () => mkSeg({ from: 115, to: 125, mutedColor: "#bbbbbb" });
+
+  const frame = (segments: ResolvedSegment[], scrubX: number) =>
+    segmentLineGradient(segments, WIN_START, WIN, CW, PL, PR, BASE, true, scrubX);
+
+  it("pads by repeating the last stop and truncates an over-long one", () => {
+    expect(padGradientStops(["a", "b"], 4)).toEqual(["a", "b", "b", "b"]);
+    expect(padGradientStops([0, 1], 4)).toEqual([0, 1, 1, 1]);
+    expect(padGradientStops([0, 0.5, 1], 3)).toEqual([0, 0.5, 1]);
+    expect(padGradientStops([0, 0.5, 1], 2)).toEqual([0, 0.5]);
+    expect(padGradientStops([], 3)).toEqual([]);
+  });
+
+  it("counts only recolorLine segments, at their own stop width", () => {
+    expect(segmentGradientStopCount([])).toBe(2);
+    expect(segmentGradientStopCount([A()])).toBe(6);
+    expect(segmentGradientStopCount([A(), B()])).toBe(10);
+    expect(segmentGradientStopCount([A(), mkSeg({ recolorLine: false })])).toBe(6);
+    expect(
+      segmentGradientStopCount([mkSeg({ mutedColors: ["#a", "#b", "#c"] })]),
+    ).toBe(7);
+  });
+
+  it("keeps any torn colors/positions pair equal in length", () => {
+    const segments = [A(), B()];
+    const count = segmentGradientStopCount(segments);
+    const frames = [70, 150, 20].map((x) => frame(segments, x)!);
+    expect(new Set(frames.map((f) => f.colors.length)).size).toBeGreaterThan(1);
+
+    for (const a of frames) {
+      for (const b of frames) {
+        expect(padGradientStops(a.colors, count)).toHaveLength(
+          padGradientStops(b.positions, count).length,
+        );
+      }
+      expect(padGradientStops(a.colors, count)).toHaveLength(
+        padGradientStops([0, 1], count).length,
+      );
+      expect(padGradientStops([BASE, BASE], count)).toHaveLength(
+        padGradientStops(a.positions, count).length,
+      );
+    }
+  });
+
+  it("pads with inert stops — the base color, at position 1", () => {
+    const segments = [A(), B()];
+    const count = segmentGradientStopCount(segments);
+    const g = frame(segments, 70)!;
+    expect(padGradientStops(g.colors, count).slice(g.colors.length)).toEqual(
+      new Array(count - g.colors.length).fill(BASE),
+    );
+    expect(
+      padGradientStops(g.positions, count).slice(g.positions.length),
+    ).toEqual(new Array(count - g.positions.length).fill(1));
   });
 });


### PR DESCRIPTION
## The crash

Scrubbing a chart with `segments` can kill the app. We hit it in production (17 events / 11 users, iOS):

```
C++ Exception: Exception in HostFunction:
Positions array must have the same size as colors array
    at play (native)
    at shopify_ContainerNativeTs1
```

Skia validates `positions.size() == colors.size()` and throws ([skia#3086](https://github.com/Shopify/react-native-skia/pull/3086)). In the Reanimated recorder that throw lands on the UI thread inside `recorder.play()` — an unhandled C++ exception, so it's a process kill, not something an error boundary can catch.

## Why

`useSegmentLineGradient` splits one snapshot into two derived values feeding a single `<LinearGradient>`:

```ts
const colors    = useDerivedValue(() => data.value?.colors    ?? [baseColor, baseColor]);
const positions = useDerivedValue(() => data.value?.positions ?? FALLBACK_POSITIONS);
```

Their mappers aren't guaranteed to settle before the Skia mapper runs, so a frame can read a fresh `colors` beside a stale `positions`. Harmless if the stop count were constant — but `segmentLineGradient` emits one span per non-focused `recolorLine` segment, so the length changes as the scrub crosses a boundary (and the `null` fallback is a third length).

Repro: three adjacent `recolorLine` segments (pre-market / regular / after-hours on a 1D chart), scrub across the boundaries. It's a race, so not every swipe.

## The fix

Pad both arrays to a stop count that depends only on the segment list, never on per-frame state:

- `segmentGradientStopCount(segments)` — what `segmentLineGradient` can emit.
- `padGradientStops(stops, count)` — repeats the last entry (truncates if longer).

Torn frames stay equal-length; worst case is one frame of stale stop positions. The padding is inert: base color, at position 1, where the gradient already ends.

Left the threshold gradient alone — it always emits exactly 4 stops, so it can't mismatch.

## Tests

`npm run verify` clean (1435 tests).

- `tests/math/segments.test.ts` — pad/truncate, the stop-count bound, inert padding, and the regression property: every pairing of one frame's `colors` with another frame's `positions` is equal-length, over frames whose raw counts differ.
- `tests/hooks/useSegmentLineGradient.test.tsx` — one stop count across at-rest and both scrub states.