### PR TITLE
fix: eliminate the one-frame tear on a candle timeframe switch

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -68,7 +68,7 @@ import { useLiveChartEngine } from "../core/useLiveChartEngine";
 import { pulseRadialOutset } from "../draw/line";
 import { resolveChartLayout } from "../hooks/resolveChartLayout";
 import { useBadge } from "../hooks/useBadge";
-import { useCandlePaths } from "../hooks/useCandlePaths";
+import { useCandlePaths, useCandleWidthLerp } from "../hooks/useCandlePaths";
 import { useCanvasLayout } from "../hooks/useCanvasLayout";
 import { useChartColors } from "../hooks/useChartColors";
 import { useChartOverlayContext } from "../hooks/useChartOverlayContext";
@@ -950,6 +950,15 @@ function useLiveChartController({
       : momentumSV.value,
   );
 
+  // Width bridge lives here (outer tree), not in ChartCandleLayer: canvas
+  // children commit one frame behind, which would lag the width target behind
+  // the engine's framing snap on a timeframe switch. See useCandleWidthLerp.
+  const displayCandleWidth = useCandleWidthLerp(
+    candleWidth,
+    transitionsCfg.candleLerpSpeed,
+    !isStatic && isCandle,
+  );
+
   // ── Overlay hooks ─────────────────────────────────────────────────────
   // Scrub/crosshair must see the same stash-backed candles as the engine.
   const candleOpts = isCandle
@@ -1376,6 +1385,7 @@ function useLiveChartController({
     candlesEngine,
     liveEngine,
     candleWidth,
+    displayCandleWidth,
     transitionsCfg,
     layoutWidth,
     onLayout,
@@ -1678,12 +1688,10 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     effectivePadding,
     candlesEngine,
     liveEngine,
-    candleWidth,
+    displayCandleWidth,
     metricsCfg,
     volumeBandHeight,
     volumeCfg,
-    isStatic,
-    transitionsCfg,
     candleGroupOpacity,
     seriesOpacity,
     palette,
@@ -1703,13 +1711,11 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     effectivePadding,
     candlesEngine,
     liveEngine,
-    candleWidth,
+    displayCandleWidth,
     true,
     metricsCfg.candle,
     volumeBandHeight,
     volumeCfg?.radius ?? 0,
-    !isStatic,
-    transitionsCfg.candleLerpSpeed,
   );
 
   return (

--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -5,7 +5,7 @@
  *
  * @see https://github.com/benjitaylor/liveline
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   cancelAnimation,
   Easing,
@@ -497,7 +497,11 @@ export function useLiveChartEngine(
   // Compare against the previous key (not a "first render" flag) so React 18
   // StrictMode's double-invoked mount effect can't fire a spurious snap.
   const lastSnapKey = useRef(config.snapKey);
-  useEffect(() => {
+  // Layout effect, not passive: a passive effect runs after the commit has
+  // painted, so the frame between them draws the new data/candleWidth against
+  // the OLD framing (a one-frame squeeze on a timeframe switch). Flipping the
+  // flag before paint lets the first frame with the new props consume the snap.
+  useLayoutEffect(() => {
     if (config.snapKey === lastSnapKey.current) return;
     lastSnapKey.current = config.snapKey;
     snapSV.set(true);

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   cancelAnimation,
   Easing,
@@ -343,7 +343,9 @@ export function useLiveChartSeriesEngine(
   // changes, consumed + cleared by the next frame (mirrors useLiveChartEngine).
   const snapSV = useSharedValue(false);
   const lastSnapKey = useRef(config.snapKey);
-  useEffect(() => {
+  // Layout effect so the snap flag lands before the commit paints — a passive
+  // effect leaves one frame of new data in the old framing (mirrors useLiveChartEngine).
+  useLayoutEffect(() => {
     if (config.snapKey === lastSnapKey.current) return;
     lastSnapKey.current = config.snapKey;
     snapSV.set(true);

--- a/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartSeriesEngine.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import {
   cancelAnimation,
   Easing,

--- a/packages/react-native-livechart/src/hooks/useCandlePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useCandlePaths.ts
@@ -17,33 +17,25 @@ import { usePathBuilder } from "./usePathBuilder";
 const CANDLE_WIDTH_LERP_SPEED = 0.08;
 
 /**
- * Candle paths (up/down bodies + up/down wicks). Each is built into a reused
- * `Skia.PathBuilder` and finalized with `detach()` each frame — a fresh
- * immutable `SkPath`, so Skia repaints without a per-curve ping-pong and no
- * mutable `SkPath` is retained across frames.
+ * Bridges the `candleWidth` prop to the UI thread and eases the displayed
+ * width toward it each frame. Must be called from the chart's OUTER component
+ * (the controller), not from inside the Skia canvas: canvas children render
+ * through Skia's own reconciler one commit behind the outer tree, so a width
+ * bridged in there lands one frame after the engine's framing targets — a
+ * timeframe switch then draws one frame of new data at the old width. See #176.
  */
-export function useCandlePaths(
-  engine: SingleEngineState,
-  padding: ChartPadding,
-  candles: SharedValue<CandlePoint[]> | undefined,
-  liveCandle: SharedValue<CandlePoint | null> | undefined,
+export function useCandleWidthLerp(
   candleWidthSecs: number,
-  active: boolean,
-  candleMetrics: CandleMetrics = CANDLE_METRICS_DEFAULTS,
-  /** Reserved volume-band height (px). `0` = no volume bars. */
-  volumeBandHeight = 0,
-  /** Corner radius (px) of the volume bars. */
-  volumeRadius = 0,
-  /** Static charts run no loops: register without starting. Default `true`. */
-  autostart = true,
   /**
    * Per-frame lerp speed (0–1) for the candle-body width as it eases toward
    * `candleWidthSecs`. `1` snaps in one frame (no "fat → thin" slide on a
    * timeframe / bucket change); `undefined` uses {@link CANDLE_WIDTH_LERP_SPEED}.
    * Resolved from `transitions.candleLerpSpeed`. See #176.
    */
-  candleLerpSpeed?: number,
-) {
+  candleLerpSpeed: number | undefined,
+  /** Static charts run no loops: register without starting. */
+  autostart: boolean,
+): SharedValue<number> {
   const targetCandleWidth = useDerivedValue(() => candleWidthSecs);
   const displayCandleWidth = useSharedValue(candleWidthSecs);
   // `transitions.candleLerpSpeed` overrides the built-in speed (0–1, already
@@ -54,16 +46,8 @@ export function useCandlePaths(
     () => candleLerpSpeed ?? CANDLE_WIDTH_LERP_SPEED,
   );
 
-  const upBodiesBuilder = usePathBuilder();
-  const downBodiesBuilder = usePathBuilder();
-  const upWicksBuilder = usePathBuilder();
-  const downWicksBuilder = usePathBuilder();
-  const upBarsBuilder = usePathBuilder();
-  const downBarsBuilder = usePathBuilder();
-
   useFrameCallback((frameInfo) => {
     "worklet";
-    if (!active) return;
     const dt = frameInfo.timeSincePreviousFrame ?? MS_PER_FRAME_60FPS;
     displayCandleWidth.set(
       lerp(
@@ -74,6 +58,36 @@ export function useCandlePaths(
       ),
     );
   }, autostart);
+
+  return displayCandleWidth;
+}
+
+/**
+ * Candle paths (up/down bodies + up/down wicks). Each is built into a reused
+ * `Skia.PathBuilder` and finalized with `detach()` each frame — a fresh
+ * immutable `SkPath`, so Skia repaints without a per-curve ping-pong and no
+ * mutable `SkPath` is retained across frames.
+ */
+export function useCandlePaths(
+  engine: SingleEngineState,
+  padding: ChartPadding,
+  candles: SharedValue<CandlePoint[]> | undefined,
+  liveCandle: SharedValue<CandlePoint | null> | undefined,
+  /** Displayed bucket width from {@link useCandleWidthLerp} (outer component). */
+  displayCandleWidth: SharedValue<number>,
+  active: boolean,
+  candleMetrics: CandleMetrics = CANDLE_METRICS_DEFAULTS,
+  /** Reserved volume-band height (px). `0` = no volume bars. */
+  volumeBandHeight = 0,
+  /** Corner radius (px) of the volume bars. */
+  volumeRadius = 0,
+) {
+  const upBodiesBuilder = usePathBuilder();
+  const downBodiesBuilder = usePathBuilder();
+  const upWicksBuilder = usePathBuilder();
+  const downWicksBuilder = usePathBuilder();
+  const upBarsBuilder = usePathBuilder();
+  const downBarsBuilder = usePathBuilder();
 
   /* istanbul ignore next -- worklet */
   const geometry = useDerivedValue(() => {

--- a/packages/react-native-livechart/tests/staticMode.test.tsx
+++ b/packages/react-native-livechart/tests/staticMode.test.tsx
@@ -126,7 +126,8 @@ describe("static mode — no per-frame loops", () => {
     render(<Harness />);
     // The live engine autostarts (true). useDegen's callback defaults to
     // autostart when not static; at minimum the engine's loop must be live.
+    // The candle-width bridge registers inert (false) in line mode — its loop
+    // only starts for candle charts (see useCandleWidthLerp).
     expect(frameCallbackCalls).toContain(true);
-    expect(frameCallbackCalls).not.toContain(false);
   });
 });


### PR DESCRIPTION
## Problem

Switching timeframes on a candle chart (new `candles` + `candleWidth` + `snapKey` in one commit) shows one frame of tear: the new data drawn against the old framing and old candle width, then everything snaps into place. Two causes, both one-frame offsets:

1. **The snapKey effect is passive.** `useEffect` runs after the commit has painted, so the first frame with the new props still consumes the old framing; the snap only lands on the frame after.
2. **The candle-width bridge lives inside the canvas.** `useCandlePaths` (called from `ChartCandleLayer`, a Skia canvas child) bridges the `candleWidth` prop to the UI thread. Skia's reconciler commits canvas children one commit behind the outer tree, so the width target lags the engine's framing snap by a frame — one frame of new data at the old width (the tail end of #176).

## Fix

1. `snapKey` flips its flag in `useLayoutEffect` (both engines), so the first painted frame with the new props consumes the snap.
2. The width bridge is extracted to `useCandleWidthLerp` and called from the chart controller (outer tree). `useCandlePaths` now takes the bridged `SharedValue` instead of the raw prop + lerp params. Same lerp behavior, just hoisted a level.

## Notes

- On line charts the hoisted bridge registers its frame callback inert (`autostart` false) — the strict `not.toContain(false)` assertion in `staticMode.test.tsx` is relaxed accordingly (the static guarantee — no started loops — is untouched).
- No public API change; `useCandlePaths` is internal.

`npm run verify` passes. We've been running this in production at FOMO for about a week — timeframe switches are clean at 120 Hz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)