### PR TITLE
feat: candle minGapPx metric — proportional bodies on dense charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable candle-body gaps.** `metrics.candle.minGapPx` (default `2`)
+  controls the minimum horizontal gap between adjacent candle bodies and their
+  aligned volume bars. Set it to `0` to let `bodyWidthRatio` keep bodies
+  proportional on dense charts. The default preserves existing rendering.
+
 ## [4.13.1] - 2026-07-30
 
 ### Fixed

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -707,6 +707,7 @@ interface CandleMetrics {
   minBodyPx: number;      // min body height so dojis stay visible, default 1
   maxBodyPx: number;      // max body width, default 40
   bodyWidthRatio: number; // body width as a fraction of the slot, default 0.8
+  minGapPx: number;       // min gap (px) between adjacent bodies; 0 = ratio-only, default 2
   bodyRadius: number;     // body corner radius (px); 0 = sharp, default 0
   wickWidth: number;      // wick (high–low line) stroke width (px), default 1
 }

--- a/docs/guides/candlestick.mdx
+++ b/docs/guides/candlestick.mdx
@@ -64,11 +64,14 @@ Bullish/bearish body and wick colors come from the palette derived from `accentC
 Override them precisely via the [`palette`](/guides/theming) prop (`candleUp`, `candleDown`,
 `wickUp`, `wickDown`).
 
-## Body & wick shape
+## Body size, spacing & wick shape
 
-The candle body radius and wick thickness live in the `metrics.candle`
-[sizing tokens](/api-reference/types#metrics). Round the body corners with `bodyRadius`
-(clamped to half the body so thin candles stay sane) and set the wick stroke with `wickWidth`:
+Candlestick geometry lives in the `metrics.candle`
+[sizing tokens](/api-reference/types#metrics). Body width is the smallest of
+`bodyWidthRatio × slot width`, `slot width - minGapPx`, and `maxBodyPx`, with a 1px floor.
+`minGapPx` defaults to `2`, preserving a visible gap between adjacent bodies. On dense charts,
+set it to `0` to let `bodyWidthRatio` keep bodies proportional instead of collapsing them to the
+1px floor:
 
 ```tsx
 <LiveChart
@@ -76,13 +79,21 @@ The candle body radius and wick thickness live in the `metrics.candle`
   candles={candles}
   liveCandle={liveCandle}
   candleWidth={60}
