### PR TITLE
feat: add axisAutoHide — fade axes out at rest, in on interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental axis auto-hide.** `LiveChart.axisAutoHide` fades the X and Y
+  axes (grid, ticks, and labels) while idle, then restores them for scrubbing,
+  panning, fling momentum, and pinch zoom. Use `true` for the defaults or
+  `AxisAutoHideConfig` to tune the fade timings, idle opacity, and delay. The
+  example app and guide include an interactive configuration demo.
+
 ## [4.16.0] - 2026-08-10
 
 ### Added

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -97,6 +97,11 @@ const SECTIONS: DemoSection[] = [
         title: "Y-range scale",
         blurb: "yRangeScale: drag the price gutter to stretch or compress the fitted Y-axis range.",
       },
+      {
+        href: "/demo/axis-auto-hide" as Href,
+        title: "Axis auto-hide",
+        blurb: "axisAutoHide: fade X/Y axes while idle and restore them as you interact.",
+      },
     ],
   },
   {

--- a/app/demo/axis-auto-hide.tsx
+++ b/app/demo/axis-auto-hide.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { LiveChart, type AxisAutoHideConfig } from "react-native-livechart";
+
+import { ChipRow, ToggleChip, ControlRow } from "../../demo-lib/ChipRow";
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME } from "../../demo-lib/theme";
+import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
+
+export const options = { title: "Axis auto-hide" };
+
+type IdleOpacity = "hidden" | "dim";
+type HideDelay = 1000 | 3000 | 5000;
+
+const IDLE_OPACITY: Record<IdleOpacity, number> = {
+  hidden: 0,
+  dim: 0.2,
+};
+
+const IDLE_OPACITY_OPTIONS: { value: IdleOpacity; label: string }[] = [
+  { value: "hidden", label: "Hidden (0%)" },
+  { value: "dim", label: "Dim (20%)" },
+];
+
+const HIDE_DELAY_OPTIONS: { value: HideDelay; label: string }[] = [
+  { value: 1000, label: "1 second" },
+  { value: 3000, label: "3 seconds" },
+  { value: 5000, label: "5 seconds" },
+];
+
+export default function AxisAutoHideScreen() {
+  const [enabled, setEnabled] = useState(true);
+  const [idleOpacity, setIdleOpacity] = useState<IdleOpacity>("hidden");
+  const [hideAfterMs, setHideAfterMs] = useState<HideDelay>(3000);
+
+  const { data, value } = useSimulatedChartData({
+    multiSeries: false,
+    candleAggregation: false,
+    tradeStream: false,
+    historySpanSeconds: 90,
+    historyRange: "1m",
+  });
+
+  const axisAutoHide: boolean | AxisAutoHideConfig = enabled
+    ? {
+        fadeInMs: 60,
+        fadeOutMs: 250,
+        idleOpacity: IDLE_OPACITY[idleOpacity],
+        hideAfterMs,
+      }
+    : false;
+
+  return (
+    <DemoScreen
+      title="Axis auto-hide"
+      docs="guides/axis-auto-hide"
+      description="A minimal chart at rest: the X and Y axes return as soon as you scrub, drag through history, fling, or pinch to zoom. Release it and watch them fade back after the selected delay."
+      chart={
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          axisAutoHide={axisAutoHide}
+          timeScroll
+          zoom
+          scrub
+        />
+      }
+    >
+      <ControlRow label="Auto-hide">
+        <ToggleChip
+          label="Enabled"
+          value={enabled}
+          onChange={setEnabled}
+        />
+      </ControlRow>
+      <ChipRow
+        label="Idle opacity"
+        options={IDLE_OPACITY_OPTIONS}
+        value={idleOpacity}
+        onChange={setIdleOpacity}
+      />
+      <ChipRow
+        label="Hide after"
+        options={HIDE_DELAY_OPTIONS}
+        value={hideAfterMs}
+        onChange={setHideAfterMs}
+      />
+    </DemoScreen>
+  );
+}

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -386,6 +386,15 @@ provided; everything else has a default.
   between labels and grid/plain reference lines.
 </ParamField>
 
