### PR TITLE
Fix extrema labels during loading and flat series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extrema labels and their connector lines now hide while the loading shell is
+  active. Flat series whose high and low resolve to the same point render one
+  extrema label instead of drawing the same label twice. Resolves
+  [#303](https://github.com/brandtnewlabs/react-native-livechart/issues/303).
+
 ## [4.21.0] - 2026-08-26
 
 ### Added

--- a/docs/guides/extrema-labels.mdx
+++ b/docs/guides/extrema-labels.mdx
@@ -32,9 +32,11 @@ rescales. It's the easiest way to show **when** the high / low happened, not jus
 />
 ```
 
-The label hides itself when the window holds no data, or when the extremum scrolls off the plot
-(the engine re-picks the visible high / low every frame). It works in **candle mode** too — the
-extrema track the highest high / lowest low.
+The label hides itself while the loading shell is active, when the window holds no data, or when
+the extremum scrolls off the plot (the engine re-picks the visible high / low every frame). When
+the high and low resolve to the same point, as they do for a flat series, the chart shows one
+label instead of drawing the same extremum twice. It works in **candle mode** too — the extrema
+track the highest high / lowest low.
 
 **`"extrema-edge"`** is a variant that keeps the readout on a clean rail: the value label pins to the
 top / bottom **edge** (still horizontally aligned with the extremum), and a dot marks the actual

--- a/packages/react-native-livechart/src/components/AxisLabelOverlay.tsx
+++ b/packages/react-native-livechart/src/components/AxisLabelOverlay.tsx
@@ -56,6 +56,22 @@ export const EXTREMA_EDGE_INSET = 2;
  *  reads it to estimate where the edge label ends. */
 export const EXTREMA_LABEL_FONT_SIZE = 11;
 
+/** Whether the high and low extrema resolve to the exact same data point. */
+export function extremaPointsCoincide(
+  firstTime: number,
+  firstValue: number,
+  secondTime: number,
+  secondValue: number,
+): boolean {
+  "worklet";
+  return (
+    Number.isFinite(firstTime) &&
+    Number.isFinite(firstValue) &&
+    firstTime === secondTime &&
+    firstValue === secondValue
+  );
+}
+
 /**
  * The batteries-included axis edge label — an animated RN text driven by a
  * `SharedValue<number>` (the chart's current top / bottom Y-axis bound). The
@@ -131,6 +147,7 @@ function ExtremaAxisLabel({
   dotSize,
   dot,
   render,
+  suppressWhen,
 }: {
   /** `"top"` floats above the max point; `"bottom"` below the min point. */
   side: "top" | "bottom";
@@ -160,6 +177,11 @@ function ExtremaAxisLabel({
   /** Whether to draw the marker dot. */
   dot: boolean;
   render?: () => React.ReactElement | null;
+  /** Hide this side when it resolves to the same point as the other extremum. */
+  suppressWhen?: {
+    timeSV: SharedValue<number>;
+    valueSV: SharedValue<number>;
+  };
 }) {
   const isCustom = render != null;
   // Resolved dot geometry. `hasDot` also gates the label's vertical offset (it
@@ -181,7 +203,16 @@ function ExtremaAxisLabel({
   useAnimatedReaction(
     () => {
       const v = valueSV.get();
-      return isCustom || !Number.isFinite(v) ? "" : format(v);
+      const t = timeSV.get();
+      const suppressed =
+        suppressWhen != null &&
+        extremaPointsCoincide(
+          t,
+          v,
+          suppressWhen.timeSV.get(),
+          suppressWhen.valueSV.get(),
+        );
+      return isCustom || !Number.isFinite(v) || suppressed ? "" : format(v);
     },
     (curr, prev) => {
       if (curr !== prev) scheduleOnRN(setValueText, curr);
@@ -211,6 +242,13 @@ function ExtremaAxisLabel({
 
     if (
       !Number.isFinite(value) ||
+      (suppressWhen != null &&
+        extremaPointsCoincide(
+          time,
+          value,
+          suppressWhen.timeSV.get(),
+          suppressWhen.valueSV.get(),
+        )) ||
       cw === 0 ||
       ch === 0 ||
       chartW <= 0 ||
@@ -324,6 +362,90 @@ function ExtremaAxisLabel({
   );
 }
 
+/** One configured top/bottom label, rendered either on its edge or extremum. */
+function AxisLabelSide({
+  side,
+  label,
+  extrema,
+  timeSV,
+  valueSV,
+  edgeValue,
+  engine,
+  formatValue,
+  defaultColor,
+  padding,
+  extremaTimeOffset,
+  hideExtrema,
+  suppressWhen,
+}: {
+  side: "top" | "bottom";
+  label: ResolvedAxisLabelConfig | null;
+  extrema: boolean;
+  timeSV?: SharedValue<number>;
+  valueSV?: SharedValue<number>;
+  edgeValue: SharedValue<number>;
+  engine: ChartEngineLayout;
+  formatValue: (v: number) => string;
+  defaultColor: string;
+  padding: ChartPadding;
+  extremaTimeOffset: number;
+  hideExtrema: boolean;
+  suppressWhen?: {
+    timeSV: SharedValue<number>;
+    valueSV: SharedValue<number>;
+  };
+}) {
+  if (!label) return null;
+
+  if (extrema) {
+    if (hideExtrema || !timeSV || !valueSV) return null;
+    return (
+      <ExtremaAxisLabel
+        side={side}
+        timeSV={timeSV}
+        valueSV={valueSV}
+        timeOffset={extremaTimeOffset}
+        edgeAnchor={label.position === "extrema-edge"}
+        engine={engine}
+        padding={padding}
+        format={label.format ?? formatValue}
+        color={label.color ?? defaultColor}
+        font={labelFont(label)}
+        dotColor={label.dotColor}
+        dotSize={label.dotSize}
+        dot={label.dot}
+        render={label.render ?? undefined}
+        suppressWhen={suppressWhen}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={{
+        position: "absolute",
+        ...(side === "top"
+          ? { top: padding.top }
+          : { bottom: padding.bottom }),
+        left: padding.left,
+        right: padding.right,
+      }}
+    >
+      {label.render ? (
+        label.render()
+      ) : (
+        <BuiltInAxisValueLabel
+          value={edgeValue}
+          format={label.format ?? formatValue}
+          color={label.color ?? defaultColor}
+          position={label.position}
+          font={labelFont(label)}
+        />
+      )}
+    </View>
+  );
+}
+
 /**
  * React Native overlay (NOT Skia) floating axis edge labels over the Skia
  * canvas — `topLabel` pinned to the plot's top edge and `bottomLabel` to its
@@ -353,6 +475,7 @@ export function AxisLabelOverlay({
   defaultColor,
   padding,
   extremaTimeOffset = 0,
+  hideExtrema = false,
 }: {
   topLabel: ResolvedAxisLabelConfig | null;
   bottomLabel: ResolvedAxisLabelConfig | null;
@@ -366,6 +489,8 @@ export function AxisLabelOverlay({
    * candle's drawn center; `0` (default) for line / multi-series.
    */
   extremaTimeOffset?: number;
+  /** Hide point-anchored extrema while the chart is showing its loading shell. */
+  hideExtrema?: boolean;
 }) {
   if (!topLabel && !bottomLabel) return null;
 
@@ -384,86 +509,42 @@ export function AxisLabelOverlay({
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="none">
-      {topLabel &&
-        (topExtrema ? (
-          <ExtremaAxisLabel
-            side="top"
-            timeSV={engine.extremaMaxTime!}
-            valueSV={engine.extremaMaxValue!}
-            timeOffset={extremaTimeOffset}
-            edgeAnchor={topMode === "extrema-edge"}
-            engine={engine}
-            padding={padding}
-            format={topLabel.format ?? formatValue}
-            color={topLabel.color ?? defaultColor}
-            font={labelFont(topLabel)}
-            dotColor={topLabel.dotColor}
-            dotSize={topLabel.dotSize}
-            dot={topLabel.dot}
-            render={topLabel.render ?? undefined}
-          />
-        ) : (
-          <View
-            style={{
-              position: "absolute",
-              top: padding.top,
-              left: padding.left,
-              right: padding.right,
-            }}
-          >
-            {topLabel.render ? (
-              topLabel.render()
-            ) : (
-              <BuiltInAxisValueLabel
-                value={engine.displayMax}
-                format={topLabel.format ?? formatValue}
-                color={topLabel.color ?? defaultColor}
-                position={topLabel.position}
-                font={labelFont(topLabel)}
-              />
-            )}
-          </View>
-        ))}
-      {bottomLabel &&
-        (bottomExtrema ? (
-          <ExtremaAxisLabel
-            side="bottom"
-            timeSV={engine.extremaMinTime!}
-            valueSV={engine.extremaMinValue!}
-            timeOffset={extremaTimeOffset}
-            edgeAnchor={bottomMode === "extrema-edge"}
-            engine={engine}
-            padding={padding}
-            format={bottomLabel.format ?? formatValue}
-            color={bottomLabel.color ?? defaultColor}
-            font={labelFont(bottomLabel)}
-            dotColor={bottomLabel.dotColor}
-            dotSize={bottomLabel.dotSize}
-            dot={bottomLabel.dot}
-            render={bottomLabel.render ?? undefined}
-          />
-        ) : (
-          <View
-            style={{
-              position: "absolute",
-              bottom: padding.bottom,
-              left: padding.left,
-              right: padding.right,
-            }}
-          >
-            {bottomLabel.render ? (
-              bottomLabel.render()
-            ) : (
-              <BuiltInAxisValueLabel
-                value={engine.displayMin}
-                format={bottomLabel.format ?? formatValue}
-                color={bottomLabel.color ?? defaultColor}
-                position={bottomLabel.position}
-                font={labelFont(bottomLabel)}
-              />
-            )}
-          </View>
-        ))}
+      <AxisLabelSide
+        side="top"
+        label={topLabel}
+        extrema={topExtrema}
+        timeSV={engine.extremaMaxTime}
+        valueSV={engine.extremaMaxValue}
+        edgeValue={engine.displayMax}
+        engine={engine}
+        formatValue={formatValue}
+        defaultColor={defaultColor}
+        padding={padding}
+        extremaTimeOffset={extremaTimeOffset}
+        hideExtrema={hideExtrema}
+      />
+      <AxisLabelSide
+        side="bottom"
+        label={bottomLabel}
+        extrema={bottomExtrema}
+        timeSV={engine.extremaMinTime}
+        valueSV={engine.extremaMinValue}
+        edgeValue={engine.displayMin}
+        engine={engine}
+        formatValue={formatValue}
+        defaultColor={defaultColor}
+        padding={padding}
+        extremaTimeOffset={extremaTimeOffset}
+        hideExtrema={hideExtrema}
+        suppressWhen={
+          topExtrema
+            ? {
+                timeSV: engine.extremaMaxTime!,
+                valueSV: engine.extremaMaxValue!,
+              }
+            : undefined
+        }
+      />
     </View>
   );
 }

--- a/packages/react-native-livechart/src/components/ExtremaConnectorOverlay.tsx
+++ b/packages/react-native-livechart/src/components/ExtremaConnectorOverlay.tsx
@@ -11,7 +11,11 @@ import type {
 } from "../core/useLiveChartEngine";
 import type { ChartPadding } from "../draw/line";
 import { usePathBuilder } from "../hooks/usePathBuilder";
-import { EXTREMA_EDGE_INSET, EXTREMA_LABEL_FONT_SIZE } from "./AxisLabelOverlay";
+import {
+  EXTREMA_EDGE_INSET,
+  EXTREMA_LABEL_FONT_SIZE,
+  extremaPointsCoincide,
+} from "./AxisLabelOverlay";
 
 /** How far off-plot (px) the extremum may sit before the connector is dropped. */
 const CONNECTOR_CULL = 24;
@@ -55,6 +59,7 @@ function ConnectorLine({
   engine,
   padding,
   config,
+  suppressWhen,
 }: {
   side: "top" | "bottom";
   timeSV: SharedValue<number>;
@@ -63,6 +68,10 @@ function ConnectorLine({
   engine: ChartEngineLayout;
   padding: ChartPadding;
   config: ResolvedConnector;
+  suppressWhen?: {
+    timeSV: SharedValue<number>;
+    valueSV: SharedValue<number>;
+  };
 }) {
   const builder = usePathBuilder();
   const { line, fontSize } = config;
@@ -88,6 +97,13 @@ function ConnectorLine({
 
     if (
       !Number.isFinite(value) ||
+      (suppressWhen != null &&
+        extremaPointsCoincide(
+          time,
+          value,
+          suppressWhen.timeSV.get(),
+          suppressWhen.valueSV.get(),
+        )) ||
       cw === 0 ||
       ch === 0 ||
       chartW <= 0 ||
@@ -153,15 +169,29 @@ export function ExtremaConnectorOverlay({
   extremaTimeOffset = 0,
   top,
   bottom,
+  hideExtrema = false,
+  suppressBottomWhenCoincident = false,
 }: {
   engine: ChartEngineLayout & Partial<ChartEngineExtrema>;
   padding: ChartPadding;
   extremaTimeOffset?: number;
   top: ResolvedConnector | null;
   bottom: ResolvedConnector | null;
+  /** Hide extrema connectors while the chart is showing its loading shell. */
+  hideExtrema?: boolean;
+  /** Drop the lower connector when both configured labels share one point. */
+  suppressBottomWhenCoincident?: boolean;
 }) {
-  const hasTop = top != null && engine.extremaMaxTime != null;
-  const hasBottom = bottom != null && engine.extremaMinTime != null;
+  const hasTop =
+    !hideExtrema &&
+    top != null &&
+    engine.extremaMaxTime != null &&
+    engine.extremaMaxValue != null;
+  const hasBottom =
+    !hideExtrema &&
+    bottom != null &&
+    engine.extremaMinTime != null &&
+    engine.extremaMinValue != null;
   if (!hasTop && !hasBottom) return null;
 
   return (
@@ -186,6 +216,16 @@ export function ExtremaConnectorOverlay({
           engine={engine}
           padding={padding}
           config={bottom!}
+          suppressWhen={
+            suppressBottomWhenCoincident &&
+            engine.extremaMaxTime != null &&
+            engine.extremaMaxValue != null
+              ? {
+                  timeSV: engine.extremaMaxTime!,
+                  valueSV: engine.extremaMaxValue!,
+                }
+              : undefined
+          }
         />
       )}
     </>

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -1574,6 +1574,7 @@ function useLiveChartController({
     // engine + reveal
     engine,
     reveal,
+    loadingActive,
     axisAutoHideOpacity,
     // loading shell styling (null → not loading)
     loadingLineColor: loadingCfg?.color,
@@ -3041,6 +3042,7 @@ function ChartView({
     topConnector,
     bottomConnector,
     canvasMode,
+    loadingActive,
   } = model;
 
   return (
@@ -3101,6 +3103,11 @@ function ChartView({
               extremaTimeOffset={extremaTimeOffset}
               top={topConnector}
               bottom={bottomConnector}
+              hideExtrema={loadingActive}
+              suppressBottomWhenCoincident={
+                topLabelCfg?.position === "extrema" ||
+                topLabelCfg?.position === "extrema-edge"
+              }
             />
           )}
 
@@ -3138,6 +3145,7 @@ function ChartView({
             defaultColor={palette.gridLabel}
             padding={effectivePadding}
             extremaTimeOffset={extremaTimeOffset}
+            hideExtrema={loadingActive}
           />
         )}
 

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -656,6 +656,7 @@ function useLiveChartSeriesController({
     // engine + reveal
     engine,
     reveal,
+    loadingActive,
     // loading shell styling (null → not loading)
     loadingLineColor: loadingCfg?.color,
     loadingStrokeWidth: loadingCfg?.strokeWidth,
@@ -1090,6 +1091,7 @@ export const LiveChartSeries = forwardRef<
     refLineCustomTagWidths,
     overlayScrubFade,
     canvasMode,
+    loadingActive,
   } = model;
 
   // Mirror the Skia overlay fade onto the RN custom-marker sibling so
@@ -1156,6 +1158,11 @@ export const LiveChartSeries = forwardRef<
               padding={effectivePadding}
               top={topConnector}
               bottom={bottomConnector}
+              hideExtrema={loadingActive}
+              suppressBottomWhenCoincident={
+                topLabelCfg?.position === "extrema" ||
+                topLabelCfg?.position === "extrema-edge"
+              }
             />
 
             {leftEdgeFadeCfg && (
@@ -1222,6 +1229,7 @@ export const LiveChartSeries = forwardRef<
             formatValue={formatValue}
             defaultColor={palette.gridLabel}
             padding={effectivePadding}
+            hideExtrema={loadingActive}
           />
 
           {/* Custom annotations — RN views floated over the canvas (non-Skia),

--- a/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/AxisLabelOverlay.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render } from "@testing-library/react-native";
 import React from "react";
 import { Text, TextInput } from "react-native";
 
-import { AxisLabelOverlay } from "../../src/components/AxisLabelOverlay";
+import {
+  AxisLabelOverlay,
+  extremaPointsCoincide,
+} from "../../src/components/AxisLabelOverlay";
 import type { ResolvedAxisLabelConfig } from "../../src/core/resolveConfig";
 import type {
   ChartEngineExtrema,
@@ -196,6 +199,69 @@ describe("AxisLabelOverlay", () => {
       expect(screen.getByText("VALLEY")).toBeTruthy();
     });
 
+    it("hides both extrema labels while loading", async () => {
+      const screen = await render(
+        <AxisLabelOverlay
+          topLabel={builtIn({
+            position: "extrema",
+            render: () => <Text>PEAK</Text>,
+          })}
+          bottomLabel={builtIn({
+            position: "extrema-edge",
+            render: () => <Text>VALLEY</Text>,
+          })}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+          hideExtrema
+        />,
+      );
+      expect(screen.queryByText("PEAK")).toBeNull();
+      expect(screen.queryByText("VALLEY")).toBeNull();
+    });
+
+    it("does not hide ordinary edge labels while loading", async () => {
+      const screen = await render(
+        <AxisLabelOverlay
+          topLabel={builtIn({ render: () => <Text>HIGH</Text> })}
+          bottomLabel={null}
+          engine={makeExtremaEngine()}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+          hideExtrema
+        />,
+      );
+      expect(screen.getByText("HIGH")).toBeTruthy();
+    });
+
+    it("suppresses the lower label when both extrema are the same point", async () => {
+      const screen = await render(
+        <AxisLabelOverlay
+          topLabel={builtIn({
+            position: "extrema",
+            render: () => <Text>PEAK</Text>,
+          })}
+          bottomLabel={builtIn({
+            position: "extrema",
+            render: () => <Text>VALLEY</Text>,
+          })}
+          engine={makeExtremaEngine({
+            maxValue: 100,
+            minValue: 100,
+            maxTime: 985,
+            minTime: 985,
+          })}
+          formatValue={fmt}
+          defaultColor="#888"
+          padding={DEFAULT_PADDING}
+        />,
+      );
+      expect(screen.getByText("PEAK").parent).toHaveStyle({ opacity: 1 });
+      expect(screen.getByText("VALLEY").parent).toHaveStyle({ opacity: 0 });
+    });
+
     it("stays mounted (hidden) when the extremum value is NaN", async () => {
       const screen = await render(
         <AxisLabelOverlay
@@ -319,5 +385,14 @@ describe("AxisLabelOverlay", () => {
       );
       expect(getAllByHostType(screen, TextInput)).toHaveLength(1);
     });
+  });
+});
+
+describe("extremaPointsCoincide", () => {
+  it("matches only the same finite point", () => {
+    expect(extremaPointsCoincide(10, 100, 10, 100)).toBe(true);
+    expect(extremaPointsCoincide(10, 100, 11, 100)).toBe(false);
+    expect(extremaPointsCoincide(10, 100, 10, 99)).toBe(false);
+    expect(extremaPointsCoincide(10, NaN, 10, NaN)).toBe(false);
   });
 });

--- a/packages/react-native-livechart/tests/components/ExtremaConnectorOverlay.test.tsx
+++ b/packages/react-native-livechart/tests/components/ExtremaConnectorOverlay.test.tsx
@@ -73,6 +73,37 @@ describe("ExtremaConnectorOverlay", () => {
     expect(screen.toJSON()).toBeNull();
   });
 
+  it("returns null while extrema are hidden for loading", async () => {
+    const screen = await render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine()}
+        padding={DEFAULT_PADDING}
+        top={dashed}
+        bottom={solid}
+        hideExtrema
+      />,
+    );
+    expect(screen.toJSON()).toBeNull();
+  });
+
+  it("suppresses the lower connector when both extrema share one point", async () => {
+    const screen = await render(
+      <ExtremaConnectorOverlay
+        engine={makeEngine({
+          maxValue: 100,
+          minValue: 100,
+          maxTime: 985,
+          minTime: 985,
+        })}
+        padding={DEFAULT_PADDING}
+        top={dashed}
+        bottom={solid}
+        suppressBottomWhenCoincident
+      />,
+    );
+    expect(screen.toJSON()).toBeTruthy();
+  });
+
   it("builds an empty path when the extremum is NaN or off-plot", async () => {
     // NaN value (no data) and an off-plot time both early-out in the worklet.
     const nan = await render(


### PR DESCRIPTION
## Summary

- Hide extrema labels and connector lines while the loading shell is active.
- Render one extrema label when the high and low resolve to the same data point.
- Apply the behavior to both `LiveChart` and `LiveChartSeries`.
- Add regression tests and update the guide and changelog.

Fixes #303

## Verification

- `npm run verify`: 110 suites passed, 1,644 tests passed, 5 skipped
- `npm run build:lib`
- React Doctor: 92/100, with no new warnings
- iPhone 17 Pro simulator on iOS 26.5: one label for a flat series and no stale extrema labels while loading