### PR TITLE
feat: timeScroll overscroll — free pan/zoom into blank space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aligned volume bars. Set it to `0` to let `bodyWidthRatio` keep bodies
   proportional on dense charts. The default preserves existing rendering.
 
+- **TradingView-style time-scroll overscroll.** `TimeScrollConfig.overscroll`
+  lets `LiveChart` and `LiveChartSeries` pan, fling, and pinch past the oldest
+  data and live edge into blank space by a configurable fraction of the visible
+  window. It defaults to `0` (the existing hard stops), clamps to `[0, 0.99]`,
+  and re-attaches to live when a released gesture settles near the live edge.
+  Runtime setting changes immediately clamp an already parked window to the new
+  bounds. The Time scroll demo now includes `Off`, `50%`, and `90%` controls.
+
 ## [4.13.1] - 2026-07-30
 
 ### Fixed

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -43,6 +43,12 @@ const HOLD_OPTIONS: { value: number; label: string }[] = [
   { value: 750, label: "750ms" },
 ];
 
+const OVERSCROLL_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: "Off" },
+  { value: 0.5, label: "50%" },
+  { value: 0.9, label: "90%" },
+];
+
 // `returnToLive` controls how the window goes back to live when timeScroll is
 // switched off mid-scroll: glide (default), instant snap, or a slower glide.
 type ReturnMode = "glide" | "instant" | "slow";
