### PR TITLE
feat: add scaled y-axis intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Display-unit Y-axis intervals.** `YAxisConfig.intervalScale` chooses and aligns
+  dynamic nice intervals after applying a constant display multiplier, while all
+  plotted data remains in its original units. Pair it with `formatValue` using the
+  same multiplier for round labels across unit conversions. Invalid multipliers
+  safely use `1`; fixed-count axes keep their exact-range behavior.
+
 ## [4.19.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dynamic nice intervals after applying a constant display multiplier, while all
   plotted data remains in its original units. Pair it with `formatValue` using the
   same multiplier for round labels across unit conversions. Invalid multipliers
-  safely use `1`; fixed-count axes keep their exact-range behavior.
+  and unrepresentable scaled ranges safely use source-unit intervals; fixed-count
+  axes keep their exact-range behavior.
 
 ## [4.19.0] - 2026-08-16
 

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -15,6 +15,9 @@ accepts all the shared theming, axis, range, layout, and text props from
 [`yRangeScale`](/guides/y-range-scale), `line`, `yAxis`,
 `referenceLines`, `formatValue`, …), plus the multi-series props below.
 
+The inherited `yAxis.intervalScale` chooses dynamic nice intervals in display units without
+changing any series values. Pair it with a `formatValue` that applies the same multiplier.
+
 On Android, the shared experimental `canvasMode="opaque"` option selects an opaque SurfaceView and
 paints the palette background inside the canvas. See
 [Android surface rendering](/guides/android-surface-rendering) for constraints and profiling guidance.

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -16,7 +16,8 @@ accepts all the shared theming, axis, range, layout, and text props from
 `referenceLines`, `formatValue`, …), plus the multi-series props below.
 
 The inherited `yAxis.intervalScale` chooses dynamic nice intervals in display units without
-changing any series values. Pair it with a `formatValue` that applies the same multiplier.
+changing any series values. Pair it with a `formatValue` that applies the same multiplier. If the
+scaled live range cannot be represented, interval selection safely falls back to source units.
 
 On Android, the shared experimental `canvasMode="opaque"` option selects an opaque SurfaceView and
 paints the palette background inside the canvas. See

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -401,9 +401,11 @@ provided; everything else has a default.
 
 <ParamField body="yAxis" type="boolean | YAxisConfig" default="true">
   Value-axis grid + labels. Pass `{ count }` for a fixed number of evenly-spaced
-  prices instead of the dynamic nice-interval grid. Use `{ labelRightMargin,
-  gridEndGap }` for a fixed right-anchored label column and deterministic gap
-  between labels and grid/plain reference lines.
+  prices instead of the dynamic nice-interval grid. Pass `{ intervalScale }`
+  with a matching `formatValue` multiplier to choose nice intervals in display
+  units without changing plotted values. Use `{ labelRightMargin, gridEndGap }`
+  for a fixed right-anchored label column and deterministic gap between labels
+  and grid/plain reference lines.
 </ParamField>
 
 <ParamField body="axisAutoHide" type="boolean | AxisAutoHideConfig" default="false">

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -403,9 +403,10 @@ provided; everything else has a default.
   Value-axis grid + labels. Pass `{ count }` for a fixed number of evenly-spaced
   prices instead of the dynamic nice-interval grid. Pass `{ intervalScale }`
   with a matching `formatValue` multiplier to choose nice intervals in display
