### PR TITLE
Fix single-point chart rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Charts now treat one line point, one multi-series point, or one committed
+  candle as valid data instead of showing the empty-state label. Resolves
+  [#302](https://github.com/brandtnewlabs/react-native-livechart/issues/302).
 - Extrema labels and their connector lines now hide while the loading shell is
   active. Flat series whose high and low resolve to the same point render one
   extrema label instead of drawing the same label twice. Resolves

--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -157,7 +157,7 @@ export default function CandlestickScreen() {
     <DemoScreen
       title="Candlestick"
       docs="guides/candlestick"
-      description={`mode="candle" with ${candleWidthSecs}s OHLC buckets plus a historical average-cost reference series. Each candle aggregates many ticks, so it shows a real body + wick. Needs ≥2 committed candles before it draws.`}
+      description={`mode="candle" with ${candleWidthSecs}s OHLC buckets plus a historical average-cost reference series. Each candle aggregates many ticks, so it shows a real body + wick. A single committed candle is enough to draw.`}
       chart={
         <LiveChart
           data={data}

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -222,7 +222,7 @@ export default function MultiSeriesScreen() {
     <DemoScreen
       title="Multi-series"
       docs="guides/multi-series"
-      description="series, onSeriesToggle, scrub, axis visibility. Use the QA reference buttons to move one line above, into, or below the plot: the custom tag takes over only off-axis, its caret flips with the edge, and its dashed connector continues right from the badge edge. Chart stays empty until at least one series has ≥2 points (toggle No series for shell)."
+      description="series, onSeriesToggle, scrub, axis visibility. Use the QA reference buttons to move one line above, into, or below the plot: the custom tag takes over only off-axis, its caret flips with the edge, and its dashed connector continues right from the badge edge. One point in any series is valid data; toggle No series for the empty shell."
       chartWrapperStyle={{ height: 360 }}
       chart={
         <>

--- a/app/demo/states-and-formatting.tsx
+++ b/app/demo/states-and-formatting.tsx
@@ -44,7 +44,7 @@ const FORMAT_OPTIONS: { value: FormatMode; label: string }[] = [
 
 export default function StatesScreen() {
   const [empty, setEmpty] = useState(false);
-  const [onePoint, setOnePoint] = useState(false);
+  const [onePoint, setOnePoint] = useState(true);
   const [loading, setLoading] = useState(false);
   const [styledLoading, setStyledLoading] = useState(false);
   const [axisLabels, setAxisLabels] = useState(true);
@@ -63,7 +63,9 @@ export default function StatesScreen() {
   const emptyData = useSharedValue<LiveChartPoint[]>([]);
   const emptyValue = useSharedValue(100);
   const [singlePointInit] = useState<LiveChartPoint[]>(() => [
-    { time: Date.now() / 1000, value: 100 },
+    // Start halfway across the default 30s window so the one historical sample
+    // and the synthetic live tip form an immediately visible segment.
+    { time: Date.now() / 1000 - 15, value: 100 },
   ]);
   const singlePointData = useSharedValue<LiveChartPoint[]>(singlePointInit);
 
@@ -77,13 +79,13 @@ export default function StatesScreen() {
   const chartData = empty ? emptyData : onePoint ? singlePointData : sim.data;
   const displayedData = loading ? emptyData : chartData;
   const chartValue = empty || onePoint || loading ? emptyValue : sim.value;
-  const showEmptyShell = empty || onePoint;
+  const showCustomEmptyText = empty;
 
   return (
     <DemoScreen
       title="States & formatting"
       docs="guides/states-and-formatting"
-      description="The chart stays in loading/empty shell until there are at least two line points and loading is false. Tap Replace data to remove live data: the loading shell appears immediately, then the returning data grows in. One point only still counts as empty. formatValue/formatTime must be worklet-safe (same pattern as src/format.ts)."
+      description="The chart shows its empty shell only when it has no points and loading is false. One point is valid data: it anchors a segment to the live tip. Tap Replace data to remove live data: the loading shell appears immediately, then the returning data grows in. formatValue/formatTime must be worklet-safe (same pattern as src/format.ts)."
       chart={
         <LiveChart
           data={displayedData}
@@ -95,7 +97,7 @@ export default function StatesScreen() {
           // for the loading shell still snaps, while returned data reveals over
           // this duration.
           transitions={{ reveal: 1200 }}
-          emptyText={showEmptyShell ? "Nothing to see here" : "No data"}
+          emptyText={showCustomEmptyText ? "Nothing to see here" : "No data"}
           formatValue={customFormat ? formatValueUsd : undefined}
           formatTime={customFormat ? formatTimeIsoUtcFragment : undefined}
           scrub={false}

--- a/docs/api-reference/livechart.mdx
+++ b/docs/api-reference/livechart.mdx
@@ -615,7 +615,8 @@ paused. See [Time-scroll → Reset zoom from a button](/guides/time-scroll#reset
 </ParamField>
 
 <ParamField body="emptyText" type="string" default='"No data"'>
-  Label shown when there are fewer than two samples and `loading` is false.
+  Label shown when there are no samples and `loading` is false. A single line point or
+  committed candle is valid data and renders normally.
 </ParamField>
 
 <ParamField body="accessibilityLabel" type="string">

--- a/docs/guides/states-and-formatting.mdx
+++ b/docs/guides/states-and-formatting.mdx
@@ -61,8 +61,9 @@ same config works on `LiveChartSeries`. The loading→live reveal duration itsel
 
 ## Empty state
 
-When there are fewer than two samples and `loading` is `false`, the chart shows an empty shell
-with a label. Customize the label with `emptyText`.
+When there are no samples and `loading` is `false`, the chart shows an empty shell with a label.
+A single line point or committed candle is valid data and renders normally. Customize the empty
+label with `emptyText`.
 
 ```tsx
 <LiveChart data={data} value={value} emptyText="Waiting for trades…" />

--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -733,7 +733,7 @@ function useLiveChartController({
   });
 
   // ── Reveal state ────────────────────────────────────────────
-  // ≥2 line points or ≥2 committed candles; morphT=1 only when !loading && hasData.
+  // ≥1 line point or ≥1 committed candle; morphT=1 only when !loading && hasData.
   const { hasData } = useLiveChartHasData({
     isCandle,
     data,

--- a/packages/react-native-livechart/src/components/LiveChartSeries.tsx
+++ b/packages/react-native-livechart/src/components/LiveChartSeries.tsx
@@ -28,6 +28,7 @@ import {
   MAX_MULTI_SERIES,
   SCRUB_OVERLAY_FADE_MS,
 } from "../constants";
+import { hasMultiSeriesChartData } from "../core/chartDataPresence";
 import {
   lineColorsSignatureFromArray,
   lineStyleSignatureFromArray,
@@ -366,11 +367,7 @@ function useLiveChartSeriesController({
 
   const hasData = useDerivedValue(() => {
     "worklet";
-    const arr = series.value;
-    for (let i = 0; i < arr.length; i++) {
-      if (arr[i].data.length >= 2) return true;
-    }
-    return false;
+    return hasMultiSeriesChartData(series.value);
   });
 
   // Resolve the loading shell: null = not loading, else the styled config.

--- a/packages/react-native-livechart/src/core/chartDataPresence.ts
+++ b/packages/react-native-livechart/src/core/chartDataPresence.ts
@@ -1,0 +1,24 @@
+import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
+
+/** A single historical line sample is enough to anchor the live tip. */
+export function hasLineChartData(points: LiveChartPoint[]): boolean {
+  "worklet";
+  return points.length > 0;
+}
+
+/** A single committed OHLC bucket is drawable as a candle. */
+export function hasCandleChartData(
+  candles: CandlePoint[] | undefined,
+): boolean {
+  "worklet";
+  return (candles?.length ?? 0) > 0;
+}
+
+/** Multi-series charts are non-empty when any series has one sample. */
+export function hasMultiSeriesChartData(series: SeriesConfig[]): boolean {
+  "worklet";
+  for (let i = 0; i < series.length; i++) {
+    if (series[i].data.length > 0) return true;
+  }
+  return false;
+}

--- a/packages/react-native-livechart/src/hooks/useChartReveal.ts
+++ b/packages/react-native-livechart/src/hooks/useChartReveal.ts
@@ -39,7 +39,7 @@ export interface ChartRevealState {
   morphT: SharedValue<number>;
   /** True while loading=true */
   isLoading: SharedValue<boolean>;
-  /** True when not loading and fewer than two samples. */
+  /** True when not loading and no samples are available. */
   isEmpty: SharedValue<boolean>;
   yAxisOpacity: SharedValue<number>;
   fillOpacity: SharedValue<number>;

--- a/packages/react-native-livechart/src/hooks/useLiveChartHasData.ts
+++ b/packages/react-native-livechart/src/hooks/useLiveChartHasData.ts
@@ -1,9 +1,13 @@
 import { useDerivedValue, type SharedValue } from "react-native-reanimated";
+import {
+  hasCandleChartData,
+  hasLineChartData,
+} from "../core/chartDataPresence";
 import type { CandlePoint, LiveChartPoint } from "../types";
 
 /**
- * Data presence for {@link LiveChart}: line mode needs ≥2 points;
- * candle mode needs ≥2 committed candles (`liveCandle` alone does not count).
+ * Data presence for {@link LiveChart}: line mode needs ≥1 point;
+ * candle mode needs ≥1 committed candle (`liveCandle` alone does not count).
  *
  * {@link useChartReveal} seeds its first-paint state off `hasData` directly (in a
  * layout effect), so no JS-thread snapshot is read during render here.
@@ -22,9 +26,9 @@ export function useLiveChartHasData({
   const hasData = useDerivedValue(() => {
     "worklet";
     if (isCandle) {
-      return (candles?.value.length ?? 0) >= 2;
+      return hasCandleChartData(candles?.value);
     }
-    return data.value.length >= 2;
+    return hasLineChartData(data.value);
   });
 
   return { hasData };

--- a/packages/react-native-livechart/src/hooks/useReverseMorphEngineInputs.ts
+++ b/packages/react-native-livechart/src/hooks/useReverseMorphEngineInputs.ts
@@ -3,6 +3,11 @@ import {
   useSharedValue,
   type SharedValue,
 } from "react-native-reanimated";
+import {
+  hasCandleChartData,
+  hasLineChartData,
+  hasMultiSeriesChartData,
+} from "../core/chartDataPresence";
 import type { CandlePoint, LiveChartPoint, SeriesConfig } from "../types";
 
 const STASH_MORPH_EPS = 0.01;
@@ -42,20 +47,19 @@ export function useSingleChartReverseMorphInputs({
       has: hasData.get(),
       m: morphT.get(),
       d: data.get(),
-      cLen: candles?.get().length ?? 0,
       c: candles?.get(),
       lc: liveCandle?.get() ?? null,
     }),
     (curr) => {
       "worklet";
       if (!curr.candle) {
-        if (curr.has && curr.d.length >= 2) {
+        if (curr.has && hasLineChartData(curr.d)) {
           lineStash.set(curr.d.slice());
           lineEngineData.set(curr.d);
         } else if (
           !curr.has &&
           curr.m > STASH_MORPH_EPS &&
-          lineStash.get().length >= 2
+          hasLineChartData(lineStash.get())
         ) {
           lineEngineData.set(lineStash.get());
         } else {
@@ -65,14 +69,14 @@ export function useSingleChartReverseMorphInputs({
       }
 
       const cArr = curr.c;
-      if (curr.has && curr.cLen >= 2 && cArr) {
+      if (curr.has && hasCandleChartData(cArr) && cArr) {
         candleStash.set(cArr.slice());
         candlesEngine.set(cArr);
         liveEngine.set(curr.lc);
       } else if (
         !curr.has &&
         curr.m > STASH_MORPH_EPS &&
-        candleStash.get().length >= 2
+        hasCandleChartData(candleStash.get())
       ) {
         candlesEngine.set(candleStash.get());
         liveEngine.set(null);
@@ -118,27 +122,14 @@ export function useMultiSeriesReverseMorphInputs({
     (curr) => {
       "worklet";
       const live = curr.live;
-
-      let anyReady = false;
-      for (let i = 0; i < live.length; i++) {
-        if (live[i].data.length >= 2) {
-          anyReady = true;
-          break;
-        }
-      }
+      const anyReady = hasMultiSeriesChartData(live);
 
       if (curr.has && anyReady) {
         seriesStash.set(snapshotSeriesWorklet(live));
         effectiveSeries.set(live);
       } else {
-        let stashReady = false;
         const stash = seriesStash.get();
-        for (let i = 0; i < stash.length; i++) {
-          if (stash[i].data.length >= 2) {
-            stashReady = true;
-            break;
-          }
-        }
+        const stashReady = hasMultiSeriesChartData(stash);
 
         if (!curr.has && curr.m > STASH_MORPH_EPS && stashReady) {
           effectiveSeries.set(seriesStash.get());

--- a/packages/react-native-livechart/src/types.ts
+++ b/packages/react-native-livechart/src/types.ts
@@ -2261,7 +2261,7 @@ export interface LiveChartCoreProps {
   transitions?: boolean | TransitionConfig;
   /**
    * Breathing-line loading shell. When this becomes `false`, the chart reveals
-   * only if there is data (≥2 line points or ≥2 committed candles).
+   * only if there is data (≥1 line point or ≥1 committed candle).
    *
    * `true` shows the shell with the defaults; pass a {@link LoadingConfig} to
    * restyle it — `color` / `strokeWidth` for the squiggle + skeleton, `amplitude`
@@ -2330,8 +2330,8 @@ export interface LiveChartCoreProps {
    */
   yRangeScale?: SharedValue<number>;
   /**
-   * Label in the empty state when `loading` is false and there are fewer than
-   * two samples (line points or committed candles). Default `"No data"`.
+   * Label in the empty state when `loading` is false and there are no line
+   * points or committed candles. Default `"No data"`.
    */
   emptyText?: string;
   /** Custom formatter for value labels (axes, badge, tooltips). Default `v => v.toFixed(2)`. */

--- a/packages/react-native-livechart/tests/core/chartDataPresence.test.ts
+++ b/packages/react-native-livechart/tests/core/chartDataPresence.test.ts
@@ -1,0 +1,43 @@
+import {
+  hasCandleChartData,
+  hasLineChartData,
+  hasMultiSeriesChartData,
+} from "../../src/core/chartDataPresence";
+import type { CandlePoint, SeriesConfig } from "../../src/types";
+
+describe("chart data presence", () => {
+  it("treats one line point as data and an empty line as empty", () => {
+    expect(hasLineChartData([{ time: 1, value: 100 }])).toBe(true);
+    expect(hasLineChartData([])).toBe(false);
+  });
+
+  it("treats one committed candle as data", () => {
+    const candle: CandlePoint = {
+      time: 1,
+      open: 100,
+      high: 105,
+      low: 95,
+      close: 102,
+    };
+
+    expect(hasCandleChartData([candle])).toBe(true);
+    expect(hasCandleChartData([])).toBe(false);
+    expect(hasCandleChartData(undefined)).toBe(false);
+  });
+
+  it("treats one point in any series as multi-series data", () => {
+    const series: SeriesConfig[] = [
+      { id: "empty", label: "Empty", data: [], value: 0 },
+      {
+        id: "one",
+        label: "One point",
+        data: [{ time: 1, value: 100 }],
+        value: 100,
+      },
+    ];
+
+    expect(hasMultiSeriesChartData(series)).toBe(true);
+    expect(hasMultiSeriesChartData([{ ...series[0] }])).toBe(false);
+    expect(hasMultiSeriesChartData([])).toBe(false);
+  });
+});

--- a/packages/react-native-livechart/tests/draw/line.test.ts
+++ b/packages/react-native-livechart/tests/draw/line.test.ts
@@ -228,6 +228,26 @@ describe("buildLinePoints", () => {
     expect(out.length).toBeGreaterThanOrEqual(4);
   });
 
+  it("connects one historical point to the live tip", () => {
+    const now = 100;
+    const out = buildLinePoints(
+      [{ time: now - 15, value: 100 }],
+      105,
+      now,
+      30,
+      90,
+      110,
+      200,
+      120,
+      pad,
+    );
+
+    expect(out).toHaveLength(4);
+    expect(out[0]).toBeGreaterThan(pad.left);
+    expect(out[0]).toBeLessThan(200 - pad.right);
+    expect(out[2]).toBe(200 - pad.right);
+  });
+
   it("uses startIdx lo-1 when lo > 0", () => {
     const now = 1000;
     const data = [


### PR DESCRIPTION
## Summary

- treat one line point, multi-series point, or committed candle as valid data
- keep reverse-morph state aligned with the same data-presence rule
- update the demo, API docs, guide, JSDoc, changelog, and regression coverage

## Verification

- npm run verify
- native iOS build
- React Doctor 89/100 with no new warnings

Fixes #302