@@ -63,6 +69,7 @@ export default function TimeScrollScreen() {
   const [mode, setMode] = useState<"candle" | "line">("candle");
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [holdMs, setHoldMs] = useState(500);
+  const [overscroll, setOverscroll] = useState(0);
   const [enabled, setEnabled] = useState(true);
   const [followViewEdge, setFollowViewEdge] = useState(true);
   const [hideLiveOnScrollBack, setHideLiveOnScrollBack] = useState(true);
@@ -118,7 +125,12 @@ export default function TimeScrollScreen() {
           badge={{ followViewEdge }}
           timeScroll={
             enabled
-              ? { gesture, scrubHoldMs: holdMs, hideLiveOnScrollBack }
+              ? {
+                  gesture,
+                  scrubHoldMs: holdMs,
+                  hideLiveOnScrollBack,
+                  overscroll,
+                }
               : false
           }
           returnToLive={RETURN_TO_LIVE[returnMode]}
@@ -180,6 +192,13 @@ export default function TimeScrollScreen() {
       <ControlRow label="Pan to scroll">
         <ToggleChip label="timeScroll" value={enabled} onChange={setEnabled} />
       </ControlRow>
+
+      <ChipRow
+        label="Overscroll (visible-window fraction)"
+        options={OVERSCROLL_OPTIONS}
+        value={overscroll}
+        onChange={setOverscroll}
+      />
 
       <ChipRow
         label="Return to live (toggle timeScroll off while scrolled back)"

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -139,7 +139,10 @@ default off.
   chart stops auto-following until you return to the live edge. Setting it back to
   `false` while scrolled back glides the window back to the live edge (eased, not
   an instant jump; never frozen at the old position). Per-series dots / value
-  labels track each series' value at the visible right edge while scrolled.
+  labels track each series' value at the visible right edge while scrolled. Pass
+  a [`TimeScrollConfig`](/api-reference/types#config-objects) with `overscroll`
+  to pan or pinch past the oldest data and live edge into blank space
+  (TradingView-style; default `0` keeps the hard stops).
   **@experimental.** See [Time-scroll](/guides/time-scroll).
 </ParamField>
 

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -325,9 +325,11 @@ provided; everything else has a default.
   `true` uses the default drag-to-scroll gesture (`"holdToScrub"` — drag scrolls,
   press-and-hold scrubs); pass a
   [`TimeScrollConfig`](/api-reference/types#config-objects) to pick `"axisDrag"`
-  (drag the x-axis strip), set `scrubHoldMs`, or set
+  (drag the x-axis strip), set `scrubHoldMs`, set
   `hideLiveOnScrollBack: false` to keep the live badge, dot, and value line visible
-  while scrolled back (hidden by default — they mark the off-screen live price).
+  while scrolled back (hidden by default — they mark the off-screen live price), or
+  set `overscroll` to drag past the data bounds into blank space
+  (TradingView-style; default `0` — hard stops).
   **@experimental.** See [Time-scroll](/guides/time-scroll).
 </ParamField>
 

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -447,6 +447,7 @@ interface TimeScrollConfig {
   gesture?: "holdToScrub" | "axisDrag"; // activation; default "holdToScrub"
   scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
   hideLiveOnScrollBack?: boolean; // hide live badge + dot + value line while scrolled back (they mark the off-screen live price); default true. Ignored with badge.followViewEdge
+  overscroll?: number; // fraction of the window (0–1) pan/zoom may travel past the data bounds into blank space (TradingView-style); default 0 (hard stops at the oldest data / live edge)
 }
 // Tunes the return-to-live glide (the `returnToLive` prop). @experimental
 interface ReturnToLiveConfig {

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -86,6 +86,22 @@ scrolls instead). Higher = more deliberate scrub, fewer accidental scrubs while 
 />
 ```
 
+### Overscroll (`overscroll`)
+
+By default the window hard-stops at the data: the oldest point on the left, the live edge on the
+right. Set `overscroll` to a fraction of the visible window (`0`–`1`) to drag **past** those bounds
+into blank space, TradingView-style — pull the latest candle toward the middle to leave room on the
+right, or pan left past loaded history (pairs well with `onVisibleRangeChange` paging while older
+data lazy-loads in).
+
+```tsx
+<LiveChart data={data} value={value} timeScroll={{ overscroll: 0.9 }} />
+```
+
+A released drag or fling that settles close to the live edge (within 2% of the window) re-attaches
+to live; anything further out stays parked where it stopped. The same bounds apply to pinch-to-zoom.
+Default `0` (hard stops).
+
 ## Pinch-to-zoom (`zoom`)
 
 Enable `zoom` for **two-finger pinch-to-zoom** of the visible window. Pinch out to zoom in (a

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -46,6 +46,7 @@ import {
   resolveScrub,
   resolveScrubAction,
   resolveTransitions,
+  resolveOverscroll,
   resolveReturnToLiveMs,
   resolveSelectionDot,
   resolveThreshold,
@@ -607,6 +608,11 @@ function useLiveChartController({
   // Glide duration for the return-to-live animation (0 = instant). A sibling of
   // `timeScroll` so it survives `timeScroll={false}` (the disable that triggers it).
   const returnToLiveMs = resolveReturnToLiveMs(returnToLive);
+  // Overscroll fraction ([0, 1)) — how far pan/zoom may travel past the data
+  // bounds into blank space. 0 (the default) keeps the classic hard stops.
+  const timeScrollOverscroll = timeScrollEnabled
+    ? resolveOverscroll(timeScroll)
+    : 0;
   const zoomCfg = resolveZoom(zoom);
   const zoomEnabled = zoomCfg !== null && !isStatic;
 
@@ -677,6 +683,7 @@ function useLiveChartController({
     static: isStatic,
     snapKey,
     scrollEnabled: timeScrollEnabled,
+    allowFutureViewEnd: timeScrollOverscroll > 0,
     returnToLiveMs,
     smoothing,
     adaptiveSpeedBoost: metricsCfg.motion.adaptiveSpeedBoost,
@@ -1089,6 +1096,7 @@ function useLiveChartController({
     minTime: scrollMinTime,
     enabled: timeScrollEnabled,
     mode: scrollGestureMode,
+    overscroll: timeScrollOverscroll,
     scrollActive,
     // Once a scrub is engaged the chart is locked: scrolling goes inert so the
     // finger only moves the price indicator across a fixed window.
@@ -1111,6 +1119,7 @@ function useLiveChartController({
     enabled: zoomEnabled,
     minTimeWindow: zoomCfg?.minTimeWindow,
     maxTimeWindow: zoomCfg?.maxTimeWindow,
+    overscroll: timeScrollOverscroll,
     onZoomStart: () => {
       "worklet";
       crosshairScrubActive.set(false);

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -39,6 +39,7 @@ import {
   resolveMarkerCluster,
   resolveMetrics,
   resolveMultiSeriesDot,
+  resolveOverscroll,
   resolveReturnToLiveMs,
   resolveScrub,
   resolveSelectionDot,
@@ -211,6 +212,11 @@ function useLiveChartSeriesController({
   // Return-to-live glide duration (0 = instant); sibling of `timeScroll` so it
   // survives `timeScroll={false}` (the disable that triggers it). See #164.
   const returnToLiveMs = resolveReturnToLiveMs(returnToLive);
+  // Overscroll fraction ([0, 1)) — how far pan/zoom may travel past the data
+  // bounds into blank space. 0 (the default) keeps the classic hard stops.
+  const timeScrollOverscroll = timeScrollEnabled
+    ? resolveOverscroll(timeScroll)
+    : 0;
   const zoomCfg = resolveZoom(zoom);
   const zoomEnabled = zoomCfg !== null;
   const scrollGestureMode =
@@ -367,6 +373,7 @@ function useLiveChartSeriesController({
     paused,
     snapKey,
     scrollEnabled: timeScrollEnabled,
+    allowFutureViewEnd: timeScrollOverscroll > 0,
     returnToLiveMs,
     smoothing,
     adaptiveSpeedBoost: metricsCfg.motion.adaptiveSpeedBoost,
@@ -508,6 +515,7 @@ function useLiveChartSeriesController({
     minTime: scrollMinTime,
     enabled: timeScrollEnabled,
     mode: scrollGestureMode,
+    overscroll: timeScrollOverscroll,
     scrollActive,
     // Once a scrub is engaged the chart is locked: scrolling goes inert so the
     // finger only moves the price indicator across a fixed window.
@@ -526,6 +534,7 @@ function useLiveChartSeriesController({
     enabled: zoomEnabled,
     minTimeWindow: zoomCfg?.minTimeWindow,
     maxTimeWindow: zoomCfg?.maxTimeWindow,
+    overscroll: timeScrollOverscroll,
     onZoomStart: () => {
       "worklet";
       crosshairScrubActive.set(false);

--- a/packages/react-native-livechart/src/core/liveChartEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartEngineTick.ts
@@ -94,6 +94,15 @@ export interface EngineTickInput {
    */
   viewEnd?: number | null;
   /**
+   * Honor a {@link viewEnd} parked at or past the live edge (blank future space)
+   * instead of falling through to following live. Set when `timeScroll.overscroll`
+   * is active — the pan/pinch gestures may then park the right edge beyond the
+   * live edge, and the engine must freeze there or the gestures render nothing.
+   * The `viewEnd >= firstDataTime` strand-guard applies in both modes. Default
+   * `false` (classic behavior: only a past `viewEnd` freezes).
+   */
+  allowFutureViewEnd?: boolean;
+  /**
    * "Return to live" glide (see #164). When time-scroll is disabled while scrolled
    * back, the engine hook clears {@link viewEnd} and animates {@link returnT} from
    * `0`→`1`; each frame the right edge interpolates from {@link returnFrom} (the
@@ -148,9 +157,13 @@ export function tickLiveChartEngineFrame(
   // before the active series' first point falls through to following live (so a
   // line/candle span mismatch never strands the window on an empty plot). When
   // time-scroll is disabled the hook clears `viewEnd` (and kicks off the glide
-  // below), so a stale edge can't keep the window frozen. See #164.
+  // below), so a stale edge can't keep the window frozen. See #164. With
+  // `allowFutureViewEnd` (timeScroll.overscroll) an edge parked past live is
+  // honored too — the data-overlap strand-guard stays in both modes.
   const scrolledBack =
-    viewEnd != null && viewEnd < liveEdge && viewEnd >= firstDataTime;
+    viewEnd != null &&
+    viewEnd >= firstDataTime &&
+    (viewEnd < liveEdge || input.allowFutureViewEnd === true);
   if (scrolledBack) {
     state.timestamp = viewEnd;
   } else if (!input.paused) {

--- a/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
+++ b/packages/react-native-livechart/src/core/liveChartSeriesEngineTick.ts
@@ -68,6 +68,13 @@ export interface MultiEngineTickInput {
    */
   viewEnd?: number | null;
   /**
+   * Honor a {@link viewEnd} parked at or past the live edge (blank future space)
+   * instead of falling through to following live. Set when `timeScroll.overscroll`
+   * is active. The `viewEnd >= firstDataTime` strand-guard applies in both modes.
+   * Default `false` (classic behavior: only a past `viewEnd` freezes).
+   */
+  allowFutureViewEnd?: boolean;
+  /**
    * "Return to live" glide (see #164). When time-scroll is disabled while scrolled
    * back, the hook clears {@link viewEnd} and animates {@link returnT} `0`→`1`;
    * each frame the right edge interpolates from {@link returnFrom} to the *current*
@@ -113,8 +120,12 @@ export function tickLiveChartSeriesEngineFrame(
   // edge AND that edge still sits within the data; a stranded edge falls through
   // to following live. When time-scroll is disabled the hook clears `viewEnd` and
   // kicks off the glide below, so a stale edge can't keep the window frozen. #164.
+  // With `allowFutureViewEnd` (timeScroll.overscroll) an edge parked past live is
+  // honored too — the data-overlap strand-guard stays in both modes.
   const scrolledBack =
-    viewEnd != null && viewEnd < liveEdge && viewEnd >= firstDataTime;
+    viewEnd != null &&
+    viewEnd >= firstDataTime &&
+    (viewEnd < liveEdge || input.allowFutureViewEnd === true);
   if (scrolledBack) {
     state.timestamp = viewEnd;
   } else if (!input.paused) {

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -30,6 +30,7 @@ import type {
   SelectionDotRingConfig,
   ReturnToLiveConfig,
   ThresholdConfig,
+  TimeScrollConfig,
   ThresholdLineConfig,
   TradeEvent,
   TransitionConfig,
@@ -558,6 +559,27 @@ export function resolveReturnToLiveMs(
   const d = prop.duration;
   if (d == null) return RETURN_TO_LIVE_MS;
   return d > 0 ? d : 0;
+}
+
+/**
+ * Overscroll ceiling — `overscroll: 1` would let the window scroll fully past
+ * the data (an all-blank plot), so the fraction clamps just short of it.
+ */
+const MAX_OVERSCROLL = 0.99;
+
+/**
+ * Resolves `timeScroll.overscroll` to a clamped `[0, 1)` fraction of the
+ * visible window that pan / fling / pinch may travel past the data bounds.
+ * `0` (booleans, omitted, or non-positive values) keeps the classic hard
+ * stops at the oldest data and the live edge. See {@link TimeScrollConfig}.
+ */
+export function resolveOverscroll(
+  prop: boolean | TimeScrollConfig | undefined,
+): number {
+  if (prop == null || typeof prop === "boolean") return 0;
+  const v = prop.overscroll;
+  if (v == null || !(v > 0)) return 0;
+  return v < MAX_OVERSCROLL ? v : MAX_OVERSCROLL;
 }
 
 /**

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -66,6 +66,12 @@ export interface EngineConfig {
    */
   scrollEnabled?: boolean;
   /**
+   * Honor a `viewEnd` parked at or past the live edge — set when
+   * `timeScroll.overscroll` is active so the pan/pinch gestures can drag into
+   * blank future space. See {@link EngineTickInput.allowFutureViewEnd}.
+   */
+  allowFutureViewEnd?: boolean;
+  /**
    * Duration (ms) of the return-to-live glide when {@link scrollEnabled} flips to
    * `false` while scrolled back. `0` snaps instantly (no animation). Defaults to
    * {@link RETURN_TO_LIVE_MS}. Resolved from `timeScroll.returnToLive`. See #164.
@@ -208,6 +214,8 @@ export interface EngineFrameRefs {
   pausedSV: SharedValue<boolean>;
   /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
   viewEndSV?: SharedValue<number | null>;
+  /** Honor a `viewEnd` past the live edge (timeScroll.overscroll). Optional. */
+  allowFutureViewEndSV?: SharedValue<boolean>;
   /** "Return to live" glide progress (0→1); the right edge eases to live. Optional. */
   returnTSV?: SharedValue<number>;
   /** Frozen right-edge time the return glide starts from. Optional. */
@@ -340,6 +348,7 @@ export function applyLiveChartEngineFrame(
   input.paused = sv.pausedSV.value;
   input.snap = snap;
   input.viewEnd = sv.viewEndSV?.value;
+  input.allowFutureViewEnd = sv.allowFutureViewEndSV?.value ?? false;
   input.returnT = sv.returnTSV?.value;
   input.returnFrom = sv.returnFromSV?.value;
   input.viewWindow = sv.viewWindowSV?.value;
@@ -430,6 +439,10 @@ export function useLiveChartEngine(
   // (the tick no longer reads it — clearing `viewEnd` is what makes it follow).
   // Defaults to enabled so a caller that omits it behaves as before.
   const scrollEnabledSV = useDerivedValue(() => config.scrollEnabled ?? true);
+  // Honor a viewEnd parked past the live edge (timeScroll.overscroll).
+  const allowFutureViewEndSV = useDerivedValue(
+    () => config.allowFutureViewEnd ?? false,
+  );
   // Return-to-live glide duration (ms); 0 = instant snap. Read by the reaction.
   const returnToLiveMsSV = useDerivedValue(
     () => config.returnToLiveMs ?? RETURN_TO_LIVE_MS,
@@ -516,6 +529,7 @@ export function useLiveChartEngine(
     windowBufferSV,
     pausedSV,
     viewEndSV: viewEnd,
+    allowFutureViewEndSV,
     returnTSV: returnT,
     returnFromSV: returnFrom,
     viewWindowSV: viewWindow,

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -40,6 +40,12 @@ export interface MultiSeriesEngineConfig {
    */
   scrollEnabled?: boolean;
   /**
+   * Honor a `viewEnd` parked at or past the live edge — set when
+   * `timeScroll.overscroll` is active so the pan/pinch gestures can drag into
+   * blank future space. See {@link MultiEngineTickInput.allowFutureViewEnd}.
+   */
+  allowFutureViewEnd?: boolean;
+  /**
    * Duration (ms) of the return-to-live glide when {@link scrollEnabled} flips to
    * `false` while scrolled back. `0` snaps instantly. Defaults to
    * {@link RETURN_TO_LIVE_MS}. Resolved from `timeScroll.returnToLive`. See #164.
@@ -77,6 +83,8 @@ export interface MultiEngineFrameRefs {
   pausedSV: SharedValue<boolean>;
   /** Pan-scroll right-edge override (null = follow live). Optional for callers/tests. */
   viewEndSV?: SharedValue<number | null>;
+  /** Honor a `viewEnd` past the live edge (timeScroll.overscroll). Optional. */
+  allowFutureViewEndSV?: SharedValue<boolean>;
   /** "Return to live" glide progress (0→1); the right edge eases to live. Optional. */
   returnTSV?: SharedValue<number>;
   /** Frozen right-edge time the return glide starts from. Optional. */
@@ -240,6 +248,7 @@ export function applyLiveChartSeriesEngineFrame(
   input.paused = sv.pausedSV.value;
   input.snap = snap;
   input.viewEnd = sv.viewEndSV?.value;
+  input.allowFutureViewEnd = sv.allowFutureViewEndSV?.value ?? false;
   input.returnT = sv.returnTSV?.value;
   input.returnFrom = sv.returnFromSV?.value;
   input.viewWindow = sv.viewWindowSV?.value;
@@ -287,6 +296,10 @@ export function useLiveChartSeriesEngine(
   // Whether time-scroll is active — drives the return-to-live reaction below.
   // Defaults to enabled (legacy behavior).
   const scrollEnabledSV = useDerivedValue(() => config.scrollEnabled ?? true);
+  // Honor a viewEnd parked past the live edge (timeScroll.overscroll).
+  const allowFutureViewEndSV = useDerivedValue(
+    () => config.allowFutureViewEnd ?? false,
+  );
   // Return-to-live glide duration (ms); 0 = instant snap. Read by the reaction.
   const returnToLiveMsSV = useDerivedValue(
     () => config.returnToLiveMs ?? RETURN_TO_LIVE_MS,
@@ -362,6 +375,7 @@ export function useLiveChartSeriesEngine(
     windowBufferSV,
     pausedSV,
     viewEndSV: viewEnd,
+    allowFutureViewEndSV,
     returnTSV: returnT,
     returnFromSV: returnFrom,
     viewWindowSV: viewWindow,

--- a/packages/react-native-livechart/src/draw/line.ts
+++ b/packages/react-native-livechart/src/draw/line.ts
@@ -229,6 +229,7 @@ export function buildLinePoints(
   canvasHeight: number,
   padding: ChartPadding,
   out?: number[],
+  omitTipBeyondData = false,
 ): number[] {
   "worklet";
   const pts: number[] = out ?? [];
@@ -326,6 +327,18 @@ export function buildLinePoints(
         padding.top + (displayMax - data[b].value) * yScale,
       );
     }
+  }
+
+  // A scrolled-back / overscrolled window can end after the last data point;
+  // the synthetic tip would then fabricate a flat segment from that point to
+  // the right edge. Callers pass `omitTipBeyondData` to end the line at the
+  // last real point instead.
+  if (
+    omitTipBeyondData &&
+    endIdx === data.length &&
+    data[endIdx - 1].time < now
+  ) {
+    return pts;
   }
 
   // Live tip at current time with smoothed value

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -105,6 +105,10 @@ export function useChartPaths(
       engine.canvasHeight.get(),
       padding,
       buf,
+      // Only a live-following chart may extend the line to the right edge; a
+      // parked (scrolled-back / overscrolled) window ends at its last real
+      // point rather than fabricating a flat line into dataless space.
+      engine.viewEnd.get() != null,
     );
 
     // Skip blending when fully revealed or no morphT provided

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -1,6 +1,8 @@
 import { Gesture } from "react-native-gesture-handler";
 import {
   cancelAnimation,
+  useAnimatedReaction,
+  useDerivedValue,
   useSharedValue,
   withDecay,
   type SharedValue,
@@ -120,6 +122,26 @@ export function panUpperBound(
 }
 
 /**
+ * Re-clamp a parked right edge after the overscroll setting changes. Reducing
+ * the allowance must not leave a stale future/history position outside the new
+ * bounds; at the classic live-edge hard stop, `null` resumes following live.
+ */
+export function clampViewEndForOverscroll(
+  viewEnd: number,
+  minTime: number,
+  windowSecs: number,
+  liveEdge: number,
+  overscroll: number,
+): number | null {
+  "worklet";
+  const lo = panLowerBound(minTime, windowSecs, liveEdge, overscroll);
+  if (viewEnd < lo) return lo;
+  const hi = panUpperBound(windowSecs, liveEdge, overscroll);
+  if (viewEnd >= hi) return overscroll > 0 ? hi : null;
+  return viewEnd;
+}
+
+/**
  * Next right-edge time after dragging `changeX` px (drag right ⇒ reveal earlier
  * time ⇒ smaller right edge), clamped to `[lo, panUpperBound]`. Without
  * overscroll, returns `null` once the drag reaches the live edge — the signal to
@@ -207,6 +229,31 @@ export function usePanScroll({
   const startX = useSharedValue(0);
   const startY = useSharedValue(0);
   const armed = useSharedValue(false);
+  const overscrollSV = useDerivedValue(() => overscroll);
+
+  // A runtime config change (the demo exposes Off / 50% / 90%) applies to an
+  // already parked window immediately. Without this, disabling overscroll while
+  // parked in the future leaves a numeric `viewEnd`; re-enabling it later revives
+  // that stale future position and makes the chart jump without a gesture.
+  useAnimatedReaction(
+    () => overscrollSV.value,
+    /* istanbul ignore next -- UI-thread config reaction; pure clamp is unit-tested */
+    (nextOverscroll) => {
+      const cur = viewEnd.get();
+      if (cur == null) return;
+      const next = clampViewEndForOverscroll(
+        cur,
+        minTime.get(),
+        displayWindow.get(),
+        liveEdge.get(),
+        nextOverscroll,
+      );
+      if (next !== cur) {
+        cancelAnimation(viewEnd);
+        viewEnd.set(next);
+      }
+    },
+  );
 
   const onStart =
     /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -71,26 +71,65 @@ export interface UsePanScrollOptions {
    * price indicator. Cleared when the finger lifts (the scrub pan's finalize).
    */
   scrubActive?: SharedValue<boolean>;
+  /**
+   * Fraction of the visible window (0–1) the pan may travel past the data
+   * bounds — into blank future space beyond the live edge and blank history
+   * before the oldest point (TradingView-style free dragging). `0` (default)
+   * keeps the classic hard stops at the data. Resolved from
+   * `timeScroll.overscroll` (see `resolveOverscroll`).
+   */
+  overscroll?: number;
 }
+
+/**
+ * Snap-to-follow zone around the live edge, as a fraction of the window. With
+ * overscroll a released drag/fling that settles within this zone re-attaches to
+ * live; anything further out stays parked where it stopped.
+ */
+export const FOLLOW_SNAP = 0.02;
 
 /**
  * Smallest valid right-edge time: keeps the window's left edge
  * (`rightEdge - window`) from passing `minTime`, and never exceeds the live edge
- * so the `[lo, liveEdge]` clamp range stays valid when history is short.
+ * so the `[lo, liveEdge]` clamp range stays valid when history is short. With
+ * `overscroll` the left edge may pass `minTime` by that fraction of the window,
+ * exposing blank space before the oldest data.
  */
 export function panLowerBound(
   minTime: number,
   windowSecs: number,
   liveEdge: number,
+  overscroll: number = 0,
 ): number {
   "worklet";
-  return Math.min(minTime + windowSecs, liveEdge);
+  return Math.min(minTime + windowSecs * (1 - overscroll), liveEdge);
+}
+
+/**
+ * Largest valid right-edge time: the live edge, pushed past it by `overscroll`
+ * (a fraction of the window) so the latest data can be dragged toward the middle
+ * of the plot, leaving blank future space on the right. `0` = the live edge.
+ */
+export function panUpperBound(
+  windowSecs: number,
+  liveEdge: number,
+  overscroll: number,
+): number {
+  "worklet";
+  return liveEdge + windowSecs * overscroll;
 }
 
 /**
  * Next right-edge time after dragging `changeX` px (drag right ⇒ reveal earlier
- * time ⇒ smaller right edge), clamped to `[lo, liveEdge]`. Returns `null` once
- * the drag reaches the live edge — the signal to resume following.
+ * time ⇒ smaller right edge), clamped to `[lo, panUpperBound]`. Without
+ * overscroll, returns `null` once the drag reaches the live edge — the signal to
+ * resume following.
+ *
+ * With overscroll it must NOT return `null` mid-drag: the pan's `onChange`
+ * re-derives `cur` from `viewEnd ?? liveEdge` each frame, so snapping to follow
+ * re-anchors every per-frame delta at the live edge and the drag can't escape it
+ * in either direction. Re-attaching to live happens only in the release decay
+ * callback (see `usePanScroll`), inside the {@link FOLLOW_SNAP} zone.
  */
 export function nextViewEnd(
   cur: number,
@@ -99,10 +138,16 @@ export function nextViewEnd(
   windowSecs: number,
   liveEdge: number,
   lo: number,
+  overscroll: number = 0,
 ): number | null {
   "worklet";
   let next = cur - (changeX / chartW) * windowSecs;
   if (next < lo) next = lo;
+  if (overscroll > 0) {
+    const hi = panUpperBound(windowSecs, liveEdge, overscroll);
+    if (next > hi) next = hi;
+    return next;
+  }
   if (next > liveEdge) next = liveEdge;
   return next >= liveEdge ? null : next;
 }
@@ -150,6 +195,7 @@ export function usePanScroll({
   onScrollStart,
   scrollActive,
   scrubActive,
+  overscroll = 0,
 }: UsePanScrollOptions): ReturnType<typeof Gesture.Pan> {
   const { viewEnd, liveEdge, displayWindow, canvasWidth, canvasHeight } = engine;
   const padLeft = padding.left;
@@ -194,8 +240,8 @@ export function usePanScroll({
       if (chartW <= 0) return;
       const edge = liveEdge.get();
       const cur = viewEnd.get() ?? edge;
-      const lo = panLowerBound(minTime.get(), win, edge);
-      viewEnd.set(nextViewEnd(cur, e.changeX, chartW, win, edge, lo));
+      const lo = panLowerBound(minTime.get(), win, edge, overscroll);
+      viewEnd.set(nextViewEnd(cur, e.changeX, chartW, win, edge, lo, overscroll));
     };
 
   const onEnd =
@@ -208,15 +254,20 @@ export function usePanScroll({
       const chartW = canvasWidth.get() - padLeft - padRight;
       if (chartW <= 0) return;
       const edge = liveEdge.get();
-      const lo = panLowerBound(minTime.get(), win, edge);
+      const lo = panLowerBound(minTime.get(), win, edge, overscroll);
+      const hi = overscroll > 0 ? panUpperBound(win, edge, overscroll) : edge;
+      // With overscroll the snap-to-follow zone widens from the exact live edge
+      // to FOLLOW_SNAP of the window around it — this release callback is the
+      // ONLY place that re-attaches to live (never mid-drag, see nextViewEnd).
+      const snapZone = overscroll > 0 ? win * FOLLOW_SNAP : 1e-3;
       const velocity = flingVelocity(e.velocityX, chartW, win);
       cancelAnimation(viewEnd);
       viewEnd.set(
-        withDecay({ velocity, clamp: [lo, edge] }, (finished) => {
+        withDecay({ velocity, clamp: [lo, hi] }, (finished) => {
           "worklet";
-          // Landed on the live-edge clamp → resume following; stopped short →
-          // stay frozen where inertia died.
-          if (finished && (viewEnd.get() ?? edge) >= edge - 1e-3) {
+          // Landed near the live edge → resume following; stopped short (or
+          // past, with overscroll) → stay frozen where inertia died.
+          if (finished && Math.abs((viewEnd.get() ?? edge) - edge) <= snapZone) {
             viewEnd.set(null);
           }
         }),

--- a/packages/react-native-livechart/src/hooks/usePinchZoom.ts
+++ b/packages/react-native-livechart/src/hooks/usePinchZoom.ts
@@ -6,7 +6,7 @@ import {
 } from "react-native-reanimated";
 
 import type { ChartPadding } from "../draw/line";
-import { panLowerBound } from "./usePanScroll";
+import { FOLLOW_SNAP, panLowerBound, panUpperBound } from "./usePanScroll";
 
 /** Engine SharedValues the pinch-zoom gesture reads/writes. */
 export interface PinchZoomEngineRefs {
@@ -44,6 +44,13 @@ export interface UsePinchZoomOptions {
   maxTimeWindow?: number;
   /** Worklet fired when a pinch activates — e.g. to clear a lingering crosshair. */
   onZoomStart?: () => void;
+  /**
+   * Fraction of the visible window (0–1) the zoomed window may travel past the
+   * data bounds — blank future space beyond the live edge, blank history before
+   * the oldest point. `0` (default) keeps the classic hard stops. Shared with
+   * {@link usePanScroll} (resolved from `timeScroll.overscroll`).
+   */
+  overscroll?: number;
 }
 
 /** Clamp a window width to `[minWin, maxWin]`. */
@@ -131,6 +138,7 @@ export function usePinchZoom({
   minTimeWindow,
   maxTimeWindow,
   onZoomStart,
+  overscroll = 0,
 }: UsePinchZoomOptions): ReturnType<typeof Gesture.Pinch> {
   const { viewWindow, viewEnd, liveEdge, displayWindow, canvasWidth } = engine;
   const padLeft = padding.left;
@@ -175,14 +183,27 @@ export function usePinchZoom({
       // doesn't compound; the right edge then keeps it under the (live) focal.
       const focalT = focalTime(e.focalX, padLeft, chartW, sEnd - sWin, sWin);
       let newEnd = zoomViewEnd(focalT, e.focalX, padLeft, chartW, newWin);
-      const lo = panLowerBound(minTime.get(), newWin, edge);
+      const lo = panLowerBound(minTime.get(), newWin, edge, overscroll);
       if (newEnd < lo) newEnd = lo;
-      if (newEnd > edge) newEnd = edge;
+      const hi = overscroll > 0 ? panUpperBound(newWin, edge, overscroll) : edge;
+      if (newEnd > hi) newEnd = hi;
       viewWindow.set(newWin);
       // Track the displayed window 1:1 (bypass the frame-loop lerp lag) so the
       // focal anchor is pixel-accurate during the gesture.
       displayWindow.set(newWin);
-      viewEnd.set(newEnd >= edge ? null : newEnd);
+      // Unlike the pan (see nextViewEnd), snapping to `null` mid-gesture is safe
+      // here: the pinch maps cumulative scale/focal from a gesture-START snapshot
+      // (`startViewEnd`), not per-frame deltas, so a snap can't re-anchor it.
+      // With overscroll, snap within the FOLLOW_SNAP zone; without, at the edge.
+      viewEnd.set(
+        overscroll > 0
+          ? Math.abs(newEnd - edge) <= newWin * FOLLOW_SNAP
+            ? null
+            : newEnd
+          : newEnd >= edge
+            ? null
+            : newEnd,
+      );
     };
 
   return Gesture.Pinch().enabled(enabled).onStart(onStart).onChange(onChange);

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1780,6 +1780,17 @@ export interface TimeScrollConfig {
    * visible edge price, which IS in view.
    */
   hideLiveOnScrollBack?: boolean;
+  /**
+   * How far pan / fling / pinch may travel past the data bounds, as a fraction
+   * of the visible window (`0`–`1`). With overscroll you can drag the latest
+   * candle toward the middle of the plot (blank future space on the right) or
+   * pan left past the oldest point into blank history — TradingView-style free
+   * dragging. A released drag that settles within a small zone of the live edge
+   * re-attaches to live. Default `0`: the window hard-stops at the oldest data
+   * and the live edge (the classic behavior). Values outside `[0, 1)` are
+   * clamped. Applies to the pinch-zoom (`zoom`) clamps too.
+   */
+  overscroll?: number;
 }
 
 /**

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -233,6 +233,53 @@ describe("buildLinePoints", () => {
     const n = out.length >> 1;
     expect(n).toBeGreaterThan(0);
   });
+
+  it("omitTipBeyondData cuts the line at the last point when the window ends after the data", () => {
+    const now = 100;
+    const data = [
+      { time: now - 25, value: 2 },
+      { time: now - 20, value: 4 },
+    ];
+    const withTip = buildLinePoints(data, 4, now, 30, 0, 10, 200, 120, pad);
+    const cut = buildLinePoints(
+      data,
+      4,
+      now,
+      30,
+      0,
+      10,
+      200,
+      120,
+      pad,
+      undefined,
+      true,
+    );
+    // The tip (pinned to the right plot edge) is dropped; nothing else changes.
+    expect(cut).toEqual(withTip.slice(0, -2));
+  });
+
+  it("omitTipBeyondData keeps the tip when data continues past the window end", () => {
+    const now = 100;
+    const data = [
+      { time: now - 5, value: 1 },
+      { time: now + 10, value: 99 },
+    ];
+    const out = buildLinePoints(
+      data,
+      1,
+      now,
+      30,
+      0,
+      10,
+      200,
+      120,
+      pad,
+      undefined,
+      true,
+    );
+    const plain = buildLinePoints(data, 1, now, 30, 0, 10, 200, 120, pad);
+    expect(out).toEqual(plain);
+  });
 });
 
 describe("badge geometry metrics overrides", () => {

--- a/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
@@ -1,5 +1,6 @@
 import {
   axisBandTop,
+  clampViewEndForOverscroll,
   flingVelocity,
   nextViewEnd,
   panLowerBound,
@@ -35,6 +36,24 @@ describe("panUpperBound", () => {
 
   it("extends past the live edge by the overscroll fraction of the window", () => {
     expect(panUpperBound(30, 1000, 0.5)).toBe(1015);
+  });
+});
+
+describe("clampViewEndForOverscroll", () => {
+  it("resumes live when overscroll is disabled from a future position", () => {
+    expect(clampViewEndForOverscroll(1027, 900, 30, 1000, 0)).toBeNull();
+  });
+
+  it("clamps a future position to a reduced overscroll allowance", () => {
+    expect(clampViewEndForOverscroll(1027, 900, 30, 1000, 0.5)).toBe(1015);
+  });
+
+  it("clamps a history position to the new lower bound", () => {
+    expect(clampViewEndForOverscroll(905, 900, 30, 1000, 0)).toBe(930);
+  });
+
+  it("keeps a position already inside the new bounds", () => {
+    expect(clampViewEndForOverscroll(980, 900, 30, 1000, 0.5)).toBe(980);
   });
 });
 

--- a/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePanScroll.test.ts
@@ -3,6 +3,7 @@ import {
   flingVelocity,
   nextViewEnd,
   panLowerBound,
+  panUpperBound,
 } from "../../src/hooks/usePanScroll";
 
 describe("panLowerBound", () => {
@@ -14,6 +15,26 @@ describe("panLowerBound", () => {
   it("clamps to the live edge when history is shorter than the window", () => {
     // minTime + window (1020) would exceed the live edge ⇒ clamp to 1000.
     expect(panLowerBound(990, 30, 1000)).toBe(1000);
+  });
+
+  it("lets the left edge pass minTime by the overscroll fraction", () => {
+    // minTime + window*(1 - 0.5) = 900 + 15 ⇒ blank history space on the left.
+    expect(panLowerBound(900, 30, 1000, 0.5)).toBe(915);
+  });
+
+  it("still clamps to the live edge with overscroll when history is short", () => {
+    // 990 + 30*(1 - 0.5) = 1005 exceeds the live edge ⇒ clamp to 1000.
+    expect(panLowerBound(990, 30, 1000, 0.5)).toBe(1000);
+  });
+});
+
+describe("panUpperBound", () => {
+  it("is the live edge when overscroll is 0", () => {
+    expect(panUpperBound(30, 1000, 0)).toBe(1000);
+  });
+
+  it("extends past the live edge by the overscroll fraction of the window", () => {
+    expect(panUpperBound(30, 1000, 0.5)).toBe(1015);
   });
 });
 
@@ -42,6 +63,31 @@ describe("nextViewEnd", () => {
   it("clamps a forward overshoot to the live edge and follows", () => {
     // 997 + 30 = 1027 > liveEdge ⇒ clamp 1000 ⇒ null.
     expect(nextViewEnd(997, -200, 200, 30, 1000, 930)).toBeNull();
+  });
+});
+
+describe("nextViewEnd with overscroll", () => {
+  it("does NOT null (resume follow) when the drag crosses the live edge", () => {
+    // 997 + 3 = 1000 = liveEdge. Mid-drag, onChange re-derives `cur` from
+    // `viewEnd ?? liveEdge` each frame — a null here would re-anchor every
+    // per-frame delta at the live edge and the drag couldn't escape it in
+    // either direction. Re-attach happens only in the release decay callback.
+    expect(nextViewEnd(997, -20, 200, 30, 1000, 930, 0.5)).toBe(1000);
+  });
+
+  it("travels into blank future space past the live edge", () => {
+    // 1000 + 3 = 1003, within the upper bound 1000 + 30*0.5 = 1015.
+    expect(nextViewEnd(1000, -20, 200, 30, 1000, 930, 0.5)).toBe(1003);
+  });
+
+  it("clamps a forward overshoot to the overscroll upper bound", () => {
+    // 1000 + 30 = 1030 > 1015 ⇒ 1015 (still a number — never null mid-drag).
+    expect(nextViewEnd(1000, -200, 200, 30, 1000, 930, 0.5)).toBe(1015);
+  });
+
+  it("clamps to the caller's (overscroll-widened) lower bound", () => {
+    // 920 - 30 = 890, below lo 915 ⇒ 915.
+    expect(nextViewEnd(920, 200, 200, 30, 1000, 915, 0.5)).toBe(915);
   });
 });
 

--- a/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartEngineTick.test.ts
@@ -677,6 +677,41 @@ describe("tickLiveChartEngineFrame", () => {
       expect(s.timestamp).toBe(1000);
     });
 
+    // timeScroll.overscroll: with allowFutureViewEnd the gestures may park the
+    // right edge past the live edge (blank future space) and the engine must
+    // honor it — without the flag a future edge falls through to following.
+    it("freezes at a future viewEnd when allowFutureViewEnd is set", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({ viewEnd: 1100, allowFutureViewEnd: true }),
+      );
+      expect(s.timestamp).toBe(1100); // parked past live
+      expect(s.liveEdge).toBe(1000); // live edge keeps tracking "now"
+    });
+
+    it("ignores a future viewEnd when allowFutureViewEnd is off", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({ viewEnd: 1100, allowFutureViewEnd: false }),
+      );
+      expect(s.timestamp).toBe(1000); // classic clamp: follow live
+    });
+
+    it("keeps the strand-guard with allowFutureViewEnd (edge before first point)", () => {
+      const s = baseState();
+      tickLiveChartEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          allowFutureViewEnd: true,
+          points: [{ time: 980, value: 1 }],
+        }),
+      );
+      expect(s.timestamp).toBe(1000); // 950 < firstTime 980 ⇒ follow live
+    });
+
     it("lets viewEnd override paused (pan wins over freeze)", () => {
       const s = { ...baseState(), timestamp: 999 };
       tickLiveChartEngineFrame(s, input({ viewEnd: 950, paused: true }));

--- a/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
+++ b/packages/react-native-livechart/tests/liveChartSeriesEngineTick.test.ts
@@ -676,6 +676,38 @@ describe("tickLiveChartSeriesEngineFrame", () => {
       expect(s.timestamp).toBe(1000);
     });
 
+    // timeScroll.overscroll: with allowFutureViewEnd a right edge parked past
+    // the live edge (blank future space) is honored instead of following live.
+    it("freezes at a future viewEnd when allowFutureViewEnd is set", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        s,
+        input({ viewEnd: 1200, allowFutureViewEnd: true }),
+      );
+      expect(s.timestamp).toBe(1200);
+      expect(s.liveEdge).toBe(1000);
+    });
+
+    it("keeps the strand-guard with allowFutureViewEnd (edge before first point)", () => {
+      const s = baseMulti();
+      tickLiveChartSeriesEngineFrame(
+        s,
+        input({
+          viewEnd: 950,
+          allowFutureViewEnd: true,
+          series: [
+            {
+              id: "a",
+              color: "#00f",
+              value: 5,
+              data: [{ time: 980, value: 5 }],
+            },
+          ],
+        }),
+      );
+      expect(s.timestamp).toBe(1000); // 950 < firstTime 980 ⇒ follow live
+    });
+
     it("lets viewEnd override paused", () => {
       const s = { ...baseMulti(), timestamp: 999 };
       tickLiveChartSeriesEngineFrame(s, input({ viewEnd: 950, paused: true }));

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -15,6 +15,7 @@ import {
   resolvePulse,
   resolveReferenceLineConfig,
   resolveLoading,
+  resolveOverscroll,
   resolveReturnToLiveMs,
   resolveTransitions,
   resolveScrub,
@@ -317,6 +318,37 @@ describe("resolveZoom", () => {
       minTimeWindow: 5,
       maxTimeWindow: 600,
     });
+  });
+});
+
+// ─── resolveOverscroll ───────────────────────────────────────────────────────
+
+describe("resolveOverscroll", () => {
+  it("is 0 for undefined and the boolean forms of timeScroll", () => {
+    expect(resolveOverscroll(undefined)).toBe(0);
+    expect(resolveOverscroll(true)).toBe(0);
+    expect(resolveOverscroll(false)).toBe(0);
+  });
+
+  it("is 0 when omitted from the config object", () => {
+    expect(resolveOverscroll({})).toBe(0);
+    expect(resolveOverscroll({ gesture: "axisDrag" })).toBe(0);
+  });
+
+  it("passes a valid fraction through", () => {
+    expect(resolveOverscroll({ overscroll: 0.5 })).toBe(0.5);
+    expect(resolveOverscroll({ overscroll: 0.9 })).toBe(0.9);
+  });
+
+  it("clamps non-positive and NaN values to 0", () => {
+    expect(resolveOverscroll({ overscroll: 0 })).toBe(0);
+    expect(resolveOverscroll({ overscroll: -0.5 })).toBe(0);
+    expect(resolveOverscroll({ overscroll: NaN })).toBe(0);
+  });
+
+  it("clamps values at or above 1 to just under 1", () => {
+    expect(resolveOverscroll({ overscroll: 1 })).toBe(0.99);
+    expect(resolveOverscroll({ overscroll: 5 })).toBe(0.99);
   });
 });
 


### PR DESCRIPTION
**What**

- New `TimeScrollConfig.overscroll?: number` — a fraction of the visible window (`0`–`1`, clamped) that pan / fling / pinch may travel past the data bounds: into blank future space beyond the live edge, and past the oldest point into blank history.
- Default `0` (or omitted) hits the exact existing code paths — all current clamps, `null`-at-edge resume-follow, and engine behavior unchanged; existing tests untouched.
- A released drag/fling that settles within 2% of the window around the live edge re-attaches to live; further out it stays parked. The engine honors a right edge parked past live via a new gated tick input (`allowFutureViewEnd`), keeping the `viewEnd >= firstDataTime` strand-guard in both modes.

**Why**

- Traders expect TradingView-style charts you can drag freely: pull the latest candle toward the middle to leave room on the right, or pan left past loaded history into blank space while lazy-loading fills it in (pairs with `onVisibleRangeChange` paging).
- Today both directions hard-stop at the data bounds, which reads as "the chart is stuck". FOMO ships this as a hard-coded patch today; this PR upstreams it as an opt-in option.

**Why re-attach on release, not mid-drag**

- The pan's `onChange` re-derives the current edge from `viewEnd ?? liveEdge` each frame — if `nextViewEnd` snapped to `null` (follow) near the live edge, every subsequent per-frame delta would re-anchor at the live edge and the drag couldn't escape in either direction. Discovered in production.
- So with overscroll active, `nextViewEnd` always returns a number; re-attaching to live happens only in the release decay callback, inside the 2%-of-window snap zone. The pinch keeps its mid-gesture snap-to-`null` — it maps cumulative scale/focal from a gesture-start snapshot, not per-frame deltas, so a snap can't re-anchor it.

**Test plan**

- New unit tests: `panLowerBound`/`panUpperBound` with overscroll, `nextViewEnd` clamping to the future bound and never nulling mid-drag with overscroll on, both engine ticks honoring a future `viewEnd` only when `allowFutureViewEnd` is set (strand-guard kept), and `resolveOverscroll` clamping to `[0, 1)`.
- All existing tests pass unmodified (default-0 path is byte-identical behavior).
- `npm run verify` green (typecheck + lint + 1454 tests), coverage thresholds pass with `jest --coverage`.
- Docs updated: time-scroll guide, `LiveChart` API reference, types reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
