### PR TITLE
chore: remove obsolete demo route exports

### DIFF
--- a/app/demo/android-surface-rendering.tsx
+++ b/app/demo/android-surface-rendering.tsx
@@ -10,8 +10,6 @@ import { DemoScreen } from "../../demo-lib/DemoScreen";
 import { colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Android surface rendering" };
-
 const MODES: { value: CanvasMode; label: string }[] = [
   { value: "transparent", label: "TextureView" },
   { value: "opaque", label: "SurfaceView" },

--- a/app/demo/axes-and-grid.tsx
+++ b/app/demo/axes-and-grid.tsx
@@ -15,8 +15,6 @@ import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Axes & grid" };
-
 type ChartKind = "single" | "multi";
 type AxisVis = "both" | "noY" | "noX" | "none";
 type GapPreset = "default" | "wide";

--- a/app/demo/axis-auto-hide.tsx
+++ b/app/demo/axis-auto-hide.tsx
@@ -7,8 +7,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Axis auto-hide" };
-
 type IdleOpacity = "hidden" | "dim";
 type HideDelay = 1000 | 3000 | 5000;
 

--- a/app/demo/badge-styling.tsx
+++ b/app/demo/badge-styling.tsx
@@ -12,8 +12,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Badge styling" };
-
 // ─── Position (tail on "right", plain pill on "left") ───────────────────────
 type Pos = "right" | "left";
 const POSITIONS: { value: Pos; label: string }[] = [

--- a/app/demo/candle-scrub.tsx
+++ b/app/demo/candle-scrub.tsx
@@ -16,8 +16,6 @@ import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Candle scrub" };
-
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 type Field = "open" | "high" | "low" | "close";

--- a/app/demo/candlestick.tsx
+++ b/app/demo/candlestick.tsx
@@ -16,8 +16,6 @@ import {
   type HistoryRange,
 } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Candlestick" };
-
 /**
  * Candle timeframes. Each pairs a visible window with a candle width AND a
  * `seedRange` whose ideal sampling interval is far finer than `candleWidthSecs`,

--- a/app/demo/coin-list.tsx
+++ b/app/demo/coin-list.tsx
@@ -17,8 +17,6 @@ import {
 import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 
-export const options = { title: "Coin list" };
-
 // Hundreds of rows, each a static sparkline, in one virtualized + recycled list.
 const COIN_COUNT = 500;
 const ROW_HEIGHT = 64;

--- a/app/demo/empty-candles.tsx
+++ b/app/demo/empty-candles.tsx
@@ -14,8 +14,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Chart gaps" };
-
 type ChartMode = "line" | "candle";
 type Scenario = "no-trades" | "unavailable" | "unknown";
 type Treatment = "raw" | "forward" | "semantic" | "styled";

--- a/app/demo/extrema-labels.tsx
+++ b/app/demo/extrema-labels.tsx
@@ -11,8 +11,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Extrema labels" };
-
 type Position = "extrema" | "extrema-edge" | "right";
 
 // `"extrema"` floats topLabel/bottomLabel at the actual high / low data point;

--- a/app/demo/historical-data.tsx
+++ b/app/demo/historical-data.tsx
@@ -9,8 +9,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { demoStyles } from "../../demo-lib/styles";
 
-export const options = { title: "Historical data fill" };
-
 const SPAN = 600; // 10 minutes of history
 const COUNT = 150;
 

--- a/app/demo/line-and-area.tsx
+++ b/app/demo/line-and-area.tsx
@@ -16,8 +16,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Line & area" };
-
 type BadgeMode = "on" | "off" | "left" | "minimal" | "noTail" | "customBg";
 
 type LineMode = "default" | "solid" | "gradient" | "tricolor" | "custom";

--- a/app/demo/line-denoising.tsx
+++ b/app/demo/line-denoising.tsx
@@ -16,8 +16,6 @@ import {
 import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 
-export const options = { title: "Line denoising" };
-
 const SPAN_SECONDS = 60;
 const POINT_COUNT = 241;
 const END_TIME = 1_700_000_060;

--- a/app/demo/loading-data-on-scroll.tsx
+++ b/app/demo/loading-data-on-scroll.tsx
@@ -13,8 +13,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME } from "../../demo-lib/theme";
 
-export const options = { title: "Loading data on scroll" };
-
 const TIME_WINDOW_SEC = 60;
 const ARCHIVE_STEP_SEC = 2;
 const ARCHIVE_ROWS = 480;

--- a/app/demo/momentum-and-degen.tsx
+++ b/app/demo/momentum-and-degen.tsx
@@ -12,8 +12,6 @@ import { ACCENT, VOLATILITY_MODES } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Momentum & degen" };
-
 type MomentumMode =
   | "auto"
   | "off"

--- a/app/demo/order-ticket.tsx
+++ b/app/demo/order-ticket.tsx
@@ -14,8 +14,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Order ticket" };
-
 type DisplayMode = "line" | "candle";
 
 const DISPLAY_OPTIONS: { value: DisplayMode; label: string }[] = [

--- a/app/demo/overlay-bridge.tsx
+++ b/app/demo/overlay-bridge.tsx
@@ -17,8 +17,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Overlay bridge" };
-
 const WINDOW_SECS = 60;
 
 type Level = { price: number; label: string; color: string };

--- a/app/demo/playback.tsx
+++ b/app/demo/playback.tsx
@@ -7,8 +7,6 @@ import { Chip, ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { ACCENT, TIME_WINDOWS } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 
-export const options = { title: "Playback" };
-
 /** Wide sine sweep (≈ -50…200) so the Y-axis clamps below are visibly testable. */
 const wave = (t: number) => 75 + 125 * Math.sin(t / 3);
 

--- a/app/demo/playground.tsx
+++ b/app/demo/playground.tsx
@@ -29,8 +29,6 @@ import {
   type HistoryRange,
 } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Playground" };
-
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 // Built once at module scope so it isn't reconstructed per render (js-hoist-intl).

--- a/app/demo/reference-lines-and-bands.tsx
+++ b/app/demo/reference-lines-and-bands.tsx
@@ -11,8 +11,6 @@ import { ACCENT, formatWholeValue } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Reference lines & bands" };
-
 const START = 100;
 
 type ChartKind = "single" | "multi";

--- a/app/demo/scroll-interaction.tsx
+++ b/app/demo/scroll-interaction.tsx
@@ -21,8 +21,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Scroll interaction" };
-
 type ActiveChart = "single" | "series" | "none";
 
 export default function ScrollInteractionScreen() {

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -23,8 +23,6 @@ import { APP_THEME } from "../../demo-lib/theme";
 import { demoStyles } from "../../demo-lib/styles";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Scrubbing" };
-
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 // Seed price for the line so the reference lines below land in-range.

--- a/app/demo/segments.tsx
+++ b/app/demo/segments.tsx
@@ -11,8 +11,6 @@ import { Chip, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 
-export const options = { title: "Segments" };
-
 // Three sessions (pre-market | regular | after-hours) partition the chart. The
 // line is ONE color at rest; scrubbing a session keeps it full and de-emphasizes
 // the others (the Robinhood model). Framed with nowOverride + timeWindow so the

--- a/app/demo/sparklines.tsx
+++ b/app/demo/sparklines.tsx
@@ -9,8 +9,6 @@ import { ACCENT, ACCENT_PRESETS } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { demoStyles } from "../../demo-lib/styles";
 
-export const options = { title: "Sparklines" };
-
 const CELL_COUNT = 24;
 const POINTS_PER_CELL = 40;
 const CELL_SPAN = 60; // seconds of history per sparkline

--- a/app/demo/states-and-formatting.tsx
+++ b/app/demo/states-and-formatting.tsx
@@ -9,8 +9,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "States & formatting" };
-
 /** Worklet-safe — same as toISOString().slice(11, 19) in UTC (Date/toISOString not reliable inside UI worklets). */
 function formatTimeIsoUtcFragment(t: number): string {
   "worklet";

--- a/app/demo/theming.tsx
+++ b/app/demo/theming.tsx
@@ -21,8 +21,6 @@ import { APP_THEME } from "../../demo-lib/theme";
 
 const googleSansCodeRegular = require("../../assets/fonts/GoogleSansCode-Regular.ttf");
 
-export const options = { title: "Theming" };
-
 const FONT_SIZES = [10, 11, 13, 15] as const;
 const WEIGHTS: FontWeight[] = ["normal", "600", "bold"];
 

--- a/app/demo/threshold.tsx
+++ b/app/demo/threshold.tsx
@@ -15,8 +15,6 @@ import { ChipRow, ControlRow, ToggleChip } from "../../demo-lib/ChipRow";
 import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME } from "../../demo-lib/theme";
 
-export const options = { title: "Threshold split" };
-
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 const CENTER = 100;

--- a/app/demo/transitions.tsx
+++ b/app/demo/transitions.tsx
@@ -9,8 +9,6 @@ import { APP_THEME } from "../../demo-lib/theme";
 import { demoStyles } from "../../demo-lib/styles";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Transitions" };
-
 const WINDOW = 300;
 const CANDLE_WIDTH = 15;
 

--- a/app/demo/working-orders.tsx
+++ b/app/demo/working-orders.tsx
@@ -14,8 +14,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Working orders" };
-
 const START = 100;
 const BUY_COLOR = "#34d399";
 const SELL_COLOR = "#f87171";

--- a/app/demo/y-range-scale.tsx
+++ b/app/demo/y-range-scale.tsx
@@ -18,8 +18,6 @@ import { ACCENT } from "../../demo-lib/shared";
 import { APP_THEME, colors } from "../../demo-lib/theme";
 import { useSimulatedChartData } from "../../sim/useSimulatedChartData";
 
-export const options = { title: "Y-range scale" };
-
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 type Mode = "line" | "candle" | "series";


### PR DESCRIPTION
## Summary

- remove redundant named route component exports from 29 Expo Router demo files
- keep default route exports unchanged
- reduce React Doctor noise without changing navigation behavior

## QA

- `npm run verify`: 111 suites passed; 1,650 tests passed, 5 skipped
- React Doctor 0.9.13 suppression-neutralized scan: 45 diagnostics, down from 74
- production Expo web export: passed with all 47 routes
- production JS bundle: 4,585,546 bytes raw / 1,160,543 bytes gzip, down 2,076 / 868 bytes

Part of #307.