-  units without changing plotted values. Use `{ labelRightMargin, gridEndGap }`
-  for a fixed right-anchored label column and deterministic gap between labels
-  and grid/plain reference lines.
+  units without changing plotted values. Scales that would make the current
+  display range overflow or underflow fall back to source-unit intervals. Use
+  `{ labelRightMargin, gridEndGap }` for a fixed right-anchored label column and
+  deterministic gap between labels and grid/plain reference lines.
 </ParamField>
 
 <ParamField body="axisAutoHide" type="boolean | AxisAutoHideConfig" default="false">

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -447,6 +447,10 @@ interface SelectionDotConfig {
 interface GridStyleConfig { color?: string; strokeWidth?: number; intervals?: number[]; opacity?: number }
 interface YAxisConfig {
   minGap?: number; // min px gap between grid lines; default 36
+  // Multiplier used to choose dynamic nice intervals without changing plotted
+  // values. Pair with formatValue using the same multiplier. Must be positive
+  // and finite; invalid values use 1. Ignored with count. Default 1.
+  intervalScale?: number;
   // Show a fixed number of evenly-spaced prices (top = high, bottom = low)
   // instead of the dynamic nice-interval grid. Values track the live range each
   // frame. `minGap` still floors the spacing; clamped to at most 15. Default 0.

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -449,7 +449,8 @@ interface YAxisConfig {
   minGap?: number; // min px gap between grid lines; default 36
   // Multiplier used to choose dynamic nice intervals without changing plotted
   // values. Pair with formatValue using the same multiplier. Must be positive
-  // and finite; invalid values use 1. Ignored with count. Default 1.
+  // and finite; invalid values use 1. Unrepresentable scaled ranges fall back
+  // to source-unit intervals. Ignored with count. Default 1.
   intervalScale?: number;
   // Show a fixed number of evenly-spaced prices (top = high, bottom = low)
   // instead of the dynamic nice-interval grid. Values track the live range each

--- a/docs/guides/axes-and-grid.mdx
+++ b/docs/guides/axes-and-grid.mdx
@@ -68,8 +68,9 @@ const formatDisplayValue = (value: number) => {
 This can turn labels such as `$9,876,543` and `$10,864,198` into round `$10,000,000` and
 `$11,000,000` intervals. The chart geometry, markers, reference lines, and scrub values stay in
 their original units. The multiplier must be positive and finite; invalid values behave as `1`.
-Fixed-count mode ignores it because `{ count }` tracks the exact visible range instead of choosing
-nice intervals.
+If applying it would overflow or underflow the current live range, interval selection safely falls
+back to source units. Fixed-count mode ignores it because `{ count }` tracks the exact visible range
+instead of choosing nice intervals.
 
 ## Right-anchored price label column
 

--- a/docs/guides/axes-and-grid.mdx
+++ b/docs/guides/axes-and-grid.mdx
@@ -43,6 +43,34 @@ the values track the live range each frame (they aren't rounded to nice numbers)
 `minGap` still acts as a floor: if `count` labels won't fit at least `minGap` px apart, the count
 drops to what fits. The count is clamped to at most 15.
 
+## Nice intervals in display units
+
+Use `intervalScale` when stored values and displayed values differ by a constant multiplier.
+The chart keeps every point in its original units, but chooses dynamic grid intervals after
+applying the multiplier. Apply the same multiplier in `formatValue`:
+
+```tsx
+const DISPLAY_SCALE = 987_654_321;
+
+const formatDisplayValue = (value: number) => {
+  "worklet";
+  return `$${Math.round(value * DISPLAY_SCALE)}`;
+};
+
+<LiveChart
+  data={data}
+  value={value}
+  yAxis={{ intervalScale: DISPLAY_SCALE }}
+  formatValue={formatDisplayValue}
+/>
+```
+
+This can turn labels such as `$9,876,543` and `$10,864,198` into round `$10,000,000` and
+`$11,000,000` intervals. The chart geometry, markers, reference lines, and scrub values stay in
+their original units. The multiplier must be positive and finite; invalid values behave as `1`.
+Fixed-count mode ignores it because `{ count }` tracks the exact visible range instead of choosing
+nice intervals.
+
 ## Right-anchored price label column
 
 Set `labelRightMargin` to place every Y-axis label at the same left X in a column whose right edge

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1586,6 +1586,7 @@ function ChartWithYAxis({ model }: { model: LiveChartModel }) {
     yAxisCfg?.minGap ?? 36,
     metricsCfg.grid,
     yAxisCfg?.count ?? 0,
+    yAxisCfg?.intervalScale ?? 1,
   );
   if (model.degenCfg) {
     return <ChartWithDegen model={model} yAxisEntries={yAxisEntries} />;

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -450,6 +450,7 @@ function useLiveChartSeriesController({
     yAxisCfg?.minGap ?? 36,
     metricsCfg.grid,
     yAxisCfg?.count ?? 0,
+    yAxisCfg?.intervalScale ?? 1,
   );
 
   const { xAxisEntries } = useXAxis(

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -89,7 +89,7 @@ export interface ResolvedBadgeConfig {
 
 export interface ResolvedYAxisConfig {
   minGap: number;
-  /** Multiplier used to choose and align dynamic nice intervals. */
+  /** Multiplier used to choose and align representable dynamic nice intervals. */
   intervalScale: number;
   /** Fixed label count (≥ 2), or 0 for the dynamic nice-interval grid. */
   count: number;

--- a/packages/react-native-livechart/src/core/resolveConfig.ts
+++ b/packages/react-native-livechart/src/core/resolveConfig.ts
@@ -89,6 +89,8 @@ export interface ResolvedBadgeConfig {
 
 export interface ResolvedYAxisConfig {
   minGap: number;
+  /** Multiplier used to choose and align dynamic nice intervals. */
+  intervalScale: number;
   /** Fixed label count (≥ 2), or 0 for the dynamic nice-interval grid. */
   count: number;
   /** undefined → keep the default centered-gutter label placement. */
@@ -486,6 +488,7 @@ export function resolveBadge(
 
 const Y_AXIS_DEFAULTS: ResolvedYAxisConfig = {
   minGap: 36,
+  intervalScale: 1,
   count: 0,
   labelRightMargin: undefined,
   gridEndGap: undefined,
@@ -503,7 +506,14 @@ export function resolveYAxis(
 ): ResolvedYAxisConfig | null {
   const resolved = resolveToggle(prop, Y_AXIS_DEFAULTS, false);
   if (resolved === null) return null;
-  return { ...resolved, count: Math.max(0, Math.floor(resolved.count)) };
+  return {
+    ...resolved,
+    count: Math.max(0, Math.floor(resolved.count)),
+    intervalScale:
+      Number.isFinite(resolved.intervalScale) && resolved.intervalScale > 0
+        ? resolved.intervalScale
+        : 1,
+  };
 }
 
 const VOLUME_DEFAULTS: ResolvedVolumeConfig = {

--- a/packages/react-native-livechart/src/draw/grid.ts
+++ b/packages/react-native-livechart/src/draw/grid.ts
@@ -89,6 +89,7 @@ export function pickInterval(
   prev: number,
 ): number {
   "worklet";
+  if (!Number.isFinite(valRange) || !Number.isFinite(pxPerUnit)) return 0;
   if (prev > 0) {
     const px = prev * pxPerUnit;
     if (px >= minGap * 0.5 && px <= minGap * 4) return prev;
@@ -103,6 +104,9 @@ export function pickInterval(
   for (let s = 0; s < divisorSets.length; s++) {
     const divs = divisorSets[s];
     let span = Math.pow(10, Math.ceil(Math.log10(valRange)));
+    // `10 ** ceil(log10(Number.MAX_VALUE))` overflows even though the input is
+    // finite. Starting from the range itself preserves a finite upper bound.
+    if (!Number.isFinite(span) && valRange > 0) span = valRange;
     let i = 0;
     while ((span / divs[i % 3]) * pxPerUnit >= minGap) {
       span /= divs[i % 3];
@@ -195,13 +199,29 @@ export function computeGridEntries(
 
   const pxPerUnit = chartH / valRange;
 
+  let appliedIntervalScale = intervalScale;
+  let scaledRange = valRange * appliedIntervalScale;
+  let pxPerScaledUnit = pxPerUnit / appliedIntervalScale;
+  // A positive finite multiplier can still overflow/underflow when combined
+  // with the live range. Fall back to source-unit interval selection so an
+  // unrepresentable display range cannot poison or freeze this UI worklet.
+  if (
+    !Number.isFinite(scaledRange) ||
+    scaledRange <= 0 ||
+    !Number.isFinite(pxPerScaledUnit) ||
+    pxPerScaledUnit <= 0
+  ) {
+    appliedIntervalScale = 1;
+    scaledRange = valRange;
+    pxPerScaledUnit = pxPerUnit;
+  }
   const interval = pickInterval(
-    valRange * intervalScale,
-    pxPerUnit / intervalScale,
+    scaledRange,
+    pxPerScaledUnit,
     minGap,
-    prevInterval,
+    appliedIntervalScale === intervalScale ? prevInterval : 0,
   );
-  const coarse = interval / intervalScale;
+  const coarse = interval / appliedIntervalScale;
   const fine = coarse / 2;
   const finePx = fine * pxPerUnit;
   const fineTarget = fineLineTargetAlpha(finePx, minGap);
@@ -234,7 +254,10 @@ export function computeGridEntries(
       fromEdge >= fadeZone ? 1 : fromEdge <= 0 ? 0 : fromEdge / fadeZone;
 
     const target = (isCoarse ? 1 : fineTarget) * edgeAlpha;
-    const key = Math.round(val * 1e10);
+    // Snap to the exact fine-grid multiple. Unlike a fixed decimal precision,
+    // this keeps adjacent sub-1e-10 source values distinct while remaining
+    // stable when the same line is recomputed on later frames.
+    const key = Math.round(val / fine) * fine;
     targets[key] = target;
   }
 
@@ -272,7 +295,7 @@ export function computeGridEntries(
     const key = Number(allKeys[i]);
     const alpha = labelAlphas[key];
     if (alpha < 0.02) continue;
-    const val = key / 1e10;
+    const val = key;
     const y = gridValueToY(val, displayMax, valRange, padTop, chartH);
     /* istanbul ignore next -- vertical clip; y stays in-band when val comes from tracked keys */
     if (y < padTop - 10 || y > canvasHeight - padBottom + 10) continue;

--- a/packages/react-native-livechart/src/draw/grid.ts
+++ b/packages/react-native-livechart/src/draw/grid.ts
@@ -165,6 +165,7 @@ export function computeGridEntries(
   minGap = 36,
   grid: GridMetrics = GRID_METRICS_DEFAULTS,
   count = 0,
+  intervalScale = 1,
 ): { entries: YAxisEntry[]; interval: number } {
   "worklet";
   const chartH = canvasHeight - padTop - padBottom;
@@ -194,7 +195,13 @@ export function computeGridEntries(
 
   const pxPerUnit = chartH / valRange;
 
-  const coarse = pickInterval(valRange, pxPerUnit, minGap, prevInterval);
+  const interval = pickInterval(
+    valRange * intervalScale,
+    pxPerUnit / intervalScale,
+    minGap,
+    prevInterval,
+  );
+  const coarse = interval / intervalScale;
   const fine = coarse / 2;
   const finePx = fine * pxPerUnit;
   const fineTarget = fineLineTargetAlpha(finePx, minGap);
@@ -272,5 +279,5 @@ export function computeGridEntries(
     entries.push({ y, label: formatValue(val), alpha });
   }
 
-  return { entries, interval: coarse };
+  return { entries, interval };
 }

--- a/packages/react-native-livechart/src/hooks/useYAxis.ts
+++ b/packages/react-native-livechart/src/hooks/useYAxis.ts
@@ -20,6 +20,7 @@ export function useYAxis(
   minGap = 36,
   gridMetrics: GridMetrics = GRID_METRICS_DEFAULTS,
   count = 0,
+  intervalScale = 1,
 ) {
   const prevInterval = useSharedValue(0);
   const labelAlphas = useSharedValue<Record<number, number>>({});
@@ -41,6 +42,7 @@ export function useYAxis(
       minGap,
       gridMetrics,
       count,
+      intervalScale,
     );
 
     prevInterval.set(result.interval);

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -649,6 +649,13 @@ export interface YAxisConfig {
   /** Minimum pixel gap between grid lines. Default `36`. */
   minGap?: number;
   /**
+   * Multiplier used to choose and align dynamic "nice" intervals without
+   * changing plotted values. Pair it with a `formatValue` that applies the
+   * same multiplier. Must be positive and finite; invalid values use `1`.
+   * Ignored when {@link count} is set. Default `1`.
+   */
+  intervalScale?: number;
+  /**
    * Show a fixed number of price labels instead of the dynamic nice-interval
    * grid. When set (≥ 2), exactly `count` labels are spaced evenly **in pixels**
    * across the plot — top label = current high, bottom = current low — so the

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -652,6 +652,8 @@ export interface YAxisConfig {
    * Multiplier used to choose and align dynamic "nice" intervals without
    * changing plotted values. Pair it with a `formatValue` that applies the
    * same multiplier. Must be positive and finite; invalid values use `1`.
+   * If applying the multiplier to the live range would overflow or underflow,
+   * interval selection falls back to source units for that range.
    * Ignored when {@link count} is set. Default `1`.
    */
   intervalScale?: number;

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -606,7 +606,12 @@ describe("LiveChart", () => {
     await render(
       <Harness
         badge={{ variant: "minimal", tail: false }}
-        yAxis={{ minGap: 48, labelRightMargin: 8, gridEndGap: 6 }}
+        yAxis={{
+          minGap: 48,
+          intervalScale: 1_000_000,
+          labelRightMargin: 8,
+          gridEndGap: 6,
+        }}
         scrub={{ tooltip: false }}
         valueLine={{ strokeWidth: 2, intervals: [6, 3] }}
       />,

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -163,7 +163,11 @@ describe("LiveChartSeries", () => {
         <LiveChartSeries
           series={series}
           scrub={{ tooltip: true }}
-          yAxis={{ labelRightMargin: 8, gridEndGap: 6 }}
+          yAxis={{
+            intervalScale: 1_000_000,
+            labelRightMargin: 8,
+            gridEndGap: 6,
+          }}
           referenceLines={[{ value: 11 }]}
           legend={{ compact: true }}
           onSeriesToggle={jest.fn()}

--- a/packages/react-native-livechart/tests/draw/grid.test.ts
+++ b/packages/react-native-livechart/tests/draw/grid.test.ts
@@ -71,6 +71,17 @@ describe("pickInterval", () => {
     const r = pickInterval(-1, 1, 36, 0);
     expect(r).toBeCloseTo(-0.2);
   });
+
+  it("returns safely for non-finite inputs", () => {
+    expect(pickInterval(Infinity, 1, 36, 0)).toBe(0);
+    expect(pickInterval(100, Infinity, 36, 0)).toBe(0);
+  });
+
+  it("keeps the initial span finite near Number.MAX_VALUE", () => {
+    const r = pickInterval(Number.MAX_VALUE, 1e-305, 36, 0);
+    expect(Number.isFinite(r)).toBe(true);
+    expect(r).toBeGreaterThan(0);
+  });
 });
 
 describe("computeGridEntries", () => {
@@ -118,6 +129,69 @@ describe("computeGridEntries", () => {
     expect(r.entries.map((entry) => Number(entry.label))).toEqual([
       10_000_000, 11_000_000, 12_000_000, 13_000_000, 14_000_000,
     ]);
+  });
+
+  it("keeps scaled entries distinct below fixed decimal precision", () => {
+    const intervalScale = 1e15;
+    const alphas: Record<number, number> = {};
+    const r = computeGridEntries(
+      0.95e-12,
+      1.45e-12,
+      360,
+      16,
+      28,
+      0,
+      alphas,
+      (value) => String(Math.round(value * intervalScale)),
+      16.67,
+      54,
+      undefined,
+      0,
+      intervalScale,
+    );
+
+    expect(r.interval).toBe(100);
+    expect(r.entries.map((entry) => Number(entry.label))).toEqual([
+      1_000, 1_100, 1_200, 1_300, 1_400,
+    ]);
+  });
+
+  it("falls back safely when scaled interval arithmetic is unrepresentable", () => {
+    const overflow = computeGridEntries(
+      0,
+      2,
+      400,
+      12,
+      28,
+      0,
+      {},
+      fmt,
+      16.67,
+      36,
+      undefined,
+      0,
+      1e308,
+    );
+    const underflow = computeGridEntries(
+      0,
+      2,
+      400,
+      12,
+      28,
+      0,
+      {},
+      fmt,
+      16.67,
+      36,
+      undefined,
+      0,
+      Number.MIN_VALUE,
+    );
+
+    expect(Number.isFinite(overflow.interval)).toBe(true);
+    expect(overflow.entries.length).toBeGreaterThan(0);
+    expect(Number.isFinite(underflow.interval)).toBe(true);
+    expect(underflow.entries.length).toBeGreaterThan(0);
   });
 
   it("fades labels toward zero and removes stale keys", () => {

--- a/packages/react-native-livechart/tests/draw/grid.test.ts
+++ b/packages/react-native-livechart/tests/draw/grid.test.ts
@@ -95,6 +95,31 @@ describe("computeGridEntries", () => {
     expect(r.interval).toBeGreaterThan(0);
   });
 
+  it("chooses nice intervals in scaled display units", () => {
+    const intervalScale = 987_654_321;
+    const alphas: Record<number, number> = {};
+    const r = computeGridEntries(
+      0.0095,
+      0.0145,
+      360,
+      16,
+      28,
+      0,
+      alphas,
+      (value) => String(Math.round(value * intervalScale)),
+      16.67,
+      54,
+      undefined,
+      0,
+      intervalScale,
+    );
+
+    expect(r.interval).toBe(1_000_000);
+    expect(r.entries.map((entry) => Number(entry.label))).toEqual([
+      10_000_000, 11_000_000, 12_000_000, 13_000_000, 14_000_000,
+    ]);
+  });
+
   it("fades labels toward zero and removes stale keys", () => {
     const alphas: Record<number, number> = { 50000: 0.5 };
     computeGridEntries(0, 100, 400, 12, 28, 0, alphas, fmt, 16.67);

--- a/packages/react-native-livechart/tests/resolveConfig.test.ts
+++ b/packages/react-native-livechart/tests/resolveConfig.test.ts
@@ -201,6 +201,7 @@ describe("resolveYAxis", () => {
   it("returns defaults for true", () => {
     expect(resolveYAxis(true)).toEqual({
       minGap: 36,
+      intervalScale: 1,
       count: 0,
       float: false,
       labelRightMargin: undefined,
@@ -211,6 +212,7 @@ describe("resolveYAxis", () => {
   it("merges partial config with defaults", () => {
     expect(resolveYAxis({ minGap: 48 })).toEqual({
       minGap: 48,
+      intervalScale: 1,
       count: 0,
       float: false,
       labelRightMargin: undefined,
@@ -221,6 +223,7 @@ describe("resolveYAxis", () => {
   it("carries through the float flag", () => {
     expect(resolveYAxis({ float: true })).toEqual({
       minGap: 36,
+      intervalScale: 1,
       count: 0,
       float: true,
       labelRightMargin: undefined,
@@ -231,6 +234,7 @@ describe("resolveYAxis", () => {
   it("carries through a fixed count", () => {
     expect(resolveYAxis({ count: 5 })).toEqual({
       minGap: 36,
+      intervalScale: 1,
       count: 5,
       float: false,
       labelRightMargin: undefined,
@@ -241,6 +245,7 @@ describe("resolveYAxis", () => {
   it("carries through right-anchored label spacing", () => {
     expect(resolveYAxis({ labelRightMargin: 8, gridEndGap: 6 })).toEqual({
       minGap: 36,
+      intervalScale: 1,
       count: 0,
       float: false,
       labelRightMargin: 8,
@@ -251,6 +256,15 @@ describe("resolveYAxis", () => {
   it("normalizes count to a non-negative integer", () => {
     expect(resolveYAxis({ count: 4.8 })?.count).toBe(4);
     expect(resolveYAxis({ count: -3 })?.count).toBe(0);
+  });
+
+  it("normalizes intervalScale to a positive finite multiplier", () => {
+    expect(resolveYAxis({ intervalScale: 1_000_000 })?.intervalScale).toBe(
+      1_000_000,
+    );
+    expect(resolveYAxis({ intervalScale: 0 })?.intervalScale).toBe(1);
+    expect(resolveYAxis({ intervalScale: -2 })?.intervalScale).toBe(1);
+    expect(resolveYAxis({ intervalScale: Infinity })?.intervalScale).toBe(1);
   });
 });
 


### PR DESCRIPTION
**What**

- Add `YAxisConfig.intervalScale` for dynamic nice intervals in display units.
- Keep plotted values, markers, reference lines, and scrub values in source units.
- Support both `LiveChart` and `LiveChartSeries`, with docs and changelog coverage.

**Bugs fixed**

- Formatted unit conversions could produce awkward Y-axis labels because interval selection used source units.

**Why interval scaling**

- A constant multiplier preserves chart geometry while choosing round ticks in display units.
- Invalid multipliers use `1`, while fixed-count axes remain unchanged.
- Scale `987,654,321` produces exact `10M` through `14M` intervals in the test case.

**Test plan**

- `npm run verify`
- Focused Jest tests for grid math, config resolution, `LiveChart`, and `LiveChartSeries`.
- Not tested on a physical device or simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
