### PR TITLE
fix: stabilize dense live line history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Dense live lines retain stable history while scrolling.** Pixel-width
-  min/max decimation buckets are now anchored to absolute time, so advancing
-  the live window translates retained interior segments instead of repeatedly
-  regrouping and reshaping them. Boundary buckets still update normally, spikes
-  remain represented, and the output stays bounded near two points per pixel.
+  min/max decimation buckets and optional denoising ranges are now anchored to
+  absolute time, so advancing the live window translates retained interior
+  segments instead of repeatedly regrouping and reshaping them. Boundary ranges
+  still update normally, spikes remain represented, and the decimated output
+  stays bounded near two points per pixel.
 
 - **Static dot glow is visibly rendered.** Dot glows use a Skia blur mask,
   preserving the halo outside the source circle instead of diluting it through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dense live lines retain stable history while scrolling.** Pixel-width
+  min/max decimation buckets are now anchored to absolute time, so advancing
+  the live window translates retained interior segments instead of repeatedly
+  regrouping and reshaping them. Boundary buckets still update normally, spikes
+  remain represented, and the output stays bounded near two points per pixel.
+
 - **Static dot glow is visibly rendered.** Dot glows use a Skia blur mask,
   preserving the halo outside the source circle instead of diluting it through
   an image filter before the crisp backing ring and dot are painted above it.

