### PR TITLE
feat: add shape-preserving line denoising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shape-preserving line denoising.** `LineConfig.simplify` opts into
+  screen-space path simplification with a pixel tolerance, removing small visual
+  wiggles while retaining endpoints and larger peaks/valleys. It affects only
+  rendered line/fill geometry; axis fitting, values, markers, and scrubbing keep
+  using the original data. `LiveChartSeries` applies the shared line setting to
+  every path, with a per-series `SeriesConfig.simplify` override. Default `0`
+  keeps existing paths unchanged. A dedicated guide and raw-vs-simplified demo
+  make the tolerance and preserved structure directly comparable.
+
 - **Vertical marker-column caps.** `MarkerClusterConfig.maxVisible` keeps only
   the oldest glyphs in a vertical stack and hides newer overflow, preventing a
   busy timestamp from growing beyond the plot. It defaults to unbounded; the

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -43,6 +43,11 @@ const SECTIONS: DemoSection[] = [
         blurb: "Badge, pulse, value line, live value overlay.",
       },
       {
+        href: "/demo/line-denoising" as Href,
+        title: "Line denoising",
+        blurb: "simplify: compare the raw path with shape-preserving pixel-tolerance cleanup.",
+      },
+      {
         href: "/demo/candlestick",
         title: "Candlestick",
         blurb: "mode=candle: timeframes, candle colors, OHLC bodies + wicks.",

--- a/app/demo/line-denoising.tsx
+++ b/app/demo/line-denoising.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import {
+  LiveChart,
+  type LineConfig,
+  type LiveChartPoint,
+} from "react-native-livechart";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
+
+import { ChipRow } from "../../demo-lib/ChipRow";
+import { DemoScreen } from "../../demo-lib/DemoScreen";
+import {
+  APP_FONT_FAMILY,
+  APP_FONT_FAMILY_MEDIUM,
+} from "../../demo-lib/fonts";
+import { ACCENT } from "../../demo-lib/shared";
+import { APP_THEME, colors } from "../../demo-lib/theme";
+
+export const options = { title: "Line denoising" };
+
+const SPAN_SECONDS = 60;
+const POINT_COUNT = 241;
+const END_TIME = 1_700_000_060;
+
+/**
+ * A deterministic signal with three distinct layers:
+ * - broad trend / waves (the structure we want to keep),
+ * - two narrow events (a peak and a dip that must survive),
+ * - high-frequency, low-amplitude sample noise (the removable detail).
+ */
+function makeNoisySignal(): LiveChartPoint[] {
+  return Array.from({ length: POINT_COUNT }, (_, i) => {
+    const t = i / (POINT_COUNT - 1);
+    const trend = t * 2.2;
+    const structure =
+      Math.sin(t * Math.PI * 2.4) * 2.3 +
+      Math.sin(t * Math.PI * 6.2) * 0.65;
+    const peak = Math.exp(-Math.pow((t - 0.57) / 0.018, 2)) * 2.8;
+    const dip = -Math.exp(-Math.pow((t - 0.79) / 0.024, 2)) * 2.3;
+    const sampleNoise =
+      (Math.sin(i * 2.73) + Math.sin(i * 5.17) * 0.42) * 0.13;
+
+    return {
+      time: END_TIME - SPAN_SECONDS + t * SPAN_SECONDS,
+      value: 100 + trend + structure + peak + dip + sampleNoise,
+    };
+  });
+}
+
+type Curve = NonNullable<LineConfig["curve"]>;
+
+const TOLERANCE_OPTIONS = [
+  { value: 0, label: "Off" },
+  { value: 0.75, label: "0.75 px" },
+  { value: 1.5, label: "1.5 px" },
+  { value: 3, label: "3 px" },
+] as const;
+
+const CURVE_OPTIONS: { value: Curve; label: string }[] = [
+  { value: "monotone", label: "Monotone" },
+  { value: "linear", label: "Linear" },
+];
+
+function SignalChart({
+  data,
+  value,
+  curve,
+  simplify,
+  color,
+}: {
+  data: SharedValue<LiveChartPoint[]>;
+  value: SharedValue<number>;
+  curve: Curve;
+  simplify: number;
+  color: string;
+}) {
+  return (
+    <LiveChart
+      static
+      data={data}
+      value={value}
+      accentColor={color}
+      theme={APP_THEME}
+      timeWindow={SPAN_SECONDS}
+      nowOverride={END_TIME}
+      windowBuffer={0}
+      insets={{ top: 8, right: 6, bottom: 8, left: 6 }}
+      line={{ width: 1.6, curve, simplify }}
+      gradient={false}
+      badge={false}
+      dot={false}
+      pulse={false}
+      valueLine={false}
+      yAxis={false}
+      xAxis={false}
+      scrub={false}
+      leftEdgeFade={false}
+      style={styles.chart}
+    />
+  );
+}
+
+export default function LineDenoisingScreen() {
+  const [tolerance, setTolerance] = useState<number>(1.5);
+  const [curve, setCurve] = useState<Curve>("monotone");
+  const [points] = useState(makeNoisySignal);
+  const data = useSharedValue<LiveChartPoint[]>(points);
+  const value = useSharedValue(points[points.length - 1].value);
+
+  return (
+    <DemoScreen
+      title="Line denoising"
+      docs="guides/line-denoising"
+      description="One signal, two paths. Remove sub-pixel sample noise while the larger trend, peak, and dip remain anchored to the original data."
+      chartWrapperStyle={styles.chartWrapper}
+      chart={
+        <View style={styles.comparison}>
+          <View style={styles.signalPanel}>
+            <View style={styles.signalHeader}>
+              <Text style={styles.signalLabel}>Raw path</Text>
+              <Text style={styles.signalMeta}>{POINT_COUNT} points</Text>
+            </View>
+            <SignalChart
+              data={data}
+              value={value}
+              curve={curve}
+              simplify={0}
+              color="#87909c"
+            />
+          </View>
+
+          <View style={styles.divider} />
+
+          <View style={styles.signalPanel}>
+            <View style={styles.signalHeader}>
+              <Text style={styles.signalLabel}>Simplified path</Text>
+              <Text style={styles.signalMeta}>
+                tolerance {tolerance.toFixed(2).replace(/\.00$/, "")} px
+              </Text>
+            </View>
+            <SignalChart
+              data={data}
+              value={value}
+              curve={curve}
+              simplify={tolerance}
+              color={ACCENT}
+            />
+          </View>
+        </View>
+      }
+    >
+      <ChipRow
+        label="Path tolerance"
+        options={TOLERANCE_OPTIONS}
+        value={tolerance}
+        onChange={setTolerance}
+      />
+      <ChipRow
+        label="Curve"
+        options={CURVE_OPTIONS}
+        value={curve}
+        onChange={setCurve}
+      />
+      <View style={styles.note}>
+        <Text style={styles.noteTitle}>Geometry only</Text>
+        <Text style={styles.noteBody}>
+          The scale, live value, markers, and scrub interpolation still read all
+          {` ${POINT_COUNT} `}source points. Only intermediate points in the
+          rendered line and fill may be removed.
+        </Text>
+      </View>
+    </DemoScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  chartWrapper: {
+    height: 382,
+  },
+  comparison: {
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    borderRadius: 14,
+    overflow: "hidden",
+    backgroundColor: colors.background,
+  },
+  signalPanel: {
+    flex: 1,
+    paddingTop: 9,
+  },
+  signalHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    paddingHorizontal: 12,
+  },
+  signalLabel: {
+    color: colors.text,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+    fontSize: 12,
+  },
+  signalMeta: {
+    color: colors.textFaint,
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: 10,
+    fontVariant: ["tabular-nums"],
+  },
+  chart: {
+    flex: 1,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.border,
+    marginHorizontal: 12,
+  },
+  note: {
+    marginTop: 12,
+    padding: 12,
+    borderLeftWidth: 2,
+    borderLeftColor: ACCENT,
+    backgroundColor: colors.chipBackground,
+  },
+  noteTitle: {
+    color: colors.text,
+    fontFamily: APP_FONT_FAMILY_MEDIUM,
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  noteBody: {
+    color: colors.textMuted,
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: 12,
+    lineHeight: 17,
+  },
+});

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -12,7 +12,7 @@ import { LiveChartSeries } from "react-native-livechart";
 accepts all the shared theming, axis, range, layout, and text props from
 [`LiveChart`](/api-reference/livechart) (`theme`, `accentColor`, `palette`, `metrics`, `font`,
 `canvasMode`, `timeWindow`, `smoothing`, [`snapKey`](/api-reference/livechart#param-snap-key),
-[`yRangeScale`](/guides/y-range-scale), `yAxis`,
+[`yRangeScale`](/guides/y-range-scale), `line`, `yAxis`,
 `referenceLines`, `formatValue`, …), plus the multi-series props below.
 
 On Android, the shared experimental `canvasMode="opaque"` option selects an opaque SurfaceView and
@@ -76,7 +76,10 @@ paints the palette background inside the canvas. See
 ## Series data
 
 <ParamField body="series" type="SharedValue<SeriesConfig[]>" required>
-  Array of series definitions. Read on the UI thread. See [`SeriesConfig`](/api-reference/types).
+  Array of series definitions. Read on the UI thread. Each series can override
+  the shared `line.simplify` screen-space tolerance with `simplify`; `0` disables
+  simplification for that series. See [Line denoising](/guides/line-denoising)
+  and [`SeriesConfig`](/api-reference/types).
 </ParamField>
 
 ## Axis labels

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -64,8 +64,11 @@ provided; everything else has a default.
   Main line styling: `width`, `color`, plus shape controls — `curve`
   (`"monotone"` smooth default | `"linear"` straight segments), `join`
   (`"round"` | `"miter"` | `"bevel"`), and `cap` (`"round"` | `"butt"` |
-  `"square"`). Pair `curve: "linear"` with `join: "miter"` + `cap: "butt"` for a
-  fully hard-edged ("edgy") line.
+  `"square"`). `simplify` is an opt-in screen-space path tolerance in pixels;
+  start around `0.75`–`1.5` to remove sub-pixel noise without changing the
+  source data, fitted range, markers, or scrub values. See
+  [Line denoising](/guides/line-denoising). Pair `curve: "linear"` with
+  `join: "miter"` + `cap: "butt"` for a fully hard-edged ("edgy") line.
 </ParamField>
 
 <ParamField body="gradient" type="boolean | GradientConfig" default="true">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -53,6 +53,7 @@ interface SeriesConfig {
   style?: "solid" | "dashed";
   intervals?: [number, number];
   curve?: "monotone" | "linear"; // interpolation; default "monotone"
+  simplify?: number;          // per-series path tolerance in px; inherits line.simplify
   strokeWidth?: number;
   glow?: boolean;
   kind?: "outcome" | "derived";
@@ -292,6 +293,9 @@ interface LineConfig {
   colors?: string[];// per-point gradient stops (left → right); wins over color
   curve?: "monotone" | "linear"; // point interpolation; default "monotone"
                     //   (smooth cubic). "linear" = straight segments / hard-edged.
+  simplify?: number; // screen-space path tolerance in px; default 0 (off).
+                    //   Removes only intermediate drawn points within the tolerance;
+                    //   source data, axis fitting, markers, and scrubbing stay exact.
   join?: "round" | "miter" | "bevel"; // corner join; default "round".
                     //   "miter" = sharp/angular peaks, "bevel" = flattened.
   cap?: "round" | "butt" | "square";  // start/end cap; default "round".

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,6 +45,7 @@
             "group": "Chart types",
             "pages": [
               "guides/line-and-area",
+              "guides/line-denoising",
               "guides/candlestick",
               "guides/multi-series",
               "guides/sparklines"

--- a/docs/guides/line-and-area.mdx
+++ b/docs/guides/line-and-area.mdx
@@ -116,6 +116,29 @@ the area fill as well, so the gradient follows the same straight segments.
   pairs all three for a fully hard-edged line.
 </Note>
 
+### Denoising dense paths
+
+Use `line.simplify` when dense samples make the plotted path look busier than the
+screen can meaningfully show:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  line={{ simplify: 1 }} // remove deviations of about one screen pixel or less
+/>
+```
+
+The tolerance is measured after points are projected into the chart, so it stays
+visually consistent across values and canvas sizes. The simplifier retains the
+line endpoints and peaks or valleys that exceed the tolerance. It only changes
+the line and area-fill geometry: the original data still drives Y-range fitting,
+the live value, markers, and scrub callbacks. `0` (the default) disables it;
+`0.75`–`1.5` is a useful starting range for subtle denoising.
+
+See [Line denoising](/guides/line-denoising) for the raw-vs-simplified example,
+tolerance guidance, multi-series overrides, and rendering-cost details.
+
 ## Badge, dot, and value line
 
 By default the chart draws a value badge at the tip, a pulsing live dot, and (optionally) a

--- a/docs/guides/line-denoising.mdx
+++ b/docs/guides/line-denoising.mdx
@@ -1,0 +1,106 @@
+---
+title: Line denoising
+icon: "wave-sine"
+description: "Remove visually noisy path detail with a pixel tolerance while keeping the original chart data exact."
+---
+
+Dense or high-frequency samples can make a line look noisy even after the chart
+has reduced overdraw to roughly pixel resolution. `line.simplify` applies a
+shape-preserving simplification pass to the **rendered path**:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  line={{ simplify: 1 }}
+/>
+```
+
+The number is a screen-space tolerance in pixels. Intermediate points may be
+removed when their deviation from the simplified path is no greater than that
+tolerance. Endpoints remain fixed, and peaks or valleys larger than the tolerance
+remain part of the path.
+
+<Note>
+  **Live example:**
+  [`app/demo/line-denoising.tsx`](https://github.com/brandtnewlabs/react-native-livechart/blob/main/app/demo/line-denoising.tsx)
+  shows the same deterministic signal raw and simplified, with live tolerance and
+  curve controls.
+</Note>
+
+## What stays exact
+
+Simplification changes only the line and area-fill geometry. It does not mutate
+the `data` shared value, and the original points still drive:
+
+- Y-axis range fitting and extrema
+- the live value and dot
+- markers anchored by time
+- scrub interpolation and callback values
+- threshold and reference-line calculations
+
+This separation is useful when the chart should read more calmly without
+changing the values a user can inspect or act on.
+
+## Choosing a tolerance
+
+Start with `0.75`–`1.5` pixels. That typically removes sub-pixel jitter while
+leaving the recognizable signal unchanged.
+
+| Value | Effect |
+| --- | --- |
+| `0` or omitted | Disabled; preserves the existing exact rendered path |
+| `0.75` | Very subtle cleanup on dense or high-DPI charts |
+| `1`–`1.5` | General-purpose denoising |
+| `2`–`3` | Stronger simplification; inspect narrow events carefully |
+
+Because tolerance is measured after mapping values to the canvas, a setting has
+a consistent visual meaning across datasets with very different value ranges.
+Zooming or resizing naturally recalculates the path for the new screen geometry.
+
+## Curve interpolation
+
+`simplify` and `curve` control different stages. Simplification selects the
+screen-space points to retain; `curve` then connects them with either the default
+monotone cubic or straight segments:
+
+```tsx
+<LiveChart
+  data={data}
+  value={value}
+  line={{
+    simplify: 1,
+    curve: "linear",
+    join: "round",
+  }}
+/>
+```
+
+Use the same tolerance when comparing curve styles: changing the curve does not
+change the source data or the tolerance unit.
+
+## Multi-series
+
+Set the shared `line.simplify` to apply one tolerance to every series:
+
+```tsx
+<LiveChartSeries series={series} line={{ simplify: 1 }} />
+```
+
+An individual `SeriesConfig` can override that value. Passing `0` opts a series
+out while the other lines keep the shared setting:
+
+```tsx
+const series = useSharedValue<SeriesConfig[]>([
+  { id: "price", data: price, value: priceNow },
+  { id: "benchmark", data: benchmark, value: benchmarkNow, simplify: 0 },
+]);
+
+<LiveChartSeries series={series} line={{ simplify: 1 }} />;
+```
+
+## Rendering cost
+
+The pass runs on the UI thread after the chart's envelope-preserving dense-data
+decimation. It reuses scratch buffers and processes bounded point ranges, avoiding
+new point-array allocation or unbounded pathological scans on every frame.

--- a/docs/guides/multi-series.mdx
+++ b/docs/guides/multi-series.mdx
@@ -47,9 +47,15 @@ Each `SeriesConfig` supports:
 | `visible`     | Show/hide the series (default `true`)                          |
 | `style`       | `"solid"` or `"dashed"` (with `intervals`)                     |
 | `curve`       | `"monotone"` (default) smooth spline or `"linear"` straight segments |
+| `simplify`    | Per-series path tolerance in screen pixels; overrides `line.simplify` |
 | `strokeWidth` | Per-series width override                                      |
 | `glow`        | Soft glow behind the line                                      |
 | `kind`        | `"outcome"` (default) or `"derived"` (subdued/dashed chip)     |
+
+Set `line={{ simplify: 1 }}` on `LiveChartSeries` to denoise every rendered
+path by roughly one screen pixel. A series can choose a different tolerance, or
+set `simplify: 0` to keep its exact point path. The shared axis, scrub values,
+and live dots continue to use the original series data.
 
 ## Dimming replacement data
 

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -922,6 +922,7 @@ function useLiveChartController({
     thresholdCfg?.fill && thresholdSeriesHasPoints
       ? thresholdSeriesGeom.samples
       : undefined,
+    lineProp?.simplify,
   );
 
   // Area-dots fill shader color as a vec4 (channels 0..1), with the config

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -397,6 +397,7 @@ function useLiveChartSeriesController({
     engine,
     effectivePadding,
     activeSeriesCount,
+    lineProp?.simplify,
   );
 
   // Per-series colors and stroke styles, derived from the off-render snapshot

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -7,6 +7,10 @@ import type {
   SingleEngineState,
 } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
+import {
+  makeLineSimplifyScratch,
+  simplifyLinePoints,
+} from "../math/simplify";
 import { drawSpline, makeSplineScratch } from "../math/spline";
 import { sampleThresholdYAt, thresholdSampleSpanX } from "../math/threshold";
 import { blendPtsY, squigglifyPts } from "../math/squiggly";
@@ -52,6 +56,8 @@ export function useChartPaths(
    *  `samples[]` (so band geometry matches the shader exactly). Takes precedence
    *  over `thresholdY`, the constant (horizontal) case. */
   thresholdSamples?: SharedValue<number[]>,
+  /** Screen-space path simplification tolerance in pixels. `0` disables it. */
+  simplifyTolerance = 0,
 ) {
   const lineBuilder = usePathBuilder();
   const fillBuilder = usePathBuilder();
@@ -61,24 +67,28 @@ export function useChartPaths(
     emptyPath: SkPath;
     ptsA: number[];
     ptsB: number[];
+    rawPts: number[];
     ptsTick: boolean;
     squigglePts: number[];
     morphA: number[];
     morphB: number[];
     morphTick: boolean;
     scratch: ReturnType<typeof makeSplineScratch>;
+    simplifyScratch: ReturnType<typeof makeLineSimplifyScratch>;
   } | null>(null);
   if (cacheRef.current === null) {
     cacheRef.current = {
       emptyPath: Skia.Path.Make(),
       ptsA: [] as number[],
       ptsB: [] as number[],
+      rawPts: [] as number[],
       ptsTick: false,
       squigglePts: [] as number[],
       morphA: [] as number[],
       morphB: [] as number[],
       morphTick: false,
       scratch: makeSplineScratch(),
+      simplifyScratch: makeLineSimplifyScratch(),
     };
   }
 
@@ -94,6 +104,10 @@ export function useChartPaths(
       engine.edgeValue.get(),
       engine.viewEnd.get(),
     );
+    const simplify =
+      Number.isFinite(simplifyTolerance) && simplifyTolerance > 0
+        ? simplifyTolerance
+        : 0;
     const realPts = buildLinePoints(
       engine.data.get(),
       tipValue,
@@ -104,22 +118,26 @@ export function useChartPaths(
       engine.canvasWidth.get(),
       engine.canvasHeight.get(),
       padding,
-      buf,
+      simplify > 0 ? cache.rawPts : buf,
       // Only a live-following chart may extend the line to the right edge; a
       // parked (scrolled-back / overscrolled) window ends at its last real
       // point rather than fabricating a flat line into dataless space.
       engine.viewEnd.get() != null,
     );
+    const renderPts =
+      simplify > 0
+        ? simplifyLinePoints(realPts, simplify, buf, cache.simplifyScratch)
+        : realPts;
 
     // Skip blending when fully revealed or no morphT provided
     const t = morphT?.get() ?? 1;
-    if (t >= 1 || realPts.length === 0) return realPts;
+    if (t >= 1 || renderPts.length === 0) return renderPts;
 
     // Compute squiggly Y values at the same X positions as the real line
     const centerY =
       (engine.canvasHeight.get() - padding.bottom + padding.top) / 2;
     const squigglyPts = squigglifyPts(
-      realPts,
+      renderPts,
       engine.timestamp.get(),
       centerY,
       squiggleAmplitude,
@@ -131,7 +149,7 @@ export function useChartPaths(
     cache.morphTick = !cache.morphTick;
     return blendPtsY(
       squigglyPts,
-      realPts,
+      renderPts,
       t,
       padding,
       engine.canvasWidth.get(),

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -4,6 +4,10 @@ import { useDerivedValue, type SharedValue } from "react-native-reanimated";
 import { MAX_MULTI_SERIES } from "../constants";
 import type { MultiEngineState } from "../core/useLiveChartEngine";
 import { buildLinePoints, type ChartPadding } from "../draw/line";
+import {
+  makeLineSimplifyScratch,
+  simplifyLinePoints,
+} from "../math/simplify";
 import { drawSpline, makeSplineScratch } from "../math/spline";
 import { usePathBuilders } from "./usePathBuilder";
 
@@ -21,25 +25,31 @@ export function useMultiSeriesLinePaths(
   engine: MultiEngineState,
   padding: ChartPadding,
   activeSeriesCount = MAX_MULTI_SERIES,
+  /** Shared screen-space simplification tolerance; a series can override it. */
+  simplifyTolerance = 0,
 ): SharedValue<SkPath[]> {
   const builders = usePathBuilders(MAX_MULTI_SERIES);
 
   const poolRef = useRef<{
     empty: SkPath;
     ptsBuf: number[];
+    simplifiedPts: number[];
     pathsA: SkPath[];
     pathsB: SkPath[];
     pathsTick: boolean;
     scratch: ReturnType<typeof makeSplineScratch>;
+    simplifyScratch: ReturnType<typeof makeLineSimplifyScratch>;
   } | null>(null);
   if (poolRef.current === null) {
     poolRef.current = {
       empty: Skia.Path.Make(),
       ptsBuf: [] as number[],
+      simplifiedPts: [] as number[],
       pathsA: [] as SkPath[],
       pathsB: [] as SkPath[],
       pathsTick: false,
       scratch: makeSplineScratch(),
+      simplifyScratch: makeLineSimplifyScratch(),
     };
   }
 
@@ -53,7 +63,7 @@ export function useMultiSeriesLinePaths(
     out.length = 0;
     const count = Math.min(activeSeriesCount, s.length, MAX_MULTI_SERIES);
     for (let i = 0; i < count; i++) {
-      const pts = buildLinePoints(
+      const rawPts = buildLinePoints(
         s[i].data,
         displays[i] ?? s[i].value,
         engine.timestamp.get(),
@@ -65,6 +75,16 @@ export function useMultiSeriesLinePaths(
         padding,
         pool.ptsBuf,
       );
+      const seriesTolerance = s[i].simplify ?? simplifyTolerance;
+      const pts =
+        Number.isFinite(seriesTolerance) && seriesTolerance > 0
+          ? simplifyLinePoints(
+              rawPts,
+              seriesTolerance,
+              pool.simplifiedPts,
+              pool.simplifyScratch,
+            )
+          : rawPts;
       const n = pts.length >> 1;
       if (n >= 2) {
         const b = slots[i];

--- a/packages/react-native-livechart/src/math/simplify.ts
+++ b/packages/react-native-livechart/src/math/simplify.ts
@@ -1,0 +1,132 @@
+/** Reusable buffers for {@link simplifyLinePoints}. */
+export interface LineSimplifyScratch {
+  keep: number[];
+  stack: number[];
+}
+
+/** Allocate simplification scratch once, outside the per-frame worklet. */
+export function makeLineSimplifyScratch(): LineSimplifyScratch {
+  return { keep: [], stack: [] };
+}
+
+/**
+ * Maximum number of points simplified as one Ramer-Douglas-Peucker range.
+ *
+ * The visible line is already bounded to roughly two points per horizontal
+ * pixel. Splitting that bounded input into overlapping ranges also bounds the
+ * simplifier's worst-case work: a pathological zig-zag cannot turn a frame into
+ * an O(n²) scan. Range endpoints are retained, so chunking can only keep a few
+ * extra points; it cannot erase additional structure.
+ */
+const MAX_RDP_RANGE_POINTS = 64;
+
+function pointSegmentDistanceSq(
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  "worklet";
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lengthSq = dx * dx + dy * dy;
+  if (lengthSq === 0) {
+    const ex = px - ax;
+    const ey = py - ay;
+    return ex * ex + ey * ey;
+  }
+
+  let t = ((px - ax) * dx + (py - ay) * dy) / lengthSq;
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  const ex = px - (ax + t * dx);
+  const ey = py - (ay + t * dy);
+  return ex * ex + ey * ey;
+}
+
+/**
+ * Simplify flat screen-space points (`[x0, y0, x1, y1, ...]`) with a bounded
+ * Ramer-Douglas-Peucker pass.
+ *
+ * `tolerance` is the maximum removable deviation in pixels. The first and last
+ * point, larger peaks/valleys, and the original point order are retained. Pass
+ * distinct reusable `out` and `scratch` buffers to avoid per-frame allocation.
+ */
+export function simplifyLinePoints(
+  points: number[],
+  tolerance: number,
+  out: number[],
+  scratch: LineSimplifyScratch,
+): number[] {
+  "worklet";
+  if (out === points) return points;
+
+  out.length = 0;
+  const count = points.length >> 1;
+  if (!(tolerance > 0) || !Number.isFinite(tolerance) || count <= 2) {
+    for (let i = 0; i < count * 2; i++) out.push(points[i]);
+    return out;
+  }
+
+  const keep = scratch.keep;
+  keep.length = count;
+  for (let i = 0; i < count; i++) keep[i] = 0;
+
+  const stack = scratch.stack;
+  stack.length = 0;
+  const toleranceSq = tolerance * tolerance;
+
+  // Adjacent ranges share one retained endpoint. That makes each range's RDP
+  // error bound independent while keeping the final polyline continuous.
+  for (let rangeStart = 0; rangeStart < count - 1; ) {
+    const rangeEnd = Math.min(
+      rangeStart + MAX_RDP_RANGE_POINTS - 1,
+      count - 1,
+    );
+    keep[rangeStart] = 1;
+    keep[rangeEnd] = 1;
+    stack.push(rangeStart, rangeEnd);
+
+    while (stack.length >= 2) {
+      const end = stack.pop()!;
+      const start = stack.pop()!;
+      if (end <= start + 1) continue;
+
+      const ax = points[start * 2];
+      const ay = points[start * 2 + 1];
+      const bx = points[end * 2];
+      const by = points[end * 2 + 1];
+      let furthest = -1;
+      let maxDistanceSq = toleranceSq;
+
+      for (let i = start + 1; i < end; i++) {
+        const distanceSq = pointSegmentDistanceSq(
+          points[i * 2],
+          points[i * 2 + 1],
+          ax,
+          ay,
+          bx,
+          by,
+        );
+        if (distanceSq > maxDistanceSq) {
+          maxDistanceSq = distanceSq;
+          furthest = i;
+        }
+      }
+
+      if (furthest >= 0) {
+        keep[furthest] = 1;
+        stack.push(start, furthest, furthest, end);
+      }
+    }
+
+    rangeStart = rangeEnd;
+  }
+
+  for (let i = 0; i < count; i++) {
+    if (keep[i] === 1) out.push(points[i * 2], points[i * 2 + 1]);
+  }
+  return out;
+}

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -422,6 +422,15 @@ export interface LineConfig {
    * pair with `join: "miter"` + `cap: "butt"` for true sharp corners (no rounding).
    */
   curve?: "monotone" | "linear";
+  /**
+   * Screen-space path simplification tolerance in pixels. Values above `0`
+   * remove intermediate points that deviate by no more than this amount while
+   * retaining endpoints and larger peaks/valleys. This changes only the drawn
+   * line/fill; axis fitting, live values, markers, and scrubbing still use the
+   * original data. Default `0` (off). Start around `0.75`–`1.5` for sub-pixel
+   * noise reduction.
+   */
+  simplify?: number;
   /** Line color override. Defaults to palette-derived accent. */
   color?: string;
   /**
@@ -1609,6 +1618,13 @@ export interface SeriesConfig {
    *   anchored to this series snap to the straight chord to match.
    */
   curve?: "monotone" | "linear";
+  /**
+   * Per-series screen-space path simplification tolerance in pixels. Overrides
+   * `LiveChartSeries.line.simplify`; `0` disables simplification for this series.
+   * Only rendered geometry is simplified — values, range fitting, and scrubbing
+   * continue to use the original points.
+   */
+  simplify?: number;
   /** Per-series stroke width override (px). Falls back to the chart line width. */
   strokeWidth?: number;
   /** Render a soft glow behind this series' line. Default `false`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -607,6 +607,10 @@ describe("LiveChart", () => {
     await render(<Harness line={{ width: 3, color: "#ff0000" }} />);
   });
 
+  it("accepts screen-space line simplification", async () => {
+    await render(<Harness line={{ simplify: 1 }} />);
+  });
+
   it("accepts LineConfig with gradient colors", async () => {
     await render(<Harness line={{ colors: ["#ff0000", "#0000ff"] }} />);
   });

--- a/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useChartPaths.test.tsx
@@ -131,6 +131,33 @@ describe("useChartPaths", () => {
     expect(result.current.fillPath.value).toBeDefined();
   });
 
+  it("simplifies the rendered path with a screen-space tolerance", async () => {
+    const { result } = await renderHook(() =>
+      useChartPaths(
+        makeEngine({
+          data: {
+            value: [
+              { time: 970, value: 1 },
+              { time: 980, value: 1.001 },
+              { time: 990, value: 0.999 },
+              { time: 1000, value: 1 },
+            ],
+          },
+        } as unknown as Partial<ChartPathsEngine>),
+        DEFAULT_PADDING,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        1,
+      ),
+    );
+    expect(result.current.linePath.value).toBeDefined();
+    expect(result.current.fillPath.value).toBeDefined();
+  });
+
   it("tips a live window at displayValue", () => {
     expect(resolveLineTipValue(9, 4, null)).toBe(9);
   });

--- a/packages/react-native-livechart/tests/hooks/useMultiSeriesLinePaths.test.tsx
+++ b/packages/react-native-livechart/tests/hooks/useMultiSeriesLinePaths.test.tsx
@@ -35,7 +35,7 @@ describe("useMultiSeriesLinePaths", () => {
         canvasHeight: { value: 300 },
       }) as unknown as MultiEngineState;
       const padding = { top: 12, right: 44, bottom: 28, left: 12 };
-      return useMultiSeriesLinePaths(engine, padding);
+      return useMultiSeriesLinePaths(engine, padding, undefined, 1);
     });
     expect(result.current.value).toHaveLength(1);
   });
@@ -53,6 +53,7 @@ describe("useMultiSeriesLinePaths", () => {
           value: 12,
           color: "#3b82f6",
           curve: "linear" as const,
+          simplify: 1,
         },
       ]);
       const displaySeriesValues = useSharedValue([12]);

--- a/packages/react-native-livechart/tests/math/simplify.test.ts
+++ b/packages/react-native-livechart/tests/math/simplify.test.ts
@@ -1,0 +1,64 @@
+import {
+  makeLineSimplifyScratch,
+  simplifyLinePoints,
+} from "../../src/math/simplify";
+
+function simplify(points: number[], tolerance: number, out: number[] = []) {
+  return simplifyLinePoints(
+    points,
+    tolerance,
+    out,
+    makeLineSimplifyScratch(),
+  );
+}
+
+describe("simplifyLinePoints", () => {
+  it.each([0, -1, Number.NaN])(
+    "copies the exact points when tolerance is %s",
+    (tolerance) => {
+      const points = [0, 0, 1, 0.2, 2, 0];
+      const out = [99];
+      expect(simplify(points, tolerance, out)).toBe(out);
+      expect(out).toEqual(points);
+    },
+  );
+
+  it("copies paths with at most two points", () => {
+    expect(simplify([0, 0, 1, 1], 1)).toEqual([0, 0, 1, 1]);
+  });
+
+  it("removes sub-tolerance wiggle while preserving endpoints", () => {
+    const points = [0, 0, 1, 0.2, 2, -0.15, 3, 0.1, 4, 0];
+    expect(simplify(points, 0.5)).toEqual([0, 0, 4, 0]);
+  });
+
+  it("retains meaningful peaks and valleys in their original order", () => {
+    const points = [0, 0, 1, 0.2, 2, 5, 3, -4, 4, 0.1, 5, 0];
+    const result = simplify(points, 0.5);
+    expect(result.slice(0, 2)).toEqual([0, 0]);
+    expect(result.slice(-2)).toEqual([5, 0]);
+    expect(result).toEqual(expect.arrayContaining([2, 5, 3, -4]));
+    expect(result.indexOf(2)).toBeLessThan(result.indexOf(3));
+  });
+
+  it("handles coincident range endpoints", () => {
+    expect(simplify([0, 0, 1, 3, 0, 0], 0.5)).toEqual([
+      0, 0, 1, 3, 0, 0,
+    ]);
+  });
+
+  it("bounds worst-case work with retained overlapping range endpoints", () => {
+    const points = Array.from({ length: 130 }, (_, i) => [i, 0]).flat();
+    expect(simplify(points, 0.5)).toEqual([
+      0, 0, 63, 0, 126, 0, 129, 0,
+    ]);
+  });
+
+  it("leaves an aliased output buffer untouched", () => {
+    const points = [0, 0, 1, 0.1, 2, 0];
+    expect(
+      simplifyLinePoints(points, 1, points, makeLineSimplifyScratch()),
+    ).toBe(points);
+    expect(points).toEqual([0, 0, 1, 0.1, 2, 0]);
+  });
+});


### PR DESCRIPTION
## Summary

- add opt-in `LineConfig.simplify` screen-space path simplification for `LiveChart`
- apply the shared setting to `LiveChartSeries` with per-series `SeriesConfig.simplify` overrides
- preserve original data for range fitting, live values, markers, and scrubbing
- reuse worklet scratch buffers and bound simplification ranges to keep per-frame cost predictable
- add focused unit and renderer coverage
- add a dedicated raw-vs-simplified example screen, guide, API documentation, navigation entry, and changelog entry

## Why

Dense samples can produce a visually noisy Skia path even when the underlying trend is clear. Consumers need an opt-in way to remove small screen-space deviations while keeping meaningful peaks, valleys, timing, and all interaction values grounded in the original dataset.

## API

```tsx
<LiveChart
  data={data}
  value={value}
  line={{ simplify: 1 }}
/>
```

The tolerance is measured in screen pixels. `0` remains the default and preserves existing rendering.

## Validation

- `npm run verify`
  - typecheck
  - lint
  - 100 test suites passed
  - 1,507 tests passed, 5 skipped
- React Doctor: 96/100, no issues found
- `npm run build:lib`
