### PR TITLE
chore: keep Jest preset aligned with Expo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,7 @@
         "expo-*",
         "@expo/vector-icons",
         "jest-expo",
+        "@react-native/jest-preset",
         "babel-preset-expo",
         "eslint-config-expo",
         "react",


### PR DESCRIPTION
## What changed

- Add `@react-native/jest-preset` to Renovate's Expo-governed dependency exclusions.
- Prevent the preset from being upgraded independently of Expo and React Native.

## Why

Renovate PR #280 upgraded `@react-native/jest-preset` from 0.86.2 to 0.87.0 while Expo 57 still pins React Native 0.86.0. The 0.87 preset expects `react-native/src/setup-env.js`, which only exists in React Native 0.87, so all 105 Jest suites fail before running any tests.

The preset must be updated as part of an Expo/React Native upgrade instead of as an independent dependency bump.

## Impact

Renovate will no longer open incompatible standalone Jest preset upgrades. This has no runtime or public API impact.

## Validation

- `npx --yes --package renovate renovate-config-validator renovate.json`
- `npm run verify` — 105 suites; 1,588 passed, 5 skipped
