### PR TITLE
feat: add custom threshold badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Custom threshold badges.** `LiveChart.renderThresholdBadge` replaces the
+  built-in Skia threshold pill with any React Native element while the chart
+  continues to position it from the live threshold value on the UI thread. Its
+  `ThresholdBadgeRenderProps` expose the live value, formatted value, Y position,
+  visibility, and resolved line config; returning `null` preserves the built-in
+  badge, and the dashed marker line remains native.
 - **Configurable threshold series badge anchor.**
   `threshold.line.labelAnchor` independently chooses whether a time-varying
   threshold badge takes its Y position and optional value from the visible
@@ -16,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `labelPosition` continues to control the badge's horizontal side. The default
   remains `"last"` for backward compatibility. Resolves
   [#292](https://github.com/brandtnewlabs/react-native-livechart/issues/292).
-- **Semantic candle gaps.** `LiveChart.candleGaps` distinguishes known no-trade,
 - **Semantic candle gaps.** `LiveChart.candleGaps` distinguishes known no-trade,
   trading-unavailable, and unknown-data intervals without inserting synthetic
   OHLC records. No-trade and downtime gaps can draw neutral previous-close marks;

--- a/app/demo/threshold.tsx
+++ b/app/demo/threshold.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from "react";
-import { useSharedValue } from "react-native-reanimated";
-import { LiveChart, type LiveChartPoint } from "react-native-livechart";
+import { StyleSheet, Text, TextInput, View } from "react-native";
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+} from "react-native-reanimated";
+import {
+  LiveChart,
+  type LiveChartPoint,
+  type ThresholdBadgeRenderProps,
+} from "react-native-livechart";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
@@ -8,6 +16,8 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 
 export const options = { title: "Threshold split" };
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 const CENTER = 100;
 
@@ -19,6 +29,31 @@ const ENTRY_LEVELS: Record<EntryLevel, number> = {
   high: CENTER * 1.03,
   low: CENTER * 0.97,
 };
