### PR TITLE
feat: add timeScroll.fling to disable release inertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Optional time-scroll release momentum.** `TimeScrollConfig.fling` on
+  `LiveChart` and `LiveChartSeries` defaults to `true`, preserving decaying
+  release momentum. Set it to `false` for a deliberate hard stop at the
+  finger's release point; a release in the live-edge snap zone still resumes
+  auto-following. The Time scroll demo now exposes a **Fling inertia** switch.
+
 ## [4.16.0] - 2026-08-10
 
 ### Added

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -70,6 +70,7 @@ export default function TimeScrollScreen() {
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [holdMs, setHoldMs] = useState(500);
   const [overscroll, setOverscroll] = useState(0);
+  const [fling, setFling] = useState(true);
   const [enabled, setEnabled] = useState(true);
   const [followViewEdge, setFollowViewEdge] = useState(true);
   const [hideLiveOnScrollBack, setHideLiveOnScrollBack] = useState(true);
@@ -109,7 +110,7 @@ export default function TimeScrollScreen() {
     <DemoScreen
       title="Time scroll"
       docs="guides/time-scroll"
-      description={`${hint} Pinch with two fingers to zoom the window in/out (anchored at your fingers). The chart stops auto-scrolling while panned; release (or fling) back to the live edge to resume. Works for line and candle; one-finger plot scrub is unchanged.${reachedStart ? "  ● Reached oldest data (onReachStart fired — page here)" : ""}`}
+      description={`${hint} Pinch with two fingers to zoom the window in/out (anchored at your fingers). The chart stops auto-scrolling while panned; ${fling ? "fling" : "release"} back to the live edge to resume. Turn off Fling inertia to stop exactly where your finger lifts. Works for line and candle; one-finger plot scrub is unchanged.${reachedStart ? "  ● Reached oldest data (onReachStart fired — page here)" : ""}`}
       chart={
         <LiveChart
           data={data}
@@ -130,6 +131,7 @@ export default function TimeScrollScreen() {
                   scrubHoldMs: holdMs,
                   hideLiveOnScrollBack,
                   overscroll,
+                  fling,
                 }
               : false
           }
@@ -199,6 +201,14 @@ export default function TimeScrollScreen() {
         value={overscroll}
         onChange={setOverscroll}
       />
+
+      <ControlRow label="Release behavior">
+        <ToggleChip
+          label="Fling inertia"
+          value={fling}
+          onChange={setFling}
+        />
+      </ControlRow>
 
       <ChipRow
         label="Return to live (toggle timeScroll off while scrolled back)"

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -467,6 +467,7 @@ interface TimeScrollConfig {
   scrubHoldMs?: number; // holdToScrub: press-hold (ms) before scrub engages; default 500
   hideLiveOnScrollBack?: boolean; // hide live badge + dot + value line while scrolled back (they mark the off-screen live price); default true. Ignored with badge.followViewEdge
   overscroll?: number; // fraction of the window (0–1) pan/zoom may travel past the data bounds into blank space (TradingView-style); default 0 (hard stops at the oldest data / live edge)
+  fling?: boolean; // keep release momentum after a fast drag; false stops exactly where the finger lifts. Default true.
 }
 // Tunes the return-to-live glide (the `returnToLive` prop). @experimental
 interface ReturnToLiveConfig {

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -86,6 +86,20 @@ scrolls instead). Higher = more deliberate scrub, fewer accidental scrubs while 
 />
 ```
 
+### Release momentum (`fling`)
+
+By default, a quick drag keeps moving with decaying momentum after you lift your finger. Set
+`fling: false` for a deliberate hard stop: the window remains exactly where the drag ends. This
+does not change the live-edge snap zone, so releasing near the live edge still resumes
+auto-following.
+
+```tsx
+<LiveChart data={data} value={value} timeScroll={{ fling: false }} />
+```
+
+`fling` defaults to `true`. The example app's **Time scroll** screen includes a **Fling inertia**
+switch to compare both behaviors.
+
 ### Overscroll (`overscroll`)
 
 By default the window hard-stops at the data: the oldest point on the left, the live edge on the

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -46,6 +46,7 @@ import {
   resolveScrub,
   resolveScrubAction,
   resolveTransitions,
+  resolveFling,
   resolveOverscroll,
   resolveReturnToLiveMs,
   resolveSelectionDot,
@@ -617,6 +618,8 @@ function useLiveChartController({
   const timeScrollOverscroll = timeScrollEnabled
     ? resolveOverscroll(timeScroll)
     : 0;
+  // Release inertia (fling) — `timeScroll.fling: false` stops the pan dead.
+  const timeScrollFling = resolveFling(timeScroll);
   const zoomCfg = resolveZoom(zoom);
   const zoomEnabled = zoomCfg !== null && !isStatic;
 
@@ -1102,6 +1105,7 @@ function useLiveChartController({
     enabled: timeScrollEnabled,
     mode: scrollGestureMode,
     overscroll: timeScrollOverscroll,
+    fling: timeScrollFling,
     scrollActive,
     // Once a scrub is engaged the chart is locked: scrolling goes inert so the
     // finger only moves the price indicator across a fixed window.

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -39,6 +39,7 @@ import {
   resolveMarkerCluster,
   resolveMetrics,
   resolveMultiSeriesDot,
+  resolveFling,
   resolveOverscroll,
   resolveReturnToLiveMs,
   resolveScrub,
@@ -221,6 +222,8 @@ function useLiveChartSeriesController({
   const timeScrollOverscroll = timeScrollEnabled
     ? resolveOverscroll(timeScroll)
     : 0;
+  // Release inertia (fling) — `timeScroll.fling: false` stops the pan dead.
+  const timeScrollFling = resolveFling(timeScroll);
   const zoomCfg = resolveZoom(zoom);
   const zoomEnabled = zoomCfg !== null;
   const scrollGestureMode =
@@ -521,6 +524,7 @@ function useLiveChartSeriesController({
     enabled: timeScrollEnabled,
     mode: scrollGestureMode,
     overscroll: timeScrollOverscroll,
+    fling: timeScrollFling,
     scrollActive,
     // Once a scrub is engaged the chart is locked: scrolling goes inert so the
     // finger only moves the price indicator across a fixed window.

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -583,6 +583,18 @@ export function resolveOverscroll(
 }
 
 /**
+ * Resolves `timeScroll.fling`: `false` disables release inertia so the window
+ * stops dead where the finger lifts. Booleans / omitted keep the default (on).
+ * See {@link TimeScrollConfig}.
+ */
+export function resolveFling(
+  prop: boolean | TimeScrollConfig | undefined,
+): boolean {
+  if (prop == null || typeof prop === "boolean") return true;
+  return prop.fling ?? true;
+}
+
+/**
  * Resolved transition durations. `undefined` for a field means "use the
  * component's built-in default" (so we don't duplicate the default constants
  * here); a number is an explicit duration in ms (clamped to ≥ 0).

--- a/packages/react-native-livechart/src/hooks/usePanScroll.ts
+++ b/packages/react-native-livechart/src/hooks/usePanScroll.ts
@@ -81,6 +81,13 @@ export interface UsePanScrollOptions {
    * `timeScroll.overscroll` (see `resolveOverscroll`).
    */
   overscroll?: number;
+  /**
+   * Fling inertia on release: a fast drag keeps scrolling and decays to a stop.
+   * `false` stops the window dead where the finger lifts (a release near the
+   * live edge still re-attaches to live). Resolved from `timeScroll.fling`
+   * (see `resolveFling`). Default `true`.
+   */
+  fling?: boolean;
 }
 
 /**
@@ -218,6 +225,7 @@ export function usePanScroll({
   scrollActive,
   scrubActive,
   overscroll = 0,
+  fling = true,
 }: UsePanScrollOptions): ReturnType<typeof Gesture.Pan> {
   const { viewEnd, liveEdge, displayWindow, canvasWidth, canvasHeight } = engine;
   const padLeft = padding.left;
@@ -307,7 +315,10 @@ export function usePanScroll({
       // to FOLLOW_SNAP of the window around it — this release callback is the
       // ONLY place that re-attaches to live (never mid-drag, see nextViewEnd).
       const snapZone = overscroll > 0 ? win * FOLLOW_SNAP : 1e-3;
-      const velocity = flingVelocity(e.velocityX, chartW, win);
+      // `fling: false` → zero velocity: the decay resolves immediately where
+      // the finger lifted, and the completion callback below still re-attaches
+      // to live when the release lands inside the snap zone.
+      const velocity = fling ? flingVelocity(e.velocityX, chartW, win) : 0;
       cancelAnimation(viewEnd);
       viewEnd.set(
         withDecay({ velocity, clamp: [lo, hi] }, (finished) => {

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1791,6 +1791,14 @@ export interface TimeScrollConfig {
    * clamped. Applies to the pinch-zoom (`zoom`) clamps too.
    */
   overscroll?: number;
+  /**
+   * Fling inertia on release: a fast drag keeps scrolling and decays to a
+   * stop (the classic momentum feel). Set `false` to stop the window dead
+   * where the finger lifts — a deliberate, TradingView-style hard stop. A
+   * release that lands within the snap zone of the live edge still
+   * re-attaches to live. Default `true`.
+   */
+  fling?: boolean;
 }
 
 /**

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -15,6 +15,7 @@ import {
   resolvePulse,
   resolveReferenceLineConfig,
   resolveLoading,
+  resolveFling,
   resolveOverscroll,
   resolveReturnToLiveMs,
   resolveTransitions,
@@ -349,6 +350,26 @@ describe("resolveOverscroll", () => {
   it("clamps values at or above 1 to just under 1", () => {
     expect(resolveOverscroll({ overscroll: 1 })).toBe(0.99);
     expect(resolveOverscroll({ overscroll: 5 })).toBe(0.99);
+  });
+});
+
+// ─── resolveFling ────────────────────────────────────────────────────────────
+
+describe("resolveFling", () => {
+  it("defaults to on for undefined and the boolean forms of timeScroll", () => {
+    expect(resolveFling(undefined)).toBe(true);
+    expect(resolveFling(true)).toBe(true);
+    expect(resolveFling(false)).toBe(true);
+  });
+
+  it("defaults to on when omitted from the config object", () => {
+    expect(resolveFling({})).toBe(true);
+    expect(resolveFling({ gesture: "axisDrag" })).toBe(true);
+  });
+
+  it("passes an explicit value through", () => {
+    expect(resolveFling({ fling: false })).toBe(false);
+    expect(resolveFling({ fling: true })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

A new opt-out on `TimeScrollConfig`: `fling?: boolean` (default `true`).

With `fling: false`, releasing a time-scroll drag stops the window dead where the finger lifts instead of decaying with momentum. Some charts (ours is a trading app) want the deliberate, TradingView-style hard stop.

## How

- `resolveFling` in `resolveConfig.ts`, mirroring `resolveOverscroll`: booleans / omitted → `true`.
- `usePanScroll` takes `fling` and passes zero velocity to `withDecay` when it's off. The decay then resolves immediately, so the existing completion callback still re-attaches to live when the release lands inside the snap zone — no behavior forked, just the velocity.
- Both chart components thread it through.

Default behavior is unchanged.

## Tests

`resolveFling` cases added to `resolveConfig.test.ts` (defaults, omitted-field, explicit values). The release handler itself is a UI-thread gesture worklet (istanbul-ignored like its siblings).

`npm run verify` passes.

We've been running the equivalent behavior in production at FOMO for a few weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)