### PR TITLE
feat: add shared series opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Shared plotted-series opacity.** `seriesOpacity` on `LiveChart` and
+  `LiveChartSeries` accepts a UI-thread `SharedValue<number>` so an app can dim
+  current chart data during a replacement load without fading axes, legends,
+  reference lines, or scrub UI. It covers line and area fills, candles and
+  volume bars, live dots, value lines, badges, and inline value labels.
+
 ## [4.15.1] - 2026-08-09
 
 ### Fixed

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -19,6 +19,16 @@ On Android, the shared experimental `canvasMode="opaque"` option selects an opaq
 paints the palette background inside the canvas. See
 [Android surface rendering](/guides/android-surface-rendering) for constraints and profiling guidance.
 
+## Series opacity
+
+<ParamField body="seriesOpacity" type="SharedValue<number>" default="1">
+  A UI-thread opacity multiplier for every plotted series. Set it to `0.5`
+  while replacement history loads, then restore it to `1` when the new data
+  arrives. It dims strokes, live dots, value lines, and inline value labels
+  without affecting axes, the legend, reference lines, or scrub UI. See
+  [Dimming replacement data](/guides/multi-series#dimming-replacement-data).
+</ParamField>
+
 ## Manual Y-range scaling
 
 <ParamField body="yRangeScale" type="SharedValue<number>" default="1">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -11,6 +11,16 @@ import { LiveChart } from "react-native-livechart";
 `LiveChart` renders one series in line or candlestick mode. Props marked **required** must be
 provided; everything else has a default.
 
+## Series opacity
+
+<ParamField body="seriesOpacity" type="SharedValue<number>" default="1">
+  A UI-thread opacity multiplier for the plotted data. Set it to `0.5` while
+  replacement history loads, then restore it to `1` when the new data arrives.
+  It affects the line and area fill, candles and volume bars, live dot, value
+  line, badge, and inline value text—not axes, reference lines, or scrub UI.
+  See [Dimming replacement data](/guides/line-and-area#dimming-replacement-data).
+</ParamField>
+
 ## Data
 
 <ParamField body="data" type="SharedValue<LiveChartPoint[]>" required>

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -11,8 +11,8 @@ import type {
   LiveChartPoint,
   ReferenceLine,
   SeriesConfig,
-  SharedValue,
 } from "react-native-livechart";
+import type { SharedValue } from "react-native-reanimated";
 ```
 
 The source `.d.ts` and JSDoc remain the canonical reference (your editor surfaces them on hover);

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -7,7 +7,12 @@ description: "Exported TypeScript types — data shapes, config objects, and the
 All types are exported from the package root:
 
 ```tsx
-import type { LiveChartPoint, SeriesConfig, ReferenceLine } from "react-native-livechart";
+import type {
+  LiveChartPoint,
+  ReferenceLine,
+  SeriesConfig,
+  SharedValue,
+} from "react-native-livechart";
 ```
 
 The source `.d.ts` and JSDoc remain the canonical reference (your editor surfaces them on hover);
@@ -54,6 +59,20 @@ interface SeriesConfig {
   valueLabel?: string;
 }
 ```
+
+Both chart components also accept this shared plotted-data opacity control:
+
+```ts
+interface LiveChartCoreProps {
+  // UI-thread value from 0 (hidden) to 1 (fully visible); default 1.
+  seriesOpacity?: SharedValue<number>;
+}
+```
+
+`seriesOpacity` dims plot data (line and area fill, candles, live dots, value
+lines, badges, and inline values) without dimming axes, legends, reference
+lines, or scrub UI. See [Line & area](/guides/line-and-area#dimming-replacement-data)
+or [Multi-series](/guides/multi-series#dimming-replacement-data).
 
 ## Momentum
 

--- a/docs/guides/line-and-area.mdx
+++ b/docs/guides/line-and-area.mdx
@@ -36,6 +36,30 @@ Override the stroke with the `line` prop, and the area fill with `gradient`:
 
 Pass `gradient={false}` to remove the area fill entirely.
 
+## Dimming replacement data
+
+Keep the current chart visible while fetching a replacement range, then dim only
+the plotted data through a UI-thread shared value. Axes, reference lines, and
+scrub controls remain readable.
+
+```tsx
+const seriesOpacity = useSharedValue(1);
+
+function beginReplacementLoad() {
+  seriesOpacity.set(0.5);
+}
+
+function finishReplacementLoad() {
+  seriesOpacity.set(1);
+}
+
+<LiveChart data={data} value={value} seriesOpacity={seriesOpacity} />;
+```
+
+`seriesOpacity` affects the line and area fill, candles and volume bars, the
+live dot, value line, badge, and inline value text. Pass the same shared value
+to a candle chart—no mode-specific configuration is required.
+
 ### Dotted area fill
 
 For a textured fill, `areaDots` paints a screen-fixed dot lattice clipped to the

--- a/docs/guides/multi-series.mdx
+++ b/docs/guides/multi-series.mdx
@@ -51,6 +51,22 @@ Each `SeriesConfig` supports:
 | `glow`        | Soft glow behind the line                                      |
 | `kind`        | `"outcome"` (default) or `"derived"` (subdued/dashed chip)     |
 
+## Dimming replacement data
+
+For a timeframe change, retain the current series while the next range loads,
+then set one UI-thread opacity multiplier for every plotted series:
+
+```tsx
+const seriesOpacity = useSharedValue(1);
+
+seriesOpacity.set(isLoadingReplacement ? 0.5 : 1);
+
+<LiveChartSeries series={series} seriesOpacity={seriesOpacity} />;
+```
+
+The multiplier covers strokes, dots, value lines, and inline value labels. It
+does not dim axes, the legend, reference lines, or scrub UI.
+
 ## Legend
 
 The legend renders toggle chips by default. Configure it with the `legend` prop, and listen for

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -257,6 +257,7 @@ function useLiveChartController({
   font: fontProp,
   insets,
   style,
+  seriesOpacity,
   canvasMode = "transparent",
 
   // ── Candlestick ─────────────────────────────────────────────────────────
@@ -335,6 +336,8 @@ function useLiveChartController({
   onReachStart,
   onDegenShake,
 }: LiveChartProps) {
+  const fullSeriesOpacity = useSharedValue(1);
+  const resolvedSeriesOpacity = seriesOpacity ?? fullSeriesOpacity;
   const emptyMarkers = useSharedValue<Marker[]>([]);
   const markersSV = markers ?? emptyMarkers;
   // Stand-in threshold value so `useThreshold` can be called unconditionally
@@ -1230,7 +1233,8 @@ function useLiveChartController({
       liveIndicatorScrollOpacity(
         hideLiveOnScrollBack,
         engine.viewEnd.value,
-      ),
+      ) *
+      resolvedSeriesOpacity.value,
   );
   // Same scrolled-back gating for the value line: it would draw a dashed line
   // at the live value's Y — a price that isn't in the scrolled-back view.
@@ -1240,7 +1244,8 @@ function useLiveChartController({
       liveIndicatorScrollOpacity(
         hideLiveOnScrollBack,
         engine.viewEnd.value,
-      ),
+      ) *
+      resolvedSeriesOpacity.value,
   );
   const liveBadgeOpacity = useDerivedValue(
     () =>
@@ -1248,7 +1253,8 @@ function useLiveChartController({
       liveIndicatorScrollOpacity(
         hideLiveOnScrollBack,
         engine.viewEnd.value,
-      ),
+      ) *
+      resolvedSeriesOpacity.value,
   );
 
   // Fade the annotation overlays (markers + reference lines) out while scrubbing
@@ -1280,6 +1286,7 @@ function useLiveChartController({
     showValue,
     valueMomentumColor,
     lineProp,
+    seriesOpacity: resolvedSeriesOpacity,
     formatValue,
     formatTime,
     isCandle,
@@ -1583,6 +1590,7 @@ function ChartFillLayer({
     thresholdIsSeries,
     thresholdSeriesHasPoints,
     thresholdFillUniforms,
+    seriesOpacity,
   } = model;
   return (
     <Group transform={degen?.shakeTransform}>
@@ -1597,62 +1605,64 @@ function ChartFillLayer({
         />
       )}
 
-      {/* Dot-lattice area fill (the under-line `fillPath` painted with a dot
-          shader). Drawn before the gradient so a gradient (if also enabled)
-          composites on top. */}
-      {areaDotsCfg && (
-        <Group opacity={reveal.fillOpacity}>
-          <AreaDotsOverlay
-            fillPath={fillPath}
-            color={areaDotColorVec}
-            spacing={areaDotsCfg.spacing}
-            size={areaDotsCfg.size}
-          />
-        </Group>
-      )}
-
-      {/* Area gradient fill */}
-      {gradientCfg && (
-        <Group opacity={reveal.fillOpacity}>
-          <Path path={fillPath} style="fill">
-            <LinearGradient
-              start={vec(0, effectivePadding.top)}
-              end={vec(0, gradientEnd)}
-              colors={gradientColors}
-              positions={gradientPositions}
-            />
-          </Path>
-        </Group>
-      )}
-
-      {/* Threshold profit/loss band — the area between the line and the threshold,
-          split into the above/below colors. Independent of the baseline area fill
-          above (set `gradient={false}` for the band alone). A time-varying series
-          paints with the per-fragment split shader; a constant value with the
-          vertical hard-stop gradient. */}
-      {thresholdCfg?.fill &&
-        (thresholdIsSeries ? (
-          // The availability gate keeps a failed shader compile from filling the
-          // band with the default paint (opaque black) — see THRESHOLD_SPLIT_AVAILABLE.
-          thresholdSeriesHasPoints && THRESHOLD_SPLIT_AVAILABLE ? (
-            <Group opacity={reveal.fillOpacity}>
-              <Path path={thresholdFillPath} style="fill">
-                <ThresholdSplitShader uniforms={thresholdFillUniforms} />
-              </Path>
-            </Group>
-          ) : null
-        ) : thresholdFillColors ? (
+      <Group opacity={seriesOpacity}>
+        {/* Dot-lattice area fill (the under-line `fillPath` painted with a dot
+            shader). Drawn before the gradient so a gradient (if also enabled)
+            composites on top. */}
+        {areaDotsCfg && (
           <Group opacity={reveal.fillOpacity}>
-            <Path path={thresholdFillPath} style="fill">
+            <AreaDotsOverlay
+              fillPath={fillPath}
+              color={areaDotColorVec}
+              spacing={areaDotsCfg.spacing}
+              size={areaDotsCfg.size}
+            />
+          </Group>
+        )}
+
+        {/* Area gradient fill */}
+        {gradientCfg && (
+          <Group opacity={reveal.fillOpacity}>
+            <Path path={fillPath} style="fill">
               <LinearGradient
-                start={vec(0, 0)}
-                end={thresholdGeom.gradientEnd}
-                colors={thresholdFillColors}
-                positions={thresholdGeom.splitPositions}
+                start={vec(0, effectivePadding.top)}
+                end={vec(0, gradientEnd)}
+                colors={gradientColors}
+                positions={gradientPositions}
               />
             </Path>
           </Group>
-        ) : null)}
+        )}
+
+        {/* Threshold profit/loss band — the area between the line and the threshold,
+            split into the above/below colors. Independent of the baseline area fill
+            above (set `gradient={false}` for the band alone). A time-varying series
+            paints with the per-fragment split shader; a constant value with the
+            vertical hard-stop gradient. */}
+        {thresholdCfg?.fill &&
+          (thresholdIsSeries ? (
+            // The availability gate keeps a failed shader compile from filling the
+            // band with the default paint (opaque black) — see THRESHOLD_SPLIT_AVAILABLE.
+            thresholdSeriesHasPoints && THRESHOLD_SPLIT_AVAILABLE ? (
+              <Group opacity={reveal.fillOpacity}>
+                <Path path={thresholdFillPath} style="fill">
+                  <ThresholdSplitShader uniforms={thresholdFillUniforms} />
+                </Path>
+              </Group>
+            ) : null
+          ) : thresholdFillColors ? (
+            <Group opacity={reveal.fillOpacity}>
+              <Path path={thresholdFillPath} style="fill">
+                <LinearGradient
+                  start={vec(0, 0)}
+                  end={thresholdGeom.gradientEnd}
+                  colors={thresholdFillColors}
+                  positions={thresholdGeom.splitPositions}
+                />
+              </Path>
+            </Group>
+          ) : null)}
+      </Group>
     </Group>
   );
 }
@@ -1675,6 +1685,7 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     isStatic,
     transitionsCfg,
     candleGroupOpacity,
+    seriesOpacity,
     palette,
     volumeOpacity,
     volumeUpColor,
@@ -1702,7 +1713,7 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
   );
 
   return (
-    <>
+    <Group opacity={seriesOpacity}>
       <Group opacity={candleGroupOpacity}>
         <Path
           path={upWicksPath}
@@ -1728,7 +1739,7 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
           </Group>
         </Group>
       )}
-    </>
+    </Group>
   );
 }
 
@@ -1775,6 +1786,7 @@ function ChartStack({
     thresholdSeriesPts,
     formatValue,
     lineGroupOpacity,
+    seriesOpacity,
     linePath,
     lineIsLinear,
     strokeWidth,
@@ -1875,49 +1887,51 @@ function ChartStack({
           full-width gradient paints the base color outside segments and each
           segment's color within — so the line itself is recolored/faded (alpha in
           the segment color reduces the line's opacity), not covered by an overlay. */}
-      <Group opacity={lineGroupOpacity}>
-        <Path
-          path={linePath}
-          style="stroke"
-          strokeWidth={strokeWidth}
-          strokeCap={lineProp?.cap ?? "round"}
-          strokeJoin={lineProp?.join ?? "round"}
-          color={lineProp?.color ?? palette.line}
-        >
-          {thresholdIsSeries ? (
-            // Time-varying split: a per-fragment shader colors the stroke above/
-            // below the threshold polyline. Supersedes line.colors + segments.
-            // An empty series renders no paint child → the plain stroke color
-            // (null here keeps the empty case out of the NaN constant gradient).
-            thresholdSeriesHasPoints ? (
-              <ThresholdSplitShader uniforms={thresholdStrokeUniforms} />
-            ) : null
-          ) : thresholdCfg && thresholdStrokeColors ? (
-            // Vertical hard split at the threshold Y — supersedes line.colors and
-            // segment recoloring for the stroke while a threshold is set.
-            <LinearGradient
-              start={vec(0, 0)}
-              end={thresholdGeom.gradientEnd}
-              colors={thresholdStrokeColors}
-              positions={thresholdGeom.splitPositions}
-            />
-          ) : hasRecolorSegments ? (
-            <SegmentLineGradient
-              engine={engine}
-              segments={resolvedSegments}
-              padding={effectivePadding}
-              baseColor={lineProp?.color ?? palette.line}
-              scrubX={crosshair.scrubX}
-              scrubActive={crosshair.scrubActive}
-            />
-          ) : lineProp?.colors?.length ? (
-            <LinearGradient
-              start={vec(0, 0)}
-              end={vec(layoutWidth, 0)}
-              colors={lineProp.colors}
-            />
-          ) : null}
-        </Path>
+      <Group opacity={seriesOpacity}>
+        <Group opacity={lineGroupOpacity}>
+          <Path
+            path={linePath}
+            style="stroke"
+            strokeWidth={strokeWidth}
+            strokeCap={lineProp?.cap ?? "round"}
+            strokeJoin={lineProp?.join ?? "round"}
+            color={lineProp?.color ?? palette.line}
+          >
+            {thresholdIsSeries ? (
+              // Time-varying split: a per-fragment shader colors the stroke above/
+              // below the threshold polyline. Supersedes line.colors + segments.
+              // An empty series renders no paint child → the plain stroke color
+              // (null here keeps the empty case out of the NaN constant gradient).
+              thresholdSeriesHasPoints ? (
+                <ThresholdSplitShader uniforms={thresholdStrokeUniforms} />
+              ) : null
+            ) : thresholdCfg && thresholdStrokeColors ? (
+              // Vertical hard split at the threshold Y — supersedes line.colors and
+              // segment recoloring for the stroke while a threshold is set.
+              <LinearGradient
+                start={vec(0, 0)}
+                end={thresholdGeom.gradientEnd}
+                colors={thresholdStrokeColors}
+                positions={thresholdGeom.splitPositions}
+              />
+            ) : hasRecolorSegments ? (
+              <SegmentLineGradient
+                engine={engine}
+                segments={resolvedSegments}
+                padding={effectivePadding}
+                baseColor={lineProp?.color ?? palette.line}
+                scrubX={crosshair.scrubX}
+                scrubActive={crosshair.scrubActive}
+              />
+            ) : lineProp?.colors?.length ? (
+              <LinearGradient
+                start={vec(0, 0)}
+                end={vec(layoutWidth, 0)}
+                colors={lineProp.colors}
+              />
+            ) : null}
+          </Path>
+        </Group>
       </Group>
 
       {isCandle && <ChartCandleLayer model={model} />}
@@ -2190,21 +2204,24 @@ function ChartValueOverlay({
     momentumSV,
     valueMomentumColor,
     reveal,
+    seriesOpacity,
   } = model;
   if (!showValue) return null;
 
   return (
     <Group transform={degen?.shakeTransform}>
-      <Group opacity={reveal.lineOpacity}>
-        <ValueTextOverlay
-          engine={engine}
-          padding={effectivePadding}
-          palette={palette}
-          font={valueFont}
-          formatValue={formatValue}
-          momentum={momentumSV}
-          momentumColor={valueMomentumColor}
-        />
+      <Group opacity={seriesOpacity}>
+        <Group opacity={reveal.lineOpacity}>
+          <ValueTextOverlay
+            engine={engine}
+            padding={effectivePadding}
+            palette={palette}
+            font={valueFont}
+            formatValue={formatValue}
+            momentum={momentumSV}
+            momentumColor={valueMomentumColor}
+          />
+        </Group>
       </Group>
     </Group>
   );

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -139,6 +139,7 @@ function useLiveChartSeriesController({
   font: fontProp,
   insets,
   style,
+  seriesOpacity,
   canvasMode = "transparent",
   timeWindow = 30,
   paused = false,
@@ -190,6 +191,8 @@ function useLiveChartSeriesController({
   renderOffAxisReferenceLine,
   leftEdgeFade = true,
 }: LiveChartSeriesProps) {
+  const fullSeriesOpacity = useSharedValue(1);
+  const resolvedSeriesOpacity = seriesOpacity ?? fullSeriesOpacity;
   const emptyMarkers = useSharedValue<Marker[]>([]);
   const markersSV = markers ?? emptyMarkers;
   const markerClusterCfg = resolveMarkerCluster(markerCluster);
@@ -589,6 +592,7 @@ function useLiveChartSeriesController({
   return {
     // passthrough props the render needs
     series,
+    seriesOpacity: resolvedSeriesOpacity,
     style,
     canvasMode,
     accessibilityLabel,
@@ -700,6 +704,7 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
     overlayScrubFade,
     renderMarker,
     series,
+    seriesOpacity,
     emptyText,
     loadingAxisLabels,
     metricsCfg,
@@ -750,30 +755,32 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
         ))}
       </Group>
 
-      {dotCfg.valueLine && (
-        <Group opacity={reveal.lineOpacity}>
-          <MultiSeriesValueLines
-            engine={engine}
-            padding={effectivePadding}
-            colors={lineColors}
-            config={dotCfg.valueLine}
-            seriesCount={activeSeriesCount}
-          />
-        </Group>
-      )}
+      <Group opacity={seriesOpacity}>
+        {dotCfg.valueLine && (
+          <Group opacity={reveal.lineOpacity}>
+            <MultiSeriesValueLines
+              engine={engine}
+              padding={effectivePadding}
+              colors={lineColors}
+              config={dotCfg.valueLine}
+              seriesCount={activeSeriesCount}
+            />
+          </Group>
+        )}
 
-      <Group opacity={reveal.lineOpacity}>
-        {Array.from({ length: activeSeriesCount }, (_, i) => (
-          <MultiSeriesStroke
-            key={i}
-            index={i}
-            paths={linePaths}
-            opacities={engine.seriesOpacities}
-            series={effectiveSeries}
-            strokeWidth={strokeWidth}
-            lineStyle={lineStyles[i]}
-          />
-        ))}
+        <Group opacity={reveal.lineOpacity}>
+          {Array.from({ length: activeSeriesCount }, (_, i) => (
+            <MultiSeriesStroke
+              key={i}
+              index={i}
+              paths={linePaths}
+              opacities={engine.seriesOpacities}
+              series={effectiveSeries}
+              strokeWidth={strokeWidth}
+              lineStyle={lineStyles[i]}
+            />
+          ))}
+        </Group>
       </Group>
 
       {xAxisCfg && (
@@ -787,19 +794,21 @@ function SeriesChartStack({ model }: { model: LiveChartSeriesModel }) {
       )}
 
       {dotCfg.show && (
-        <Group opacity={reveal.dotOpacity}>
-          <MultiSeriesDots
-            engine={engine}
-            padding={effectivePadding}
-            colors={lineColors}
-            radius={dotCfg.radius}
-            ring={dotCfg.ring}
-            ringColor={palette.badgeOuterBg}
-            color={dotCfg.color}
-            pulse={dotCfg.pulse}
-            viewEnd={engine.viewEnd}
-            seriesCount={activeSeriesCount}
-          />
+        <Group opacity={seriesOpacity}>
+          <Group opacity={reveal.dotOpacity}>
+            <MultiSeriesDots
+              engine={engine}
+              padding={effectivePadding}
+              colors={lineColors}
+              radius={dotCfg.radius}
+              ring={dotCfg.ring}
+              ringColor={palette.badgeOuterBg}
+              color={dotCfg.color}
+              pulse={dotCfg.pulse}
+              viewEnd={engine.viewEnd}
+              seriesCount={activeSeriesCount}
+            />
+          </Group>
         </Group>
       )}
 
@@ -872,21 +881,24 @@ function SeriesValueLabelLayer({ model }: { model: LiveChartSeriesModel }) {
     lineColors,
     skiaFont,
     reveal,
+    seriesOpacity,
     degenShakeTransform,
     activeSeriesCount,
   } = model;
   if (!dotCfg.valueLabel) return null;
   return (
     <Group transform={degenShakeTransform}>
-      <Group opacity={reveal.dotOpacity}>
-        <MultiSeriesValueLabels
-          engine={engine}
-          padding={effectivePadding}
-          colors={lineColors}
-          font={skiaFont}
-          dotRadius={dotOuterRadius}
-          seriesCount={activeSeriesCount}
-        />
+      <Group opacity={seriesOpacity}>
+        <Group opacity={reveal.dotOpacity}>
+          <MultiSeriesValueLabels
+            engine={engine}
+            padding={effectivePadding}
+            colors={lineColors}
+            font={skiaFont}
+            dotRadius={dotOuterRadius}
+            seriesCount={activeSeriesCount}
+          />
+        </Group>
       </Group>
     </Group>
   );

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1926,6 +1926,14 @@ export interface LiveChartCoreProps {
   /** Container View style. */
   style?: ViewStyle;
   /**
+   * UI-thread opacity multiplier for the plotted data. Set a value from `0`
+   * (hidden) to `1` (fully visible), such as `0.5` while replacement data loads.
+   * Applies to every plotted series — line/fill/candles, live dots, value lines,
+   * and inline values — without affecting axes, reference lines, legends, or
+   * scrub UI. Default `1`.
+   */
+  seriesOpacity?: SharedValue<number>;
+  /**
    * Canvas composition mode. `"transparent"` keeps Skia's default compositing
    * path (TextureView on Android) and can reveal content behind the chart.
    * `"opaque"` makes the canvas own and paint its palette background; on Android

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -171,6 +171,19 @@ describe("LiveChart", () => {
     });
   });
 
+  it("applies series opacity to line and candle data layers", () => {
+    const seriesOpacity = { value: 0.5 } as SharedValue<number>;
+    const matchingOpacityGroups = (screen: ReturnType<typeof render>) =>
+      screen
+        .UNSAFE_getAllByType(View)
+        .filter((view) => view.props.opacity === seriesOpacity);
+
+    expect(matchingOpacityGroups(render(<Harness seriesOpacity={seriesOpacity} />))).toHaveLength(2);
+    expect(
+      matchingOpacityGroups(render(<CandleHarness seriesOpacity={seriesOpacity} />)),
+    ).toHaveLength(3);
+  });
+
   it("opts into an opaque canvas and replaces destination-alpha masks", () => {
     const screen = render(
       <Harness canvasMode="opaque" theme="light" loading />,

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { View } from "react-native";
-import { useSharedValue } from "react-native-reanimated";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
 
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
@@ -56,6 +56,40 @@ describe("LiveChartSeries", () => {
     }
     const screen = render(<H />);
     await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+  });
+
+  it("applies one series opacity to every plotted series layer", async () => {
+    const seriesOpacity = { value: 0.5 } as SharedValue<number>;
+    const initial: SeriesConfig[] = [
+      {
+        id: "a",
+        label: "A",
+        data: [
+          { time: 1_700_000_000, value: 10 },
+          { time: 1_700_000_030, value: 12 },
+        ],
+        value: 12,
+        color: "#3b82f6",
+      },
+    ];
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>(initial);
+      return (
+        <LiveChartSeries
+          series={series}
+          seriesOpacity={seriesOpacity}
+          dot={{ valueLabel: true, valueLine: true }}
+        />
+      );
+    }
+
+    const screen = render(<H />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    expect(
+      screen
+        .UNSAFE_getAllByType(View)
+        .filter((view) => view.props.opacity === seriesOpacity),
+    ).toHaveLength(3);
   });
 
   it("forwards configurable crosshair fade distance and line cap", async () => {


### PR DESCRIPTION
## Summary

- Add a seriesOpacity UI-thread shared value to LiveChart and LiveChartSeries.
- Apply it to single-series line/candle data and multi-series strokes, dots, value lines, and labels while keeping axes, legends, reference lines, and scrub UI fully readable.
- Document the API, loading-range usage, changelog, and regression coverage.

## Verification

- npm run verify