### PR TITLE
docs: fix line denoising changelog placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Shape-preserving line denoising.** `LineConfig.simplify` opts into
+  screen-space path simplification with a pixel tolerance, removing small visual
+  wiggles while retaining endpoints and larger peaks/valleys. It affects only
+  rendered line/fill geometry; axis fitting, values, markers, and scrubbing keep
+  using the original data. `LiveChartSeries` applies the shared line setting to
+  every path, with a per-series `SeriesConfig.simplify` override. Default `0`
+  keeps existing paths unchanged. A dedicated guide and raw-vs-simplified demo
+  make the tolerance and preserved structure directly comparable.
+
 ## [4.18.0] - 2026-08-12
 
 ### Added
@@ -42,15 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.17.0] - 2026-08-10
 
 ### Added
-
-- **Shape-preserving line denoising.** `LineConfig.simplify` opts into
-  screen-space path simplification with a pixel tolerance, removing small visual
-  wiggles while retaining endpoints and larger peaks/valleys. It affects only
-  rendered line/fill geometry; axis fitting, values, markers, and scrubbing keep
-  using the original data. `LiveChartSeries` applies the shared line setting to
-  every path, with a per-series `SeriesConfig.simplify` override. Default `0`
-  keeps existing paths unchanged. A dedicated guide and raw-vs-simplified demo
-  make the tolerance and preserved structure directly comparable.
 
 - **Vertical marker-column caps.** `MarkerClusterConfig.maxVisible` keeps only
   the oldest glyphs in a vertical stack and hides newer overflow, preventing a


### PR DESCRIPTION
## Summary

- move the shape-preserving line denoising entry from `4.17.0` to `Unreleased`
- preserve the existing release-note wording

## Why

PR #267 merged after the `4.18.0` release, but its changelog entry was added beneath `4.17.0`. That incorrectly claims the API shipped in an older version and prevents the next release notes from picking it up from `Unreleased`.

## Impact

Documentation only. No runtime or public API behavior changes.

## Validation

- `git diff --check origin/main..codex/fix-line-denoising-changelog`
- confirmed the branch diff is limited to `CHANGELOG.md`
- React Doctor not applicable because no React or TypeScript files changed
