### PR TITLE
fix: snap the reveal to 0 when chart data collapses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Live-data collapse no longer morphs over the loading shell.** When data is
+  cleared or `loading` becomes true, `LiveChart` and `LiveChartSeries` now snap
+  directly to the loading/empty state instead of visibly flattening stale paths.
+  The loading/empty → live grow-in remains configurable with
+  `transitions.reveal`.
+
 ## [4.16.0] - 2026-08-10
 
 ### Added

--- a/app/demo/states-and-formatting.tsx
+++ b/app/demo/states-and-formatting.tsx
@@ -75,21 +75,26 @@ export default function StatesScreen() {
   });
 
   const chartData = empty ? emptyData : onePoint ? singlePointData : sim.data;
-  const chartValue = empty || onePoint ? emptyValue : sim.value;
+  const displayedData = loading ? emptyData : chartData;
+  const chartValue = empty || onePoint || loading ? emptyValue : sim.value;
   const showEmptyShell = empty || onePoint;
 
   return (
     <DemoScreen
       title="States & formatting"
       docs="guides/states-and-formatting"
-      description="The chart stays in loading/empty shell until there are at least two line points and loading is false. One point only still counts as empty. formatValue/formatTime must be worklet-safe (same pattern as src/format.ts)."
+      description="The chart stays in loading/empty shell until there are at least two line points and loading is false. Tap Replace data to remove live data: the loading shell appears immediately, then the returning data grows in. One point only still counts as empty. formatValue/formatTime must be worklet-safe (same pattern as src/format.ts)."
       chart={
         <LiveChart
-          data={chartData}
+          data={displayedData}
           value={chartValue}
           accentColor={ACCENT}
           theme={APP_THEME}
           loading={loading && loadingCfg}
+          // The longer grow-in makes the contrast intentional: leaving live data
+          // for the loading shell still snaps, while returned data reveals over
+          // this duration.
+          transitions={{ reveal: 1200 }}
           emptyText={showEmptyShell ? "Nothing to see here" : "No data"}
           formatValue={customFormat ? formatValueUsd : undefined}
           formatTime={customFormat ? formatTimeIsoUtcFragment : undefined}
@@ -115,7 +120,7 @@ export default function StatesScreen() {
           }}
         />
         <Chip
-          label={loading ? "Loading…" : "Loading 2s"}
+          label={loading ? "Replacing…" : "Replace data (2s)"}
           active={loading}
           disabled={loading}
           onPress={() => {

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -416,15 +416,17 @@ provided; everything else has a default.
   Breathing-line loading shell until data is ready. `true` uses the defaults; pass
   a [`LoadingConfig`](/api-reference/types#loadingconfig) to restyle it (`color`,
   `strokeWidth`, `amplitude`, `speed`, and `axisLabels` to toggle the skeleton
-  Y-axis placeholders). `false` / omitted is "not loading". The loading→live reveal
-  duration is set via the `transitions` prop below — see
+  Y-axis placeholders). `false` / omitted is "not loading". Entering loading or
+  empty snaps immediately; the loading→live grow-in duration is set via the
+  `transitions` prop below — see
   [Transitions](/guides/transitions).
 </ParamField>
 
 <ParamField body="transitions" type="boolean | TransitionConfig">
   Tune or disable the built-in transition animations. `true` / omitted keeps the
   defaults; `false` makes them instant (no grow-in when data appears or the
-  timeframe changes, no candle↔line crossfade, candle width snaps); a
+  timeframe changes, no candle↔line crossfade, candle width snaps); leaving
+  live data for loading/empty already snaps; a
   [`TransitionConfig`](/api-reference/types#config-objects) sets per-transition
   durations in ms — `reveal` (default `600`) and `mode` (default `300`), `0` to
   snap — plus `candleLerpSpeed` (default `0.08`, `1` = instant), the per-frame

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -474,7 +474,7 @@ interface ReturnToLiveConfig {
 }
 // Tune/disable the built-in transition animations — the object form of `transitions`.
 interface TransitionConfig {
-  reveal?: number;          // grow-in/collapse on data appear, timeframe change, candle→line; default 600 (0 = snap)
+  reveal?: number;          // grow-in when data appears, on timeframe change, or candle→line; default 600 (0 = snap)
   mode?: number;            // candle↔line crossfade (single-series LiveChart only); default 300 (0 = snap)
   candleLerpSpeed?: number; // candle-width ease speed (0–1, like smoothing); candle mode; default 0.08 (1 = instant resize)
 }

--- a/docs/guides/states-and-formatting.mdx
+++ b/docs/guides/states-and-formatting.mdx
@@ -25,6 +25,12 @@ While you wait for data, pass `loading` to render a breathing-line placeholder.
 <LiveChart data={data} value={value} loading={!ready} />
 ```
 
+If an already-live dataset is cleared for a replacement request, the chart switches to its loading
+or empty shell **immediately** — it never visibly morphs the now-stale line flat over the
+placeholder. When replacement data arrives, the usual grow-in runs; tune that direction with
+[`transitions.reveal`](/guides/transitions). The **Replace data** control in the example app shows
+the full handoff with a deliberately slow grow-in.
+
 ### Styling the loading shell
 
 `loading` also takes a `LoadingConfig` object to restyle the shell — the squiggle and the skeleton

--- a/docs/guides/transitions.mdx
+++ b/docs/guides/transitions.mdx
@@ -56,6 +56,11 @@ also on a timeframe change, and when a line chart's data appears) and the **mode
   **bodies resize** when `candleWidth` changes. Same units as `smoothing` (`0`–`1`); `1` snaps in
   one frame. See [Candle-width resize](#candle-width-resize-on-a-timeframe-change) below.
 
+Leaving a live chart is deliberately different: when data is cleared or `loading` becomes true,
+the chart **snaps** to the loading/empty shell so a stale path never visibly collapses flat over the
+placeholder. `transitions.reveal` controls only the next loading/empty → live grow-in. Try
+**Replace data** in the [States & formatting example](/guides/states-and-formatting).
+
 <Note>
   `transitions` covers the **entry / mode** animations only. The live value's easing toward its
   target is the separate `smoothing` prop (`1` = instant), and `static` suppresses all per-frame

--- a/packages/react-native-livechart/src/hooks/useChartReveal.ts
+++ b/packages/react-native-livechart/src/hooks/useChartReveal.ts
@@ -87,11 +87,18 @@ export function useChartReveal(
         return;
       }
       if (prev !== chartVisible) {
+        // Collapse (live → loading/empty) snaps: the data is already gone, so
+        // animating would draw the stale line morphing flat over the loading
+        // shell.
+        if (!chartVisible) {
+          morphT.set(0);
+          return;
+        }
         // 0ms → withTiming resolves on the next frame (effectively a snap), so an
         // explicit `transitions={{ reveal: 0 }}` / `transitions={false}` removes
         // the grow-in without a special-case branch.
         morphT.set(
-          withTiming(chartVisible ? 1 : 0, {
+          withTiming(1, {
             duration: revealDuration,
             easing: Easing.out(Easing.cubic),
           }),

--- a/packages/react-native-livechart/src/hooks/useChartReveal.ts
+++ b/packages/react-native-livechart/src/hooks/useChartReveal.ts
@@ -51,8 +51,9 @@ export interface ChartRevealState {
 /**
  * Drives loading / empty / live visibility.
  *
- * Chart is fully revealed only when `!loading && hasData`. `morphT` animates
- * between 0 and 1 when that condition changes. `isEmpty` is derived as
+ * Chart is fully revealed only when `!loading && hasData`. Data appearing
+ * grows `morphT` from 0 to 1; data disappearing snaps it to 0 so stale paths
+ * never visibly flatten over a loading or empty shell. `isEmpty` is derived as
  * `!loading && !hasData` for the empty overlay label.
  */
 export function useChartReveal(


### PR DESCRIPTION
## Problem

When a live chart's data goes away — e.g. the host swaps tokens and the replacement data hasn't loaded yet — `useChartReveal` animates `morphT` from 1 back to 0 over the reveal duration. But the data is already gone at that point, so the user sees the stale line visibly morphing flat on top of the loading shell for a moment.

## Fix

In the reveal reaction, a collapse (`chartVisible` going false) now snaps `morphT` to 0 instead of animating. The grow-in direction is unchanged: appearing data still eases in with the existing `withTiming` ramp, and `transitions={{ reveal: 0 }}` still works as before.

## Notes

The change is inside the UI-thread reaction that Jest's Worklets stub doesn't execute (same as the existing skipped cases in `useChartReveal.test.ts`), so there's no new unit test — happy to add one if you have a preferred way to exercise the mapper. Verified on device: swapping data sources now cuts straight to the loading shell with no flat-line morph.

`npm run verify` passes.

We've been running this in production at FOMO for a few weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)