### PR TITLE
feat: add scrub.snapToCandles — crosshair snaps to candle centers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Candle-snapping crosshair.** `ScrubConfig.snapToCandles` quantizes the
+  scrub X to the hovered candle's center, so the crosshair — and the time,
+  tooltip, and trailing dim derived from it — jumps candle-to-candle instead
+  of gliding (the tick-to-tick feel of pro charting tools). Gaps between
+  candles and line mode keep the raw X; defaults to `false`. The Candlestick
+  demo includes a **Snap to candles** switch.
+
 ## [4.17.0] - 2026-08-10
 
 ### Added

--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -85,6 +85,7 @@ export default function CandlestickScreen() {
   const [volumeHeight, setVolumeHeight] = useState(48);
   const [volumeRound, setVolumeRound] = useState(2);
   const [customVolumeColors, setCustomVolumeColors] = useState(false);
+  const [snapToCandles, setSnapToCandles] = useState(false);
 
   const tf = TIMEFRAMES.find((t) => t.label === tfLabel) ?? TIMEFRAMES[1];
   const candleWidthSecs = tf.candleWidthSecs;
@@ -137,7 +138,7 @@ export default function CandlestickScreen() {
                 }
               : false
           }
-          scrub={{ tooltip: true }}
+          scrub={{ tooltip: true, snapToCandles }}
         />
       }
     >
@@ -199,6 +200,14 @@ export default function CandlestickScreen() {
           </ControlRow>
         </>
       )}