+<ParamField body="axisAutoHide" type="boolean | AxisAutoHideConfig" default="false">
+  Fade the X and Y axes (grid, ticks, and labels) out while the chart is idle,
+  then show them for scrubbing, panning, fling momentum, and pinch zoom. `true`
+  uses the default timing; pass
+  [`AxisAutoHideConfig`](/api-reference/types#config-objects) to set the fade
+  durations, idle opacity, and idle delay. **Experimental; `LiveChart` only.**
+  See [Axis auto-hide](/guides/axis-auto-hide).
+</ParamField>
+
 <ParamField body="topLabel" type="boolean | AxisLabelConfig" default="false">
   Edge label floated at the plot's **top**. `true` shows the built-in value
   label — the chart's current top Y-axis bound, formatted and updated each frame

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -452,6 +452,13 @@ interface YAxisConfig {
   float?: boolean;
 }
 interface XAxisConfig { minGap?: number } // default 60
+// Fades both axes while LiveChart is idle. @experimental
+interface AxisAutoHideConfig {
+  fadeInMs?: number;    // interaction-start fade duration; default 60
+  fadeOutMs?: number;   // fade back to idle; default 250
+  idleOpacity?: number; // axes' resting opacity (0 = hidden); default 0
+  hideAfterMs?: number; // idle delay before fade-out; default 3000
+}
 // Volume bars below the candles (candle mode only). Bars normalize to the largest
 // visible volume; the candle plot shrinks by `maxHeight` to make room. @see CandlePoint.volume
 interface VolumeConfig {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,7 +56,8 @@
               "guides/scrubbing",
               "guides/order-ticket",
               "guides/time-scroll",
-              "guides/y-range-scale"
+              "guides/y-range-scale",
+              "guides/axis-auto-hide"
             ]
           },
           {

--- a/docs/guides/axis-auto-hide.mdx
+++ b/docs/guides/axis-auto-hide.mdx
@@ -1,0 +1,69 @@
+---
+title: Axis auto-hide
+icon: "eye-slash"
+description: "Keep a LiveChart minimal at rest while preserving axes during interaction."
+---
+
+<Note>
+  **Live example:**
+  [`app/demo/axis-auto-hide.tsx`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/demo/axis-auto-hide.tsx)
+  in the example app.
+</Note>
+
+`axisAutoHide` keeps the chart uncluttered at rest: its X and Y axes — grid,
+ticks, and labels — are faded to an idle opacity. They fade back in when a user
+scrubs, time-scrolls, flings, or pinch-zooms, then return to their idle opacity
+after interaction has settled.
+
+```tsx
+<LiveChart data={data} value={value} axisAutoHide />
+```
+
+The feature is opt-in and experimental. It currently applies to `LiveChart`,
+not `LiveChartSeries`; it has no effect on an axis already disabled with
+`xAxis={false}` or `yAxis={false}`.
+
+## Configure the idle state
+
+Pass an `AxisAutoHideConfig` to tune the transition. All durations are in
+milliseconds. These are the defaults used by `axisAutoHide`:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  axisAutoHide={{
+    fadeInMs: 60,
+    fadeOutMs: 250,
+    idleOpacity: 0,
+    hideAfterMs: 3000,
+  }}
+/>
+```
+
+- `fadeInMs` — duration to reveal the axes when interaction begins.
+- `fadeOutMs` — duration to return to the idle state.
+- `idleOpacity` — resting opacity from `0` (hidden) to `1` (fully visible).
+- `hideAfterMs` — delay after interaction settles before the fade-out begins.
+
+The axes continue to calculate their latest values while hidden, so the labels
+are current the instant they reappear. Toggle the feature at runtime if needed:
+passing `false` immediately restores fully visible axes; enabling it starts at
+the configured idle opacity.
+
+## Time scroll and zoom
+
+Time-scroll momentum and pinch zoom count as interaction even after no finger
+is held down. Pair the feature with these optional gestures for a compact
+brokerage-style chart that exposes its scale exactly when a user needs it:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  axisAutoHide={{ idleOpacity: 0.2, hideAfterMs: 1500 }}
+  timeScroll
+  zoom
+  scrub
+/>
+```

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1151,6 +1151,27 @@ function useLiveChartController({
     axisAutoHideCfg ? axisIdleOpacity : 1,
   );
   const axisAutoHideEnabled = axisAutoHideCfg !== null;
+  const lastAxisAutoHide = useRef({
+    enabled: axisAutoHideEnabled,
+    idleOpacity: axisIdleOpacity,
+  });
+  // `useSharedValue` only reads its initial value on mount. Keep prop changes
+  // in sync as well: turning auto-hide off must immediately restore the axes,
+  // and turning it on starts from the configured idle opacity.
+  useEffect(() => {
+    if (
+      lastAxisAutoHide.current.enabled === axisAutoHideEnabled &&
+      lastAxisAutoHide.current.idleOpacity === axisIdleOpacity
+    ) {
+      return;
+    }
+    lastAxisAutoHide.current = {
+      enabled: axisAutoHideEnabled,
+      idleOpacity: axisIdleOpacity,
+    };
+    cancelAnimation(axisAutoHideOpacity);
+    axisAutoHideOpacity.value = axisAutoHideEnabled ? axisIdleOpacity : 1;
+  }, [axisAutoHideEnabled, axisAutoHideOpacity, axisIdleOpacity]);
   useAnimatedReaction(
     () => ({
       gesture: scrollActive.value || crosshairScrubActive.value,

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -2,10 +2,13 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
+  cancelAnimation,
   useAnimatedReaction,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
+  withDelay,
+  withSequence,
   withTiming,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
@@ -294,6 +297,7 @@ function useLiveChartController({
   // ── Overlays ────────────────────────────────────────────────────────────
   yAxis = true,
   xAxis = true,
+  axisAutoHide = false,
   topLabel,
   bottomLabel,
   badge = true,
@@ -1131,6 +1135,57 @@ function useLiveChartController({
     },
   });
 
+  // Axis auto-hide: fade both axes out at rest and back in while the user
+  // interacts. Any movement — scrub / time-scroll touch, or a viewEnd /
+  // viewWindow change (fling momentum, pinch-zoom) — shows the axes; once the
+  // touch lifts and the view settles, they fade back out after `hideAfterMs`.
+  // Only the axis groups' opacity animates; the axis worklets keep running
+  // underneath so a fade-in shows current labels.
+  const axisAutoHideCfg =
+    axisAutoHide === true ? {} : axisAutoHide === false ? null : axisAutoHide;
+  const axisIdleOpacity = axisAutoHideCfg?.idleOpacity ?? 0;
+  const axisFadeInMs = axisAutoHideCfg?.fadeInMs ?? 60;
+  const axisFadeOutMs = axisAutoHideCfg?.fadeOutMs ?? 250;
+  const axisHideAfterMs = axisAutoHideCfg?.hideAfterMs ?? 3000;
+  const axisAutoHideOpacity = useSharedValue(
+    axisAutoHideCfg ? axisIdleOpacity : 1,
+  );
+  const axisAutoHideEnabled = axisAutoHideCfg !== null;
+  useAnimatedReaction(
+    () => ({
+      gesture: scrollActive.value || crosshairScrubActive.value,
+      viewEnd: engine.viewEnd.value,
+      viewWindow: engine.viewWindow.value,
+    }),
+    (curr, prev) => {
+      if (!axisAutoHideEnabled || prev === null) return;
+      const moved =
+        curr.gesture !== prev.gesture ||
+        curr.viewEnd !== prev.viewEnd ||
+        curr.viewWindow !== prev.viewWindow;
+      if (!moved) return;
+      cancelAnimation(axisAutoHideOpacity);
+      axisAutoHideOpacity.value = curr.gesture
+        ? withTiming(1, { duration: axisFadeInMs })
+        : // Movement without a held touch (gesture end, fling, pinch): show,
+          // then fade back out once the chart goes untouched for a while.
+          withSequence(
+            withTiming(1, { duration: axisFadeInMs }),
+            withDelay(
+              axisHideAfterMs,
+              withTiming(axisIdleOpacity, { duration: axisFadeOutMs }),
+            ),
+          );
+    },
+    [
+      axisAutoHideEnabled,
+      axisIdleOpacity,
+      axisFadeInMs,
+      axisFadeOutMs,
+      axisHideAfterMs,
+    ],
+  );
+
   // Paging callbacks: report the visible range / proximity to the oldest data so
   // a host can lazily load history. Inert unless a callback is supplied.
   useVisibleRange({
@@ -1358,6 +1413,7 @@ function useLiveChartController({
     // engine + reveal
     engine,
     reveal,
+    axisAutoHideOpacity,
     // loading shell styling (null → not loading)
     loadingLineColor: loadingCfg?.color,
     loadingStrokeWidth: loadingCfg?.strokeWidth,
@@ -1502,9 +1558,15 @@ function ChartYAxisLayer({
     yAxisFloat,
     yAxisCfg,
     liveBadgeOpacity,
+    axisAutoHideOpacity,
   } = model;
+  // Fold the axis auto-hide fade into the reveal opacity (1 when the feature
+  // is off).
+  const yAxisGroupOpacity = useDerivedValue(
+    () => reveal.yAxisOpacity.value * axisAutoHideOpacity.value,
+  );
   return (
-    <Group opacity={reveal.yAxisOpacity}>
+    <Group opacity={yAxisGroupOpacity}>
       <YAxisOverlay
         variant={variant}
         float={variant === "labels" && yAxisFloat}
@@ -1545,14 +1607,17 @@ function ChartXAxisLayer({ model }: { model: LiveChartModel }) {
     skiaFont,
   );
   return (
-    <XAxisOverlay
-      entries={xAxisEntries}
-      engine={engine}
-      padding={effectivePadding}
-      palette={palette}
-      font={skiaFont}
-      volumeBandHeight={volumeBandHeight}
-    />
+    // Axis auto-hide fade (1 when the feature is off).
+    <Group opacity={model.axisAutoHideOpacity}>
+      <XAxisOverlay
+        entries={xAxisEntries}
+        engine={engine}
+        padding={effectivePadding}
+        palette={palette}
+        font={skiaFont}
+        volumeBandHeight={volumeBandHeight}
+      />
+    </Group>
   );
 }
 

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -33,6 +33,7 @@ export { usePriceY, useTimeX } from "./hooks/useChartOverlayContext";
 
 export type {
   AreaDotsConfig,
+  AxisAutoHideConfig,
   AxisLabelConfig,
   BadgeConfig,
   BadgeMetrics,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -738,6 +738,22 @@ export interface XAxisConfig {
 }
 
 /**
+ * Auto-hide both axes while idle (see {@link LiveChartCoreProps.axisAutoHide}).
+ *
+ * @experimental
+ */
+export interface AxisAutoHideConfig {
+  /** Fade-in duration (ms) when interaction starts — near-instant. Default `60`. */
+  fadeInMs?: number;
+  /** Fade-out duration (ms) back to idle. Default `250`. */
+  fadeOutMs?: number;
+  /** Axis opacity while idle (0 = fully hidden). Default `0`. */
+  idleOpacity?: number;
+  /** Untouched time (ms) before the axes fade back out. Default `3000`. */
+  hideAfterMs?: number;
+}
+
+/**
  * Morfi-style on-canvas tooltip for {@link LiveChartSeries}: a time-range pill
  * above the guide plus one value pill at every visible series intersection.
  *
@@ -2038,6 +2054,15 @@ export interface LiveChartCoreProps {
   yAxis?: boolean | YAxisConfig;
   /** X-axis time labels. `true` = defaults, `false` = hidden, or pass `XAxisConfig`. Default `true`. */
   xAxis?: boolean | XAxisConfig;
+  /**
+   * Auto-hide both axes while the chart is at rest: the X/Y axes (grid, ticks,
+   * labels) fade in on any interaction — scrubbing, time-scrolling, flinging,
+   * pinch-zooming — and fade back out once the chart goes untouched for
+   * `hideAfterMs`. `true` = defaults, or pass `AxisAutoHideConfig`. Default off.
+   *
+   * @experimental
+   */
+  axisAutoHide?: boolean | AxisAutoHideConfig;
   /**
    * Label floated at the top edge of the plot area. `true` = the built-in value
    * label showing the chart's current TOP Y-axis bound (updated each frame),

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -230,6 +230,20 @@ describe("LiveChart", () => {
     render(<Harness gradient={false} yAxis={false} badge={false} />);
   });
 
+  it("renders with axisAutoHide enabled (defaults and config object)", () => {
+    render(<Harness axisAutoHide />);
+    render(
+      <Harness
+        axisAutoHide={{
+          fadeInMs: 50,
+          fadeOutMs: 100,
+          idleOpacity: 0.2,
+          hideAfterMs: 1000,
+        }}
+      />,
+    );
+  });
+
   it("does not register disabled optional subsystem worklets", () => {
     const badgeSpy = jest.spyOn(badgeHooks, "useBadge");
     const candlePathSpy = jest.spyOn(candlePathHooks, "useCandlePaths");

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -231,8 +231,8 @@ describe("LiveChart", () => {
   });
 
   it("renders with axisAutoHide enabled (defaults and config object)", () => {
-    render(<Harness axisAutoHide />);
-    render(
+    const screen = render(<Harness axisAutoHide />);
+    screen.rerender(
       <Harness
         axisAutoHide={{
           fadeInMs: 50,
@@ -242,6 +242,9 @@ describe("LiveChart", () => {
         }}
       />,
     );
+    // `useSharedValue` keeps its initial value, so runtime configuration changes
+    // need to reset the axis group opacity instead of leaving the axes stuck.
+    screen.rerender(<Harness axisAutoHide={false} />);
   });
 
   it("does not register disabled optional subsystem worklets", () => {


### PR DESCRIPTION
## What

An opt-in `axisAutoHide` prop on `LiveChart` (default off): both axes (grid, ticks, labels) stay hidden while the chart is at rest, fade in on any interaction — scrub, time-scroll drag, fling, pinch-zoom — and fade back out once the chart goes untouched for a while. Robinhood-style minimal charts that still give you the axes the moment you engage.

`true` uses defaults, or pass a config:

```tsx
axisAutoHide={{ fadeInMs: 60, fadeOutMs: 250, idleOpacity: 0, hideAfterMs: 3000 }}
```

## How

- A UI-thread reaction watches `scrollActive` / `crosshairScrubActive` plus `viewEnd` / `viewWindow`, so touchless movement (fling momentum, pinch) also counts as interaction. Held touch → fade to 1; movement without a held touch → show, then `withDelay(hideAfterMs)` fade back to `idleOpacity`.
- Only the axis groups' opacity animates — the Y-axis layer multiplies it into the existing reveal opacity, the X-axis overlay gets a wrapping `Group`. The axis worklets keep running underneath, so a fade-in always shows current labels.
- `AxisAutoHideConfig` exported, marked `@experimental` like the other gesture-adjacent options.

Off by default; when off, the shared opacity value is constant 1 and nothing changes.

## Tests

Render coverage for both forms (`true` and a full config object) in `LiveChart.test.tsx`. The fade reaction itself is a UI-thread mapper Jest's Worklets stub doesn't execute (same as the reveal reaction).

`npm run verify` passes.

This is LiveChart-only for now (our use case); happy to mirror it on LiveChartSeries if you'd like it there too. We've been running it in production at FOMO for a few weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)