### PR TITLE
fix: pinch zoom jumps sideways when a finger lifts

### DIFF
--- a/packages/react-native-livechart/src/hooks/usePinchZoom.ts
+++ b/packages/react-native-livechart/src/hooks/usePinchZoom.ts
@@ -163,8 +163,14 @@ export function usePinchZoom({
 
   const onChange =
     /* istanbul ignore next -- gesture worklet runs on the UI thread, not in Jest */
-    (e: { scale: number; focalX: number }) => {
+    (e: { scale: number; focalX: number; numberOfPointers: number }) => {
       "worklet";
+      // When a finger lifts at the end of the pinch, the recognizer's focal
+      // point jumps from the two-finger midpoint to the remaining finger. A
+      // change event computed from that jumped focal throws the window
+      // sideways (and can even snap it back to following live). Ignore
+      // change events once fewer than two pointers remain.
+      if (e.numberOfPointers < 2) return;
       const chartW = canvasWidth.get() - padLeft - padRight;
       if (chartW <= 0 || e.scale <= 0) return;
       const edge = liveEdge.get();


### PR DESCRIPTION
**What**

- Guard `usePinchZoom`'s `onChange` on `e.numberOfPointers >= 2` so only true two-finger events drive the zoom.

**Bugs fixed**

- Ending a fast pinch sometimes threw the window sideways (often snapping back to the live edge) — one finger lifts before the other, the recognizer's focal jumps from the two-finger midpoint to the remaining finger, and the zoom math re-derives the right edge from that jumped `focalX`.

**Why the jump is large**

- `newEnd` moves by `dX/chartW × (startWindow − newWindow)` per focal shift `dX`, so zoomed in 3× a half-screen focal jump shifts the view by a full window width.
- If the jumped `newEnd` lands within `FOLLOW_SNAP` of the live edge, `viewEnd` snaps to `null` and the chart re-attaches to live — the most visible form of the bug.

**Test plan**

- Reproduced in our app (fast pinch-in on a candle chart, second finger lifting late); with the guard the view stays anchored at the focal.
- Existing `usePinchZoom` tests pass; the worklet itself is istanbul-ignored per repo convention, so no new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)