### PR TITLE
chore: keep Renovate on TypeScript 6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,11 @@
       "groupName": "github actions"
     },
     {
+      "description": "Expo SDK 57 and its @typescript-eslint toolchain require the TypeScript 6 API.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    },
+    {
       "description": "Expo's eslint-plugin-react stack does not support ESLint 10 yet.",
       "matchPackageNames": ["eslint"],
       "allowedVersions": "<10"


### PR DESCRIPTION
## Summary

- constrain Renovate TypeScript updates to versions below 7
- keep Expo SDK 57 and the installed `@typescript-eslint` toolchain on their supported TypeScript 6 API
- prevent the closed TypeScript 7 upgrade from being recreated

## Verification

- `renovate-config-validator renovate.json`
- `npm run verify` (110 suites, 1,638 tests)