-  metrics={{ candle: { bodyRadius: 3, wickWidth: 2 } }}
+  metrics={{
+    candle: {
+      bodyWidthRatio: 0.9,
+      minGapPx: 0,
+      bodyRadius: 3,
+      wickWidth: 2,
+    },
+  }}
 />
 ```
 
-`bodyRadius` defaults to `0` (sharp corners); `wickWidth` defaults to `1`. Width/spacing tokens
-(`bodyWidthRatio`, `maxBodyPx`, `minBodyPx`) live in the same namespace — see
-[`CandleMetrics`](/api-reference/types#metrics).
+The 1px body floor takes precedence when a slot is too narrow to preserve the configured gap.
+Volume bars automatically use the same body width and spacing. `bodyRadius` defaults to `0`
+(sharp corners), and `wickWidth` defaults to `1`. See
+[`CandleMetrics`](/api-reference/types#metrics) for every sizing token and default.
 
 ## Volume bars
 

--- a/docs/guides/theming.mdx
+++ b/docs/guides/theming.mdx
@@ -89,7 +89,7 @@ The five namespaces:
 | Namespace    | Controls                                                                                  |
 | ------------ | ----------------------------------------------------------------------------------------- |
 | `badge`      | Value-pill geometry: `padX`, `padY`, `tailLength`, `marginEdge`, `dotGap`, `tailSpread`.   |
-| `candle`     | Candle geometry: `minBodyPx`, `maxBodyPx`, `bodyWidthRatio`.                               |
+| `candle`     | Candle geometry: `minBodyPx`, `maxBodyPx`, `bodyWidthRatio`, `minGapPx`, `bodyRadius`, `wickWidth`. |
 | `grid`       | Grid + axis-label fade: `fadeInSpeed`, `fadeOutSpeed`.                                     |
 | `motion`     | Lerp speeds: `badgeColorSpeed`, `adaptiveSpeedBoost` (extra catch-up on top of `smoothing`). |
 | `emptyState` | No-data layout: `labelOpacity`, `gapPad`, `gapFadeWidth`.                                  |

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -68,6 +68,7 @@ export const CANDLE_METRICS_DEFAULTS: CandleMetrics = {
   minBodyPx: 1,
   maxBodyPx: 40,
   bodyWidthRatio: 0.8,
+  minGapPx: 2,
   bodyRadius: 0,
   wickWidth: 1,
 };

--- a/packages/react-native-livechart/src/draw/candle.ts
+++ b/packages/react-native-livechart/src/draw/candle.ts
@@ -144,7 +144,11 @@ export function buildCandleGeometry(
   const slotPx = (candleWidthSecs / windowSecs) * chartW;
   const bodyW = Math.max(
     1,
-    Math.min(slotPx * metrics.bodyWidthRatio, slotPx - 2, metrics.maxBodyPx),
+    Math.min(
+      slotPx * metrics.bodyWidthRatio,
+      slotPx - metrics.minGapPx,
+      metrics.maxBodyPx,
+    ),
   );
 
   const bodies: CandleRect[] = [];

--- a/packages/react-native-livechart/src/draw/volume.ts
+++ b/packages/react-native-livechart/src/draw/volume.ts
@@ -113,7 +113,11 @@ export function buildVolumeGeometry(
   const slotPx = (candleWidthSecs / windowSecs) * chartW;
   const bodyW = Math.max(
     1,
-    Math.min(slotPx * metrics.bodyWidthRatio, slotPx - 2, metrics.maxBodyPx),
+    Math.min(
+      slotPx * metrics.bodyWidthRatio,
+      slotPx - metrics.minGapPx,
+      metrics.maxBodyPx,
+    ),
   );
 
   const winEnd = winStart + windowSecs;

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1700,6 +1700,8 @@ export interface CandleMetrics {
   maxBodyPx: number;
   /** Body width as a fraction of the per-candle slot width (0–1). Default `0.8`. */
   bodyWidthRatio: number;
+  /** Minimum horizontal gap (px) enforced between adjacent candle bodies. `0` lets `bodyWidthRatio` alone control body width on dense charts. Default `2`. */
+  minGapPx: number;
   /** Corner radius (px) of candle bodies. `0` = sharp corners. Default `0`. */
   bodyRadius: number;
   /** Wick (high–low line) stroke width in px. Default `1`. */

--- a/packages/react-native-livechart/tests/draw/candle.test.ts
+++ b/packages/react-native-livechart/tests/draw/candle.test.ts
@@ -214,6 +214,7 @@ describe("candle geometry metrics overrides", () => {
       minBodyPx: 1,
       maxBodyPx: 20,
       bodyWidthRatio: 0.8,
+      minGapPx: 2,
       bodyRadius: 0,
       wickWidth: 1,
     });
@@ -228,10 +229,33 @@ describe("candle geometry metrics overrides", () => {
       minBodyPx: 1,
       maxBodyPx: 40,
       bodyWidthRatio: 0.5,
+      minGapPx: 2,
       bodyRadius: 0,
       wickWidth: 1,
     });
     expect(thin.bodies[0].w).toBe(20); // 40 * 0.5
+  });
+
+  it("lets minGapPx: 0 keep bodies proportional on tiny slots", () => {
+    // chartW = 60 - 20 = 40, windowSecs 800 → slotPx = 3; slotPx - 2 clamps to the 1px floor.
+    const def = buildCandleGeometry(c, null, pad, 60, 210, 0, 800, 90, 110, 60, {
+      minBodyPx: 1,
+      maxBodyPx: 40,
+      bodyWidthRatio: 0.9,
+      minGapPx: 2,
+      bodyRadius: 0,
+      wickWidth: 1,
+    });
+    expect(def.bodies[0].w).toBe(1); // min(3 * 0.9, 3 - 2, 40)
+    const dense = buildCandleGeometry(c, null, pad, 60, 210, 0, 800, 90, 110, 60, {
+      minBodyPx: 1,
+      maxBodyPx: 40,
+      bodyWidthRatio: 0.9,
+      minGapPx: 0,
+      bodyRadius: 0,
+      wickWidth: 1,
+    });
+    expect(dense.bodies[0].w).toBeCloseTo(2.7, 5); // 3 * 0.9
   });
 
   it("floors body height at minBodyPx for a doji", () => {
@@ -242,6 +266,7 @@ describe("candle geometry metrics overrides", () => {
       minBodyPx: 6,
       maxBodyPx: 40,
       bodyWidthRatio: 0.8,
+      minGapPx: 2,
       bodyRadius: 0,
       wickWidth: 1,
     });

--- a/packages/react-native-livechart/tests/draw/volume.test.ts
+++ b/packages/react-native-livechart/tests/draw/volume.test.ts
@@ -289,6 +289,7 @@ describe("buildVolumeGeometry", () => {
         minBodyPx: 1,
         maxBodyPx: 40,
         bodyWidthRatio: 0.5,
+        minGapPx: 2,
         bodyRadius: 0,
         wickWidth: 1,
       },

--- a/packages/react-native-livechart/tests/draw/volume.test.ts
+++ b/packages/react-native-livechart/tests/draw/volume.test.ts
@@ -296,4 +296,49 @@ describe("buildVolumeGeometry", () => {
     );
     expect(r.bars[0].w).toBe(20); // 40 * 0.5
   });
+
+  it("lets minGapPx: 0 keep bars proportional on tiny slots", () => {
+    // chartW = 60 - 20 = 40, windowSecs 800 → slotPx = 3.
+    const def = buildVolumeGeometry(
+      [vc(0, 1, 2, 0, 1, 5)],
+      null,
+      pad,
+      60,
+      100,
+      0,
+      800,
+      20,
+      60,
+      {
+        minBodyPx: 1,
+        maxBodyPx: 40,
+        bodyWidthRatio: 0.9,
+        minGapPx: 2,
+        bodyRadius: 0,
+        wickWidth: 1,
+      },
+    );
+    expect(def.bars[0].w).toBe(1); // min(3 * 0.9, 3 - 2, 40)
+
+    const dense = buildVolumeGeometry(
+      [vc(0, 1, 2, 0, 1, 5)],
+      null,
+      pad,
+      60,
+      100,
+      0,
+      800,
+      20,
+      60,
+      {
+        minBodyPx: 1,
+        maxBodyPx: 40,
+        bodyWidthRatio: 0.9,
+        minGapPx: 0,
+        bodyRadius: 0,
+        wickWidth: 1,
+      },
+    );
+    expect(dense.bars[0].w).toBeCloseTo(2.7, 5); // 3 * 0.9
+  });
 });

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -1529,6 +1529,7 @@ describe("resolveMetrics", () => {
       minBodyPx: 1,
       maxBodyPx: 40,
       bodyWidthRatio: 0.8,
+      minGapPx: 2,
       bodyRadius: 0,
       wickWidth: 1,
     });
@@ -1570,6 +1571,7 @@ describe("resolveMetrics", () => {
       minBodyPx: 1,
       maxBodyPx: 12,
       bodyWidthRatio: 0.8,
+      minGapPx: 2,
       bodyRadius: 0,
       wickWidth: 1,
     });


### PR DESCRIPTION
**What**
- New `CandleMetrics.minGapPx`: the minimum horizontal gap (px) enforced between adjacent candle bodies, replacing the hardcoded `slotPx - 2` clamp in the candle and volume body-width math.
- Default `2` — every existing chart renders pixel-identical. Set `0` to let `bodyWidthRatio` alone control body width.

**Why**
- Our spot chart lets users zoom out to hundreds of candles, so slots shrink to 2–3px.
- At that density the hardcoded 2px gap clamps every body to the 1px floor — a wall of hairlines.
- `bodyWidthRatio` can't express this today; the gap clamp always wins on tiny slots.

**Test plan**
- `npm run verify` (typecheck + lint + test) green: 99 suites, 1437 tests.
- New case in `tests/draw/candle.test.ts`: on a 3px slot with `bodyWidthRatio: 0.9`, default metrics give a 1px body while `minGapPx: 0` gives the proportional 2.7px body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)