### PR TITLE
feat: add imperative zoom reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **External pinch-zoom reset.** `LiveChart` and `LiveChartSeries` now expose a
+  shared `LiveChartHandle` through `ref`; call `resetZoom()` from a button or any
+  outside event to restore the configured `timeWindow`, clear the focal-point
+  offset, and resume following the live edge. The reset runs on the UI thread,
+  is safe when already reset, and is demonstrated by the Time scroll example's
+  visible-window readout and Reset zoom control.
+
 - **Display-unit Y-axis intervals.** `YAxisConfig.intervalScale` chooses and aligns
   dynamic nice intervals after applying a constant display multiplier, while all
   plotted data remains in its original units. Pair it with `formatValue` using the

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -12,8 +12,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Time scroll" };
-
 // 5-minute window of 15s candles (20 visible), but seed ~5 windows of history so
 // there's somewhere to scroll back into. `maxPoints` (tick buffer) stays well
 // longer than the seed so the oldest committed candles don't re-bucket as you

--- a/app/demo/time-scroll.tsx
+++ b/app/demo/time-scroll.tsx
@@ -1,9 +1,13 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Alert } from "react-native";
-import { LiveChart, type ScrubActionPoint } from "react-native-livechart";
+import {
+  LiveChart,
+  type LiveChartHandle,
+  type ScrubActionPoint,
+} from "react-native-livechart";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
-import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
+import { Chip, ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
@@ -66,6 +70,7 @@ const RETURN_TO_LIVE: Record<ReturnMode, boolean | { duration: number }> = {
 };
 
 export default function TimeScrollScreen() {
+  const chartRef = useRef<LiveChartHandle>(null);
   const [mode, setMode] = useState<"candle" | "line">("candle");
   const [gesture, setGesture] = useState<Gesture>("holdToScrub");
   const [holdMs, setHoldMs] = useState(500);
@@ -84,6 +89,7 @@ export default function TimeScrollScreen() {
   const [orderTicket, setOrderTicket] = useState(true);
   const [floatAxis, setFloatAxis] = useState(true);
   const [reachedStart, setReachedStart] = useState(false);
+  const [visibleWindowSecs, setVisibleWindowSecs] = useState(WINDOW_SECS);
 
   // candleAggregation gives us both the line `data` and `candles`; the toggle
   // just switches which the chart renders. Time-scroll is mode-agnostic — it
@@ -117,6 +123,7 @@ export default function TimeScrollScreen() {
       description={`${hint} Pinch with two fingers to zoom the window in/out (anchored at your fingers). The chart stops auto-scrolling while panned; ${fling ? "fling" : "release"} back to the live edge to resume. Turn off Fling inertia to stop exactly where your finger lifts. Works for line and candle; one-finger plot scrub is unchanged.${reachedStart ? "  ● Reached oldest data (onReachStart fired — page here)" : ""}`}
       chart={
         <LiveChart
+          ref={chartRef}
           data={data}
           value={value}
           mode={mode}
@@ -148,6 +155,7 @@ export default function TimeScrollScreen() {
           // `following`), rather than flashing — `onReachStart` is a one-shot
           // edge trigger (it fires once to cue a page-in, then re-arms).
           onVisibleRangeChange={(r) => {
+            setVisibleWindowSecs(r.endSec - r.startSec);
             console.log(
               `visible range: ${r.startSec.toFixed(0)}–${r.endSec.toFixed(0)} following=${r.following}`,
             );
@@ -227,8 +235,15 @@ export default function TimeScrollScreen() {
         onChange={setReturnMode}
       />
 
-      <ControlRow label="Pinch to zoom">
+      <ControlRow
+        label={`Pinch to zoom · visible ${Math.round(visibleWindowSecs)}s`}
+      >
         <ToggleChip label="zoom" value={zoomOn} onChange={setZoomOn} />
+        <Chip
+          label="Reset zoom"
+          active={false}
+          onPress={() => chartRef.current?.resetZoom()}
+        />
       </ControlRow>
 
       <ControlRow label="One-finger scrub">

--- a/app/showcase/fomo-perps.tsx
+++ b/app/showcase/fomo-perps.tsx
@@ -3,7 +3,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Canvas, Path, Skia } from "@shopify/react-native-skia";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import {
   Modal,
   Pressable,
@@ -17,6 +17,7 @@ import {
   LiveChart,
   type CandlePoint,
   type LiveChartHandle,
+  type LiveChartPoint,
   type Marker,
   type ReferenceLine,
   type ScrubActionPoint,
@@ -202,6 +203,18 @@ const INTERVALS = [
 
 type IntervalId = (typeof INTERVALS)[number]["id"];
 const INTERVAL_GROUPS = ["Minutes", "Hours", "Days"] as const;
+type IntervalGroup = (typeof INTERVAL_GROUPS)[number];
+type Interval = (typeof INTERVALS)[number];
+
+// Build the sheet's groups once. The old filter().map() chain rebuilt all three
+// groups on every render even though the interval catalog is static.
+const INTERVALS_BY_GROUP = INTERVALS.reduce<Record<IntervalGroup, Interval[]>>(
+  (groups, interval) => {
+    groups[interval.group].push(interval);
+    return groups;
+  },
+  { Minutes: [], Hours: [], Days: [] },
+);
 
 // Range pills under the chart: each zooms the visible window to a multiple of the
 // interval's base window (more candles in view) — a quick zoom-out layered on top
@@ -223,46 +236,50 @@ const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 // ── ETH mark: octahedron drawn into a small Skia canvas, on a white disc. ─────
-function EthMark({ size = 22 }: { size?: number }) {
-  const paths = useMemo(() => {
-    const cx = size / 2;
-    const top = size * 0.05;
-    const waistY = size * 0.42;
-    const beltY = size * 0.58;
-    const bottom = size * 0.95;
-    const halfW = size * 0.3;
-    // PathBuilder → immutable SkPath (the mutable SkPath.moveTo/lineTo/close are
-    // deprecated). Built once in useMemo, so the per-frame allocation caveat that
-    // keeps the chart's hot paths on the mutable pool doesn't apply here.
-    const tri = (
-      ax: number,
-      ay: number,
-      bx: number,
-      by: number,
-      dx: number,
-      dy: number,
-    ) => {
-      const b = Skia.PathBuilder.Make();
-      b.moveTo(ax, ay);
-      b.lineTo(bx, by);
-      b.lineTo(dx, dy);
-      b.close();
-      return b.build();
-    };
-    return {
-      ul: tri(cx, top, cx - halfW, waistY, cx, beltY),
-      ur: tri(cx, top, cx + halfW, waistY, cx, beltY),
-      ll: tri(cx, beltY, cx - halfW, waistY, cx, bottom),
-      lr: tri(cx, beltY, cx + halfW, waistY, cx, bottom),
-    };
-  }, [size]);
+const ETH_MARK_SIZE = 22;
 
+function makeTriangle(
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+  dx: number,
+  dy: number,
+) {
+  const builder = Skia.PathBuilder.Make();
+  builder.moveTo(ax, ay);
+  builder.lineTo(bx, by);
+  builder.lineTo(dx, dy);
+  builder.close();
+  return builder.build();
+}
+
+function makeEthPaths(size: number) {
+  const cx = size / 2;
+  const top = size * 0.05;
+  const waistY = size * 0.42;
+  const beltY = size * 0.58;
+  const bottom = size * 0.95;
+  const halfW = size * 0.3;
+  return {
+    ul: makeTriangle(cx, top, cx - halfW, waistY, cx, beltY),
+    ur: makeTriangle(cx, top, cx + halfW, waistY, cx, beltY),
+    ll: makeTriangle(cx, beltY, cx - halfW, waistY, cx, bottom),
+    lr: makeTriangle(cx, beltY, cx + halfW, waistY, cx, bottom),
+  };
+}
+
+// The mark is always rendered at one size, so build immutable Skia paths once at
+// module initialization instead of carrying a manual React memoization contract.
+const ETH_MARK_PATHS = makeEthPaths(ETH_MARK_SIZE);
+
+function EthMark() {
   return (
-    <Canvas style={{ width: size, height: size }}>
-      <Path path={paths.ul} color="#8A8FA6" />
-      <Path path={paths.ur} color="#62677D" />
-      <Path path={paths.ll} color="#777C93" />
-      <Path path={paths.lr} color="#4E5468" />
+    <Canvas style={{ width: ETH_MARK_SIZE, height: ETH_MARK_SIZE }}>
+      <Path path={ETH_MARK_PATHS.ul} color="#8A8FA6" />
+      <Path path={ETH_MARK_PATHS.ur} color="#62677D" />
+      <Path path={ETH_MARK_PATHS.ll} color="#777C93" />
+      <Path path={ETH_MARK_PATHS.lr} color="#4E5468" />
     </Canvas>
   );
 }
@@ -637,10 +654,79 @@ export default function FomoPerpsShowcase() {
     <View style={[styles.root, { paddingTop: insets.top }]}>
       <StatusBar style="light" />
 
-      {/* ── Header */}
+      <PerpsHeader onBack={() => router.back()} displayValue={displayValue} />
+
+      <PerpsChart
+        chartRef={chartRef}
+        data={data}
+        value={value}
+        chartMode={chartMode}
+        candleMode={candleMode}
+        displayCandles={displayCandles}
+        displayLive={displayLive}
+        interval={interval}
+        visibleWindow={visibleWindow}
+        markers={markers}
+        trendColor={trendColor}
+        onScrubAction={onScrubAction}
+        referenceLines={referenceLines}
+        onReferenceLinePress={setCancelIdx}
+        isScrubbing={isScrubbing}
+        displayValue={displayValue}
+      />
+
+      <PerpsControls
+        intervalId={intervalId}
+        range={range}
+        candleMode={candleMode}
+        onOpenIntervals={() => setIntervalSheet(true)}
+        onSelectRange={selectRange}
+        onToggleMode={() =>
+          setChartMode((mode) => (mode === "line" ? "candle" : "line"))
+        }
+      />
+
+      <HoldersPanel />
+
+      <TradeActions
+        bottomInset={insets.bottom}
+        onOpenMarketTicket={openMarketTicket}
+      />
+
+      <IntervalSheet
+        visible={intervalSheet}
+        intervalId={intervalId}
+        onSelect={setIntervalId}
+        onClose={() => setIntervalSheet(false)}
+      />
+      <OrderTicketSheet
+        ticket={ticket}
+        sizeChip={sizeChip}
+        onSize={setSizeChip}
+        onConfirm={confirmTicket}
+        onClose={() => setTicket(null)}
+      />
+      <CancelOrderDialog
+        order={cancelTarget}
+        onCancelOrder={cancelOrder}
+        onClose={() => setCancelIdx(null)}
+      />
+    </View>
+  );
+}
+
+function PerpsHeader({
+  onBack,
+  displayValue,
+}: {
+  onBack: () => void;
+  displayValue: SharedValue<number>;
+}) {
+  return (
+    <>
       <View style={styles.header}>
         <Pressable
-          onPress={() => router.back()}
+          onPress={onBack}
           hitSlop={12}
           style={styles.backButton}
           accessibilityRole="button"
@@ -649,7 +735,7 @@ export default function FomoPerpsShowcase() {
           <Ionicons name="chevron-back" size={26} color={C.white} />
         </Pressable>
         <View style={styles.ethDisc}>
-          <EthMark size={22} />
+          <EthMark />
         </View>
         <View style={styles.headerTitle}>
           <View style={styles.headerTitleRow}>
@@ -666,7 +752,6 @@ export default function FomoPerpsShowcase() {
         </View>
       </View>
 
-      {/* ── Price block: live readout (left) + open interest (right) */}
       <View style={styles.priceBlock}>
         <PriceReadout value={displayValue} />
         <View style={styles.oiBlock}>
@@ -677,354 +762,434 @@ export default function FomoPerpsShowcase() {
           <Text style={styles.oiLabel}>Open interest</Text>
         </View>
       </View>
+    </>
+  );
+}
 
-      {/* ── Hero chart */}
-      <View style={styles.chartWrap}>
-        <LiveChart
-          ref={chartRef}
-          data={data}
-          value={value}
-          style={styles.chartCanvas}
-          theme="dark"
-          // JetBrains Mono (regular): a monospace face → fixed-width / tabular
-          // figures, so the live badge + axis prices don't jitter as digits tick.
-          // Also avoids the chart-default medium (500) weight that read as semibold.
-          font={{ typeface: JetBrainsMono_400Regular }}
-          mode={chartMode}
-          candles={candleMode ? displayCandles : undefined}
-          liveCandle={candleMode ? displayLive : undefined}
-          candleWidth={interval.candleWidthSecs}
-          timeWindow={visibleWindow}
-          // Trade tape: co-located buy/sell bursts piled into vertical COLUMNS that
-          // stack UP off the candles (color = buy/sell) — see the Markers guide's
-          // vertical-stacking direction.
-          markers={markers}
-          markerCluster={{ direction: "vertical", overlap: 0.6, maxBeforeGroup: 12 }}
-          // Stable green accent in candle mode (bodies carry the up/down color);
-          // trend-flipping green/red for the line + its badge/dot.
-          accentColor={candleMode ? C.green : trendColor}
-          line={{ color: trendColor, width: 2 }}
-          gradient={{ topOpacity: 0.18, bottomOpacity: 0 }}
-          // Live-dot pulse ring at half the default radius (20 → 10).
-          pulse={{ maxRadius: 10 }}
-          // Pull the value pill in toward the live dot — the gap is the dot→badge
-          // `dotGap` (default 12), not the pulse, so the badge widens left to nearly
-          // meet the dot. (The badge stays flush-right; only its left edge moves.)
-          metrics={{ badge: { dotGap: 4 } }}
-          // Brand candle colors.
-          palette={{
-            candleUp: C.green,
-            candleDown: C.red,
-            wickUp: C.green,
-            wickDown: C.red,
-          }}
-          // Dark-grey volume band below the candles (candle mode only).
-          volume={
-            candleMode
-              ? {
-                  upColor: C.volUp,
-                  downColor: C.volDown,
-                  maxHeight: 26,
-                  radius: 1,
-                  opacity: 1,
-                }
-              : false
+function PerpsChart({
+  chartRef,
+  data,
+  value,
+  chartMode,
+  candleMode,
+  displayCandles,
+  displayLive,
+  interval,
+  visibleWindow,
+  markers,
+  trendColor,
+  onScrubAction,
+  referenceLines,
+  onReferenceLinePress,
+  isScrubbing,
+  displayValue,
+}: {
+  chartRef: RefObject<LiveChartHandle | null>;
+  data: SharedValue<LiveChartPoint[]>;
+  value: SharedValue<number>;
+  chartMode: "line" | "candle";
+  candleMode: boolean;
+  displayCandles: SharedValue<CandlePoint[]>;
+  displayLive: SharedValue<CandlePoint | null>;
+  interval: Interval;
+  visibleWindow: number;
+  markers: SharedValue<Marker[]>;
+  trendColor: string;
+  onScrubAction: (point: ScrubActionPoint) => void;
+  referenceLines: ReferenceLine[];
+  onReferenceLinePress: (index: number) => void;
+  isScrubbing: SharedValue<boolean>;
+  displayValue: SharedValue<number>;
+}) {
+  return (
+    <View style={styles.chartWrap}>
+      <LiveChart
+        ref={chartRef}
+        data={data}
+        value={value}
+        style={styles.chartCanvas}
+        theme="dark"
+        // JetBrains Mono keeps the live badge and axis prices from jittering.
+        font={{ typeface: JetBrainsMono_400Regular }}
+        mode={chartMode}
+        candles={candleMode ? displayCandles : undefined}
+        liveCandle={candleMode ? displayLive : undefined}
+        candleWidth={interval.candleWidthSecs}
+        timeWindow={visibleWindow}
+        markers={markers}
+        markerCluster={{
+          direction: "vertical",
+          overlap: 0.6,
+          maxBeforeGroup: 12,
+        }}
+        accentColor={candleMode ? C.green : trendColor}
+        line={{ color: trendColor, width: 2 }}
+        gradient={{ topOpacity: 0.18, bottomOpacity: 0 }}
+        pulse={{ maxRadius: 10 }}
+        metrics={{ badge: { dotGap: 4 } }}
+        palette={{
+          candleUp: C.green,
+          candleDown: C.red,
+          wickUp: C.green,
+          wickDown: C.red,
+        }}
+        volume={
+          candleMode
+            ? {
+                upColor: C.volUp,
+                downColor: C.volDown,
+                maxHeight: 26,
+                radius: 1,
+                opacity: 1,
+              }
+            : false
+        }
+        formatValue={formatUsd}
+        valueLine={{ intervals: [2, 4], strokeWidth: 1.5, color: trendColor }}
+        badge={{ followViewEdge: true, tail: false, radius: 1 }}
+        renderTooltip={PerpsTooltip}
+        scrub={{ tooltipPlacement: "top", dimOpacity: 1 }}
+        timeScroll={{ gesture: "holdToScrub", scrubHoldMs: 450 }}
+        zoom
+        scrubAction={{
+          icon: "+",
+          snap: 0.5,
+          text: true,
+          dismissOnAction: true,
+        }}
+        onScrubAction={onScrubAction}
+        referenceLines={referenceLines}
+        onReferenceLinePress={(_line, index) => onReferenceLinePress(index)}
+        onScrub={(point: ScrubPoint | null) => {
+          "worklet";
+          if (point === null) {
+            isScrubbing.set(false);
+            displayValue.set(value.get());
+            return;
           }
-          formatValue={formatUsd}
-          // Fine dotted live-price rail (matches the reference's dotted line, not
-          // the chart's default [4,4] dashes).
-          valueLine={{ intervals: [2, 4], strokeWidth: 1.5, color: trendColor }}
-          // Let the layout auto-size the right gutter (price labels + live badge)
-          // and the bottom (x-axis + volume band) — pinning insets.right/bottom
-          // here would collapse the gutter (clipping) and overlap the volume band.
-          // Rectangular pill, no pointer tail (matches the reference); tracks the
-          // last visible price as you scroll back.
-          badge={{ followViewEdge: true, tail: false, radius: 1 }}
-          renderTooltip={PerpsTooltip}
-          scrub={{ tooltipPlacement: "top", dimOpacity: 1 }}
-          // One-finger drag pans history; press-and-hold to scrub; two-finger
-          // pinch zooms the window. All coexist with the order-ticket reticle.
-          timeScroll={{ gesture: "holdToScrub", scrubHoldMs: 450 }}
-          zoom
-          // dismissOnAction: clear the reticle once the order is placed via the
-          // badge, so no crosshair lingers after the ticket opens.
-          scrubAction={{ icon: "+", snap: 0.5, text: true, dismissOnAction: true }}
-          onScrubAction={onScrubAction}
-          referenceLines={referenceLines}
-          onReferenceLinePress={(_line, index) => setCancelIdx(index)}
-          onScrub={(point: ScrubPoint | null) => {
-            "worklet";
-            if (point === null) {
-              isScrubbing.set(false);
-              displayValue.set(value.get());
-              return;
-            }
-            isScrubbing.set(true);
-            displayValue.set(point.value);
-          }}
-        />
-      </View>
-
-      {/* ── Controls: candle-interval button · range pills · type toggle */}
-      <View style={styles.controls}>
-        {/* Interval button shows in both modes (it also sets the line window). */}
-        <Pressable
-          onPress={() => setIntervalSheet(true)}
-          hitSlop={8}
-          style={styles.intervalBtn}
-          accessibilityRole="button"
-          accessibilityLabel="Candle intervals"
-        >
-          <CandleGlyph tint={C.red} />
-          <Text style={styles.intervalText}>{intervalId}</Text>
-          <Ionicons name="chevron-expand" size={14} color={C.muted} />
-        </Pressable>
-
-        <View style={styles.rangeRow}>
-          {RANGES.map((r) => {
-            const active = r === range;
-            return (
-              <Pressable
-                key={r}
-                onPress={() => selectRange(r)}
-                hitSlop={6}
-                style={[styles.rangeChip, active && styles.rangeChipActive]}
-              >
-                <Text
-                  style={[styles.rangeText, active && styles.rangeTextActive]}
-                >
-                  {r}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-
-        <View style={styles.controlsDivider} />
-        <Pressable
-          onPress={() =>
-            setChartMode((m) => (m === "line" ? "candle" : "line"))
-          }
-          hitSlop={10}
-          style={styles.typeBtn}
-          accessibilityRole="button"
-          accessibilityLabel={
-            candleMode ? "Switch to line chart" : "Switch to candlestick chart"
-          }
-        >
-          {candleMode ? (
-            <Ionicons name="pulse" size={20} color={C.green} />
-          ) : (
-            <CandleGlyph tint={C.red} />
-          )}
-        </Pressable>
-      </View>
-
-      {/* ── Scrolling lower content (tabs + holders) so the screen never overflows */}
-      <ScrollView
-        style={styles.lower}
-        contentContainerStyle={styles.lowerContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <View style={styles.tabs}>
-          <View style={[styles.tab, styles.tabActive]}>
-            <Text style={styles.tabActiveText}>Holders</Text>
-          </View>
-          <View style={styles.tab}>
-            <Text style={styles.tabText}>About</Text>
-          </View>
-        </View>
-
-        <View style={styles.filterRow}>
-          <Text style={styles.filterLabel}>Friends only</Text>
-          <View style={styles.toggleTrack}>
-            <View style={styles.toggleKnob} />
-          </View>
-          <View style={{ flex: 1 }} />
-          <Text style={styles.filterMuted}>Leveraged size</Text>
-          <Ionicons
-            name="information-circle-outline"
-            size={15}
-            color={C.faint}
-          />
-        </View>
-
-        <HolderRow
-          initial="0"
-          avatar="#2B2230"
-          name="0xnobi"
-          lev="3×"
-          side="Long"
-          entry="$1,796.00"
-          value="$5,832.16"
-          pnl={-175.65}
-        />
-        <HolderRow
-          initial="f"
-          avatar="#23303A"
-          name="faeklbby"
-          lev="25×"
-          side="Long"
-          entry="$1,674.08"
-          value="$4,080.23"
-          pnl={160.96}
-        />
-        <HolderRow
-          initial="C"
-          avatar="#3A2433"
-          name="ColdObedientPerch"
-          lev="13×"
-          side="Short"
-          entry="$1,710.60"
-          value="$666.80"
-          pnl={-13.33}
-        />
-      </ScrollView>
-
-      {/* ── Short / Long CTAs → market order ticket */}
-      <View style={[styles.cta, { paddingBottom: insets.bottom + 12 }]}>
-        <Pressable
-          style={[styles.ctaBtn, { backgroundColor: C.red }]}
-          onPress={() => openMarketTicket("short")}
-          accessibilityRole="button"
-          accessibilityLabel="Short ETH"
-        >
-          <Text style={styles.ctaText}>Short</Text>
-        </Pressable>
-        <Pressable
-          style={[styles.ctaBtn, { backgroundColor: C.green }]}
-          onPress={() => openMarketTicket("long")}
-          accessibilityRole="button"
-          accessibilityLabel="Long ETH"
-        >
-          <Text style={styles.ctaText}>Long</Text>
-        </Pressable>
-      </View>
-
-      {/* ── Candle intervals bottom sheet */}
-      <Modal
-        visible={intervalSheet}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setIntervalSheet(false)}
-      >
-        <Pressable
-          style={styles.backdrop}
-          onPress={() => setIntervalSheet(false)}
-        >
-          <AnimatedPressable
-            style={styles.sheet}
-            entering={SlideInDown.duration(260)}
-          >
-            <View style={styles.sheetHandle} />
-            <Text style={styles.sheetTitle}>Candle intervals</Text>
-            <Text style={styles.sheetSub}>
-              Choose the time period represented by each candle on the chart.
-            </Text>
-            {INTERVAL_GROUPS.map((group) => (
-              <View key={group} style={styles.intervalGroup}>
-                <Text style={styles.intervalGroupLabel}>{group}</Text>
-                <View style={styles.intervalGrid}>
-                  {INTERVALS.filter((i) => i.group === group).map((i) => {
-                    const active = i.id === intervalId;
-                    return (
-                      <Pressable
-                        key={i.id}
-                        style={[
-                          styles.intervalCell,
-                          active && styles.intervalCellActive,
-                        ]}
-                        onPress={() => {
-                          setIntervalId(i.id);
-                          setIntervalSheet(false);
-                        }}
-                      >
-                        <Text
-                          style={[
-                            styles.intervalCellText,
-                            active && styles.intervalCellTextActive,
-                          ]}
-                        >
-                          {i.id}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-              </View>
-            ))}
-            <Pressable
-              style={styles.sheetClose}
-              onPress={() => setIntervalSheet(false)}
-            >
-              <Text style={styles.sheetCloseText}>Close</Text>
-            </Pressable>
-          </AnimatedPressable>
-        </Pressable>
-      </Modal>
-
-      {/* ── Order ticket sheet (market via CTA, limit via chart reticle) */}
-      <Modal
-        visible={ticket !== null}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setTicket(null)}
-      >
-        <Pressable style={styles.backdrop} onPress={() => setTicket(null)}>
-          <AnimatedPressable
-            style={styles.sheet}
-            entering={SlideInDown.duration(260)}
-          >
-            <View style={styles.sheetHandle} />
-            {ticket ? (
-              <OrderTicketBody
-                ticket={ticket}
-                sizeChip={sizeChip}
-                onSize={setSizeChip}
-                onConfirm={confirmTicket}
-                onCancel={() => setTicket(null)}
-              />
-            ) : null}
-          </AnimatedPressable>
-        </Pressable>
-      </Modal>
-
-      {/* ── Cancel working-order sheet (tap an order's badge) */}
-      <Modal
-        visible={cancelTarget !== undefined}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setCancelIdx(null)}
-      >
-        <Pressable
-          style={styles.centerBackdrop}
-          onPress={() => setCancelIdx(null)}
-        >
-          <Pressable style={styles.dialog}>
-            <Text style={styles.dialogTitle}>
-              Cancel {cancelTarget?.side === "long" ? "long" : "short"} limit?
-            </Text>
-            <Text style={styles.dialogSub}>
-              @ {cancelTarget ? USD.format(cancelTarget.price) : ""}
-            </Text>
-            <View style={styles.dialogRow}>
-              <Pressable
-                style={[styles.dialogBtn, styles.dialogKeep]}
-                onPress={() => setCancelIdx(null)}
-              >
-                <Text style={styles.dialogKeepText}>Keep</Text>
-              </Pressable>
-              <Pressable
-                style={[styles.dialogBtn, { backgroundColor: C.red }]}
-                onPress={cancelOrder}
-              >
-                <Text style={styles.dialogConfirmText}>Cancel order</Text>
-              </Pressable>
-            </View>
-          </Pressable>
-        </Pressable>
-      </Modal>
+          isScrubbing.set(true);
+          displayValue.set(point.value);
+        }}
+      />
     </View>
+  );
+}
+
+function PerpsControls({
+  intervalId,
+  range,
+  candleMode,
+  onOpenIntervals,
+  onSelectRange,
+  onToggleMode,
+}: {
+  intervalId: IntervalId;
+  range: (typeof RANGES)[number];
+  candleMode: boolean;
+  onOpenIntervals: () => void;
+  onSelectRange: (range: (typeof RANGES)[number]) => void;
+  onToggleMode: () => void;
+}) {
+  return (
+    <View style={styles.controls}>
+      <Pressable
+        onPress={onOpenIntervals}
+        hitSlop={8}
+        style={styles.intervalBtn}
+        accessibilityRole="button"
+        accessibilityLabel="Candle intervals"
+      >
+        <CandleGlyph tint={C.red} />
+        <Text style={styles.intervalText}>{intervalId}</Text>
+        <Ionicons name="chevron-expand" size={14} color={C.muted} />
+      </Pressable>
+
+      <View style={styles.rangeRow}>
+        {RANGES.map((rangeOption) => {
+          const active = rangeOption === range;
+          return (
+            <Pressable
+              key={rangeOption}
+              onPress={() => onSelectRange(rangeOption)}
+              hitSlop={6}
+              style={[styles.rangeChip, active && styles.rangeChipActive]}
+            >
+              <Text
+                style={[styles.rangeText, active && styles.rangeTextActive]}
+              >
+                {rangeOption}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View style={styles.controlsDivider} />
+      <Pressable
+        onPress={onToggleMode}
+        hitSlop={10}
+        style={styles.typeBtn}
+        accessibilityRole="button"
+        accessibilityLabel={
+          candleMode ? "Switch to line chart" : "Switch to candlestick chart"
+        }
+      >
+        {candleMode ? (
+          <Ionicons name="pulse" size={20} color={C.green} />
+        ) : (
+          <CandleGlyph tint={C.red} />
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+function HoldersPanel() {
+  return (
+    <ScrollView
+      style={styles.lower}
+      contentContainerStyle={styles.lowerContent}
+      showsVerticalScrollIndicator={false}
+    >
+      <View style={styles.tabs}>
+        <View style={[styles.tab, styles.tabActive]}>
+          <Text style={styles.tabActiveText}>Holders</Text>
+        </View>
+        <View style={styles.tab}>
+          <Text style={styles.tabText}>About</Text>
+        </View>
+      </View>
+
+      <View style={styles.filterRow}>
+        <Text style={styles.filterLabel}>Friends only</Text>
+        <View style={styles.toggleTrack}>
+          <View style={styles.toggleKnob} />
+        </View>
+        <View style={{ flex: 1 }} />
+        <Text style={styles.filterMuted}>Leveraged size</Text>
+        <Ionicons name="information-circle-outline" size={15} color={C.faint} />
+      </View>
+
+      <HolderRow
+        initial="0"
+        avatar="#2B2230"
+        name="0xnobi"
+        lev="3×"
+        side="Long"
+        entry="$1,796.00"
+        value="$5,832.16"
+        pnl={-175.65}
+      />
+      <HolderRow
+        initial="f"
+        avatar="#23303A"
+        name="faeklbby"
+        lev="25×"
+        side="Long"
+        entry="$1,674.08"
+        value="$4,080.23"
+        pnl={160.96}
+      />
+      <HolderRow
+        initial="C"
+        avatar="#3A2433"
+        name="ColdObedientPerch"
+        lev="13×"
+        side="Short"
+        entry="$1,710.60"
+        value="$666.80"
+        pnl={-13.33}
+      />
+    </ScrollView>
+  );
+}
+
+function TradeActions({
+  bottomInset,
+  onOpenMarketTicket,
+}: {
+  bottomInset: number;
+  onOpenMarketTicket: (side: TicketSide) => void;
+}) {
+  return (
+    <View style={[styles.cta, { paddingBottom: bottomInset + 12 }]}>
+      <Pressable
+        style={[styles.ctaBtn, { backgroundColor: C.red }]}
+        onPress={() => onOpenMarketTicket("short")}
+        accessibilityRole="button"
+        accessibilityLabel="Short ETH"
+      >
+        <Text style={styles.ctaText}>Short</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.ctaBtn, { backgroundColor: C.green }]}
+        onPress={() => onOpenMarketTicket("long")}
+        accessibilityRole="button"
+        accessibilityLabel="Long ETH"
+      >
+        <Text style={styles.ctaText}>Long</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function IntervalSheet({
+  visible,
+  intervalId,
+  onSelect,
+  onClose,
+}: {
+  visible: boolean;
+  intervalId: IntervalId;
+  onSelect: (interval: IntervalId) => void;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose} accessible={false}>
+        <AnimatedPressable
+          style={styles.sheet}
+          entering={SlideInDown.duration(260)}
+          accessible={false}
+        >
+          <View style={styles.sheetHandle} />
+          <Text style={styles.sheetTitle}>Candle intervals</Text>
+          <Text style={styles.sheetSub}>
+            Choose the time period represented by each candle on the chart.
+          </Text>
+          {INTERVAL_GROUPS.map((group) => (
+            <View key={group} style={styles.intervalGroup}>
+              <Text style={styles.intervalGroupLabel}>{group}</Text>
+              <View style={styles.intervalGrid}>
+                {INTERVALS_BY_GROUP[group].map((interval) => {
+                  const active = interval.id === intervalId;
+                  return (
+                    <Pressable
+                      key={interval.id}
+                      style={[
+                        styles.intervalCell,
+                        active && styles.intervalCellActive,
+                      ]}
+                      onPress={() => {
+                        onSelect(interval.id);
+                        onClose();
+                      }}
+                    >
+                      <Text
+                        style={[
+                          styles.intervalCellText,
+                          active && styles.intervalCellTextActive,
+                        ]}
+                      >
+                        {interval.id}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+          ))}
+          <Pressable style={styles.sheetClose} onPress={onClose}>
+            <Text style={styles.sheetCloseText}>Close</Text>
+          </Pressable>
+        </AnimatedPressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function OrderTicketSheet({
+  ticket,
+  sizeChip,
+  onSize,
+  onConfirm,
+  onClose,
+}: {
+  ticket: Ticket | null;
+  sizeChip: (typeof SIZE_CHIPS)[number];
+  onSize: (size: (typeof SIZE_CHIPS)[number]) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      visible={ticket !== null}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose} accessible={false}>
+        <AnimatedPressable
+          style={styles.sheet}
+          entering={SlideInDown.duration(260)}
+          accessible={false}
+        >
+          <View style={styles.sheetHandle} />
+          {ticket ? (
+            <OrderTicketBody
+              ticket={ticket}
+              sizeChip={sizeChip}
+              onSize={onSize}
+              onConfirm={onConfirm}
+              onCancel={onClose}
+            />
+          ) : null}
+        </AnimatedPressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function CancelOrderDialog({
+  order,
+  onCancelOrder,
+  onClose,
+}: {
+  order: WorkingOrder | undefined;
+  onCancelOrder: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      visible={order !== undefined}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={styles.centerBackdrop}
+        onPress={onClose}
+        accessible={false}
+      >
+        <Pressable style={styles.dialog} accessible={false}>
+          <Text style={styles.dialogTitle}>
+            Cancel {order?.side === "long" ? "long" : "short"} limit?
+          </Text>
+          <Text style={styles.dialogSub}>
+            @ {order ? USD.format(order.price) : ""}
+          </Text>
+          <View style={styles.dialogRow}>
+            <Pressable
+              style={[styles.dialogBtn, styles.dialogKeep]}
+              onPress={onClose}
+            >
+              <Text style={styles.dialogKeepText}>Keep</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.dialogBtn, { backgroundColor: C.red }]}
+              onPress={onCancelOrder}
+            >
+              <Text style={styles.dialogConfirmText}>Cancel order</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
   );
 }
 

--- a/app/showcase/fomo-perps.tsx
+++ b/app/showcase/fomo-perps.tsx
@@ -3,7 +3,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Canvas, Path, Skia } from "@shopify/react-native-skia";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Modal,
   Pressable,
@@ -16,6 +16,7 @@ import {
 import {
   LiveChart,
   type CandlePoint,
+  type LiveChartHandle,
   type Marker,
   type ReferenceLine,
   type ScrubActionPoint,
@@ -429,6 +430,7 @@ const SIZE_CHIPS = ["0.1", "0.5", "1.0", "Max"] as const;
 export default function FomoPerpsShowcase() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const chartRef = useRef<LiveChartHandle>(null);
 
   const [chartMode, setChartMode] = useState<"line" | "candle">("candle");
   const [intervalId, setIntervalId] = useState<IntervalId>("15m");
@@ -438,12 +440,6 @@ export default function FomoPerpsShowcase() {
   const [sizeChip, setSizeChip] = useState<(typeof SIZE_CHIPS)[number]>("0.5");
   const [orders, setOrders] = useState<WorkingOrder[]>([]);
   const [cancelIdx, setCancelIdx] = useState<number | null>(null);
-  // Toggled 0↔1 on every range tap so `visibleWindow` changes by an (imperceptible)
-  // 1s even when re-tapping the ALREADY-active range. That forces the engine's
-  // timeWindow-change zoom reset to fire, so re-tapping the active pill zooms back
-  // out — React bails on a same-state `setRange`, so otherwise the tap is a no-op.
-  const [zoomBump, setZoomBump] = useState(0);
-
   const interval = INTERVALS.find((i) => i.id === intervalId) ?? INTERVALS[2];
   const candleMode = chartMode === "candle";
   // Candle interval sets granularity (candle width); the range pill scales how wide
@@ -451,17 +447,16 @@ export default function FomoPerpsShowcase() {
   // is bucketed — never the feed itself — so switching either keeps the price
   // continuous. Clamp the window so it always fits inside the fixed seeded history.
   const baseWindow = interval.candleWidthSecs * VISIBLE_CANDLES;
-  const visibleWindow =
-    Math.min(
-      Math.round(baseWindow * RANGE_FACTORS[range]),
-      FIXED_HISTORY_SECS - 600,
-    ) + zoomBump;
+  const visibleWindow = Math.min(
+    Math.round(baseWindow * RANGE_FACTORS[range]),
+    FIXED_HISTORY_SECS - 600,
+  );
 
-  // Range tap: select it AND flip `zoomBump`, so re-tapping the active range still
-  // changes `timeWindow` (by 1s) and resets any pinch-zoom — see `zoomBump`.
+  // A range tap also resets any focal-anchored pinch override. This matters when
+  // re-tapping the active pill, where React correctly skips the same-state update.
   const selectRange = (r: (typeof RANGES)[number]) => {
     setRange(r);
-    setZoomBump((b) => (b === 0 ? 1 : 0));
+    chartRef.current?.resetZoom();
   };
 
   // ONE fixed feed: fine base candles over a fixed span. Nothing here depends on the
@@ -686,6 +681,7 @@ export default function FomoPerpsShowcase() {
       {/* ── Hero chart */}
       <View style={styles.chartWrap}>
         <LiveChart
+          ref={chartRef}
           data={data}
           value={value}
           style={styles.chartCanvas}

--- a/docs/api-reference/livechart-series.mdx
+++ b/docs/api-reference/livechart-series.mdx
@@ -193,6 +193,11 @@ default off.
   [Time-scroll](/guides/time-scroll#pinch-to-zoom-zoom).
 </ParamField>
 
+Attach a `ref` typed as [`LiveChartHandle`](/api-reference/types#imperative-handle) and call
+`ref.current?.resetZoom()` to return the shared window to `timeWindow` and the live edge. This is
+the same imperative reset exposed by `LiveChart`. See
+[Time-scroll → Reset zoom from a button](/guides/time-scroll#reset-zoom-from-a-button).
+
 <ParamField body="onVisibleRangeChange" type="(range: VisibleRange) => void">
   Called as the visible window changes (~1 Hz) with `{ startSec, endSec,
   following }`. **@experimental.**

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -381,6 +381,14 @@ provided; everything else has a default.
   [Time-scroll](/guides/time-scroll#pinch-to-zoom-zoom).
 </ParamField>
 
+### Resetting pinch zoom
+
+Attach a `ref` typed as [`LiveChartHandle`](/api-reference/types#imperative-handle) and call
+`ref.current?.resetZoom()` from a button or any other outside event. It returns the visible width
+to `timeWindow`, clears the focal-point offset, and resumes following the live edge. The reset is
+scheduled on the UI thread and is safe when the chart is already reset. A paused chart remains
+paused. See [Time-scroll → Reset zoom from a button](/guides/time-scroll#reset-zoom-from-a-button).
+
 <ParamField body="onVisibleRangeChange" type="(range: VisibleRange) => void">
   Called as the visible window changes (throttled to ~1 Hz) with
   `{ startSec, endSec, following }`. Useful for paging a data source alongside

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -8,6 +8,7 @@ All types are exported from the package root:
 
 ```tsx
 import type {
+  LiveChartHandle,
   LiveChartPoint,
   ReferenceLine,
   SeriesConfig,
@@ -582,6 +583,21 @@ interface FontConfig {
   fontManager?: SkFontMgr | null;
 }
 ```
+
+## Imperative handle
+
+`LiveChart` and `LiveChartSeries` accept a ref with the same exported handle:
+
+```ts
+interface LiveChartHandle {
+  // Reset built-in pinch zoom to timeWindow and clear its focal offset so the
+  // chart follows the live edge again. Safe when already reset.
+  resetZoom(): void;
+}
+```
+
+Use `useRef<LiveChartHandle>(null)` and pass the ref to either chart. A paused chart remains paused.
+See [Time-scroll → Reset zoom from a button](/guides/time-scroll#reset-zoom-from-a-button).
 
 ## AxisLabelConfig
 

--- a/docs/guides/time-scroll.mdx
+++ b/docs/guides/time-scroll.mdx
@@ -137,6 +137,40 @@ Pass a `ZoomConfig` to set them explicitly:
 
 The Y-range auto-fits the visible window as you zoom, and candle bars re-flow to the new width.
 
+### Reset zoom from a button
+
+Both chart components expose a `resetZoom()` method through a
+[`LiveChartHandle`](/api-reference/types#imperative-handle). Call it from any outside event to
+clear the focal-anchored pinch window and return to the configured `timeWindow` at the live edge:
+
+```tsx
+import { useRef } from "react";
+import { Button } from "react-native";
+import { LiveChart, type LiveChartHandle } from "react-native-livechart";
+
+const chartRef = useRef<LiveChartHandle>(null);
+
+<Button title="Reset zoom" onPress={() => chartRef.current?.resetZoom()} />
+
+<LiveChart
+  ref={chartRef}
+  data={data}
+  value={value}
+  timeWindow={300}
+  timeScroll
+  zoom
+/>
+```
+
+The same handle works on `LiveChartSeries`. Resetting clears both state values changed by a
+focal pinch: the overridden window width and its shifted right edge. That means the chart resumes
+following live data instead of staying parked at the pinch anchor while its width returns to
+normal. Calling it again is a safe no-op. A paused chart remains paused, and the displayed width
+uses the chart's normal `smoothing` as it settles back to `timeWindow`.
+
+The example app's **Time scroll** screen includes a **Reset zoom** button and a live visible-window
+readout so the behavior can be exercised directly.
+
 ## Paging callbacks (`onVisibleRangeChange`, `onReachStart`)
 
 To lazily page in history as the user scrolls/zooms back, two callbacks report the visible window:

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -11,7 +19,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from "react-native-reanimated";
-import { scheduleOnRN } from "react-native-worklets";
+import { scheduleOnRN, scheduleOnUI } from "react-native-worklets";
 
 /**
  * Single-series live chart. UX and prop vocabulary parallel Benji Taylor’s
@@ -94,7 +102,7 @@ import { useReferenceLinePress } from "../hooks/useReferenceLinePress";
 import { useModeBlend } from "../hooks/useModeBlend";
 import { resolveMomentumProp, useMomentum } from "../hooks/useMomentum";
 import { AXIS_GRAB_MIN_PX, usePanScroll } from "../hooks/usePanScroll";
-import { usePinchZoom } from "../hooks/usePinchZoom";
+import { resetPinchZoom, usePinchZoom } from "../hooks/usePinchZoom";
 import {
   SERIES_INDICATOR_FADE_MS,
   useSeriesIndicatorOpacity,
@@ -134,6 +142,7 @@ import {
 } from "../theme";
 import type {
   CandlePoint,
+  LiveChartHandle,
   LiveChartPalette,
   LiveChartPoint,
   LiveChartProps,
@@ -2912,13 +2921,23 @@ function ChartView({
   );
 }
 
-export function LiveChart(props: LiveChartProps) {
-  const model = useLiveChartController(props);
-  if (model.yAxisCfg) {
-    return <ChartWithYAxis model={model} />;
-  }
-  if (model.degenCfg) {
-    return <ChartWithDegen model={model} yAxisEntries={null} />;
-  }
-  return <ChartView model={model} yAxisEntries={null} degen={null} />;
-}
+export const LiveChart = forwardRef<LiveChartHandle, LiveChartProps>(
+  function LiveChart(props, ref) {
+    const model = useLiveChartController(props);
+    const { viewEnd, viewWindow } = model.engine;
+    useImperativeHandle(
+      ref,
+      () => ({
+        resetZoom: () => scheduleOnUI(resetPinchZoom, { viewEnd, viewWindow }),
+      }),
+      [viewEnd, viewWindow],
+    );
+    if (model.yAxisCfg) {
+      return <ChartWithYAxis model={model} />;
+    }
+    if (model.degenCfg) {
+      return <ChartWithDegen model={model} yAxisEntries={null} />;
+    }
+    return <ChartView model={model} yAxisEntries={null} degen={null} />;
+  },
+);

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -5,7 +5,12 @@
  * @see https://github.com/benjitaylor/liveline
  */
 import { Canvas, Group, Rect } from "@shopify/react-native-skia";
-import { useLayoutEffect, useState } from "react";
+import {
+  forwardRef,
+  useImperativeHandle,
+  useLayoutEffect,
+  useState,
+} from "react";
 import { StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -16,7 +21,7 @@ import Animated, {
   withTiming,
   type SharedValue,
 } from "react-native-reanimated";
-import { scheduleOnRN } from "react-native-worklets";
+import { scheduleOnRN, scheduleOnUI } from "react-native-worklets";
 import {
   DEFAULT_ACCENT_COLOR,
   HOLD_TO_SCRUB_MS,
@@ -62,7 +67,7 @@ import { useMarkers } from "../hooks/useMarkers";
 import { useMultiSeriesDegen } from "../hooks/useMultiSeriesDegen";
 import { useMultiSeriesLinePaths } from "../hooks/useMultiSeriesLinePaths";
 import { usePanScroll } from "../hooks/usePanScroll";
-import { usePinchZoom } from "../hooks/usePinchZoom";
+import { resetPinchZoom, usePinchZoom } from "../hooks/usePinchZoom";
 import { useMultiSeriesReverseMorphInputs } from "../hooks/useReverseMorphEngineInputs";
 import {
   SERIES_INDICATOR_FADE_MS,
@@ -86,7 +91,12 @@ import {
   leftEdgeFadeColorsFromBgRgb,
   resolveTheme,
 } from "../theme";
-import type { LiveChartSeriesProps, Marker, SeriesConfig } from "../types";
+import type {
+  LiveChartHandle,
+  LiveChartSeriesProps,
+  Marker,
+  SeriesConfig,
+} from "../types";
 import { AxisLabelOverlay } from "./AxisLabelOverlay";
 import { ChartOverlayLayer } from "./ChartOverlayLayer";
 import {
@@ -1027,8 +1037,19 @@ function SeriesTooltipLayer({
   );
 }
 
-export function LiveChartSeries(props: LiveChartSeriesProps) {
+export const LiveChartSeries = forwardRef<
+  LiveChartHandle,
+  LiveChartSeriesProps
+>(function LiveChartSeries(props, ref) {
   const model = useLiveChartSeriesController(props);
+  const { viewEnd, viewWindow } = model.engine;
+  useImperativeHandle(
+    ref,
+    () => ({
+      resetZoom: () => scheduleOnUI(resetPinchZoom, { viewEnd, viewWindow }),
+    }),
+    [viewEnd, viewWindow],
+  );
   const {
     rootGesture,
     backgroundColor,
@@ -1274,4 +1295,4 @@ export function LiveChartSeries(props: LiveChartSeriesProps) {
       {legendCfg.position === "bottom" ? legend : null}
     </View>
   );
-}
+});

--- a/packages/react-native-livechart/src/hooks/usePinchZoom.ts
+++ b/packages/react-native-livechart/src/hooks/usePinchZoom.ts
@@ -26,6 +26,27 @@ export interface PinchZoomEngineRefs {
   canvasWidth: SharedValue<number>;
 }
 
+/** The pinch state cleared by the public chart handle's `resetZoom()` method. */
+export type PinchZoomResetRefs = Pick<
+  PinchZoomEngineRefs,
+  "viewWindow" | "viewEnd"
+>;
+
+/**
+ * Clear the focal-anchored pinch overrides so the engine follows its configured
+ * `timeWindow` and live edge again. Safe to call when the chart is already reset.
+ */
+export function resetPinchZoom({
+  viewWindow,
+  viewEnd,
+}: PinchZoomResetRefs): void {
+  "worklet";
+  cancelAnimation(viewWindow);
+  cancelAnimation(viewEnd);
+  viewWindow.set(null);
+  viewEnd.set(null);
+}
+
 export interface UsePinchZoomOptions {
   engine: PinchZoomEngineRefs;
   padding: ChartPadding;

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -61,6 +61,7 @@ export type {
   LegendStyle,
   LineConfig,
   LiveChartCoreProps,
+  LiveChartHandle,
   LiveChartMetrics,
   LiveChartMetricsOverride,
   LiveChartPalette,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -1951,6 +1951,22 @@ export interface ZoomConfig {
   maxTimeWindow?: number;
 }
 
+/** Imperative methods exposed by `LiveChart` and `LiveChartSeries`. */
+export interface LiveChartHandle {
+  /**
+   * Reset built-in pinch/time-window zoom to the configured `timeWindow` and
+   * clear the focal-point offset so the chart follows the live edge again.
+   * Safe to call when already reset. A paused chart remains paused.
+   *
+   * ```tsx
+   * const chartRef = useRef<LiveChartHandle>(null);
+   * <Button title="Reset zoom" onPress={() => chartRef.current?.resetZoom()} />
+   * <LiveChart ref={chartRef} data={data} value={value} zoom />
+   * ```
+   */
+  resetZoom(): void;
+}
+
 /**
  * The visible time range reported by {@link LiveChartCoreProps.onVisibleRangeChange}.
  *

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -14,6 +14,7 @@ import * as xAxisHooks from "../src/hooks/useXAxis";
 import * as yAxisHooks from "../src/hooks/useYAxis";
 import type {
   CandlePoint,
+  LiveChartHandle,
   LiveChartPoint,
   LiveChartProps,
   Marker,
@@ -162,6 +163,18 @@ async function layoutFirst(screen: Awaited<ReturnType<typeof render>>) {
 }
 
 describe("LiveChart", () => {
+  it("exposes an imperative pinch-zoom reset", async () => {
+    const ref = React.createRef<LiveChartHandle>();
+    function RefHarness() {
+      const data = useSharedValue([{ time: 1700000000, value: 50 }]);
+      const value = useSharedValue(50);
+      return <LiveChart ref={ref} data={data} value={value} zoom />;
+    }
+
+    await render(<RefHarness />);
+    expect(ref.current?.resetZoom).toBeInstanceOf(Function);
+  });
+
   it("renders with defaults", async () => {
     const screen = await render(<Harness />);
     const views = getAllByHostType(screen, View);

--- a/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChartSeries.test.tsx
@@ -5,10 +5,33 @@ import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 import { LiveChartSeries } from "../src/components/LiveChartSeries";
-import type { ChartOverlayContext, SeriesConfig } from "../src/types";
+import type {
+  ChartOverlayContext,
+  LiveChartHandle,
+  SeriesConfig,
+} from "../src/types";
 import { getAllByHostType } from "./rntl14";
 
 describe("LiveChartSeries", () => {
+  it("exposes an imperative pinch-zoom reset", async () => {
+    const ref = React.createRef<LiveChartHandle>();
+    function H() {
+      const series = useSharedValue<SeriesConfig[]>([
+        {
+          id: "a",
+          label: "A",
+          data: [{ time: 1_700_000_000, value: 10 }],
+          value: 10,
+          color: "#3b82f6",
+        },
+      ]);
+      return <LiveChartSeries ref={ref} series={series} zoom />;
+    }
+
+    await render(<H />);
+    expect(ref.current?.resetZoom).toBeInstanceOf(Function);
+  });
+
   it("opts into an opaque canvas and replaces destination-alpha masks", async () => {
     const initial: SeriesConfig[] = [
       {

--- a/packages/react-native-livechart/tests/hooks/usePinchZoom.test.ts
+++ b/packages/react-native-livechart/tests/hooks/usePinchZoom.test.ts
@@ -1,9 +1,39 @@
+import type { SharedValue } from "react-native-reanimated";
+
 import {
   clampWindow,
   focalTime,
+  resetPinchZoom,
   zoomViewEnd,
   zoomWindowBounds,
 } from "../../src/hooks/usePinchZoom";
+
+describe("resetPinchZoom", () => {
+  const mutable = (initial: number | null) => {
+    const shared = {
+      value: initial,
+      set(next: number | null) {
+        shared.value = next;
+      },
+    };
+    return shared as unknown as SharedValue<number | null>;
+  };
+
+  it("clears both pinch overrides and is idempotent", () => {
+    const state = {
+      viewWindow: mutable(45),
+      viewEnd: mutable(1_700_000_000),
+    };
+
+    resetPinchZoom(state);
+    expect(state.viewWindow.value).toBeNull();
+    expect(state.viewEnd.value).toBeNull();
+
+    resetPinchZoom(state);
+    expect(state.viewWindow.value).toBeNull();
+    expect(state.viewEnd.value).toBeNull();
+  });
+});
 
 describe("clampWindow", () => {
   it("passes a value already in range through", () => {


### PR DESCRIPTION
## Summary

- expose a shared `LiveChartHandle.resetZoom()` ref API from both `LiveChart` and `LiveChartSeries`
- reset pinch-window and focal-offset overrides on the UI thread, restoring the configured `timeWindow` and live-edge following
- add a Reset zoom control and visible-window readout to the Time scroll example
- replace the Fomo showcase's one-second reset workaround with the public API
- document the API and add unit/component coverage
- resolve React Doctor findings in the changed examples by removing an unused route export, moving static Skia path construction out of render, splitting Fomo Perps into focused components, and pre-grouping interval options
- keep sheet controls individually accessible by preventing backdrop containers from merging their descendants

## Why

Built-in pinch zoom stored its effective time window and focal anchor inside the chart engine, so an outside event such as a button could not restore the configured view. The imperative handle provides that missing bridge while keeping the actual reset on the UI thread.

## QA

- `npm run verify` passed
- pre-commit test suite: 105 suites passed; 1,591 passed and 5 skipped
- focused reset tests: 115 passed
- React Doctor 0.9.12: 100/100, zero diagnostics across the full PR diff and affected-file scan, with no React Doctor checks skipped and no ignores or suppressions added
- agent-device on iPhone 17 Pro: pinched the Time scroll example from a 300s window to 167s, pressed Reset zoom, and verified it returned to 300s with live-edge following restored
- agent-device on iPhone 17 Pro: verified Fomo Perps cold launch, interval sheet, 1m selection, chart mode toggle, and individually accessible modal controls
