### PR TITLE
Add focused candle scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Focused candle scrubbing.** `ScrubConfig.dimTarget: "otherCandles"` keeps
+  the candle under the finger at full color while dimming every other candle
+  body and wick to `dimOpacity` (`0.5` for the brokerage-style treatment).
+  The vertical scrub guide and selection dot hide in this mode, leaving the
+  focused candle as the sole position indicator. Other candles ease into and
+  out of the dim with configurable `dimFadeMs` (default `60`; `0` is instant).
+  Switching the same chart to line mode falls back to the standard guide, dot,
+  and trailing fade. The default `"future"` target preserves the existing
+  behavior. The Candle scrub demo enables it.
+
 ## [4.18.0] - 2026-08-12
 
 ### Added

--- a/app/demo/candle-scrub.tsx
+++ b/app/demo/candle-scrub.tsx
@@ -3,7 +3,6 @@ import { StyleSheet, Text, TextInput, View } from "react-native";
 import {
   LiveChart,
   type CandlePoint,
-  type TooltipRenderProps,
 } from "react-native-livechart";
 import Animated, {
   useAnimatedProps,
@@ -71,26 +70,6 @@ function OhlcCell({
   );
 }
 
-/**
- * The custom candle tooltip: just the scrubbed time, pinned to the top edge of
- * the plot (`scrub.tooltipPlacement: "top"`). It reads `ctx.timeStr` (formatted
- * UI-side), so the OHLC can live in the header above the chart instead.
- */
-function TimeTooltip({ timeStr }: TooltipRenderProps) {
-  const animatedProps = useAnimatedProps(() => {
-    const t = timeStr.get();
-    return { text: t, defaultValue: t };
-  });
-  return (
-    <AnimatedTextInput
-      editable={false}
-      underlineColorAndroid="transparent"
-      style={styles.timeText}
-      animatedProps={animatedProps}
-    />
-  );
-}
-
 export default function CandleScrubScreen() {
   const windowSecs = 300;
   const candleWidthSecs = 15;
@@ -120,7 +99,7 @@ export default function CandleScrubScreen() {
     <DemoScreen
       title="Candle scrub"
       docs="guides/scrubbing"
-      description="Brokerage-style candle scrub: O/H/L/C in a header above the chart, the time pinned to the top edge, and the crosshair kept. A custom renderTooltip shows only ctx.timeStr; the OHLC comes from onScrub's point.candle (live candle when idle)."
+      description="Brokerage-style candle scrub: O/H/L/C in a header above the chart and the selected candle as the sole position indicator. The header reads onScrub's point.candle and returns to the live candle when idle."
       chart={
         <View style={styles.wrap}>
           <View style={styles.header}>
@@ -146,14 +125,13 @@ export default function CandleScrubScreen() {
               accentColor={ACCENT}
               theme={APP_THEME}
               timeWindow={windowSecs}
-              // Reserve a top band so the candles sit *below* the pinned time
-              // label — the label parks at the canvas edge and the crosshair line
-              // stops at it, neither overlapping the data (cf. the extrema labels).
-              insets={{ top: 28 }}
-              // Custom tooltip = time only, pinned to the top edge. The crosshair
-              // line + selection dot stay (the built-in OHLC stack is replaced).
-              scrub={{ tooltipPlacement: "top", tooltipMargin: 4 }}
-              renderTooltip={TimeTooltip}
+              scrub={{
+                tooltip: false,
+                snapToCandles: true,
+                dimTarget: "otherCandles",
+                dimOpacity: 0.5,
+                dimFadeMs: 60,
+              }}
               onScrub={(point) => {
                 "worklet";
                 if (point && point.candle) {
@@ -173,8 +151,9 @@ export default function CandleScrubScreen() {
       }
     >
       <Text style={demoStyles.scrubReadout}>
-        Press and drag across the candles. The header shows the scrubbed O/H/L/C
-        and the time pins to the top; release to return to the live candle.
+        Press and drag across the candles. The selected candle stays at full
+        strength while the others dim, with no extra line or dot; the header
+        shows its O/H/L/C. Release to return to the live candle.
       </Text>
     </DemoScreen>
   );
@@ -199,15 +178,4 @@ const styles = StyleSheet.create({
     marginTop: 1,
   },
   chart: { flex: 1 },
-  timeText: {
-    // Hug the "HH:MM:SS" text (8 monospace glyphs ≈ 58px) instead of a wide box,
-    // so when the label clamps to the canvas edge the *text* reaches the edge
-    // rather than sitting inset inside an 80px box.
-    width: 64,
-    textAlign: "center",
-    color: colors.textMuted,
-    fontSize: 12,
-    padding: 0,
-    fontFamily: "JetBrainsMono_400Regular",
-  },
 });

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -370,7 +370,9 @@ interface ScrubConfig {
   // LiveChartSeries only: opt-in Morfi-style time + per-series value pills.
   // false/omitted preserves the existing guide-only default.
   seriesTooltip?: boolean | PerSeriesTooltipConfig;
-  dimOpacity?: number; // opacity of content right of the crosshair; default 0.3 (1 = off)
+  dimTarget?: "future" | "otherCandles"; // default "future"; otherCandles hides the scrub line/dot in candle mode, falls back to future in line mode
+  dimOpacity?: number; // opacity of the selected dim target; clamped to [0, 1]; default 0.3
+  dimFadeMs?: number; // otherCandles fade-in/out duration; default 60; 0 = instant
   crosshairLineColor?: string; crosshairDimColor?: string; // crosshairDimColor = legacy colored mask
   crosshairStrokeWidth?: number; // line width in px; default 1
   crosshairOvershoot?: number; // extend past top/bottom in px; preserves a custom top-tooltip stop; negatives clamp to 0; default 0

--- a/docs/guides/scrubbing.mdx
+++ b/docs/guides/scrubbing.mdx
@@ -201,18 +201,40 @@ function OhlcTooltip({ candle }: TooltipRenderProps) {
 that only shows the close + date needs no candle-specific code at all. This is handy when the active
 candle is shown elsewhere in your UI and you want a minimal (or empty) in-chart tooltip.
 
-## Trailing fade (`dimOpacity`)
+## Scrub dimming (`dimTarget`, `dimOpacity`)
 
-While scrubbing, the chart content to the **right** of the crosshair (the "future") is faded so the
-part you're inspecting stands out. This is done by erasing the trailing content's alpha — it reveals
-the **real background**, so it works on any background color (no need to match a mask color).
-
-`dimOpacity` sets the opacity of that trailing region: `1` disables the fade, `0` fully hides it.
-Default `0.3`.
+By default, scrubbing fades chart content to the **right** of the crosshair (the "future") so the
+part you're inspecting stands out. Set `dimTarget: "otherCandles"` in candle mode to keep the
+candle under the finger at full strength while fading every other candle body and wick:
 
 ```tsx
-<LiveChart data={data} value={value} scrub={{ dimOpacity: 0.3 }} />
+<LiveChart
+  mode="candle"
+  candles={candles}
+  liveCandle={liveCandle}
+  scrub={{
+    tooltip: false,
+    snapToCandles: true,
+    dimTarget: "otherCandles",
+    dimOpacity: 0.5,
+    dimFadeMs: 60,
+  }}
+/>
 ```
+
+`dimOpacity` is clamped to `[0, 1]`: `1` disables the fade and `0` fully hides the selected target.
+Default `0.3`. With `"otherCandles"`, volume bars stay unchanged and gaps select no candle. The
+vertical crosshair and scrub selection dot are hidden so the focused candle is the sole position
+indicator. If the chart switches to line mode while keeping this config, scrubbing falls back to the
+standard guide, selection dot, and `"future"` fade. The default `dimTarget: "future"` preserves the
+existing trailing fade.
+
+`dimFadeMs` controls how quickly the other candles ease toward `dimOpacity` and return to full
+strength on release. It defaults to `60` ms; set it to `0` for the previous instant change. The
+selected candle remains fully opaque while the surrounding batch animates.
+
+The trailing fade erases content alpha, revealing the **real background**, so it works on any
+background color (no need to match a mask color).
 
 <Note>
   `crosshairDimColor` is the legacy alternative: a solid (usually semi-transparent) color painted
@@ -220,7 +242,8 @@ Default `0.3`.
   background — prefer `dimOpacity`. When `crosshairDimColor` is set, it overrides the fade.
 </Note>
 
-The same `dimOpacity` option works on `LiveChartSeries`.
+The default `dimTarget: "future"` and its `dimOpacity` work on `LiveChartSeries`;
+`"otherCandles"` focus rendering is candle-mode only.
 
 ## Hide overlays while scrubbing (`hideOverlaysOnScrub`)
 

--- a/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CrosshairOverlay.tsx
@@ -29,6 +29,7 @@ export function CrosshairOverlay({
   children,
   renderTooltip,
   lineTop,
+  showLine = true,
   selectionDot,
   selectionY,
   scrubActive,
@@ -70,6 +71,8 @@ export function CrosshairOverlay({
    *  top-pinned custom tooltip instead of running up through it. -1 (or omitted)
    *  → start at `padding.top`. Fed by {@link CustomTooltipOverlay}. */
   lineTop?: SharedValue<number>;
+  /** Draw the vertical scrub guide. Default true. */
+  showLine?: boolean;
   /** Resolved selection-dot config; `null` hides it, a `component` renders the
    *  consumer's dot, otherwise the built-in dot. */
   selectionDot?: ResolvedSelectionDotConfig | null;
@@ -229,15 +232,17 @@ export function CrosshairOverlay({
       ) : null}
 
       <Group opacity={visibleOpacity}>
-        <Line
-          p1={p1}
-          p2={p2}
-          color={crosshairLineColor ?? palette.crosshairLine}
-          strokeWidth={crosshairStrokeWidth}
-          strokeCap={crosshairLineCap}
-        >
-          {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
-        </Line>
+        {showLine ? (
+          <Line
+            p1={p1}
+            p2={p2}
+            color={crosshairLineColor ?? palette.crosshairLine}
+            strokeWidth={crosshairStrokeWidth}
+            strokeCap={crosshairLineCap}
+          >
+            {crosshairDash ? <DashPathEffect intervals={crosshairDash} /> : null}
+          </Line>
+        ) : null}
 
         {/* Selection dot at the scrub intersection. `null` hides it; a custom
             component renders the consumer's dot; otherwise the built-in dot. */}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -70,6 +70,10 @@ import {
 import { resolveSegment, type ResolvedSegment } from "../core/resolveSegment";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
 import { pulseRadialOutset } from "../draw/line";
+import {
+  computeCandleFocusClip,
+  HIDDEN_CANDLE_FOCUS_CLIP,
+} from "../draw/candle";
 import { resolveChartLayout } from "../hooks/resolveChartLayout";
 import { useBadge } from "../hooks/useBadge";
 import { useCandlePaths, useCandleWidthLerp } from "../hooks/useCandlePaths";
@@ -1778,6 +1782,42 @@ function ChartFillLayer({
   );
 }
 
+type CandlePaths = ReturnType<typeof useCandlePaths>;
+
+/** One batched candle pass: two body paths and two wick paths. */
+function CandlePathBatch({
+  paths,
+  wickWidth,
+  palette,
+}: {
+  paths: CandlePaths;
+  wickWidth: number;
+  palette: LiveChartPalette;
+}) {
+  return (
+    <>
+      <Path
+        path={paths.upWicksPath}
+        style="stroke"
+        strokeWidth={wickWidth}
+        color={palette.wickUp}
+      />
+      <Path
+        path={paths.downWicksPath}
+        style="stroke"
+        strokeWidth={wickWidth}
+        color={palette.wickDown}
+      />
+      <Path path={paths.upBodiesPath} style="fill" color={palette.candleUp} />
+      <Path
+        path={paths.downBodiesPath}
+        style="fill"
+        color={palette.candleDown}
+      />
+    </>
+  );
+}
+
 /**
  * Candle/volume paths are a mode-specific subsystem. Keeping their hooks in a
  * child means a line chart never registers the candle-width frame callback or
@@ -1799,15 +1839,10 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     volumeOpacity,
     volumeUpColor,
     volumeDownColor,
+    scrubCfg,
+    crosshair,
   } = model;
-  const {
-    upBodiesPath,
-    downBodiesPath,
-    upWicksPath,
-    downWicksPath,
-    upBarsPath,
-    downBarsPath,
-  } = useCandlePaths(
+  const paths = useCandlePaths(
     engine,
     effectivePadding,
     candlesEngine,
@@ -1818,31 +1853,97 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     volumeBandHeight,
     volumeCfg?.radius ?? 0,
   );
+  const focusOtherCandles = scrubCfg?.dimTarget === "otherCandles";
+  const candleDimOpacity = scrubCfg?.dimOpacity ?? 1;
+  const candleDimFadeMs = scrubCfg?.dimFadeMs ?? 0;
+  // Destructure the two SharedValues before entering worklets. Closing over the
+  // whole crosshair object would also serialize its RNGH gesture instances.
+  const scrubActive = crosshair.scrubActive;
+  // ChartCandleLayer is single-series only; useCrosshair always supplies this
+  // value (it is optional on the shared state type only for LiveChartSeries).
+  const scrubCandle = crosshair.scrubCandle!;
+  const inactiveCandleOpacity = useDerivedValue(() => {
+    const target =
+      focusOtherCandles && scrubActive.get() && scrubCandle.get()
+        ? candleDimOpacity
+        : 1;
+    return candleDimFadeMs > 0
+      ? withTiming(target, { duration: candleDimFadeMs })
+      : target;
+  }, [
+    focusOtherCandles,
+    scrubActive,
+    scrubCandle,
+    candleDimOpacity,
+    candleDimFadeMs,
+  ]);
+  const focusedCandleOpacity = useDerivedValue(
+    () => (focusOtherCandles && scrubActive.get() && scrubCandle.get() ? 1 : 0),
+    [focusOtherCandles, scrubActive, scrubCandle],
+  );
+  const focusedCandleClip = useDerivedValue(() => {
+    if (!focusOtherCandles || !scrubActive.get()) {
+      return HIDDEN_CANDLE_FOCUS_CLIP;
+    }
+    return computeCandleFocusClip(
+      scrubCandle.get(),
+      effectivePadding,
+      engine.canvasWidth.get(),
+      engine.canvasHeight.get(),
+      engine.timestamp.get() - engine.displayWindow.get(),
+      engine.displayWindow.get(),
+      displayCandleWidth.get(),
+    );
+  }, [
+    focusOtherCandles,
+    scrubActive,
+    scrubCandle,
+    effectivePadding,
+    engine.canvasWidth,
+    engine.canvasHeight,
+    engine.timestamp,
+    engine.displayWindow,
+    displayCandleWidth,
+  ]);
 
   return (
     <Group opacity={seriesOpacity}>
       <Group opacity={candleGroupOpacity}>
-        <Path
-          path={upWicksPath}
-          style="stroke"
-          strokeWidth={metricsCfg.candle.wickWidth}
-          color={palette.wickUp}
-        />
-        <Path
-          path={downWicksPath}
-          style="stroke"
-          strokeWidth={metricsCfg.candle.wickWidth}
-          color={palette.wickDown}
-        />
-        <Path path={upBodiesPath} style="fill" color={palette.candleUp} />
-        <Path path={downBodiesPath} style="fill" color={palette.candleDown} />
+        {focusOtherCandles ? (
+          <>
+            <Group opacity={inactiveCandleOpacity}>
+              <CandlePathBatch
+                paths={paths}
+                wickWidth={metricsCfg.candle.wickWidth}
+                palette={palette}
+              />
+            </Group>
+            <Group opacity={focusedCandleOpacity} clip={focusedCandleClip}>
+              <CandlePathBatch
+                paths={paths}
+                wickWidth={metricsCfg.candle.wickWidth}
+                palette={palette}
+              />
+            </Group>
+          </>
+        ) : (
+          <CandlePathBatch
+            paths={paths}
+            wickWidth={metricsCfg.candle.wickWidth}
+            palette={palette}
+          />
+        )}
       </Group>
 
       {volumeCfg && (
         <Group opacity={candleGroupOpacity}>
           <Group opacity={volumeOpacity}>
-            <Path path={upBarsPath} style="fill" color={volumeUpColor} />
-            <Path path={downBarsPath} style="fill" color={volumeDownColor} />
+            <Path path={paths.upBarsPath} style="fill" color={volumeUpColor} />
+            <Path
+              path={paths.downBarsPath}
+              style="fill"
+              color={volumeDownColor}
+            />
           </Group>
         </Group>
       )}
@@ -2219,6 +2320,10 @@ function ChartScrubLayer({
   // Skia tooltip is suppressed here while it's active — the line pill in line
   // mode, and the OHLC stack in candle mode (see the stack gate below).
   const customTooltipActive = renderTooltip != null;
+  // `otherCandles` is candle-only. If a consumer switches this chart to line
+  // mode without also rewriting its scrub config, preserve the standard line
+  // scrub (guide, selection dot, and trailing fade).
+  const dimsFuture = !isCandle || scrubCfg?.dimTarget === "future";
 
   if (!scrubCfg) return null;
 
@@ -2243,11 +2348,12 @@ function ChartScrubLayer({
           font={skiaFont}
           showTooltip={scrubCfg.tooltip && !customTooltipActive}
           lineTop={crosshair.tooltipLineTop}
-          selectionDot={selectionDot}
+          showLine={dimsFuture}
+          selectionDot={dimsFuture ? selectionDot : null}
           selectionY={crosshair.scrubDotY}
           scrubActive={crosshair.scrubActive}
           selectionColor={selectionColor}
-          dimOpacity={scrubCfg.dimOpacity}
+          dimOpacity={dimsFuture ? scrubCfg.dimOpacity : 1}
           liveDotExtent={liveDotExtent}
           crosshairLineColor={scrubCfg.crosshairLineColor}
           crosshairStrokeWidth={scrubCfg.crosshairStrokeWidth}
@@ -2256,7 +2362,9 @@ function ChartScrubLayer({
           crosshairFadeDistance={scrubCfg.crosshairFadeDistance}
           crosshairLineCap={scrubCfg.crosshairLineCap}
           crosshairDash={scrubCfg.crosshairDash}
-          crosshairDimColor={scrubCfg.crosshairDimColor}
+          crosshairDimColor={
+            dimsFuture ? scrubCfg.crosshairDimColor : undefined
+          }
           tooltipBackground={scrubCfg.tooltipBackground}
           tooltipColor={scrubCfg.tooltipColor}
           tooltipBorderColor={scrubCfg.tooltipBorderColor}

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -71,6 +71,7 @@ import { resolveSegment, type ResolvedSegment } from "../core/resolveSegment";
 import { useLiveChartEngine } from "../core/useLiveChartEngine";
 import { pulseRadialOutset } from "../draw/line";
 import {
+  computeCandleFocusPassOpacity,
   computeCandleFocusClip,
   HIDDEN_CANDLE_FOCUS_CLIP,
 } from "../draw/candle";
@@ -131,6 +132,7 @@ import {
   resolveTheme,
 } from "../theme";
 import type {
+  CandlePoint,
   LiveChartPalette,
   LiveChartPoint,
   LiveChartProps,
@@ -1862,6 +1864,15 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
   // ChartCandleLayer is single-series only; useCrosshair always supplies this
   // value (it is optional on the shared state type only for LiveChartSeries).
   const scrubCandle = crosshair.scrubCandle!;
+  // Keep the last selection after scrubCandle clears so its clipped full-
+  // strength pass can cover the base batch until the release fade completes.
+  const lastScrubCandle = useSharedValue<CandlePoint | null>(null);
+  useAnimatedReaction(
+    () => (focusOtherCandles ? scrubCandle.get() : null),
+    (candle) => {
+      if (candle) lastScrubCandle.set(candle);
+    },
+  );
   const inactiveCandleOpacity = useDerivedValue(() => {
     const target =
       focusOtherCandles && scrubActive.get() && scrubCandle.get()
@@ -1877,16 +1888,29 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     candleDimOpacity,
     candleDimFadeMs,
   ]);
-  const focusedCandleOpacity = useDerivedValue(
-    () => (focusOtherCandles && scrubActive.get() && scrubCandle.get() ? 1 : 0),
-    [focusOtherCandles, scrubActive, scrubCandle],
-  );
+  const focusedCandleOpacity = useDerivedValue(() => {
+    const currentCandle = scrubCandle.get();
+    const focusCandle = currentCandle ?? lastScrubCandle.get();
+    if (!focusOtherCandles || !focusCandle) return 0;
+    return computeCandleFocusPassOpacity(
+      scrubActive.get(),
+      currentCandle !== null,
+      inactiveCandleOpacity.get(),
+    );
+  }, [
+    focusOtherCandles,
+    scrubActive,
+    scrubCandle,
+    lastScrubCandle,
+    inactiveCandleOpacity,
+  ]);
   const focusedCandleClip = useDerivedValue(() => {
-    if (!focusOtherCandles || !scrubActive.get()) {
+    if (!focusOtherCandles) {
       return HIDDEN_CANDLE_FOCUS_CLIP;
     }
+    const focusCandle = scrubCandle.get() ?? lastScrubCandle.get();
     return computeCandleFocusClip(
-      scrubCandle.get(),
+      focusCandle,
       effectivePadding,
       engine.canvasWidth.get(),
       engine.canvasHeight.get(),
@@ -1896,8 +1920,8 @@ function ChartCandleLayer({ model }: { model: LiveChartModel }) {
     );
   }, [
     focusOtherCandles,
-    scrubActive,
     scrubCandle,
+    lastScrubCandle,
     effectivePadding,
     engine.canvasWidth,
     engine.canvasHeight,

--- a/packages/react-native-livechart/src/constants.ts
+++ b/packages/react-native-livechart/src/constants.ts
@@ -40,6 +40,13 @@ export const RETURN_TO_LIVE_MS = 450;
 export const SCRUB_OVERLAY_FADE_MS = 150;
 
 /**
+ * Duration (ms) of the candle-focus opacity transition used by
+ * `scrub.dimTarget: "otherCandles"`. The selected candle remains fully opaque;
+ * the shared candle batch eases toward `dimOpacity` and back to full strength.
+ */
+export const SCRUB_CANDLE_DIM_FADE_MS = 60;
+
+/**
  * Base wave amplitude (px) of the breathing loading squiggle — it breathes
  * between `0.4×` and `1.0×` this. Overridable via `loading={{ amplitude }}`.
  */

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -811,8 +811,19 @@ export function resolveScrub(
     const seriesTooltip =
       typeof prop === "object" ? prop.seriesTooltip : undefined;
     resolved.seriesTooltip = resolvePerSeriesTooltip(seriesTooltip);
-    resolved.dimOpacity = Math.max(0, Math.min(1, resolved.dimOpacity));
-    resolved.dimFadeMs = Math.max(0, resolved.dimFadeMs);
+    // `resolveToggle` shallow-merges object props, so an explicitly undefined
+    // optional field replaces its default. Restore the public defaults before
+    // normalizing; otherwise the numeric clamps produce NaN and an undefined
+    // dimTarget selects neither candle scrub rendering path.
+    resolved.dimTarget = resolved.dimTarget ?? SCRUB_DEFAULTS.dimTarget;
+    resolved.dimOpacity = Math.max(
+      0,
+      Math.min(1, resolved.dimOpacity ?? SCRUB_DEFAULTS.dimOpacity),
+    );
+    resolved.dimFadeMs = Math.max(
+      0,
+      resolved.dimFadeMs ?? SCRUB_DEFAULTS.dimFadeMs,
+    );
     resolved.crosshairOvershoot = Math.max(0, resolved.crosshairOvershoot);
     resolved.crosshairFadeDistance = Math.max(
       0,

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -54,6 +54,7 @@ import {
   LOADING_WAVE_SPEED,
   MOTION_METRICS_DEFAULTS,
   RETURN_TO_LIVE_MS,
+  SCRUB_CANDLE_DIM_FADE_MS,
 } from "../constants";
 
 // ─── Resolved types (all fields required, no optionals) ──────────────────────
@@ -152,8 +153,12 @@ export interface ResolvedScrubConfig {
   tooltip: boolean;
   /** Opt-in per-series pill tooltip for LiveChartSeries; null keeps guide-only behavior. */
   seriesTooltip: ResolvedPerSeriesTooltipConfig | null;
-  /** Opacity of content right of the crosshair while scrubbing (dstOut fade). */
+  /** Content affected by dimOpacity while scrubbing. */
+  dimTarget: "future" | "otherCandles";
+  /** Opacity of the content selected by dimTarget while scrubbing. */
   dimOpacity: number;
+  /** Candle-focus dim transition duration in milliseconds. */
+  dimFadeMs: number;
   /** undefined → palette.crosshairLine */
   crosshairLineColor: string | undefined;
   /** Vertical crosshair line width in px. */
@@ -716,7 +721,9 @@ export function resolveXAxis(
 const SCRUB_DEFAULTS: ResolvedScrubConfig = {
   tooltip: true,
   seriesTooltip: null,
+  dimTarget: "future",
   dimOpacity: 0.3,
+  dimFadeMs: SCRUB_CANDLE_DIM_FADE_MS,
   crosshairLineColor: undefined,
   crosshairStrokeWidth: 1,
   crosshairOvershoot: 0,
@@ -804,6 +811,8 @@ export function resolveScrub(
     const seriesTooltip =
       typeof prop === "object" ? prop.seriesTooltip : undefined;
     resolved.seriesTooltip = resolvePerSeriesTooltip(seriesTooltip);
+    resolved.dimOpacity = Math.max(0, Math.min(1, resolved.dimOpacity));
+    resolved.dimFadeMs = Math.max(0, resolved.dimFadeMs);
     resolved.crosshairOvershoot = Math.max(0, resolved.crosshairOvershoot);
     resolved.crosshairFadeDistance = Math.max(
       0,

--- a/packages/react-native-livechart/src/draw/candle.ts
+++ b/packages/react-native-livechart/src/draw/candle.ts
@@ -37,6 +37,21 @@ export const HIDDEN_CANDLE_FOCUS_CLIP: CandleFocusClip = {
   height: 0,
 };
 
+/**
+ * Keep the full-strength candle pass visible while a candle is selected and
+ * while the shared dimmed batch is still returning to full opacity. The latter
+ * prevents the selected candle from briefly dropping to the dim opacity when a
+ * scrub ends or moves into a gap.
+ */
+export function computeCandleFocusPassOpacity(
+  scrubActive: boolean,
+  hasScrubCandle: boolean,
+  inactiveCandleOpacity: number,
+): number {
+  "worklet";
+  return (scrubActive && hasScrubCandle) || inactiveCandleOpacity < 1 ? 1 : 0;
+}
+
 function candleTimeToX(
   t: number,
   padLeft: number,

--- a/packages/react-native-livechart/src/draw/candle.ts
+++ b/packages/react-native-livechart/src/draw/candle.ts
@@ -22,6 +22,21 @@ export interface CandleGeometry {
   wicks: CandleWick[];
 }
 
+export interface CandleFocusClip {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Stable off-canvas clip used when no candle is focused. */
+export const HIDDEN_CANDLE_FOCUS_CLIP: CandleFocusClip = {
+  x: -1,
+  y: 0,
+  width: 0,
+  height: 0,
+};
+
 function candleTimeToX(
   t: number,
   padLeft: number,
@@ -42,6 +57,54 @@ function candleValueToY(
 ): number {
   "worklet";
   return padTop + ((displayMax - v) / valRange) * chartH;
+}
+
+/**
+ * Return the visible screen-space time slot occupied by one candle bucket.
+ * The focus renderer clips the existing batched candle paths to this strip,
+ * repainting only the selected body and wick without building another SkPath.
+ */
+export function computeCandleFocusClip(
+  candle: CandlePoint | null,
+  padding: ChartPadding,
+  canvasW: number,
+  canvasH: number,
+  winStart: number,
+  windowSecs: number,
+  candleWidthSecs: number,
+): CandleFocusClip {
+  "worklet";
+  if (!candle || windowSecs <= 0 || candleWidthSecs <= 0) {
+    return HIDDEN_CANDLE_FOCUS_CLIP;
+  }
+
+  const chartLeft = padding.left;
+  const chartRight = canvasW - padding.right;
+  const chartTop = padding.top;
+  const chartBottom = canvasH - padding.bottom;
+  const chartW = chartRight - chartLeft;
+  const chartH = chartBottom - chartTop;
+  if (chartW <= 0 || chartH <= 0) return HIDDEN_CANDLE_FOCUS_CLIP;
+
+  const bucketLeft = candleTimeToX(
+    candle.time,
+    padding.left,
+    winStart,
+    windowSecs,
+    chartW,
+  );
+  const bucketRight = candleTimeToX(
+    candle.time + candleWidthSecs,
+    padding.left,
+    winStart,
+    windowSecs,
+    chartW,
+  );
+  const x = Math.max(chartLeft, bucketLeft);
+  const right = Math.min(chartRight, bucketRight);
+  if (right <= x) return HIDDEN_CANDLE_FOCUS_CLIP;
+
+  return { x, y: chartTop, width: right - x, height: chartH };
 }
 
 /** One candle → bodies/wicks; top-level worklet (no nested closures). */

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -854,13 +854,36 @@ export interface ScrubConfig {
    */
   seriesTooltip?: boolean | PerSeriesTooltipConfig;
   /**
-   * Opacity of the chart content to the *right* of the crosshair (the "future")
-   * while scrubbing — `0` fully fades it out, `1` disables the dim. Implemented
-   * by erasing the content's alpha (`dstOut`), so it reveals the real background
-   * and works on any background color. Default `0.3`. Ignored when
-   * `crosshairDimColor` is set (that uses the legacy colored mask instead).
+   * Which content {@link dimOpacity} fades while scrubbing.
+   *
+   * - `"future"` fades all chart content to the right of the crosshair.
+   * - `"otherCandles"` keeps the candle under the finger at full strength and
+   *   fades every other candle body and wick. Outside candle mode it falls back
+   *   to the standard `"future"` behavior. When the finger is in a gap between
+   *   candle buckets no candle is selected. Volume bars are unchanged. The
+   *   vertical crosshair and scrub selection dot are hidden so the focused
+   *   candle is the sole position indicator.
+   *
+   * Default `"future"`.
+   */
+  dimTarget?: "future" | "otherCandles";
+  /**
+   * Opacity of the content selected by {@link dimTarget} while scrubbing — `0`
+   * fully fades it out, `1` disables the dim. Values are clamped to `[0, 1]`.
+   *
+   * With the default `dimTarget: "future"`, the fade is implemented by erasing
+   * the trailing content's alpha (`dstOut`), so it reveals the real background
+   * and works on any background color. Default `0.3`. `crosshairDimColor`
+   * overrides this opacity only for the `"future"` target.
    */
   dimOpacity?: number;
+  /**
+   * Duration in milliseconds for other candles to ease toward
+   * {@link dimOpacity} when a focused-candle scrub starts, and back to full
+   * strength on release. Used only with `dimTarget: "otherCandles"`.
+   * Set `0` for an instant change. Negative values clamp to `0`. Default `60`.
+   */
+  dimFadeMs?: number;
   /** Vertical crosshair line stroke. Omit to use theme `crosshairLine`. */
   crosshairLineColor?: string;
   /** Vertical crosshair line width in px. Default `1`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -894,8 +894,38 @@ describe("LiveChart", () => {
     });
   });
 
+  it("renders candle mode with other-candle scrub dimming", async () => {
+    const screen = await render(
+      <CandleHarness
+        scrub={{
+          dimTarget: "otherCandles",
+          dimOpacity: 0.5,
+          snapToCandles: true,
+        }}
+      />,
+    );
+    const views = getAllByHostType(screen, View);
+    await fireEvent(views[0], "layout", {
+      nativeEvent: { layout: { width: 400, height: 300 } },
+    });
+  });
+
   it("treats scrub.snapToCandles as a no-op in line mode", async () => {
     await render(<Harness scrub={{ snapToCandles: true }} />);
+  });
+
+  it("restores the standard scrub when switching other-candle dimming to line mode", async () => {
+    const scrub = {
+      dimTarget: "otherCandles" as const,
+      crosshairLineColor: "#123abc",
+    };
+    const screen = await render(<CandleHarness scrub={scrub} />);
+
+    expect(JSON.stringify(screen.toJSON())).not.toContain("#123abc");
+
+    await screen.rerender(<CandleHarness mode="line" scrub={scrub} />);
+
+    expect(JSON.stringify(screen.toJSON())).toContain("#123abc");
   });
 
   it("renders candle mode with an instant candleLerpSpeed (transitions)", async () => {

--- a/packages/react-native-livechart/tests/components/overlays.test.tsx
+++ b/packages/react-native-livechart/tests/components/overlays.test.tsx
@@ -538,6 +538,36 @@ describe("CrosshairOverlay", () => {
     await render(<Fixture />);
   });
 
+  it("can hide the crosshair line and selection dot while keeping the overlay", async () => {
+    function Fixture() {
+      const scrubX = useSharedValue(100);
+      const crosshairOpacity = useSharedValue(1);
+      const scrubActive = useSharedValue(true);
+      const selectionY = useSharedValue(120);
+      const tooltipLayout = useSharedValue<TooltipLayout>(hiddenTooltip);
+      return (
+        <CrosshairOverlay
+          scrubX={scrubX}
+          crosshairOpacity={crosshairOpacity}
+          tooltipLayout={tooltipLayout}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          palette={palette}
+          font={font}
+          scrubActive={scrubActive}
+          showLine={false}
+          selectionDot={null}
+          selectionY={selectionY}
+          showTooltip={false}
+          dimOpacity={1}
+        />
+      );
+    }
+    const tree = JSON.stringify((await render(<Fixture />)).toJSON());
+    expect(tree).not.toContain(palette.crosshairLine);
+    expect(tree).not.toContain('"cx"');
+  });
+
   it("applies crosshair stroke width, overshoot, and disabled edge fade", async () => {
     function Fixture() {
       const scrubX = useSharedValue(100);

--- a/packages/react-native-livechart/tests/draw/candle.test.ts
+++ b/packages/react-native-livechart/tests/draw/candle.test.ts
@@ -2,6 +2,7 @@ import type { CandlePoint } from "../../src/types";
 import {
   buildCandleGeometry,
   computeCandleFocusClip,
+  computeCandleFocusPassOpacity,
   HIDDEN_CANDLE_FOCUS_CLIP,
 } from "../../src/draw/candle";
 
@@ -251,6 +252,15 @@ describe("computeCandleFocusClip", () => {
         60,
       ),
     ).toBe(HIDDEN_CANDLE_FOCUS_CLIP);
+  });
+});
+
+describe("computeCandleFocusPassOpacity", () => {
+  it("keeps the selected candle full-strength through the release fade", () => {
+    expect(computeCandleFocusPassOpacity(true, true, 1)).toBe(1);
+    expect(computeCandleFocusPassOpacity(false, false, 0.5)).toBe(1);
+    expect(computeCandleFocusPassOpacity(false, false, 0.99)).toBe(1);
+    expect(computeCandleFocusPassOpacity(false, false, 1)).toBe(0);
   });
 });
 

--- a/packages/react-native-livechart/tests/draw/candle.test.ts
+++ b/packages/react-native-livechart/tests/draw/candle.test.ts
@@ -1,5 +1,9 @@
 import type { CandlePoint } from "../../src/types";
-import { buildCandleGeometry } from "../../src/draw/candle";
+import {
+  buildCandleGeometry,
+  computeCandleFocusClip,
+  HIDDEN_CANDLE_FOCUS_CLIP,
+} from "../../src/draw/candle";
 
 const pad = { top: 10, right: 10, bottom: 10, left: 10 };
 
@@ -201,6 +205,52 @@ describe("buildCandleGeometry", () => {
     const chartW = 200 - 10 - 10;
     const xCenter = 10 + ((0 + 30) / 60) * chartW;
     expect(result.bodies[0].x).toBeCloseTo(xCenter - result.bodies[0].w / 2, 1);
+  });
+});
+
+describe("computeCandleFocusClip", () => {
+  const candle = makeCandle(30, 100, 120, 80, 110);
+
+  it("maps the selected candle bucket to its visible plot strip", () => {
+    expect(computeCandleFocusClip(candle, pad, 200, 100, 0, 120, 60)).toEqual({
+      x: 55,
+      y: 10,
+      width: 90,
+      height: 80,
+    });
+  });
+
+  it("clips a partially visible bucket to the plot bounds", () => {
+    const leftEdgeCandle = makeCandle(-30, 100, 120, 80, 110);
+    expect(
+      computeCandleFocusClip(leftEdgeCandle, pad, 200, 100, 0, 120, 60),
+    ).toEqual({ x: 10, y: 10, width: 45, height: 80 });
+  });
+
+  it("hides the focus pass without a visible valid bucket", () => {
+    expect(computeCandleFocusClip(null, pad, 200, 100, 0, 120, 60)).toBe(
+      HIDDEN_CANDLE_FOCUS_CLIP,
+    );
+    expect(computeCandleFocusClip(candle, pad, 200, 100, 0, 0, 60)).toBe(
+      HIDDEN_CANDLE_FOCUS_CLIP,
+    );
+    expect(computeCandleFocusClip(candle, pad, 200, 100, 0, 120, 0)).toBe(
+      HIDDEN_CANDLE_FOCUS_CLIP,
+    );
+    expect(computeCandleFocusClip(candle, pad, 0, 100, 0, 120, 60)).toBe(
+      HIDDEN_CANDLE_FOCUS_CLIP,
+    );
+    expect(
+      computeCandleFocusClip(
+        makeCandle(200, 100, 120, 80, 110),
+        pad,
+        200,
+        100,
+        0,
+        120,
+        60,
+      ),
+    ).toBe(HIDDEN_CANDLE_FOCUS_CLIP);
   });
 });
 

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -652,6 +652,20 @@ describe("resolveScrub", () => {
     expect(resolveScrub({ dimFadeMs: -1 })?.dimFadeMs).toBe(0);
   });
 
+  it("restores dim defaults when optional fields are explicitly undefined", () => {
+    expect(
+      resolveScrub({
+        dimTarget: undefined,
+        dimOpacity: undefined,
+        dimFadeMs: undefined,
+      }),
+    ).toMatchObject({
+      dimTarget: "future",
+      dimOpacity: 0.3,
+      dimFadeMs: 60,
+    });
+  });
+
   it("normalizes the crosshairDash shorthand", () => {
     // `true` → a default dash, an array passes through, `false` → solid.
     expect(resolveScrub(true)?.crosshairDash).toBeUndefined();

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -589,7 +589,9 @@ describe("resolveScrub", () => {
   const DEFAULTS = {
     tooltip: true,
     seriesTooltip: null,
+    dimTarget: "future",
     dimOpacity: 0.3,
+    dimFadeMs: 60,
     crosshairLineColor: undefined,
     crosshairStrokeWidth: 1,
     crosshairOvershoot: 0,
@@ -636,6 +638,18 @@ describe("resolveScrub", () => {
       ...DEFAULTS,
       dimOpacity: 0.5,
     });
+  });
+
+  it("supports candle-focus dimming and clamps its opacity", () => {
+    expect(
+      resolveScrub({ dimTarget: "otherCandles", dimOpacity: 1.5 }),
+    ).toMatchObject({ dimTarget: "otherCandles", dimOpacity: 1 });
+    expect(resolveScrub({ dimOpacity: -0.25 })?.dimOpacity).toBe(0);
+  });
+
+  it("supports a configurable candle-focus fade and clamps negatives", () => {
+    expect(resolveScrub({ dimFadeMs: 240 })?.dimFadeMs).toBe(240);
+    expect(resolveScrub({ dimFadeMs: -1 })?.dimFadeMs).toBe(0);
   });
 
   it("normalizes the crosshairDash shorthand", () => {


### PR DESCRIPTION
## Summary

- add `scrub.dimTarget: "otherCandles"` so the candle under the finger keeps its full up/down colors while every other candle body and wick dims
- add configurable `scrub.dimFadeMs` (60 ms by default, 0 for instant) and keep the focused render on the UI thread by reusing the existing batched candle paths with a clipped full-strength pass
- hide the scrub guide and selection dot in focused-candle mode, remove the candle demo's time tooltip, and leave volume unchanged
- preserve standard line-chart scrubbing when a chart switches modes without rewriting its `otherCandles` config
- update the candle scrub demo, public types/JSDoc, guide, API reference, changelog, and regression coverage

## Why

Focused candle scrubbing gives the touched OHLC bar a clear visual priority without adding another positional marker. The configurable, short opacity transition keeps the interaction responsive while avoiding a hard visual snap.

## Validation

- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm test -- --runInBand --silent` — 99/99 suites passed; 1,530 passed and 5 skipped
- `npm run verify` — typecheck and lint passed; its parallel Jest phase reproduced repository resource-saturation timeouts in 4 otherwise-passing suites, all of which passed in the serial full run above
- React Doctor — 96/100, unchanged; only the existing Expo route `options` export warning
- agent-device QA — iPhone 17 Pro simulator: focused colors, dim/release animation, no scrub line/dot/time tooltip, and return-to-live behavior verified
- React profiling — 0 React commits during a 15.1 s scrub interaction