--- a/docs/guides/line-denoising.mdx
+++ b/docs/guides/line-denoising.mdx
@@ -102,5 +102,7 @@ const series = useSharedValue<SeriesConfig[]>([
 ## Rendering cost
 
 The pass runs on the UI thread after the chart's envelope-preserving dense-data
-decimation. It reuses scratch buffers and processes bounded point ranges, avoiding
-new point-array allocation or unbounded pathological scans on every frame.
+decimation. It reuses scratch buffers and processes bounded ranges anchored to
+an absolute screen-pixel grid, so a moving live window does not repartition and
+reshape retained history. This avoids new point-array allocation or unbounded
+pathological scans on every frame.

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -439,8 +439,9 @@ displayValue += (target - displayValue) * factor;</pre>
       <h3>Pixel decimation</h3>
       <p class="muted" style="font-size:14px;margin-bottom:14px">
         A wide <code>timeWindow</code> can pack 1000+ points into a few hundred pixels. Once the line is denser than
-        ~2 points per pixel, <code>buildLinePoints</code> keeps only the <b>lowest and highest sample in each pixel
-        column</b> — so every spike's envelope survives while the vertex count stays bounded by the canvas width.
+        ~2 points per pixel, <code>buildLinePoints</code> keeps only the <b>lowest and highest sample in each pixel-width
+        time bucket</b>. Buckets are anchored to absolute time, so advancing the viewport translates retained history
+        without regrouping it, while every spike's envelope survives and the vertex count stays bounded by canvas width.
         Fewer <code>cubicTo</code> calls, same shape. Toggle it and watch the count.
       </p>
       <div class="chart-canvas-wrap"><canvas id="decim-canvas"></canvas></div>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -442,6 +442,8 @@ displayValue += (target - displayValue) * factor;</pre>
         ~2 points per pixel, <code>buildLinePoints</code> keeps only the <b>lowest and highest sample in each pixel-width
         time bucket</b>. Buckets are anchored to absolute time, so advancing the viewport translates retained history
         without regrouping it, while every spike's envelope survives and the vertex count stays bounded by canvas width.
+        Optional line simplification uses the same stable absolute grid for its bounded ranges, preventing denoising from
+        selecting different historical vertices as the left edge advances.
         Fewer <code>cubicTo</code> calls, same shape. Toggle it and watch the count.
       </p>
       <div class="chart-canvas-wrap"><canvas id="decim-canvas"></canvas></div>

--- a/packages/react-native-livechart/src/draw/line.ts
+++ b/packages/react-native-livechart/src/draw/line.ts
@@ -293,15 +293,18 @@ export function buildLinePoints(
       );
     }
   } else {
-    // Min/max-per-pixel-column decimation: within each pixel column keep the
-    // lowest- and highest-value samples (emitted in their original time order)
-    // so the line's envelope and any volatility spikes survive at full vertical
-    // fidelity while the point count stays bounded by the canvas width.
+    // Min/max-per-pixel-width decimation: anchor buckets to absolute time, not
+    // the moving viewport origin. Existing samples then keep the same bucket as
+    // `now` advances, so interior history translates without being reshaped;
+    // only the buckets entering or leaving the viewport can change. Within each
+    // bucket keep the lowest- and highest-value samples (emitted in their
+    // original time order) so the line's envelope and volatility spikes survive
+    // at full vertical fidelity while the point count stays bounded by width.
     let curCol = -2147483648;
     let minIdx = startIdx;
     let maxIdx = startIdx;
     for (let i = startIdx; i < endIdx; i++) {
-      const col = ((data[i].time - winStart) * xScale) | 0;
+      const col = Math.floor(data[i].time * xScale);
       if (col !== curCol) {
         if (curCol !== -2147483648) {
           const a = minIdx <= maxIdx ? minIdx : maxIdx;

--- a/packages/react-native-livechart/src/hooks/useChartPaths.ts
+++ b/packages/react-native-livechart/src/hooks/useChartPaths.ts
@@ -108,14 +108,17 @@ export function useChartPaths(
       Number.isFinite(simplifyTolerance) && simplifyTolerance > 0
         ? simplifyTolerance
         : 0;
+    const now = engine.timestamp.get();
+    const windowSecs = engine.displayWindow.get();
+    const canvasWidth = engine.canvasWidth.get();
     const realPts = buildLinePoints(
       engine.data.get(),
       tipValue,
-      engine.timestamp.get(),
-      engine.displayWindow.get(),
+      now,
+      windowSecs,
       engine.displayMin.get(),
       engine.displayMax.get(),
-      engine.canvasWidth.get(),
+      canvasWidth,
       engine.canvasHeight.get(),
       padding,
       simplify > 0 ? cache.rawPts : buf,
@@ -124,9 +127,18 @@ export function useChartPaths(
       // point rather than fabricating a flat line into dataless space.
       engine.viewEnd.get() != null,
     );
+    const chartWidth = canvasWidth - padding.left - padding.right;
+    const absoluteXOffset =
+      windowSecs > 0 ? (now - windowSecs) * (chartWidth / windowSecs) : 0;
     const renderPts =
       simplify > 0
-        ? simplifyLinePoints(realPts, simplify, buf, cache.simplifyScratch)
+        ? simplifyLinePoints(
+            realPts,
+            simplify,
+            buf,
+            cache.simplifyScratch,
+            absoluteXOffset,
+          )
         : realPts;
 
     // Skip blending when fully revealed or no morphT provided

--- a/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
+++ b/packages/react-native-livechart/src/hooks/useMultiSeriesLinePaths.ts
@@ -62,15 +62,21 @@ export function useMultiSeriesLinePaths(
     const out = pool.pathsTick ? pool.pathsA : pool.pathsB;
     out.length = 0;
     const count = Math.min(activeSeriesCount, s.length, MAX_MULTI_SERIES);
+    const now = engine.timestamp.get();
+    const windowSecs = engine.displayWindow.get();
+    const canvasWidth = engine.canvasWidth.get();
+    const chartWidth = canvasWidth - padding.left - padding.right;
+    const absoluteXOffset =
+      windowSecs > 0 ? (now - windowSecs) * (chartWidth / windowSecs) : 0;
     for (let i = 0; i < count; i++) {
       const rawPts = buildLinePoints(
         s[i].data,
         displays[i] ?? s[i].value,
-        engine.timestamp.get(),
-        engine.displayWindow.get(),
+        now,
+        windowSecs,
         engine.displayMin.get(),
         engine.displayMax.get(),
-        engine.canvasWidth.get(),
+        canvasWidth,
         engine.canvasHeight.get(),
         padding,
         pool.ptsBuf,
@@ -83,6 +89,7 @@ export function useMultiSeriesLinePaths(
               seriesTolerance,
               pool.simplifiedPts,
               pool.simplifyScratch,
+              absoluteXOffset,
             )
           : rawPts;
       const n = pts.length >> 1;

--- a/packages/react-native-livechart/src/math/simplify.ts
+++ b/packages/react-native-livechart/src/math/simplify.ts
@@ -20,6 +20,16 @@ export function makeLineSimplifyScratch(): LineSimplifyScratch {
  */
 const MAX_RDP_RANGE_POINTS = 64;
 
+/**
+ * Width of each RDP range on the stable, absolute screen-pixel grid.
+ *
+ * Dense line input contains at most two representatives per pixel bucket. A
+ * 30 px range therefore stays within the 64-point work bound even when the
+ * decimator and simplifier grids have different phases. Fixed-width ranges
+ * also keep their membership stable as the viewport advances.
+ */
+const RDP_RANGE_WIDTH_PX = 30;
+
 function pointSegmentDistanceSq(
   px: number,
   py: number,
@@ -46,48 +56,31 @@ function pointSegmentDistanceSq(
   return ex * ex + ey * ey;
 }
 
-/**
- * Simplify flat screen-space points (`[x0, y0, x1, y1, ...]`) with a bounded
- * Ramer-Douglas-Peucker pass.
- *
- * `tolerance` is the maximum removable deviation in pixels. The first and last
- * point, larger peaks/valleys, and the original point order are retained. Pass
- * distinct reusable `out` and `scratch` buffers to avoid per-frame allocation.
- */
-export function simplifyLinePoints(
+function simplifyRdpGroup(
   points: number[],
-  tolerance: number,
-  out: number[],
-  scratch: LineSimplifyScratch,
-): number[] {
+  keep: number[],
+  stack: number[],
+  toleranceSq: number,
+  rangeStart: number,
+  rangeEnd: number,
+): void {
   "worklet";
-  if (out === points) return points;
-
-  out.length = 0;
-  const count = points.length >> 1;
-  if (!(tolerance > 0) || !Number.isFinite(tolerance) || count <= 2) {
-    for (let i = 0; i < count * 2; i++) out.push(points[i]);
-    return out;
+  if (rangeStart === rangeEnd) {
+    keep[rangeStart] = 1;
+    return;
   }
 
-  const keep = scratch.keep;
-  keep.length = count;
-  for (let i = 0; i < count; i++) keep[i] = 0;
-
-  const stack = scratch.stack;
-  stack.length = 0;
-  const toleranceSq = tolerance * tolerance;
-
-  // Adjacent ranges share one retained endpoint. That makes each range's RDP
-  // error bound independent while keeping the final polyline continuous.
-  for (let rangeStart = 0; rangeStart < count - 1; ) {
-    const rangeEnd = Math.min(
-      rangeStart + MAX_RDP_RANGE_POINTS - 1,
-      count - 1,
+  // Oversized fixed-X groups are split into overlapping subranges. The group
+  // contents are themselves stable, so this point-count guard cannot move
+  // until that absolute group reaches a viewport edge.
+  for (let chunkStart = rangeStart; chunkStart < rangeEnd; ) {
+    const chunkEnd = Math.min(
+      chunkStart + MAX_RDP_RANGE_POINTS - 1,
+      rangeEnd,
     );
-    keep[rangeStart] = 1;
-    keep[rangeEnd] = 1;
-    stack.push(rangeStart, rangeEnd);
+    keep[chunkStart] = 1;
+    keep[chunkEnd] = 1;
+    stack.push(chunkStart, chunkEnd);
 
     while (stack.length >= 2) {
       const end = stack.pop()!;
@@ -122,8 +115,80 @@ export function simplifyLinePoints(
       }
     }
 
-    rangeStart = rangeEnd;
+    chunkStart = chunkEnd;
   }
+}
+
+/**
+ * Simplify flat screen-space points (`[x0, y0, x1, y1, ...]`) with a bounded
+ * Ramer-Douglas-Peucker pass.
+ *
+ * `tolerance` is the maximum removable deviation in pixels. The first and last
+ * point, larger peaks/valleys, and the original point order are retained. Pass
+ * distinct reusable `out` and `scratch` buffers to avoid per-frame allocation.
+ * `absoluteXOffset` maps the viewport-relative X coordinates back onto a fixed
+ * screen-pixel grid; live chart callers should pass `winStart * xScale` so
+ * historical range membership does not change as the window advances.
+ */
+export function simplifyLinePoints(
+  points: number[],
+  tolerance: number,
+  out: number[],
+  scratch: LineSimplifyScratch,
+  absoluteXOffset = 0,
+): number[] {
+  "worklet";
+  if (out === points) return points;
+
+  out.length = 0;
+  const count = points.length >> 1;
+  if (!(tolerance > 0) || !Number.isFinite(tolerance) || count <= 2) {
+    for (let i = 0; i < count * 2; i++) out.push(points[i]);
+    return out;
+  }
+
+  const keep = scratch.keep;
+  keep.length = count;
+  for (let i = 0; i < count; i++) keep[i] = 0;
+
+  const stack = scratch.stack;
+  stack.length = 0;
+  const toleranceSq = tolerance * tolerance;
+  const stableXOffset = Number.isFinite(absoluteXOffset) ? absoluteXOffset : 0;
+
+  // Partition on a fixed absolute-X grid rather than by the first visible
+  // point's array index. Dropping a point from the left edge then affects only
+  // that edge range; fully visible historical ranges keep identical endpoints
+  // and RDP choices while translating across the viewport.
+  let groupStart = 0;
+  let groupKey = Math.floor(
+    (points[0] + stableXOffset) / RDP_RANGE_WIDTH_PX,
+  );
+  for (let i = 1; i < count; i++) {
+    const nextKey = Math.floor(
+      (points[i * 2] + stableXOffset) / RDP_RANGE_WIDTH_PX,
+    );
+    if (nextKey !== groupKey) {
+      simplifyRdpGroup(
+        points,
+        keep,
+        stack,
+        toleranceSq,
+        groupStart,
+        i - 1,
+      );
+      groupStart = i;
+      groupKey = nextKey;
+    }
+  }
+  simplifyRdpGroup(
+    points,
+    keep,
+    stack,
+    toleranceSq,
+    groupStart,
+    count - 1,
+  );
 
   for (let i = 0; i < count; i++) {
     if (keep[i] === 1) out.push(points[i * 2], points[i * 2 + 1]);

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -18,6 +18,10 @@ import {
   resolvePadding,
 } from "../../src/draw/line";
 import { BADGE_METRICS_DEFAULTS } from "../../src/constants";
+import {
+  makeLineSimplifyScratch,
+  simplifyLinePoints,
+} from "../../src/math/simplify";
 
 describe("gutterCenteredTextLeftX", () => {
   it("matches grid label placement", () => {
@@ -412,6 +416,55 @@ describe("buildLinePoints decimation", () => {
       // Drop the synthetic live tip, reconstruct each retained source time
       // from its screen X, and compare only shared interior buckets. The bins
       // at either viewport edge are expected to gain or lose samples.
+      for (let i = 0; i < points.length - 2; i += 2) {
+        const time = winStart + (points[i] - pad.left) / xScale;
+        const relativeTime = time - baseTime;
+        if (relativeTime > 10.5 && relativeTime < 19.5) {
+          times.push(Number(relativeTime.toFixed(6)));
+        }
+      }
+      return times;
+    };
+
+    expect(retainedTimes(firstNow)).toEqual(retainedTimes(secondNow));
+  });
+
+  it("keeps simplified dense history stable as the live window advances", () => {
+    const samplesPerSecond = 100;
+    const baseTime = 1_800_000_000;
+    const data = Array.from({ length: 2201 }, (_, i) => ({
+      time: baseTime + i / samplesPerSecond,
+      value:
+        Math.sin(i * 0.31) * 4 + Math.cos(i * 0.07) * 2 +
+        (i % 170 === 0 ? 8 : 0),
+    }));
+    const windowSecs = 10;
+    const firstNow = baseTime + 20;
+    const secondNow = baseTime + 20.03;
+    const xScale = chartW / windowSecs;
+
+    const retainedTimes = (now: number): number[] => {
+      const raw = buildLinePoints(
+        data,
+        data[2000].value,
+        now,
+        windowSecs,
+        -15,
+        15,
+        canvasW,
+        canvasH,
+        pad,
+      );
+      const winStart = now - windowSecs;
+      const points = simplifyLinePoints(
+        raw,
+        1,
+        [],
+        makeLineSimplifyScratch(),
+        winStart * xScale,
+      );
+      const times: number[] = [];
+
       for (let i = 0; i < points.length - 2; i += 2) {
         const time = winStart + (points[i] - pad.left) / xScale;
         const relativeTime = time - baseTime;

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -381,4 +381,47 @@ describe("buildLinePoints decimation", () => {
     for (let i = 1; i < out.length; i += 2) minY = Math.min(minY, out[i]);
     expect(minY).toBeCloseTo(pad.top, 0);
   });
+
+  it("keeps dense interior representatives stable as the live window advances", () => {
+    const samplesPerSecond = 100;
+    const baseTime = 1_800_000_000;
+    const data = Array.from({ length: 2201 }, (_, i) => ({
+      time: baseTime + i / samplesPerSecond,
+      value: i,
+    }));
+    const windowSecs = 10;
+    const firstNow = baseTime + 20;
+    const secondNow = baseTime + 20.03;
+    const xScale = chartW / windowSecs;
+
+    const retainedTimes = (now: number): number[] => {
+      const points = buildLinePoints(
+        data,
+        2000,
+        now,
+        windowSecs,
+        0,
+        data.length,
+        canvasW,
+        canvasH,
+        pad,
+      );
+      const winStart = now - windowSecs;
+      const times: number[] = [];
+
+      // Drop the synthetic live tip, reconstruct each retained source time
+      // from its screen X, and compare only shared interior buckets. The bins
+      // at either viewport edge are expected to gain or lose samples.
+      for (let i = 0; i < points.length - 2; i += 2) {
+        const time = winStart + (points[i] - pad.left) / xScale;
+        const relativeTime = time - baseTime;
+        if (relativeTime > 10.5 && relativeTime < 19.5) {
+          times.push(Number(relativeTime.toFixed(6)));
+        }
+      }
+      return times;
+    };
+
+    expect(retainedTimes(firstNow)).toEqual(retainedTimes(secondNow));
+  });
 });

--- a/packages/react-native-livechart/tests/math/simplify.test.ts
+++ b/packages/react-native-livechart/tests/math/simplify.test.ts
@@ -3,12 +3,18 @@ import {
   simplifyLinePoints,
 } from "../../src/math/simplify";
 
-function simplify(points: number[], tolerance: number, out: number[] = []) {
+function simplify(
+  points: number[],
+  tolerance: number,
+  out: number[] = [],
+  absoluteXOffset = 0,
+) {
   return simplifyLinePoints(
     points,
     tolerance,
     out,
     makeLineSimplifyScratch(),
+    absoluteXOffset,
   );
 }
 
@@ -47,11 +53,34 @@ describe("simplifyLinePoints", () => {
     ]);
   });
 
-  it("bounds worst-case work with retained overlapping range endpoints", () => {
+  it("bounds worst-case work with retained fixed-grid range endpoints", () => {
     const points = Array.from({ length: 130 }, (_, i) => [i, 0]).flat();
     expect(simplify(points, 0.5)).toEqual([
-      0, 0, 63, 0, 126, 0, 129, 0,
+      0, 0, 29, 0, 30, 0, 59, 0, 60, 0, 89, 0, 90, 0, 119, 0, 120, 0,
+      129, 0,
     ]);
+  });
+
+  it("keeps retained interior geometry stable while a live window advances", () => {
+    const frame = (startX: number) =>
+      Array.from({ length: 201 }, (_, i) => {
+        const absoluteX = startX + i;
+        const y =
+          Math.sin(absoluteX * 0.31) * 4 +
+          (absoluteX % 17 === 0 ? 8 : 0);
+        return [absoluteX - startX, y];
+      }).flat();
+    const retainedInterior = (startX: number) => {
+      const result = simplify(frame(startX), 1, [], startX);
+      const retained: number[] = [];
+      for (let i = 0; i < result.length; i += 2) {
+        const absoluteX = result[i] + startX;
+        if (absoluteX > 40 && absoluteX < 160) retained.push(absoluteX);
+      }
+      return retained;
+    };
+
+    expect(retainedInterior(0)).toEqual(retainedInterior(1));
   });
 
   it("leaves an aliased output buffer untouched", () => {


### PR DESCRIPTION
## Summary

- anchor dense line min/max decimation buckets to absolute time instead of the moving viewport origin
- anchor bounded denoising ranges to the same stable absolute-X grid
- preserve extrema, fixed path order, and the canvas-width output bound
- add rolling-window regressions for both raw and simplified dense paths
- update the drawing-layer and denoising documentation plus changelog

## Root cause

The dense-path bucket index was derived from `time - winStart`. As `winStart` advanced, historical samples repeatedly crossed pixel-column boundaries, changing each bucket's selected min/max representatives. After fixing that, the optional RDP simplifier still partitioned its input by the first visible point's array index, so its range endpoints shifted whenever a point left the window. Both stages could therefore select different historical vertices.

Decimation buckets now remain fixed in absolute time, and simplification ranges remain fixed on an absolute screen-pixel grid while the time window and layout are unchanged. Fully visible history translates left intact; only boundary ranges change.

Closes #271.

## Validation

- `npm run verify` — 102 suites passed; 1,574 tests passed, 5 skipped
- React Doctor — 100/100, no issues
- agent-device on iPhone 17 Pro simulator — Line, 1m, 20 trades/sec, normal volatility, Trade stream off, Degen off; reviewed separate denoising-off and denoising-1.5 px captures frame-by-frame