+
+      <ControlRow label="Scrub crosshair">
+        <ToggleChip
+          label="Snap to candles"
+          value={snapToCandles}
+          onChange={setSnapToCandles}
+        />
+      </ControlRow>
 
       <ControlRow label="Empty state">
         <ToggleChip

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -385,6 +385,7 @@ interface ScrubConfig {
   panGestureDelay?: number; // press-and-hold ms before scrubbing activates; default 0
   clampToPlot?: boolean; // plain scrub: ignore starts beyond the plot's X bounds and clamp active drags; default false
   hideOverlaysOnScrub?: boolean; // fade markers + reference lines out while scrubbing; default false
+  snapToCandles?: boolean; // candle mode: snap the crosshair to candle centers (tick-to-tick); gaps between candles + line mode keep the raw X; default false
 }
 interface PerSeriesTooltipConfig {
   alwaysShow?: boolean;      // pin value pills to visible endpoints while idle; default false

--- a/docs/guides/candlestick.mdx
+++ b/docs/guides/candlestick.mdx
@@ -147,6 +147,8 @@ Pass `scrub` to enable the crosshair: the built-in tooltip shows the scrubbed ca
 stacked with its time. For full control — a minimal pill, your own layout, or to mirror the active
 candle elsewhere in your UI — pass [`renderTooltip`](/guides/scrubbing#custom-tooltip-in-candle-mode),
 which receives the scrubbed bucket as `ctx.candle`. The JS-thread [`onScrub`](/guides/scrubbing)
-callback also includes `point.candle` for the OHLC under the crosshair.
+callback also includes `point.candle` for the OHLC under the crosshair. Set
+[`scrub.snapToCandles`](/guides/scrubbing#snap-to-candle-centers-snaptocandles) to make the
+crosshair jump from candle center to candle center instead of gliding.
 
 See the full prop list in the [`LiveChart` reference](/api-reference/livechart).

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -52,6 +52,29 @@ to the nearest plot edge. Scrub-action gestures retain their existing behavior.
 The option works on `LiveChart` and `LiveChartSeries` and defaults to `false`
 for backwards compatibility.
 
+## Snap to candle centers (`snapToCandles`)
+
+In candle mode the crosshair glides continuously under the finger by default. Set
+`snapToCandles` to quantize the scrub X to the hovered candle's center: the crosshair — and
+everything derived from it (the time, tooltip, and trailing dim) — jumps from candle to candle
+instead, the tick-to-tick feel of pro charting tools:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  mode="candle"
+  candles={candles}
+  liveCandle={liveCandle}
+  candleWidth={60}
+  scrub={{ snapToCandles: true }}
+/>
+```
+
+A position in a gap between candles keeps the raw finger X, and the option is a no-op in line
+mode. Defaults to `false`. The example app's **Candlestick** screen includes a **Snap to
+candles** switch to compare both behaviors.
+
 ## Customizing the tooltip
 
 The default pill shows the value on the first row and the time on the second, offset to the side of

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1095,6 +1095,8 @@ function useLiveChartController({
       : 0,
     scrollActive,
     scrubCfg?.clampToPlot ?? false,
+    // Candle mode: snap the crosshair to candle centers (tick-to-tick).
+    scrubCfg?.snapToCandles ?? false,
   );
 
   // Capture only the shared value in the worklets below. Referencing

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -192,6 +192,8 @@ export interface ResolvedScrubConfig {
   hideOverlaysOnScrub: boolean;
   /** Reject outside plain-scrub starts and clamp active scrub X to the plot. */
   clampToPlot: boolean;
+  /** Candle mode: quantize the scrub X to the hovered candle's center. */
+  snapToCandles: boolean;
 }
 
 export interface ResolvedPerSeriesTooltipConfig {
@@ -734,6 +736,7 @@ const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   panGestureDelay: 0,
   hideOverlaysOnScrub: false,
   clampToPlot: false,
+  snapToCandles: false,
 };
 
 const PER_SERIES_TOOLTIP_DEFAULTS: ResolvedPerSeriesTooltipConfig = {

--- a/packages/react-native-livechart/src/hooks/crosshairShared.ts
+++ b/packages/react-native-livechart/src/hooks/crosshairShared.ts
@@ -4,6 +4,7 @@ import type { DerivedValue, SharedValue } from "react-native-reanimated";
 import { measureFontTextWidth } from "../lib/measureFontTextWidth";
 import { type ChartPadding } from "../draw/line";
 import { interpolateAtTime } from "../math/interpolate";
+import { pickCandleAtTime } from "../math/pickCandle";
 import type { CandlePoint } from "../types";
 
 const TOOLTIP_PAD_X = 8;
@@ -288,6 +289,36 @@ export function computeScrubTime(
   const winStart = timestamp - windowSecs;
   const fraction = (scrubX - padding.left) / chartW;
   return winStart + fraction * windowSecs;
+}
+
+/**
+ * Quantizes a scrub X to the center of the candle whose time bucket contains
+ * it (`scrub.snapToCandles`) — the inverse of {@link computeScrubTime}
+ * followed by the forward mapping of the picked candle's center. Returns the
+ * raw X unchanged when the position falls in a gap between candles or when
+ * the plot has no horizontal extent / time window yet.
+ */
+export function snapScrubXToCandleCenter(
+  x: number,
+  candles: CandlePoint[],
+  liveCandle: CandlePoint | null,
+  candleWidthSecs: number,
+  padding: ChartPadding,
+  canvasWidth: number,
+  timestamp: number,
+  windowSecs: number,
+): number {
+  "worklet";
+  const chartW = canvasWidth - padding.left - padding.right;
+  if (chartW <= 0 || windowSecs <= 0) return x;
+  const winStart = timestamp - windowSecs;
+  const t = winStart + ((x - padding.left) / chartW) * windowSecs;
+  const candle = pickCandleAtTime(candles, liveCandle, t, candleWidthSecs);
+  if (!candle) return x;
+  return (
+    padding.left +
+    ((candle.time + candleWidthSecs / 2 - winStart) / windowSecs) * chartW
+  );
 }
 
 /**

--- a/packages/react-native-livechart/src/hooks/useCrosshair.ts
+++ b/packages/react-native-livechart/src/hooks/useCrosshair.ts
@@ -37,6 +37,7 @@ import {
   SCRUB_ACTIVATE_X_PX,
   SCRUB_FAIL_Y_PX,
   snapPrice,
+  snapScrubXToCandleCenter,
   startPlainScrub,
   type CrosshairState,
   updatePlainScrub,
@@ -157,6 +158,12 @@ export function useCrosshair(
    * Default `false`.
    */
   clampToPlot = false,
+  /**
+   * Candle mode: quantize the plain-scrub X to the hovered candle's center
+   * before it enters `scrubX` (`scrub.snapToCandles`). No-op in line mode.
+   * Default `false`.
+   */
+  snapToCandles = false,
 ): CrosshairState {
   const scrubX = useSharedValue(-1);
   const scrubActive = useSharedValue(false);
@@ -519,6 +526,26 @@ export function useCrosshair(
       ? SCRUB_ACTION_PRESS_HOLD_MS
       : panGestureDelay;
 
+  // `scrub.snapToCandles`: quantize the scrub X to the hovered candle's center
+  // before it enters `scrubX`, so the crosshair — and everything derived from
+  // it (time, tooltip, dim edge) — jumps candle-to-candle instead of gliding.
+  // Line mode and gaps between candles pass the raw X through.
+  /* istanbul ignore next -- worklet, called only from UI-thread gesture handlers */
+  const snapCandleX = (x: number): number => {
+    "worklet";
+    if (!snapToCandles || !isCandleMode || !candlesSV) return x;
+    return snapScrubXToCandleCenter(
+      x,
+      candlesSV.get(),
+      liveCandleSV?.get() ?? null,
+      candleWidthSecs,
+      padding,
+      engine.canvasWidth.get(),
+      engine.timestamp.get(),
+      engine.displayWindow.get(),
+    );
+  };
+
   let gesture = Gesture.Pan()
     .maxPointers(1)
     .shouldCancelWhenOutside(false)
@@ -618,7 +645,7 @@ export function useCrosshair(
         // guard needed. (Plain-scrub counterpart of the scrub-action tap defer.)
         if (deferTapHit !== undefined && deferTapHit(e.x, e.y)) return;
         startPlainScrub(
-          e.x,
+          snapCandleX(e.x),
           padding,
           engine.canvasWidth.get(),
           clampPlainScrubToPlot,
@@ -653,7 +680,7 @@ export function useCrosshair(
           return;
         }
         updatePlainScrub(
-          e.x,
+          snapCandleX(e.x),
           padding,
           engine.canvasWidth.get(),
           clampPlainScrubToPlot,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -961,6 +961,15 @@ export interface ScrubConfig {
    * Default `false`.
    */
   clampToPlot?: boolean;
+  /**
+   * Candle mode: snap the crosshair to candle centers. The scrub X is
+   * quantized to the hovered candle's center before it drives the crosshair,
+   * so the line — and everything derived from it (the time, tooltip, and
+   * trailing dim) — jumps from candle to candle instead of gliding, the
+   * tick-to-tick feel of pro charting tools. A position in a gap between
+   * candles keeps the raw finger X; no effect in line mode. Default `false`.
+   */
+  snapToCandles?: boolean;
 }
 
 /**

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -866,6 +866,20 @@ describe("LiveChart", () => {
     await render(<CandleHarness scrub />);
   });
 
+  it("renders candle mode with a candle-snapping scrub crosshair", async () => {
+    const screen = await render(
+      <CandleHarness scrub={{ snapToCandles: true }} />,
+    );
+    const views = getAllByHostType(screen, View);
+    await fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+  });
+
+  it("treats scrub.snapToCandles as a no-op in line mode", async () => {
+    await render(<Harness scrub={{ snapToCandles: true }} />);
+  });
+
   it("renders candle mode with an instant candleLerpSpeed (transitions)", async () => {
     const screen = await render(
       <CandleHarness transitions={{ candleLerpSpeed: 1 }} />,

--- a/packages/react-native-livechart/tests/hooks/crosshairShared.test.ts
+++ b/packages/react-native-livechart/tests/hooks/crosshairShared.test.ts
@@ -7,7 +7,9 @@ import {
   computeValueAtY,
   pointInRect,
   snapPrice,
+  snapScrubXToCandleCenter,
 } from "../../src/hooks/crosshairShared";
+import type { CandlePoint } from "../../src/types";
 
 const font = {
   getSize: () => 12,
@@ -80,6 +82,74 @@ describe("snapPrice", () => {
     expect(snapPrice(64.3, 0.5)).toBe(64.5);
     expect(snapPrice(64.1, 0.5)).toBe(64);
     expect(snapPrice(64.236, 0.01)).toBeCloseTo(64.24);
+  });
+});
+
+describe("snapScrubXToCandleCenter", () => {
+  const candle = (time: number): CandlePoint => ({
+    time,
+    open: 1,
+    high: 2,
+    low: 0,
+    close: 1,
+  });
+
+  // chartW = 320 - 10 - 10 = 300 px over windowSecs = 300 s (1 px/s), so with
+  // timestamp = 1000 the window starts at t = 700 and x maps to t = 690 + x.
+  const padding = { top: 12, right: 10, bottom: 28, left: 10 };
+  const canvasWidth = 320;
+  const timestamp = 1000;
+  const windowSecs = 300;
+  const candleWidthSecs = 60;
+  // Committed buckets [700, 760) and [760, 820), a gap [820, 880), then
+  // [880, 940); the live candle owns [940, 1000).
+  const candles = [candle(700), candle(760), candle(880)];
+  const live = candle(940);
+
+  const snap = (x: number, width = canvasWidth, win = windowSecs) =>
+    snapScrubXToCandleCenter(
+      x,
+      candles,
+      live,
+      candleWidthSecs,
+      padding,
+      width,
+      timestamp,
+      win,
+    );
+
+  it("quantizes every X over a bucket to that candle's center", () => {
+    // Bucket [700, 760): center 730 → x = 40.
+    expect(snap(15)).toBeCloseTo(40);
+    expect(snap(40)).toBeCloseTo(40);
+    expect(snap(69)).toBeCloseTo(40);
+    // Bucket [760, 820): center 790 → x = 100.
+    expect(snap(75)).toBeCloseTo(100);
+    expect(snap(129)).toBeCloseTo(100);
+  });
+
+  it("snaps to the live candle's center", () => {
+    // Live bucket [940, 1000): center 970 → x = 280.
+    expect(snap(255)).toBeCloseTo(280);
+  });
+
+  it("passes the raw X through in a gap between candles", () => {
+    // t = 830 falls in the empty [820, 880) bucket.
+    expect(snap(140)).toBe(140);
+  });
+
+  it("passes the raw X through before the first candle", () => {
+    // t = 695 predates the oldest bucket.
+    expect(snap(5)).toBe(5);
+  });
+
+  it("guards a plot without horizontal extent", () => {
+    expect(snap(40, padding.left + padding.right)).toBe(40); // chartW = 0
+    expect(snap(40, 0)).toBe(40); // chartW < 0
+  });
+
+  it("guards a zero-length time window", () => {
+    expect(snap(40, canvasWidth, 0)).toBe(40);
   });
 });
 

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -609,6 +609,7 @@ describe("resolveScrub", () => {
     panGestureDelay: 0,
     hideOverlaysOnScrub: false,
     clampToPlot: false,
+    snapToCandles: false,
   };
 
   it("returns null for undefined", () => {
@@ -689,6 +690,12 @@ describe("resolveScrub", () => {
   it("defaults clampToPlot to false and carries it when set", () => {
     expect(resolveScrub(true)?.clampToPlot).toBe(false);
     expect(resolveScrub({ clampToPlot: true })?.clampToPlot).toBe(true);
+  });
+
+  it("defaults snapToCandles to false and carries it when set", () => {
+    expect(resolveScrub(true)?.snapToCandles).toBe(false);
+    expect(resolveScrub({})?.snapToCandles).toBe(false);
+    expect(resolveScrub({ snapToCandles: true })?.snapToCandles).toBe(true);
   });
 
   it("carries a custom tooltipBorderRadius", () => {


### PR DESCRIPTION
**What**

- New opt-in `ScrubConfig.snapToCandles` (default `false`): quantizes the scrub X to the hovered candle's center, so the crosshair — and everything derived from it (time, tooltip, trailing dim) — jumps tick-to-tick, TradingView-style, instead of gliding.
- Gaps between candles and line mode pass the raw X through; the Candlestick demo gains a **Snap to candles** switch.

**Why a pure helper in `crosshairShared`**

- `snapScrubXToCandleCenter` (the inverse of `computeScrubTime`, then the forward mapping of the picked candle's center via `pickCandleAtTime`) is unit-testable under Jest; the gesture-side gate stays a thin istanbul-ignored worklet like its siblings.

**Why LiveChart only**

- `LiveChartSeries` has no candle mode, so the flag is wired through `useCrosshair`'s two plain-scrub call sites (`startPlainScrub` / `updatePlainScrub`) and is inert everywhere else. Default behavior is unchanged.

**Test plan**

- `resolveScrub` default/carry cases; snap-math unit tests (center quantization across a bucket, live candle, gap + pre-history pass-through, zero-width plot/window guards); render coverage in candle and line mode with the flag on.
- `npm run verify` green; coverage thresholds hold (branches 91.6, functions 95.3, lines 97.0, statements 96.2).
- The gesture handlers are UI-thread worklets (istanbul-ignored like their siblings), so snap-while-dragging wasn't exercised under Jest; the equivalent behavior has been running in production at FOMO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