+
+/**
+ * A realistic custom threshold badge: a brokerage-style average-cost tag with
+ * an icon, distinct chrome, and a UI-thread value readout. The chart owns its
+ * position; this component owns only the contents and visual treatment.
+ */
+function AverageCostBadge({ valueStr }: ThresholdBadgeRenderProps) {
+  const animatedProps = useAnimatedProps(() => {
+    const text = valueStr.get();
+    return { text, defaultValue: text };
+  });
+  return (
+    <View style={styles.averageCostBadge}>
+      <View style={styles.averageCostIcon}>
+        <Text style={styles.averageCostIconText}>B/E</Text>
+      </View>
+      <AnimatedTextInput
+        editable={false}
+        underlineColorAndroid="transparent"
+        style={styles.averageCostValue}
+        animatedProps={animatedProps}
+      />
+    </View>
+  );
+}
 
 /**
  * Smooth, bounded, quasi-random price as a function of time (seconds): a few
@@ -65,7 +100,8 @@ function useSmoothPriceFeed() {
       value.set(v);
       // Commit a point every 3rd tick (~10Hz, matching the seed density) so the
       // 1000-point cap keeps ~100s of history instead of eroding to ~33s.
-      if (++tick % 3 !== 0) return;
+      tick += 1;
+      if (tick % 3 !== 0) return;
       const point: LiveChartPoint = { time: now, value: v };
       // Append IN PLACE on the UI thread (only `point` crosses the bridge) — never
       // re-clone the growing array JS→UI, matching the sim's hot path so the line
@@ -115,6 +151,8 @@ export default function ThresholdScreen() {
   const [showValue, setShowValue] = useState(true);
   const [labelSide, setLabelSide] = useState<"left" | "right">("left");
   const [labelAnchor, setLabelAnchor] = useState<"first" | "last">("last");
+  const [badgeRenderer, setBadgeRenderer] =
+    useState<"built-in" | "custom">("built-in");
   const [colorMode, setColorMode] = useState<"default" | "custom">("default");
   const [entry, setEntry] = useState<EntryLevel>("start");
 
@@ -184,6 +222,11 @@ export default function ThresholdScreen() {
                 : true
               : false,
           }}
+          renderThresholdBadge={
+            badgeRenderer === "custom"
+              ? (ctx) => <AverageCostBadge {...ctx} />
+              : undefined
+          }
           scrub={false}
         />
       }
@@ -246,6 +289,16 @@ export default function ThresholdScreen() {
       )}
 
       <ChipRow
+        label="Badge renderer"
+        options={[
+          { value: "built-in", label: "Built-in" },
+          { value: "custom", label: "Custom RN" },
+        ]}
+        value={badgeRenderer}
+        onChange={setBadgeRenderer}
+      />
+
+      <ChipRow
         label="Colors"
         options={[
           { value: "default", label: "Green / Red" },
@@ -280,3 +333,43 @@ export default function ThresholdScreen() {
     </DemoScreen>
   );
 }
+
+const styles = StyleSheet.create({
+  averageCostBadge: {
+    height: 30,
+    paddingHorizontal: 5,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#2dd4bf",
+    backgroundColor: "#0f172a",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    shadowColor: "#000",
+    shadowOpacity: 0.28,
+    shadowRadius: 5,
+    shadowOffset: { width: 0, height: 2 },
+  },
+  averageCostIcon: {
+    minWidth: 27,
+    height: 20,
+    borderRadius: 5,
+    backgroundColor: "#2dd4bf",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  averageCostIconText: {
+    color: "#042f2e",
+    fontSize: 9,
+    fontWeight: "800",
+  },
+  averageCostValue: {
+    width: 58,
+    height: 24,
+    padding: 0,
+    color: "#f8fafc",
+    fontSize: 12,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -304,15 +304,24 @@ provided; everything else has a default.
 
 <ParamField body="threshold" type="ThresholdConfig">
   Color the line above vs. below a live threshold value — green above, red below
-  by default. Use a `SharedValue<number>` for a live benchmark or a
-  `LiveChartPoint[]` / `SharedValue<LiveChartPoint[]>` for a time-varying series.
+  by default. Use a live scalar `SharedValue<number>`, a `LiveChartPoint[]`
+  history, or a live `SharedValue<LiveChartPoint[]>` series.
   Optionally adds a tinted profit/loss `fill` band and a dashed marker `line`; a
   series marker badge can independently select its
   horizontal `labelPosition` and first/last visible `labelAnchor`. Supersedes
-  `line.color`/`colors` and segment
-  recoloring for the main stroke while set. See
+  `line.color`/`colors` and segment recoloring for the main stroke while set. See
   [`ThresholdConfig`](/api-reference/types#thresholdconfig). Single-series,
   line mode only.
+</ParamField>
+
+<ParamField body="renderThresholdBadge" type="(ctx: ThresholdBadgeRenderProps) => ReactElement | null">
+  Replace the built-in Skia threshold pill with a custom **React Native**
+  element. The chart measures it and pins it to the threshold's live Y position
+  and `threshold.line.labelPosition` on the UI thread; the dashed marker line
+  remains native. The context exposes `value`, `valueStr`, `y`, and `visible`
+  SharedValues plus the resolved line config. Return `null`/`undefined` to keep
+  the built-in badge. Requires `threshold.line`. See
+  [Custom threshold badge](/guides/threshold#custom-threshold-badge).
 </ParamField>
 
 ## Scrubbing

--- a/docs/api-reference/types.mdx
+++ b/docs/api-reference/types.mdx
@@ -398,6 +398,13 @@ interface ThresholdLineConfig {
   strokeWidth?: number;              // default 1
   showValue?: boolean;               // append the formatted value to the label; default false
 }
+interface ThresholdBadgeRenderProps {
+  line: ThresholdLineConfig;          // resolved marker-line config
+  value: SharedValue<number>;         // live threshold value
+  valueStr: SharedValue<string>;      // formatted with the chart's formatValue
+  y: SharedValue<number>;             // live canvas Y (NaN when geometry is unavailable)
+  visible: SharedValue<boolean>;      // whether the badge is inside the plot
+}
 interface BadgeConfig {
   variant?: "default" | "minimal";
   tail?: boolean;        // pointed tail toward the dot; false = pill sits flush

--- a/docs/guides/threshold.mdx
+++ b/docs/guides/threshold.mdx
@@ -85,6 +85,55 @@ threshold={{
 While a threshold is set it supersedes `line.color` / `line.colors` and segment
 recoloring for the main stroke.
 
+## Custom threshold badge
+
+Use `renderThresholdBadge` when the badge needs React Native content the built-in
+Skia pill cannot provide: a branded average-cost tag, icon, status chip, blur, or
+an interactive child. The chart still owns the position and follows the live
+threshold on the UI thread; your component owns only the badge's contents and
+chrome. The dashed marker line remains built in.
+
+```tsx
+import { TextInput, View, Text } from "react-native";
+import Animated, { useAnimatedProps } from "react-native-reanimated";
+import {
+  LiveChart,
+  type ThresholdBadgeRenderProps,
+} from "react-native-livechart";
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+function AverageCostBadge({ valueStr }: ThresholdBadgeRenderProps) {
+  const animatedProps = useAnimatedProps(() => {
+    const text = valueStr.get();
+    return { text, defaultValue: text };
+  });
+
+  return (
+    <View style={{ flexDirection: "row", backgroundColor: "#0f172a" }}>
+      <Text>B/E</Text>
+      <AnimatedTextInput editable={false} animatedProps={animatedProps} />
+    </View>
+  );
+}
+
+<LiveChart
+  data={data}
+  value={value}
+  threshold={{
+    value: breakEven,
+    line: { label: "Break-even", showValue: true },
+  }}
+  renderThresholdBadge={(ctx) => <AverageCostBadge {...ctx} />}
+/>
+```
+
+`ThresholdBadgeRenderProps` contains `value`, `valueStr`, `y`, and `visible`
+SharedValues plus the resolved `line` config. Bind `valueStr` to animated text as
+above so the badge value updates without a React render. Returning `null` or
+`undefined` keeps the built-in badge. `renderThresholdBadge` has no effect unless
+`threshold.line` is enabled.
+
 ## Time-varying threshold (a series)
 
 Pass a `LiveChartPoint[]` as `value` instead of a `SharedValue<number>` and the

--- a/packages/react-native-livechart/src/components/CustomThresholdBadgeOverlay.tsx
+++ b/packages/react-native-livechart/src/components/CustomThresholdBadgeOverlay.tsx
@@ -1,0 +1,74 @@
+import { StyleSheet, View, type LayoutChangeEvent } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  type SharedValue,
+} from "react-native-reanimated";
+
+import type { ChartEngineLayout } from "../core/useLiveChartEngine";
+import type { ChartPadding } from "../draw/line";
+
+/** Inset from the anchored edge, matching the built-in threshold badge. */
+const EDGE_INSET = 2;
+
+/**
+ * React Native overlay for a custom threshold badge. The chart owns the
+ * position, measuring the returned element and pinning its vertical center to
+ * the live threshold Y on the UI thread. The consumer owns only its contents and
+ * chrome.
+ */
+export function CustomThresholdBadgeOverlay({
+  element,
+  engine,
+  padding,
+  y,
+  visible,
+  position,
+}: {
+  element: React.ReactElement;
+  engine: ChartEngineLayout;
+  padding: ChartPadding;
+  y: SharedValue<number>;
+  visible: SharedValue<boolean>;
+  position: "left" | "right";
+}) {
+  const size = useSharedValue({ width: 0, height: 0 });
+  const onLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    size.set({ width, height });
+  };
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const canvasWidth = engine.canvasWidth.get();
+    const yy = y.get();
+    const measured = size.get();
+    const show = visible.get() && canvasWidth > 0 && Number.isFinite(yy);
+    const translateX =
+      position === "right"
+        ? canvasWidth - padding.right - EDGE_INSET - measured.width
+        : EDGE_INSET;
+    return {
+      opacity: show ? 1 : 0,
+      transform: [
+        { translateX },
+        { translateY: yy - measured.height / 2 },
+      ],
+    };
+  });
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      <Animated.View
+        pointerEvents="box-none"
+        onLayout={onLayout}
+        style={[styles.anchor, animatedStyle]}
+      >
+        {element}
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  anchor: { position: "absolute", top: 0, left: 0 },
+});

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -160,6 +160,7 @@ import type {
   Marker,
   ReferenceLine,
 } from "../types";
