### PR TITLE
chore(release): v4.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.21.0] - 2026-08-26
+
 ### Added
 
 - **Time-varying reference lines.** `ReferenceLine.series` draws a historical
@@ -1286,6 +1288,8 @@ Initial public release.
   compiles it with your own Reanimated/Worklets version. `dist/` contains only `.d.ts`
   declarations — there is no precompiled runtime `dist/*.js`.
 
+[4.21.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v4.21.0
+[4.20.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v4.20.0
 [4.19.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v4.19.0
 [4.18.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v4.18.0
 [4.17.0]: https://github.com/brandtnewlabs/react-native-livechart/releases/tag/v4.17.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -17853,7 +17853,7 @@
       }
     },
     "packages/react-native-livechart": {
-      "version": "4.20.0",
+      "version": "4.21.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~19.2.14",

--- a/packages/react-native-livechart/package.json
+++ b/packages/react-native-livechart/package.json
@@ -67,5 +67,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "4.20.0"
+  "version": "4.21.0"
 }


### PR DESCRIPTION
## Summary
- release the backward-compatible reference-line, threshold-badge, and semantic gap APIs as v4.21.0
- move the accumulated entries from Unreleased into the dated 4.21.0 changelog section
- restore the missing 4.20.0 release link

## Verification
- `npx -y npm@10 ci`
- `npm run verify` (110 suites, 1,638 passed, 5 skipped)
- `npm pack --dry-run -w react-native-livechart`
- `npm publish --dry-run -w react-native-livechart`