+import { CustomThresholdBadgeOverlay } from "./CustomThresholdBadgeOverlay";
 import {
   ThresholdBadgeOverlay,
   ThresholdLineOverlay,
@@ -356,6 +357,7 @@ function useLiveChartController({
   renderMarker,
   renderTooltip,
   renderOverlay,
+  renderThresholdBadge,
   renderReferenceLine,
   renderOffAxisReferenceLine,
   referenceLineGrouping,
@@ -984,6 +986,21 @@ function useLiveChartController({
     thresholdCfg && !thresholdIsSeries && !Array.isArray(thresholdCfg.value)
       ? (thresholdCfg.value ?? thresholdSeriesGeom.badgeValue)
       : thresholdSeriesGeom.badgeValue;
+  const hasCustomThresholdBadge =
+    thresholdCfg?.line != null && renderThresholdBadge != null;
+  const thresholdMarkerValueStr = useDerivedValue(() =>
+    hasCustomThresholdBadge ? formatValue(thresholdMarkerValue.get()) : "",
+  );
+  const thresholdCustomBadge =
+    thresholdCfg?.line && renderThresholdBadge
+      ? renderThresholdBadge({
+          line: thresholdCfg.line,
+          value: thresholdMarkerValue,
+          valueStr: thresholdMarkerValueStr,
+          y: thresholdMarkerLineY,
+          visible: thresholdBadgeVisible,
+        })
+      : null;
   const thresholdSeriesPts = thresholdIsSeries
     ? thresholdSeriesGeom.screenPts
     : undefined;
@@ -1543,6 +1560,7 @@ function useLiveChartController({
     thresholdMarkerVisible,
     thresholdBadgeVisible,
     thresholdMarkerValue,
+    thresholdCustomBadge,
     thresholdSeriesPts,
     badgeUsesRightGutter,
     // theme / layout / fonts
@@ -2258,6 +2276,7 @@ function ChartStack({
     thresholdMarkerVisible,
     thresholdBadgeVisible,
     thresholdMarkerValue,
+    thresholdCustomBadge,
     thresholdSeriesPts,
     formatValue,
     lineGroupOpacity,
@@ -2484,7 +2503,7 @@ function ChartStack({
 
       {/* Threshold label badge — on top of the line/dot/markers so it's never
           painted over (the dashed marker line itself stays behind the line, above). */}
-      {thresholdCfg?.line && (
+      {thresholdCfg?.line && thresholdCustomBadge == null && (
         <ThresholdBadgeOverlay
           engine={engine}
           padding={effectivePadding}
@@ -3005,6 +3024,10 @@ function ChartView({
     formatValue,
     topLabelCfg,
     bottomLabelCfg,
+    thresholdCfg,
+    thresholdMarkerLineY,
+    thresholdBadgeVisible,
+    thresholdCustomBadge,
     markersActive,
     renderMarker,
     renderTooltip,
@@ -3115,6 +3138,19 @@ function ChartView({
             defaultColor={palette.gridLabel}
             padding={effectivePadding}
             extremaTimeOffset={extremaTimeOffset}
+          />
+        )}
+
+        {/* Custom threshold badge — a native view positioned from the same live
+            value/Y SharedValues as the built-in Skia badge. */}
+        {thresholdCustomBadge && thresholdCfg?.line && (
+          <CustomThresholdBadgeOverlay
+            element={thresholdCustomBadge}
+            engine={engine}
+            padding={effectivePadding}
+            y={thresholdMarkerLineY}
+            visible={thresholdBadgeVisible}
+            position={thresholdCfg.line.labelPosition}
           />
         )}
 

--- a/packages/react-native-livechart/src/index.ts
+++ b/packages/react-native-livechart/src/index.ts
@@ -114,6 +114,7 @@ export type {
   SeriesConfig,
   ThemeMode,
   ThresholdConfig,
+  ThresholdBadgeRenderProps,
   ThresholdLineConfig,
   TooltipRenderProps,
   TradeEvent,

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -568,6 +568,25 @@ export interface ThresholdLineConfig {
   labelColor?: string;
 }
 
+/**
+ * Context passed to {@link LiveChartProps.renderThresholdBadge}. The chart
+ * floats the returned React Native element over the canvas and pins it to the
+ * live threshold on the UI thread. Bind the SharedValues to animated content
+ * when its displayed value must update without React re-renders.
+ */
+export interface ThresholdBadgeRenderProps {
+  /** Resolved marker-line config for the badge being rendered. */
+  line: ThresholdLineConfig;
+  /** Live threshold value in Y-axis units. */
+  value: SharedValue<number>;
+  /** The threshold value formatted with the chart's `formatValue`. */
+  valueStr: SharedValue<string>;
+  /** Canvas Y pixel of the threshold (`NaN` when geometry is unavailable). */
+  y: SharedValue<number>;
+  /** Whether the threshold badge currently belongs inside the visible plot. */
+  visible: SharedValue<boolean>;
+}
+
 /** Object form of {@link ThresholdConfig.fill} — band tuning. */
 export interface ThresholdFillConfig {
   /** Band fill opacity (0–1), applied to the above/below colors. Multiplies an
@@ -2552,10 +2571,21 @@ export interface LiveChartProps extends LiveChartCoreProps {
   segments?: ChartSegment[];
   /**
    * Color the line above vs. below a live threshold value (break-even / average
-   * cost, VWAP, previous close, a peg). Always a `SharedValue` so the split tracks
-   * live on the UI thread. See {@link ThresholdConfig}.
+   * cost, VWAP, previous close, a peg). Supports a live scalar or a static/live
+   * time-varying series. See {@link ThresholdConfig}.
    */
   threshold?: ThresholdConfig;
+  /**
+   * Render the threshold line's badge as a custom **React Native** element
+   * instead of the built-in Skia pill. The chart measures and pins the element
+   * to the threshold's live Y position and configured `labelPosition` on the UI
+   * thread (see {@link ThresholdBadgeRenderProps}); the dashed marker line stays
+   * built in. Requires `threshold.line`. Return `null`/`undefined` to keep the
+   * built-in badge. Single-series line mode only.
+   */
+  renderThresholdBadge?: (
+    ctx: ThresholdBadgeRenderProps,
+  ) => ReactElement | null | undefined;
   /** Render the live value as a large text overlay in the top-left. Default `false`. */
   showValue?: boolean;
   /** Tint the `showValue` text by momentum (green up / red down). Default `false`. */

--- a/packages/react-native-livechart/tests/LiveChart.test.tsx
+++ b/packages/react-native-livechart/tests/LiveChart.test.tsx
@@ -723,6 +723,39 @@ describe("LiveChart", () => {
     );
   });
 
+  it("replaces the threshold badge with a custom React Native element", async () => {
+    let captured:
+      | Parameters<NonNullable<LiveChartProps["renderThresholdBadge"]>>[0]
+      | undefined;
+    const screen = await render(
+      <ThresholdHarness
+        thresholdValue={12.5}
+        thresholdExtra={{ line: true }}
+        formatValue={(v) => `$${v.toFixed(2)}`}
+        renderThresholdBadge={(ctx) => {
+          captured = ctx;
+          return <View testID="custom-threshold-badge" />;
+        }}
+      />,
+    );
+    expect(screen.getByTestId("custom-threshold-badge")).toBeTruthy();
+    expect(captured?.line.labelPosition).toBe("left");
+    expect(captured?.value.get()).toBe(12.5);
+    expect(captured?.valueStr.get()).toBe("$12.50");
+    expect(typeof captured?.visible.get()).toBe("boolean");
+  });
+
+  it("keeps the built-in threshold badge when the custom renderer opts out", async () => {
+    await layoutFirst(
+      await render(
+        <ThresholdHarness
+          thresholdExtra={{ line: { label: "Break-even", showValue: true } }}
+          renderThresholdBadge={() => null}
+        />,
+      ),
+    );
+  });
+
   it("accepts a bare dashed marker line (no label)", async () => {
     await layoutFirst(
       await render(

--- a/packages/react-native-livechart/tests/components/CustomThresholdBadgeOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/CustomThresholdBadgeOverlay.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import { Text } from "react-native";
+
+import { CustomThresholdBadgeOverlay } from "../../src/components/CustomThresholdBadgeOverlay";
+import type { ChartEngineLayout } from "../../src/core/useLiveChartEngine";
+import { DEFAULT_PADDING } from "../../src/draw/line";
+import { withSharedValueAccessors } from "../support/sharedValueMock";
+
+function sv<T>(value: T) {
+  return withSharedValueAccessors({ current: { value } }).current as never;
+}
+
+function engine(canvasWidth = 400): ChartEngineLayout {
+  return withSharedValueAccessors({
+    canvasWidth: { value: canvasWidth },
+  }) as unknown as ChartEngineLayout;
+}
+
+describe("CustomThresholdBadgeOverlay", () => {
+  it.each(["left", "right"] as const)(
+    "floats and measures a custom element on the %s",
+    async (position) => {
+      const screen = await render(
+        <CustomThresholdBadgeOverlay
+          element={<Text testID="badge">Break-even</Text>}
+          engine={engine()}
+          padding={DEFAULT_PADDING}
+          y={sv(120)}
+          visible={sv(true)}
+          position={position}
+        />,
+      );
+      const badge = screen.getByTestId("badge");
+      await fireEvent(badge.parent!, "layout", {
+        nativeEvent: { layout: { x: 0, y: 0, width: 80, height: 24 } },
+      });
+      expect(badge).toBeTruthy();
+    },
+  );
+
+  it("keeps the element mounted but hidden before layout/off-axis", async () => {
+    const screen = await render(
+      <CustomThresholdBadgeOverlay
+        element={<Text testID="badge">Hidden</Text>}
+        engine={engine(0)}
+        padding={DEFAULT_PADDING}
+        y={sv(Number.NaN)}
+        visible={sv(false)}
+        position="left"
+      />,
+    );
+    expect(screen.getByTestId("badge")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- add `LiveChart.renderThresholdBadge` for custom React Native threshold badges
- expose live threshold value, formatted value, Y position, visibility, and resolved line config through `ThresholdBadgeRenderProps`
- preserve the built-in Skia badge when the renderer returns `null`/`undefined`, while keeping the dashed marker line native
- document the API and add a realistic average-cost badge to the Threshold example

## Verification

- `npm run verify` — 106 suites passed; 1,596 tests passed, 5 skipped
- React Doctor — 96/100 (two pre-existing maintainability warnings, no errors)
- iOS example app verified with agent-device; recording attached in the PR comments

Closes #291
