### PR TITLE
refactor: split complex demo screens

### DIFF
--- a/app/demo/axes-and-grid.tsx
+++ b/app/demo/axes-and-grid.tsx
@@ -72,6 +72,88 @@ const GRID_STYLES: Record<GridLineStyle, GridStyleConfig | undefined> = {
   blue: { intervals: [], color: "rgba(96,165,250,0.5)", opacity: 1 },
 };
 
+function resolveYAxis(
+  visible: boolean,
+  gap: GapPreset,
+  count: YCountPreset,
+  column: YAxisColumnPreset,
+): YAxisConfig | boolean {
+  if (!visible) return false;
+
+  const config: YAxisConfig = {};
+  if (gap === "wide") config.minGap = 72;
+  if (count !== "auto") config.count = Number(count);
+  if (column !== "off") {
+    config.labelRightMargin = column === "tight" ? 8 : 24;
+    config.gridEndGap = column === "tight" ? 4 : 12;
+  }
+  return Object.keys(config).length > 0 ? config : true;
+}
+
+function axisLabel(
+  custom: boolean,
+  enabled: boolean,
+  label: "HIGH" | "LOW",
+): AxisLabelConfig | boolean | undefined {
+  if (custom) {
+    return {
+      render: () => (
+        <Text style={[demoStyles.scrubReadout, { marginBottom: 0 }]}>
+          {label}
+        </Text>
+      ),
+    };
+  }
+  return enabled || undefined;
+}
+
+type AxesChartProps = {
+  which: ChartKind;
+  data: ReturnType<typeof useSimulatedChartData>["data"];
+  value: ReturnType<typeof useSimulatedChartData>["value"];
+  series: ReturnType<typeof useSimulatedChartData>["series"];
+  yAxis: YAxisConfig | boolean;
+  xAxis: boolean | { minGap: number };
+  gridStyle: GridStyleConfig | undefined;
+  leftEdgeFade: { width: number } | undefined;
+  insets: { bottom: number } | undefined;
+  topLabel: AxisLabelConfig | boolean | undefined;
+  bottomLabel: AxisLabelConfig | boolean | undefined;
+};
+
+function AxesChart({
+  which,
+  data,
+  value,
+  series,
+  yAxis,
+  xAxis,
+  gridStyle,
+  leftEdgeFade,
+  insets,
+  topLabel,
+  bottomLabel,
+}: AxesChartProps) {
+  const common = {
+    accentColor: ACCENT,
+    theme: APP_THEME,
+    yAxis,
+    xAxis,
+    gridStyle,
+    leftEdgeFade,
+    insets,
+    scrub: true,
+    topLabel,
+    bottomLabel,
+    formatValue: formatWholeValue,
+  };
+  return which === "single" ? (
+    <LiveChart data={data} value={value} {...common} />
+  ) : (
+    <LiveChartSeries series={series} {...common} />
+  );
+}
+
 export default function AxesGridScreen() {
   const [vis, setVis] = useState<AxisVis>("both");
   const [gap, setGap] = useState<GapPreset>("default");
@@ -89,25 +171,18 @@ export default function AxesGridScreen() {
   // obvious. `undefined` keeps the chart's built-in fade.
   const leftEdgeFade = edgeFade ? { width: 64 } : undefined;
 
-  const yOn = vis !== "noY" && vis !== "none";
-  const xOn = vis !== "noX" && vis !== "none";
-
-  // `count` shows a fixed number of evenly-spaced prices (high→low) instead of
-  // the dynamic nice-interval grid; `minGap` still acts as a floor on spacing.
-  const yCountVal = yCount === "auto" ? 0 : Number(yCount);
-  const yAxisCfg: YAxisConfig = {};
-  if (gap === "wide") yAxisCfg.minGap = 72;
-  if (yCountVal > 0) yAxisCfg.count = yCountVal;
-  if (yAxisColumn !== "off") {
-    yAxisCfg.labelRightMargin = yAxisColumn === "tight" ? 8 : 24;
-    yAxisCfg.gridEndGap = yAxisColumn === "tight" ? 4 : 12;
-  }
-  const yAxis = !yOn
-    ? false
-    : Object.keys(yAxisCfg).length > 0
-      ? yAxisCfg
-      : true;
-  const xAxis = !xOn ? false : gap === "wide" ? { minGap: 100 } : true;
+  const yAxis = resolveYAxis(
+    vis !== "noY" && vis !== "none",
+    gap,
+    yCount,
+    yAxisColumn,
+  );
+  const xAxis =
+    vis === "noX" || vis === "none"
+      ? false
+      : gap === "wide"
+        ? { minGap: 100 }
+        : true;
 
   // An explicit inset overrides the auto-padding — including the live-dot pulse's
   // reserved room — so the plot fills to the edge (the pulse ring may clip there).
@@ -124,18 +199,8 @@ export default function AxesGridScreen() {
     historyRange: "1m",
   });
 
-  // Built-in high/low labels: the chart floats its current top / bottom Y-axis
-  // bound at each edge, formatted and updated on the UI thread — no hand-rolled
-  // animated text needed. A `render` escape hatch demos a fully custom element.
-  const customTop: AxisLabelConfig = {
-    render: () => <Text style={[demoStyles.scrubReadout, { marginBottom: 0 }]}>HIGH</Text>,
-  };
-  const customBottom: AxisLabelConfig = {
-    render: () => <Text style={[demoStyles.scrubReadout, { marginBottom: 0 }]}>LOW</Text>,
-  };
-
-  const topLabel = customLabel ? customTop : highLow ? true : undefined;
-  const bottomLabel = customLabel ? customBottom : highLow ? true : undefined;
+  const topLabel = axisLabel(customLabel, highLow, "HIGH");
+  const bottomLabel = axisLabel(customLabel, highLow, "LOW");
 
   return (
     <DemoScreen
@@ -143,38 +208,19 @@ export default function AxesGridScreen() {
       docs="guides/axes-and-grid"
       description="Hide Y, X, or both; axis minGap; a fixed Y-axis price count; explicit insets (bottom 0 fills the plot to the edge). Toggle single vs multi chart, and Robinhood-style high/low edge labels (built-in or a custom render)."
       chart={
-        which === "single" ? (
-          <LiveChart
-            data={data}
-            value={value}
-            accentColor={ACCENT}
-            theme={APP_THEME}
-            yAxis={yAxis}
-            xAxis={xAxis}
-            gridStyle={gridStyle}
-            leftEdgeFade={leftEdgeFade}
-            insets={insets}
-            scrub
-            topLabel={topLabel}
-            bottomLabel={bottomLabel}
-            formatValue={formatWholeValue}
-          />
-        ) : (
-          <LiveChartSeries
-            series={series}
-            accentColor={ACCENT}
-            theme={APP_THEME}
-            yAxis={yAxis}
-            xAxis={xAxis}
-            gridStyle={gridStyle}
-            leftEdgeFade={leftEdgeFade}
-            insets={insets}
-            scrub
-            topLabel={topLabel}
-            bottomLabel={bottomLabel}
-            formatValue={formatWholeValue}
-          />
-        )
+        <AxesChart
+          which={which}
+          data={data}
+          value={value}
+          series={series}
+          yAxis={yAxis}
+          xAxis={xAxis}
+          gridStyle={gridStyle}
+          leftEdgeFade={leftEdgeFade}
+          insets={insets}
+          topLabel={topLabel}
+          bottomLabel={bottomLabel}
+        />
       }
     >
       <ChipRow

--- a/app/demo/empty-candles.tsx
+++ b/app/demo/empty-candles.tsx
@@ -105,6 +105,51 @@ function labelFor(kind: Scenario): string {
   return "Feed unavailable";
 }
 
+function resolveChartGaps(
+  treatment: Treatment,
+  gap: ChartGap,
+  scenario: Scenario,
+  styled: StyledGapControls,
+): ChartGap[] | ChartGapsConfig | undefined {
+  if (treatment === "semantic") return [gap];
+  if (treatment === "forward") {
+    return {
+      gaps: [gap],
+      styles: { [scenario]: { bridge: {}, band: false, label: false } },
+    };
+  }
+  if (treatment !== "styled") return undefined;
+
+  const style: ChartGapStyle = {
+    bridge: styled.bridge
+      ? {
+          color: styled.independentColors ? "#16a34a" : undefined,
+          opacity: styled.bridgeOpacity,
+          strokeWidth: styled.bridgeWidth,
+          strokeCap: styled.bridgeCap,
+        }
+      : false,
+    band: styled.band
+      ? {
+          fillColor: styled.independentColors ? "#7c3aed" : undefined,
+          fillOpacity: styled.bandFillOpacity,
+          borderColor: styled.independentColors ? "#f59e0b" : undefined,
+          borderOpacity: styled.borderOpacity,
+          borderWidth: styled.borderWidth,
+          intervals: DASH_INTERVALS[styled.dashPattern],
+        }
+      : false,
+    label:
+      styled.band && styled.label
+        ? {
+            color: styled.independentColors ? "#7c3aed" : undefined,
+            position: styled.labelPosition,
+          }
+        : false,
+  };
+  return { gaps: [gap], styles: { [scenario]: style } };
+}
+
 function GapChart({
   mode,
   scenario,
@@ -161,50 +206,7 @@ function GapChart({
       .filter((candle) => candle.time < gap.from || candle.time >= gap.to),
   );
 
-  let chartGaps: ChartGap[] | ChartGapsConfig | undefined;
-  if (treatment === "semantic") {
-    chartGaps = [gap];
-  } else if (treatment === "forward") {
-    chartGaps = {
-      gaps: [gap],
-      styles: {
-        [scenario]: {
-          bridge: {},
-          band: false,
-          label: false,
-        },
-      },
-    };
-  } else if (treatment === "styled") {
-    const style: ChartGapStyle = {
-      bridge: styled.bridge
-        ? {
-            color: styled.independentColors ? "#16a34a" : undefined,
-            opacity: styled.bridgeOpacity,
-            strokeWidth: styled.bridgeWidth,
-            strokeCap: styled.bridgeCap,
-          }
-        : false,
-      band: styled.band
-        ? {
-            fillColor: styled.independentColors ? "#7c3aed" : undefined,
-            fillOpacity: styled.bandFillOpacity,
-            borderColor: styled.independentColors ? "#f59e0b" : undefined,
-            borderOpacity: styled.borderOpacity,
-            borderWidth: styled.borderWidth,
-            intervals: DASH_INTERVALS[styled.dashPattern],
-          }
-        : false,
-      label:
-        styled.band && styled.label
-          ? {
-              color: styled.independentColors ? "#7c3aed" : undefined,
-              position: styled.labelPosition,
-            }
-          : false,
-    };
-    chartGaps = { gaps: [gap], styles: { [scenario]: style } };
-  }
+  const chartGaps = resolveChartGaps(treatment, gap, scenario, styled);
 
   return (
     <LiveChart

--- a/app/demo/markers-and-trades.tsx
+++ b/app/demo/markers-and-trades.tsx
@@ -1,7 +1,18 @@
 import { BlurView } from "expo-blur";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { LiveChart, type Marker, type MarkerKind } from "react-native-livechart";
+import {
+  LiveChart,
+  type Marker,
+  type MarkerClusterConfig,
+  type MarkerKind,
+} from "react-native-livechart";
 import { useSharedValue } from "react-native-reanimated";
 
 import { DemoScreen } from "../../demo-lib/DemoScreen";
@@ -17,7 +28,10 @@ type Side = "buy" | "sell";
 const BUY_COLOR = "#16a34a";
 const SELL_COLOR = "#dc2626";
 
-const VOLATILITY_OPTIONS = VOLATILITY_MODES.map((m) => ({ value: m, label: m }));
+const VOLATILITY_OPTIONS = VOLATILITY_MODES.map((m) => ({
+  value: m,
+  label: m,
+}));
 
 /**
  * The full built-in glyph library — drawn into the Skia canvas with no `icon` /
@@ -129,6 +143,173 @@ function GlassMarker({ side }: { side: Side }) {
   );
 }
 
+function resolveMarkerCluster(
+  stacked: boolean,
+  vertical: boolean,
+  overlap: number,
+  maxVisible: number | undefined,
+  groupBadge: GroupBadge,
+): "anchored" | MarkerClusterConfig {
+  if (!stacked) return "anchored";
+  return {
+    mode: "stacked",
+    direction: vertical ? "vertical" : "horizontal",
+    overlap,
+    maxBeforeGroup: vertical ? 20 : 5,
+    maxVisible: vertical ? maxVisible : undefined,
+    groupBadge:
+      groupBadge === "count"
+        ? "count"
+        : groupBadge === "custom"
+          ? CUSTOM_GROUP_BADGE
+          : "marker",
+    showGroupCount: groupBadge === "marker+count",
+  };
+}
+
+type MarkersChartProps = {
+  data: ReturnType<typeof useSimulatedChartData>["data"];
+  value: ReturnType<typeof useSimulatedChartData>["value"];
+  tradeStream: ReturnType<typeof useSimulatedChartData>["tradeStream"];
+  markers: ReturnType<typeof useSharedValue<Marker[]>>;
+  hitRadius: number;
+  stacked: boolean;
+  vertical: boolean;
+  overlap: number;
+  maxVisible: number | undefined;
+  groupBadge: GroupBadge;
+  custom: boolean;
+  streamOn: boolean;
+  setHover: Dispatch<SetStateAction<string>>;
+};
+
+function MarkersChart(props: MarkersChartProps) {
+  return (
+    <LiveChart
+      data={props.data}
+      value={props.value}
+      accentColor={ACCENT}
+      theme={APP_THEME}
+      timeWindow={WINDOW}
+      markers={props.markers}
+      markerHitRadius={props.hitRadius}
+      markerCluster={resolveMarkerCluster(
+        props.stacked,
+        props.vertical,
+        props.overlap,
+        props.maxVisible,
+        props.groupBadge,
+      )}
+      renderMarker={
+        props.custom
+          ? (marker) => (
+              <GlassMarker
+                side={(marker.data as { side?: Side })?.side ?? "buy"}
+              />
+            )
+          : undefined
+      }
+      tradeStream={props.streamOn ? props.tradeStream : undefined}
+      onMarkerPress={(event) => {
+        const side = (event?.marker.data as { side?: Side } | undefined)?.side;
+        props.setHover(
+          event
+            ? event.isGrouped
+              ? `group of ${event.members?.length ?? 0} (tap #${event.index})`
+              : `${side ?? "marker"} @ (${event.point.x.toFixed(0)}, ${event.point.y.toFixed(0)})`
+            : "missed — tap a pill",
+        );
+      }}
+      scrub={false}
+    />
+  );
+}
+
+type CollisionControlsProps = {
+  stacked: boolean;
+  setStacked: Dispatch<SetStateAction<boolean>>;
+  vertical: boolean;
+  setVertical: Dispatch<SetStateAction<boolean>>;
+  overlap: number;
+  setOverlap: Dispatch<SetStateAction<number>>;
+  maxVisible: number | undefined;
+  setMaxVisible: Dispatch<SetStateAction<number | undefined>>;
+  groupBadge: GroupBadge;
+  setGroupBadge: Dispatch<SetStateAction<GroupBadge>>;
+};
+
+function CollisionControls(props: CollisionControlsProps) {
+  if (!props.stacked) {
+    return (
+      <ControlRow label="Collision">
+        <ToggleChip
+          label="markerCluster: stacked"
+          value={false}
+          onChange={props.setStacked}
+        />
+      </ControlRow>
+    );
+  }
+  return (
+    <>
+      <ControlRow label="Collision">
+        <ToggleChip
+          label="markerCluster: stacked"
+          value
+          onChange={props.setStacked}
+        />
+        <ToggleChip
+          label="vertical column"
+          value={props.vertical}
+          onChange={props.setVertical}
+        />
+      </ControlRow>
+      <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+        With stacking on, co-located markers fan apart horizontally
+        (overlapping, left-over-right); a dense burst collapses to a count badge
+        (tap it for the member list). Switch on the vertical column to pile them
+        up the value axis instead (buys down, sells up) — the
+        transactions-on-the-candle look. Cap a vertical column to keep the
+        oldest glyphs near the line and hide newer overflow.
+      </Text>
+      <ChipRow
+        label="Overlap"
+        options={OVERLAP_OPTIONS}
+        value={props.overlap}
+        onChange={props.setOverlap}
+      />
+      {props.vertical ? (
+        <>
+          <ChipRow
+            label="Vertical column cap (maxVisible)"
+            options={MAX_VISIBLE_OPTIONS}
+            value={props.maxVisible}
+            onChange={props.setMaxVisible}
+          />
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            Try a capped column with Burst ×12: `maxBeforeGroup` stays at 20
+            here, so `maxVisible` can hide the newest markers instead of
+            collapsing the burst to a count badge.
+          </Text>
+        </>
+      ) : null}
+      <ChipRow
+        label="Collapsed group badge"
+        options={GROUP_BADGE_OPTIONS}
+        value={props.groupBadge}
+        onChange={props.setGroupBadge}
+      />
+      <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+        A collapsed burst can show the round count, the representative buy/sell
+        pill (`groupBadge: &quot;marker&quot;`, optionally with a corner
+        &quot;+N&quot; via `showGroupCount`), or a dedicated custom badge — here
+        a purple ★ pill (`groupBadge: {"{"} icon: &quot;★&quot;, pill: true{" "}
+        {"}"}`), its own glyph independent of the members. All drawn in Skia.
+      </Text>
+    </>
+  );
+}
+
 export default function MarkersScreen() {
   const [auto, setAuto] = useState(true);
   const [hover, setHover] = useState("Tap a marker");
@@ -226,59 +407,20 @@ export default function MarkersScreen() {
       docs="guides/markers-and-trades"
       description="Buy / sell markers anchored to the line — green + pill (buy), red − pill (sell). Tap a pill to hover; optional tradeStream overlay."
       chart={
-        <LiveChart
+        <MarkersChart
           data={data}
           value={value}
-          accentColor={ACCENT}
-          theme={APP_THEME}
-          timeWindow={WINDOW}
+          tradeStream={tradeStream}
           markers={markers}
-          markerHitRadius={hitRadius}
-          markerCluster={
-            stacked
-              ? {
-                  mode: "stacked",
-                  direction: vertical ? "vertical" : "horizontal",
-                  overlap,
-                  maxBeforeGroup: vertical ? 20 : 5,
-                  maxVisible: vertical ? maxVisible : undefined,
-                  // #165: collapsed-group look — a count circle, the representative
-                  // buy/sell pill (optionally with a corner "+N"), or a dedicated
-                  // custom group badge (its own glyph, distinct from the members).
-                  groupBadge:
-                    groupBadge === "count"
-                      ? "count"
-                      : groupBadge === "custom"
-                        ? CUSTOM_GROUP_BADGE
-                        : "marker",
-                  // `showGroupCount` is its own concern — demoed by "Pill +N".
-                  // "Custom" shows just the dedicated badge (no corner count) so the
-                  // two ideas don't blur together; the count still composes with it.
-                  showGroupCount: groupBadge === "marker+count",
-                }
-              : "anchored"
-          }
-          renderMarker={
-            custom
-              ? (m) => (
-                  <GlassMarker
-                    side={(m.data as { side?: Side })?.side ?? "buy"}
-                  />
-                )
-              : undefined
-          }
-          tradeStream={streamOn ? tradeStream : undefined}
-          onMarkerPress={(e) => {
-            const side = (e?.marker.data as { side?: Side } | undefined)?.side;
-            setHover(
-              e
-                ? e.isGrouped
-                  ? `group of ${e.members?.length ?? 0} (tap #${e.index})`
-                  : `${side ?? "marker"} @ (${e.point.x.toFixed(0)}, ${e.point.y.toFixed(0)})`
-                : "missed — tap a pill",
-            );
-          }}
-          scrub={false}
+          hitRadius={hitRadius}
+          stacked={stacked}
+          vertical={vertical}
+          overlap={overlap}
+          maxVisible={maxVisible}
+          groupBadge={groupBadge}
+          custom={custom}
+          streamOn={streamOn}
+          setHover={setHover}
         />
       }
     >
@@ -295,7 +437,11 @@ export default function MarkersScreen() {
         <Chip label="Sell −" active={false} onPress={() => spawn("sell")} />
         <Chip label="Fan ×4" active={false} onPress={() => spawnCluster(4)} />
         <Chip label="Burst ×9" active={false} onPress={() => spawnCluster(9)} />
-        <Chip label="Burst ×12" active={false} onPress={() => spawnCluster(12)} />
+        <Chip
+          label="Burst ×12"
+          active={false}
+          onPress={() => spawnCluster(12)}
+        />
         <Chip label="Clear" active={false} onPress={() => markers.set([])} />
       </ControlRow>
       <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
@@ -326,60 +472,18 @@ export default function MarkersScreen() {
         onChange={setHitRadius}
       />
 
-      <ControlRow label="Collision">
-        <ToggleChip label="markerCluster: stacked" value={stacked} onChange={setStacked} />
-        {stacked ? (
-          <ToggleChip label="vertical column" value={vertical} onChange={setVertical} />
-        ) : null}
-      </ControlRow>
-      <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-        With stacking on, co-located markers fan apart horizontally (overlapping,
-        left-over-right); a dense burst collapses to a count badge (tap it for the
-        member list). Switch on the vertical column to pile them up the value axis
-        instead (buys down, sells up) — the transactions-on-the-candle look. Cap
-        a vertical column to keep the oldest glyphs near the line and hide newer
-        overflow.
-      </Text>
-      {stacked ? (
-        <ChipRow
-          label="Overlap"
-          options={OVERLAP_OPTIONS}
-          value={overlap}
-          onChange={setOverlap}
-        />
-      ) : null}
-      {stacked && vertical ? (
-        <ChipRow
-          label="Vertical column cap (maxVisible)"
-          options={MAX_VISIBLE_OPTIONS}
-          value={maxVisible}
-          onChange={(cap) => setMaxVisible(cap)}
-        />
-      ) : null}
-      {stacked && vertical ? (
-        <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-          Try a capped column with Burst ×12: `maxBeforeGroup` stays at 20 here,
-          so `maxVisible` can hide the newest markers instead of collapsing the
-          burst to a count badge.
-        </Text>
-      ) : null}
-      {stacked ? (
-        <ChipRow
-          label="Collapsed group badge"
-          options={GROUP_BADGE_OPTIONS}
-          value={groupBadge}
-          onChange={setGroupBadge}
-        />
-      ) : null}
-      {stacked ? (
-        <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-          A collapsed burst can show the round count, the representative buy/sell
-          pill (`groupBadge: &quot;marker&quot;`, optionally with a corner
-          &quot;+N&quot; via `showGroupCount`), or a dedicated custom badge — here a
-          purple ★ pill (`groupBadge: {'{'} icon: &quot;★&quot;, pill: true {'}'}`),
-          its own glyph independent of the members. All drawn in Skia.
-        </Text>
-      ) : null}
+      <CollisionControls
+        stacked={stacked}
+        setStacked={setStacked}
+        vertical={vertical}
+        setVertical={setVertical}
+        overlap={overlap}
+        setOverlap={setOverlap}
+        maxVisible={maxVisible}
+        setMaxVisible={setMaxVisible}
+        groupBadge={groupBadge}
+        setGroupBadge={setGroupBadge}
+      />
 
       <ControlRow label="Custom render">
         <ToggleChip label="renderMarker" value={custom} onChange={setCustom} />
@@ -391,7 +495,11 @@ export default function MarkersScreen() {
       </Text>
 
       <ControlRow label="Trade stream">
-        <ToggleChip label="tradeStream" value={streamOn} onChange={setStreamOn} />
+        <ToggleChip
+          label="tradeStream"
+          value={streamOn}
+          onChange={setStreamOn}
+        />
       </ControlRow>
       <ChipRow
         label="Volatility"
@@ -413,7 +521,8 @@ const glass = StyleSheet.create({
     borderRadius: 999,
     borderWidth: StyleSheet.hairlineWidth,
     // Hairline rim sells the "glass" edge; overflow clips the blur to the pill.
-    borderColor: APP_THEME === "dark" ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.12)",
+    borderColor:
+      APP_THEME === "dark" ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.12)",
     overflow: "hidden",
   },
   dot: { width: 6, height: 6, borderRadius: 3 },

--- a/app/demo/multi-series.tsx
+++ b/app/demo/multi-series.tsx
@@ -1,5 +1,11 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { StyleSheet, Text, TextInput, View } from "react-native";
 import {
   formatTime,
@@ -13,6 +19,7 @@ import Animated, {
   useAnimatedProps,
   useAnimatedStyle,
   useSharedValue,
+  type SharedValue,
 } from "react-native-reanimated";
 import { ACCENT, TIME_WINDOWS } from "../../demo-lib/shared";
 
@@ -23,6 +30,24 @@ import { demoStyles } from "../../demo-lib/styles";
 import { APP_THEME } from "../../demo-lib/theme";
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+function SeriesReadout({ text }: { text: SharedValue<string> }) {
+  const animatedProps = useAnimatedProps(() => {
+    const value = text.get();
+    return { text: value, defaultValue: value };
+  });
+  return (
+    <AnimatedTextInput
+      editable={false}
+      multiline
+      numberOfLines={2}
+      scrollEnabled={false}
+      underlineColorAndroid="transparent"
+      style={demoStyles.scrubReadout}
+      animatedProps={animatedProps}
+    />
+  );
+}
 
 function CustomTargetTag({ ctx }: { ctx: ReferenceLineRenderProps }) {
   const caretStyle = useAnimatedStyle(() => ({
@@ -86,13 +111,15 @@ const THEME_OPTIONS: { value: "dark" | "light"; label: string }[] = [
   { value: "light", label: "Light" },
 ];
 
-const AXIS_OPTIONS: { value: "both" | "noY" | "noX" | "none"; label: string }[] =
-  [
-    { value: "both", label: "Both" },
-    { value: "noY", label: "No Y" },
-    { value: "noX", label: "No X" },
-    { value: "none", label: "None" },
-  ];
+const AXIS_OPTIONS: {
+  value: "both" | "noY" | "noX" | "none";
+  label: string;
+}[] = [
+  { value: "both", label: "Both" },
+  { value: "noY", label: "No Y" },
+  { value: "noX", label: "No X" },
+  { value: "none", label: "None" },
+];
 
 // Per-series interpolation. "linear" draws straight segments between samples
 // instead of the default monotone cubic.
@@ -108,6 +135,208 @@ const QA_REFERENCE_EDGE_OPTIONS: { value: number; label: string }[] = [
   { value: 33.8, label: "In range" },
   { value: 0, label: "Below" },
 ];
+
+type DotLegendControlsProps = {
+  dots: boolean;
+  setDots: Dispatch<SetStateAction<boolean>>;
+  ring: boolean;
+  setRing: Dispatch<SetStateAction<boolean>>;
+  pulse: boolean;
+  setPulse: Dispatch<SetStateAction<boolean>>;
+  valueLabels: boolean;
+  setValueLabels: Dispatch<SetStateAction<boolean>>;
+  valueLines: boolean;
+  setValueLines: Dispatch<SetStateAction<boolean>>;
+  dotRadius: number;
+  setDotRadius: Dispatch<SetStateAction<number>>;
+  legendVisible: boolean;
+  setLegendVisible: Dispatch<SetStateAction<boolean>>;
+  legendCompact: boolean;
+  setLegendCompact: Dispatch<SetStateAction<boolean>>;
+  legendPosition: "top" | "bottom";
+  setLegendPosition: Dispatch<SetStateAction<"top" | "bottom">>;
+  styled: boolean;
+  setStyled: Dispatch<SetStateAction<boolean>>;
+  legendStyled: boolean;
+  setLegendStyled: Dispatch<SetStateAction<boolean>>;
+  curve: "monotone" | "linear";
+  setCurve: Dispatch<SetStateAction<"monotone" | "linear">>;
+};
+
+function DotLegendControls(props: DotLegendControlsProps) {
+  return (
+    <>
+      <ControlRow label="Dot">
+        <ToggleChip label="Dots" value={props.dots} onChange={props.setDots} />
+        <ToggleChip label="Ring" value={props.ring} onChange={props.setRing} />
+        <ToggleChip
+          label="Pulse"
+          value={props.pulse}
+          onChange={props.setPulse}
+        />
+        <ToggleChip
+          label="Labels"
+          value={props.valueLabels}
+          onChange={props.setValueLabels}
+        />
+        <ToggleChip
+          label="Value lines"
+          value={props.valueLines}
+          onChange={props.setValueLines}
+        />
+      </ControlRow>
+      <ChipRow
+        options={DOT_RADIUS_OPTIONS}
+        value={props.dotRadius}
+        onChange={props.setDotRadius}
+      />
+      <ControlRow label="Legend">
+        <ToggleChip
+          label="Visible"
+          value={props.legendVisible}
+          onChange={props.setLegendVisible}
+        />
+        <ToggleChip
+          label="Compact"
+          value={props.legendCompact}
+          onChange={props.setLegendCompact}
+        />
+      </ControlRow>
+      <ChipRow
+        options={LEGEND_POSITION_OPTIONS}
+        value={props.legendPosition}
+        onChange={props.setLegendPosition}
+      />
+      <ControlRow label="Per-series style">
+        <ToggleChip
+          label="Styled lines"
+          value={props.styled}
+          onChange={props.setStyled}
+        />
+        <ToggleChip
+          label="Legend style"
+          value={props.legendStyled}
+          onChange={props.setLegendStyled}
+        />
+      </ControlRow>
+      <ChipRow
+        label="Curve (per-series interpolation)"
+        options={CURVE_OPTIONS}
+        value={props.curve}
+        onChange={props.setCurve}
+      />
+    </>
+  );
+}
+
+type PlaybackControlsProps = {
+  paused: boolean;
+  setPaused: Dispatch<SetStateAction<boolean>>;
+  exaggerate: boolean;
+  setExaggerate: Dispatch<SetStateAction<boolean>>;
+  degen: boolean;
+  setDegen: Dispatch<SetStateAction<boolean>>;
+  loading: boolean;
+  setLoading: Dispatch<SetStateAction<boolean>>;
+  showRef: boolean;
+  setShowRef: Dispatch<SetStateAction<boolean>>;
+  panZoom: boolean;
+  setPanZoom: Dispatch<SetStateAction<boolean>>;
+};
+
+function PlaybackControls(props: PlaybackControlsProps) {
+  return (
+    <ControlRow label="Playback & theme">
+      <ToggleChip
+        label="Pause"
+        value={props.paused}
+        onChange={props.setPaused}
+      />
+      <ToggleChip
+        label="Exaggerate"
+        value={props.exaggerate}
+        onChange={props.setExaggerate}
+      />
+      <ToggleChip label="Degen" value={props.degen} onChange={props.setDegen} />
+      <Chip
+        label={props.loading ? "…" : "Load"}
+        active={props.loading}
+        disabled={props.loading}
+        onPress={() => {
+          props.setLoading(true);
+          setTimeout(() => props.setLoading(false), 2000);
+        }}
+      />
+      <ToggleChip
+        label="QA connector"
+        value={props.showRef}
+        onChange={props.setShowRef}
+      />
+      <ToggleChip
+        label="Pan + zoom"
+        value={props.panZoom}
+        onChange={props.setPanZoom}
+      />
+    </ControlRow>
+  );
+}
+
+type ChartSettingsControlsProps = {
+  windowSecs: number;
+  setWindowSecs: Dispatch<SetStateAction<number>>;
+  smoothing: number;
+  setSmoothing: Dispatch<SetStateAction<number>>;
+  scrubDim: number;
+  setScrubDim: Dispatch<SetStateAction<number>>;
+  seriesTooltip: boolean;
+  setSeriesTooltip: Dispatch<SetStateAction<boolean>>;
+  tooltipAlwaysShow: boolean;
+  setTooltipAlwaysShow: Dispatch<SetStateAction<boolean>>;
+  styledTooltip: boolean;
+  setStyledTooltip: Dispatch<SetStateAction<boolean>>;
+};
+
+function ChartSettingsControls(props: ChartSettingsControlsProps) {
+  return (
+    <>
+      <ChipRow
+        label="Time window"
+        options={WINDOW_OPTIONS}
+        value={props.windowSecs}
+        onChange={props.setWindowSecs}
+      />
+      <ChipRow
+        label="Responsiveness"
+        options={RESPONSIVENESS_OPTIONS}
+        value={props.smoothing}
+        onChange={props.setSmoothing}
+      />
+      <ChipRow
+        label="Scrub trailing fade (dimOpacity)"
+        options={SCRUB_DIM_OPTIONS}
+        value={props.scrubDim}
+        onChange={props.setScrubDim}
+      />
+      <ControlRow label="Series scrub tooltip">
+        <ToggleChip
+          label="Pills"
+          value={props.seriesTooltip}
+          onChange={props.setSeriesTooltip}
+        />
+        <ToggleChip
+          label="Pin while idle"
+          value={props.tooltipAlwaysShow}
+          onChange={props.setTooltipAlwaysShow}
+        />
+        <ToggleChip
+          label="Styled"
+          value={props.styledTooltip}
+          onChange={props.setStyledTooltip}
+        />
+      </ControlRow>
+    </>
+  );
+}
 
 export default function MultiSeriesScreen() {
   const seriesVisibilityRef = useRef<Record<string, boolean>>({});
@@ -136,10 +365,6 @@ export default function MultiSeriesScreen() {
   );
 
   const readoutText = useSharedValue("—");
-  const readoutProps = useAnimatedProps(() => {
-    const text = readoutText.get();
-    return { text, defaultValue: text };
-  });
 
   const [pulse, setPulse] = useState(true);
   const [valueLines, setValueLines] = useState(false);
@@ -226,15 +451,7 @@ export default function MultiSeriesScreen() {
       chartWrapperStyle={{ height: 360 }}
       chart={
         <>
-          <AnimatedTextInput
-            editable={false}
-            multiline
-            numberOfLines={2}
-            scrollEnabled={false}
-            underlineColorAndroid="transparent"
-            style={demoStyles.scrubReadout}
-            animatedProps={readoutProps}
-          />
+          <SeriesReadout text={readoutText} />
           <LiveChartSeries
             series={seriesSource}
             accentColor={ACCENT}
@@ -337,134 +554,69 @@ export default function MultiSeriesScreen() {
         </>
       }
     >
-      <ChipRow label="Data" options={DATA_OPTIONS} value={empty} onChange={setEmpty} />
-
-      <ControlRow label="Dot">
-        <ToggleChip label="Dots" value={dots} onChange={setDots} />
-        <ToggleChip label="Ring" value={ring} onChange={setRing} />
-        <ToggleChip label="Pulse" value={pulse} onChange={setPulse} />
-        <ToggleChip label="Labels" value={valueLabels} onChange={setValueLabels} />
-        <ToggleChip
-          label="Value lines"
-          value={valueLines}
-          onChange={setValueLines}
-        />
-      </ControlRow>
       <ChipRow
-        options={DOT_RADIUS_OPTIONS}
-        value={dotRadius}
-        onChange={setDotRadius}
+        label="Data"
+        options={DATA_OPTIONS}
+        value={empty}
+        onChange={setEmpty}
       />
 
-      <ControlRow label="Legend">
-        <ToggleChip
-          label="Visible"
-          value={legendVisible}
-          onChange={setLegendVisible}
-        />
-        <ToggleChip
-          label="Compact"
-          value={legendCompact}
-          onChange={setLegendCompact}
-        />
-      </ControlRow>
-      <ChipRow
-        options={LEGEND_POSITION_OPTIONS}
-        value={legendPosition}
-        onChange={setLegendPosition}
+      <DotLegendControls
+        dots={dots}
+        setDots={setDots}
+        ring={ring}
+        setRing={setRing}
+        pulse={pulse}
+        setPulse={setPulse}
+        valueLabels={valueLabels}
+        setValueLabels={setValueLabels}
+        valueLines={valueLines}
+        setValueLines={setValueLines}
+        dotRadius={dotRadius}
+        setDotRadius={setDotRadius}
+        legendVisible={legendVisible}
+        setLegendVisible={setLegendVisible}
+        legendCompact={legendCompact}
+        setLegendCompact={setLegendCompact}
+        legendPosition={legendPosition}
+        setLegendPosition={setLegendPosition}
+        styled={styled}
+        setStyled={setStyled}
+        legendStyled={legendStyled}
+        setLegendStyled={setLegendStyled}
+        curve={curve}
+        setCurve={setCurve}
       />
 
-      <ControlRow label="Per-series style">
-        <ToggleChip label="Styled lines" value={styled} onChange={setStyled} />
-        <ToggleChip
-          label="Legend style"
-          value={legendStyled}
-          onChange={setLegendStyled}
-        />
-      </ControlRow>
-
-      <ChipRow
-        label="Curve (per-series interpolation)"
-        options={CURVE_OPTIONS}
-        value={curve}
-        onChange={setCurve}
+      <ChartSettingsControls
+        windowSecs={windowSecs}
+        setWindowSecs={setWindowSecs}
+        smoothing={smoothing}
+        setSmoothing={setSmoothing}
+        scrubDim={scrubDim}
+        setScrubDim={setScrubDim}
+        seriesTooltip={seriesTooltip}
+        setSeriesTooltip={setSeriesTooltip}
+        tooltipAlwaysShow={tooltipAlwaysShow}
+        setTooltipAlwaysShow={setTooltipAlwaysShow}
+        styledTooltip={styledTooltip}
+        setStyledTooltip={setStyledTooltip}
       />
 
-      <ChipRow
-        label="Time window"
-        options={WINDOW_OPTIONS}
-        value={windowSecs}
-        onChange={setWindowSecs}
+      <PlaybackControls
+        paused={paused}
+        setPaused={setPaused}
+        exaggerate={exaggerate}
+        setExaggerate={setExaggerate}
+        degen={degen}
+        setDegen={setDegen}
+        loading={loading}
+        setLoading={setLoading}
+        showRef={showRef}
+        setShowRef={setShowRef}
+        panZoom={panZoom}
+        setPanZoom={setPanZoom}
       />
-
-      <ChipRow
-        label="Responsiveness"
-        options={RESPONSIVENESS_OPTIONS}
-        value={smoothing}
-        onChange={setSmoothing}
-      />
-
-      <ChipRow
-        label="Scrub trailing fade (dimOpacity)"
-        options={SCRUB_DIM_OPTIONS}
-        value={scrubDim}
-        onChange={setScrubDim}
-      />
-
-      <ControlRow label="Series scrub tooltip">
-        <ToggleChip
-          label="Pills"
-          value={seriesTooltip}
-          onChange={setSeriesTooltip}
-        />
-        <ToggleChip
-          label="Pin while idle"
-          value={tooltipAlwaysShow}
-          onChange={setTooltipAlwaysShow}
-        />
-        <ToggleChip
-          label="Styled"
-          value={styledTooltip}
-          onChange={setStyledTooltip}
-        />
-      </ControlRow>
-
-      <ControlRow label="Playback & theme">
-        <ToggleChip
-          label="Pause"
-          value={paused}
-          onChange={() => setPaused((p) => !p)}
-        />
-        <ToggleChip
-          label="Exaggerate"
-          value={exaggerate}
-          onChange={() => setExaggerate((e) => !e)}
-        />
-        <ToggleChip
-          label="Degen"
-          value={degen}
-          onChange={() => setDegen((d) => !d)}
-        />
-        <Chip
-          label={loading ? "…" : "Load"}
-          active={loading}
-          disabled={loading}
-          onPress={() => {
-            setLoading(true);
-            setTimeout(() => setLoading(false), 2000);
-          }}
-        />
-        <ToggleChip
-          label="QA connector"
-          value={showRef}
-          onChange={() => setShowRef((r) => !r)}
-        />
-        <ToggleChip
-          label="Pan + zoom"
-          value={panZoom}
-          onChange={() => setPanZoom((p) => !p)}
-        />
-      </ControlRow>
       <ChipRow
         label="QA reference edge"
         options={QA_REFERENCE_EDGE_OPTIONS}

--- a/app/demo/scrubbing.tsx
+++ b/app/demo/scrubbing.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Circle, Group } from "@shopify/react-native-skia";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import {
   formatTime,
   LiveChart,
@@ -104,7 +104,14 @@ const DOT_OPTIONS: { value: DotMode; label: string }[] = [
 function RingSelectionDot({ x, y, opacity, size }: SelectionDotProps) {
   return (
     <Group opacity={opacity}>
-      <Circle cx={x} cy={y} r={size + 3} color="#fbbf24" style="stroke" strokeWidth={2} />
+      <Circle
+        cx={x}
+        cy={y}
+        r={size + 3}
+        color="#fbbf24"
+        style="stroke"
+        strokeWidth={2}
+      />
       <Circle cx={x} cy={y} r={size - 1} color="#fbbf24" />
     </Group>
   );
@@ -158,6 +165,234 @@ function OhlcTooltip({ candle }: TooltipRenderProps) {
       />
     </View>
   );
+}
+
+type TooltipControlsProps = {
+  scrubMode: ScrubMode;
+  setScrubMode: Dispatch<SetStateAction<ScrubMode>>;
+  tooltipPlacement: TooltipPlacement;
+  setTooltipPlacement: Dispatch<SetStateAction<TooltipPlacement>>;
+  tooltipMargin: number;
+  setTooltipMargin: Dispatch<SetStateAction<number>>;
+  dateOnly: boolean;
+  setDateOnly: Dispatch<SetStateAction<boolean>>;
+  timeRow: boolean;
+  setTimeRow: Dispatch<SetStateAction<boolean>>;
+  roundedTip: boolean;
+  setRoundedTip: Dispatch<SetStateAction<boolean>>;
+  styledTooltip: boolean;
+  setStyledTooltip: Dispatch<SetStateAction<boolean>>;
+  customTooltip: boolean;
+  setCustomTooltip: Dispatch<SetStateAction<boolean>>;
+  dimOpacity: number;
+  setDimOpacity: Dispatch<SetStateAction<number>>;
+  dotMode: DotMode;
+  setDotMode: Dispatch<SetStateAction<DotMode>>;
+};
+
+function TooltipControls(props: TooltipControlsProps) {
+  return (
+    <>
+      <ChipRow
+        label="Scrub"
+        options={SCRUB_OPTIONS}
+        value={props.scrubMode}
+        onChange={props.setScrubMode}
+      />
+      <ChipRow
+        label="Tooltip placement"
+        options={PLACEMENT_OPTIONS}
+        value={props.tooltipPlacement}
+        onChange={props.setTooltipPlacement}
+      />
+      <ChipRow
+        label="Tooltip margin (edge gap)"
+        options={MARGIN_OPTIONS}
+        value={props.tooltipMargin}
+        onChange={props.setTooltipMargin}
+      />
+      <ControlRow label="Tooltip">
+        <ToggleChip
+          label="Date only"
+          value={props.dateOnly}
+          onChange={props.setDateOnly}
+        />
+        <ToggleChip
+          label="Time row"
+          value={props.timeRow}
+          onChange={props.setTimeRow}
+        />
+        <ToggleChip
+          label="Rounded"
+          value={props.roundedTip}
+          onChange={props.setRoundedTip}
+        />
+        <ToggleChip
+          label="Styled"
+          value={props.styledTooltip}
+          onChange={props.setStyledTooltip}
+        />
+        <ToggleChip
+          label="Custom render"
+          value={props.customTooltip}
+          onChange={props.setCustomTooltip}
+        />
+      </ControlRow>
+      <ChipRow
+        label="Trailing fade (dimOpacity)"
+        options={DIM_OPTIONS}
+        value={props.dimOpacity}
+        onChange={props.setDimOpacity}
+      />
+      <ChipRow
+        label="Selection dot"
+        options={DOT_OPTIONS}
+        value={props.dotMode}
+        onChange={props.setDotMode}
+      />
+    </>
+  );
+}
+
+type CrosshairControlsProps = {
+  crosshairDash: boolean;
+  setCrosshairDash: Dispatch<SetStateAction<boolean>>;
+  thickCrosshair: boolean;
+  setThickCrosshair: Dispatch<SetStateAction<boolean>>;
+  crosshairOvershootEnabled: boolean;
+  setCrosshairOvershootEnabled: Dispatch<SetStateAction<boolean>>;
+  crosshairFade: boolean;
+  setCrosshairFade: Dispatch<SetStateAction<boolean>>;
+  crosshairFadeDistance: number;
+  setCrosshairFadeDistance: Dispatch<SetStateAction<number>>;
+  crosshairLineCap: CrosshairLineCapChoice;
+  setCrosshairLineCap: Dispatch<SetStateAction<CrosshairLineCapChoice>>;
+  holdToScrub: boolean;
+  setHoldToScrub: Dispatch<SetStateAction<boolean>>;
+  clampToPlot: boolean;
+  setClampToPlot: Dispatch<SetStateAction<boolean>>;
+  hideOverlays: boolean;
+  setHideOverlays: Dispatch<SetStateAction<boolean>>;
+};
+
+function CrosshairControls(props: CrosshairControlsProps) {
+  return (
+    <>
+      <ControlRow label="Crosshair">
+        <ToggleChip
+          label="Dashed"
+          value={props.crosshairDash}
+          onChange={props.setCrosshairDash}
+        />
+        <ToggleChip
+          label="3px wide"
+          value={props.thickCrosshair}
+          onChange={props.setThickCrosshair}
+        />
+        <ToggleChip
+          label="6px overshoot"
+          value={props.crosshairOvershootEnabled}
+          onChange={props.setCrosshairOvershootEnabled}
+        />
+        <ToggleChip
+          label="Edge fade"
+          value={props.crosshairFade}
+          onChange={props.setCrosshairFade}
+        />
+      </ControlRow>
+      <ChipRow
+        label="Crosshair fade distance"
+        options={FADE_DISTANCE_OPTIONS}
+        value={props.crosshairFadeDistance}
+        onChange={props.setCrosshairFadeDistance}
+      />
+      <ChipRow
+        label="Crosshair line cap"
+        options={LINE_CAP_OPTIONS}
+        value={props.crosshairLineCap}
+        onChange={props.setCrosshairLineCap}
+      />
+      <ControlRow label="Gesture">
+        <ToggleChip
+          label="Hold to scrub (250ms)"
+          value={props.holdToScrub}
+          onChange={props.setHoldToScrub}
+        />
+        <ToggleChip
+          label="Clamp to plot"
+          value={props.clampToPlot}
+          onChange={props.setClampToPlot}
+        />
+      </ControlRow>
+      <ControlRow label="Overlays">
+        <ToggleChip
+          label="Hide on scrub"
+          value={props.hideOverlays}
+          onChange={props.setHideOverlays}
+        />
+      </ControlRow>
+    </>
+  );
+}
+
+type ScrubSettings = {
+  scrubMode: ScrubMode;
+  dimOpacity: number;
+  panGestureDelay: number;
+  clampToPlot: boolean;
+  hideOverlays: boolean;
+  tooltipPlacement: TooltipPlacement;
+  tooltipMargin: number;
+  dateOnly: boolean;
+  timeRow: boolean;
+  roundedTip: boolean;
+  crosshairDash: boolean;
+  thickCrosshair: boolean;
+  crosshairOvershootEnabled: boolean;
+  crosshairFade: boolean;
+  crosshairFadeDistance: number;
+  crosshairLineCap: CrosshairLineCapChoice;
+  styledTooltip: boolean;
+};
+
+function resolveScrub(settings: ScrubSettings): ScrubConfig | boolean {
+  if (settings.scrubMode === "off") return false;
+  return {
+    tooltip: settings.scrubMode !== "noTooltip",
+    dimOpacity: settings.dimOpacity,
+    panGestureDelay: settings.panGestureDelay,
+    clampToPlot: settings.clampToPlot,
+    hideOverlaysOnScrub: settings.hideOverlays,
+    tooltipPlacement: settings.tooltipPlacement,
+    tooltipMargin: settings.tooltipMargin,
+    tooltipShowValue: !settings.dateOnly,
+    tooltipShowTime: settings.dateOnly || settings.timeRow,
+    tooltipBorderRadius: settings.roundedTip ? 16 : 5,
+    crosshairDash: settings.crosshairDash ? [3, 4] : false,
+    crosshairStrokeWidth: settings.thickCrosshair ? 3 : 1,
+    crosshairOvershoot: settings.crosshairOvershootEnabled ? 6 : 0,
+    crosshairFade: settings.crosshairFade,
+    crosshairFadeDistance: settings.crosshairFadeDistance,
+    crosshairLineCap:
+      settings.crosshairLineCap === "default"
+        ? undefined
+        : settings.crosshairLineCap,
+    ...(settings.styledTooltip
+      ? {
+          tooltipBackground: "#1e293b",
+          tooltipColor: "#fbbf24",
+          tooltipBorderColor: "#fbbf24",
+          crosshairLineColor: "#fbbf24",
+        }
+      : {}),
+  };
+}
+
+function resolveSelectionDot(mode: DotMode) {
+  if (mode === "custom") return { component: RingSelectionDot };
+  if (mode === "styled")
+    return { size: 6, color: "#fbbf24", ring: { width: 2 } };
+  return mode === "off" ? false : true;
 }
 
 export default function ScrubbingScreen() {
@@ -251,55 +486,30 @@ export default function ScrubbingScreen() {
     );
   }, [markers]);
 
-  const scrub: ScrubConfig | boolean =
-    scrubMode === "off"
-      ? false
-      : {
-          tooltip: scrubMode !== "noTooltip",
-          dimOpacity,
-          panGestureDelay,
-          clampToPlot,
-          hideOverlaysOnScrub: hideOverlays,
-          // Tooltip layout knobs — apply to the built-in pill and the custom
-          // render alike (placement + margin position either one).
-          tooltipPlacement,
-          tooltipMargin,
-          tooltipShowValue: !dateOnly,
-          // Date only means hide the value while keeping the date visible. The
-          // separate Time row toggle can add the date to the normal value view.
-          tooltipShowTime: dateOnly || timeRow,
-          tooltipBorderRadius: roundedTip ? 16 : 5,
-          // `true` → default [4,4] dash; pass explicit [on, off] intervals for
-          // finer control. Omit / `false` → solid.
-          crosshairDash: crosshairDash ? [3, 4] : false,
-          crosshairStrokeWidth: thickCrosshair ? 3 : 1,
-          crosshairOvershoot: crosshairOvershootEnabled ? 6 : 0,
-          crosshairFade,
-          crosshairFadeDistance,
-          crosshairLineCap:
-            crosshairLineCap === "default" ? undefined : crosshairLineCap,
-          // The "Styled" toggle recolors the built-in pill + crosshair line.
-          ...(styledTooltip
-            ? {
-                tooltipBackground: "#1e293b",
-                tooltipColor: "#fbbf24",
-                tooltipBorderColor: "#fbbf24",
-                crosshairLineColor: "#fbbf24",
-              }
-            : {}),
-        };
+  const scrub = resolveScrub({
+    scrubMode,
+    dimOpacity,
+    panGestureDelay,
+    clampToPlot,
+    hideOverlays,
+    tooltipPlacement,
+    tooltipMargin,
+    dateOnly,
+    timeRow,
+    roundedTip,
+    crosshairDash,
+    thickCrosshair,
+    crosshairOvershootEnabled,
+    crosshairFade,
+    crosshairFadeDistance,
+    crosshairLineCap,
+    styledTooltip,
+  });
 
   // The `boolean | SelectionDotConfig` idiom: `true` = built-in dot, `false` =
   // hidden, a config tweaks size/color/ring, and `{ component }` swaps in a
   // fully custom Skia dot.
-  const selectionDot =
-    dotMode === "custom"
-      ? { component: RingSelectionDot }
-      : dotMode === "styled"
-        ? { size: 6, color: "#fbbf24", ring: { width: 2 } }
-        : dotMode === "off"
-          ? false
-          : true;
+  const selectionDot = resolveSelectionDot(dotMode);
 
   return (
     <DemoScreen
@@ -362,115 +572,48 @@ export default function ScrubbingScreen() {
         animatedProps={readoutProps}
       />
 
-      <ChipRow
-        label="Scrub"
-        options={SCRUB_OPTIONS}
-        value={scrubMode}
-        onChange={setScrubMode}
+      <TooltipControls
+        scrubMode={scrubMode}
+        setScrubMode={setScrubMode}
+        tooltipPlacement={tooltipPlacement}
+        setTooltipPlacement={setTooltipPlacement}
+        tooltipMargin={tooltipMargin}
+        setTooltipMargin={setTooltipMargin}
+        dateOnly={dateOnly}
+        setDateOnly={setDateOnly}
+        timeRow={timeRow}
+        setTimeRow={setTimeRow}
+        roundedTip={roundedTip}
+        setRoundedTip={setRoundedTip}
+        styledTooltip={styledTooltip}
+        setStyledTooltip={setStyledTooltip}
+        customTooltip={customTooltip}
+        setCustomTooltip={setCustomTooltip}
+        dimOpacity={dimOpacity}
+        setDimOpacity={setDimOpacity}
+        dotMode={dotMode}
+        setDotMode={setDotMode}
       />
-      <ChipRow
-        label="Tooltip placement"
-        options={PLACEMENT_OPTIONS}
-        value={tooltipPlacement}
-        onChange={setTooltipPlacement}
+      <CrosshairControls
+        crosshairDash={crosshairDash}
+        setCrosshairDash={setCrosshairDash}
+        thickCrosshair={thickCrosshair}
+        setThickCrosshair={setThickCrosshair}
+        crosshairOvershootEnabled={crosshairOvershootEnabled}
+        setCrosshairOvershootEnabled={setCrosshairOvershootEnabled}
+        crosshairFade={crosshairFade}
+        setCrosshairFade={setCrosshairFade}
+        crosshairFadeDistance={crosshairFadeDistance}
+        setCrosshairFadeDistance={setCrosshairFadeDistance}
+        crosshairLineCap={crosshairLineCap}
+        setCrosshairLineCap={setCrosshairLineCap}
+        holdToScrub={holdToScrub}
+        setHoldToScrub={setHoldToScrub}
+        clampToPlot={clampToPlot}
+        setClampToPlot={setClampToPlot}
+        hideOverlays={hideOverlays}
+        setHideOverlays={setHideOverlays}
       />
-      <ChipRow
-        label="Tooltip margin (edge gap)"
-        options={MARGIN_OPTIONS}
-        value={tooltipMargin}
-        onChange={setTooltipMargin}
-      />
-      <ControlRow label="Tooltip">
-        {/* Date-only + rounded restyle the built-in pill; Custom render swaps in
-            a brand-blue RN pill. Placement/margin apply to the custom one too. */}
-        {/* tooltipShowValue / tooltipShowTime drop a row independently — combine
-            for value-only / time-only / both. */}
-        <ToggleChip label="Date only" value={dateOnly} onChange={setDateOnly} />
-        <ToggleChip label="Time row" value={timeRow} onChange={setTimeRow} />
-        <ToggleChip
-          label="Rounded"
-          value={roundedTip}
-          onChange={setRoundedTip}
-        />
-        <ToggleChip
-          label="Styled"
-          value={styledTooltip}
-          onChange={setStyledTooltip}
-        />
-        <ToggleChip
-          label="Custom render"
-          value={customTooltip}
-          onChange={setCustomTooltip}
-        />
-      </ControlRow>
-      <ChipRow
-        label="Trailing fade (dimOpacity)"
-        options={DIM_OPTIONS}
-        value={dimOpacity}
-        onChange={setDimOpacity}
-      />
-      <ChipRow
-        label="Selection dot"
-        options={DOT_OPTIONS}
-        value={dotMode}
-        onChange={setDotMode}
-      />
-      <ControlRow label="Crosshair">
-        {/* Geometry and edge-fade controls live together for visual QA. */}
-        <ToggleChip
-          label="Dashed"
-          value={crosshairDash}
-          onChange={setCrosshairDash}
-        />
-        <ToggleChip
-          label="3px wide"
-          value={thickCrosshair}
-          onChange={setThickCrosshair}
-        />
-        <ToggleChip
-          label="6px overshoot"
-          value={crosshairOvershootEnabled}
-          onChange={setCrosshairOvershootEnabled}
-        />
-        <ToggleChip
-          label="Edge fade"
-          value={crosshairFade}
-          onChange={setCrosshairFade}
-        />
-      </ControlRow>
-      <ChipRow
-        label="Crosshair fade distance"
-        options={FADE_DISTANCE_OPTIONS}
-        value={crosshairFadeDistance}
-        onChange={setCrosshairFadeDistance}
-      />
-      <ChipRow
-        label="Crosshair line cap"
-        options={LINE_CAP_OPTIONS}
-        value={crosshairLineCap}
-        onChange={setCrosshairLineCap}
-      />
-      <ControlRow label="Gesture">
-        <ToggleChip
-          label="Hold to scrub (250ms)"
-          value={holdToScrub}
-          onChange={setHoldToScrub}
-        />
-        <ToggleChip
-          label="Clamp to plot"
-          value={clampToPlot}
-          onChange={setClampToPlot}
-        />
-      </ControlRow>
-      <ControlRow label="Overlays">
-        {/* scrub.hideOverlaysOnScrub — fade markers + reference lines while
-            scrubbing. Toggle off to see them stay put under the crosshair. */}
-        <ToggleChip
-          label="Hide on scrub"
-          value={hideOverlays}
-          onChange={setHideOverlays}
-        />
-      </ControlRow>
 
       <ChipRow
         label="Display"

--- a/app/demo/theming.tsx
+++ b/app/demo/theming.tsx
@@ -5,10 +5,16 @@ import {
   useFonts as useJetBrainsFonts,
 } from "@expo-google-fonts/jetbrains-mono";
 import { useFonts } from "expo-font";
-import { useState } from "react";
+import {
+  useState,
+  type ComponentProps,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import {
   LiveChart,
   MONO_FONT_FAMILY,
+  type FontConfig,
   type FontWeight,
   type LiveChartMetricsOverride,
 } from "react-native-livechart";
@@ -69,6 +75,158 @@ const WEIGHT_OPTIONS = WEIGHTS.map((w) => ({ value: w, label: w }));
 /** Platform `matchFont` mono vs bundled fonts via Skia `typeface` (+ expo-font for RN labels). */
 type SkiaFontFamilyDemo = "platformMono" | "jetbrainsMono" | "googleSansCode";
 
+type LiveChartProps = ComponentProps<typeof LiveChart>;
+
+function resolveMetrics(
+  roomyBadge: boolean,
+  fastMotion: boolean,
+): LiveChartMetricsOverride | undefined {
+  if (!roomyBadge && !fastMotion) return undefined;
+  return {
+    ...(roomyBadge ? { badge: ROOMY_BADGE } : {}),
+    ...(fastMotion ? FAST_MOTION : {}),
+  };
+}
+
+function resolveGradient(mode: GradientMode): LiveChartProps["gradient"] {
+  switch (mode) {
+    case "off":
+      return false;
+    case "custom":
+      return { topOpacity: 0.5, bottomOpacity: 0.05 };
+    case "multi":
+      return { colors: MULTI_GRADIENT_COLORS };
+    case "on":
+      return true;
+  }
+}
+
+function resolveTypeface(
+  family: SkiaFontFamilyDemo,
+): FontConfig["typeface"] | undefined {
+  if (family === "jetbrainsMono") return JetBrainsMono_400Regular;
+  if (family === "googleSansCode") return googleSansCodeRegular;
+  return undefined;
+}
+
+type ThemedChartProps = {
+  data: ReturnType<typeof useSimulatedChartData>["data"];
+  value: ReturnType<typeof useSimulatedChartData>["value"];
+  accent: string;
+  theme: "dark" | "light";
+  gradientMode: GradientMode;
+  lineWide: boolean;
+  lineColor: boolean;
+  fontSize: number;
+  fontWeight: FontWeight;
+  skiaFontFamily: SkiaFontFamilyDemo;
+  gridDashed: boolean;
+  metrics: LiveChartMetricsOverride | undefined;
+  paletteOverride: boolean;
+  roundedStyle: boolean;
+};
+
+function ThemedChart(props: ThemedChartProps) {
+  return (
+    <LiveChart
+      data={props.data}
+      value={props.value}
+      accentColor={props.accent}
+      theme={props.theme}
+      gradient={resolveGradient(props.gradientMode)}
+      line={
+        props.lineWide || props.lineColor
+          ? {
+              width: props.lineWide ? 4 : 2,
+              color: props.lineColor ? "#f472b6" : undefined,
+            }
+          : undefined
+      }
+      font={{
+        fontFamily: MONO_FONT_FAMILY,
+        fontSize: props.fontSize,
+        fontWeight: props.fontWeight,
+        ...(resolveTypeface(props.skiaFontFamily)
+          ? { typeface: resolveTypeface(props.skiaFontFamily) }
+          : {}),
+      }}
+      gridStyle={
+        props.gridDashed ? { intervals: [1, 3], opacity: 0.8 } : undefined
+      }
+      metrics={props.metrics}
+      palette={
+        props.paletteOverride
+          ? { gridLine: "rgba(96,165,250,0.35)", gridLabel: "#60a5fa" }
+          : undefined
+      }
+      style={
+        props.roundedStyle
+          ? { borderRadius: 16, overflow: "hidden", margin: 4 }
+          : undefined
+      }
+      scrub={false}
+    />
+  );
+}
+
+type FontControlsProps = {
+  family: SkiaFontFamilyDemo;
+  setFamily: Dispatch<SetStateAction<SkiaFontFamilyDemo>>;
+  jetbrainsLoaded: boolean;
+  googleSansLoaded: boolean;
+};
+
+function FontControls(props: FontControlsProps) {
+  const options: {
+    family: SkiaFontFamilyDemo;
+    label: string;
+    fontFamily?: string;
+  }[] = [
+    { family: "platformMono", label: "Platform mono" },
+    {
+      family: "jetbrainsMono",
+      label: "JetBrains Mono",
+      fontFamily: props.jetbrainsLoaded
+        ? "JetBrainsMono_400Regular"
+        : undefined,
+    },
+    {
+      family: "googleSansCode",
+      label: "Google Sans Code",
+      fontFamily: props.googleSansLoaded ? "GoogleSansCodeRegular" : undefined,
+    },
+  ];
+  return (
+    <>
+      <Text style={demoStyles.sectionLabel}>Font (Skia)</Text>
+      <View style={demoStyles.buttonRow}>
+        {options.map((option) => (
+          <Pressable
+            key={option.family}
+            style={[
+              demoStyles.chip,
+              props.family === option.family && demoStyles.chipActive,
+            ]}
+            onPress={() => props.setFamily(option.family)}
+          >
+            <Text
+              style={[
+                demoStyles.chipText,
+                props.family === option.family && demoStyles.chipTextActive,
+                option.fontFamily
+                  ? { fontFamily: option.fontFamily }
+                  : undefined,
+              ]}
+            >
+              {option.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </>
+  );
+}
+
 export default function ThemingScreen() {
   const [jetbrainsLoaded] = useJetBrainsFonts({
     JetBrainsMono_400Regular,
@@ -79,9 +237,7 @@ export default function ThemingScreen() {
 
   const [theme, setTheme] = useState<"dark" | "light">(APP_THEME);
   const [accent, setAccent] = useState(ACCENT_PRESETS[0]);
-  const [gradientOn, setGradientOn] = useState(true);
-  const [gradientCfg, setGradientCfg] = useState(false);
-  const [gradientMulti, setGradientMulti] = useState(false);
+  const [gradientMode, setGradientMode] = useState<GradientMode>("on");
   const [lineWide, setLineWide] = useState(false);
   const [lineColor, setLineColor] = useState(false);
   const [fontSize, setFontSize] = useState(11);
@@ -96,26 +252,7 @@ export default function ThemingScreen() {
 
   // Merge the two metric toggles into a single override (or undefined when both
   // are off, so the chart keeps its built-in defaults).
-  const metrics: LiveChartMetricsOverride | undefined =
-    roomyBadge || fastMotion
-      ? {
-          ...(roomyBadge ? { badge: ROOMY_BADGE } : {}),
-          ...(fastMotion ? FAST_MOTION : {}),
-        }
-      : undefined;
-
-  const gradientMode: GradientMode = !gradientOn
-    ? "off"
-    : gradientMulti
-      ? "multi"
-      : gradientCfg
-        ? "custom"
-        : "on";
-  const setGradientMode = (mode: GradientMode) => {
-    setGradientOn(mode !== "off");
-    setGradientCfg(mode === "custom");
-    setGradientMulti(mode === "multi");
-  };
+  const metrics = resolveMetrics(roomyBadge, fastMotion);
 
   const { data, value } = useSimulatedChartData({
     multiSeries: false,
@@ -133,55 +270,21 @@ export default function ThemingScreen() {
       docs="guides/theming"
       description="Theming: theme, accent, gradient, line, font (Skia: system / JetBrains / Google Sans Code), grid & palette, container style"
       chart={
-        <LiveChart
+        <ThemedChart
           data={data}
           value={value}
-          accentColor={accent}
+          accent={accent}
           theme={theme}
-          gradient={
-            gradientMulti
-              ? { colors: MULTI_GRADIENT_COLORS }
-              : gradientCfg
-                ? { topOpacity: 0.5, bottomOpacity: 0.05 }
-                : gradientOn
-          }
-          line={
-            lineWide || lineColor
-              ? {
-                  width: lineWide ? 4 : 2,
-                  color: lineColor ? "#f472b6" : undefined,
-                }
-              : undefined
-          }
-          font={{
-            fontFamily: MONO_FONT_FAMILY,
-            fontSize,
-            fontWeight,
-            ...(skiaFontFamily === "jetbrainsMono"
-              ? { typeface: JetBrainsMono_400Regular }
-              : skiaFontFamily === "googleSansCode"
-                ? { typeface: googleSansCodeRegular }
-                : {}),
-          }}
-          gridStyle={
-            gridDashed ? { intervals: [1, 3], opacity: 0.8 } : undefined
-          }
+          gradientMode={gradientMode}
+          lineWide={lineWide}
+          lineColor={lineColor}
+          fontSize={fontSize}
+          fontWeight={fontWeight}
+          skiaFontFamily={skiaFontFamily}
+          gridDashed={gridDashed}
           metrics={metrics}
-          palette={
-            paletteOverride
-              ? { gridLine: "rgba(96,165,250,0.35)", gridLabel: "#60a5fa" }
-              : undefined
-          }
-          style={
-            roundedStyle
-              ? {
-                  borderRadius: 16,
-                  overflow: "hidden",
-                  margin: 4,
-                }
-              : undefined
-          }
-          scrub={false}
+          paletteOverride={paletteOverride}
+          roundedStyle={roundedStyle}
         />
       }
     >
@@ -219,59 +322,12 @@ export default function ThemingScreen() {
         />
       </ControlRow>
 
-      <Text style={demoStyles.sectionLabel}>Font (Skia)</Text>
-      <View style={demoStyles.buttonRow}>
-        <Pressable
-          style={[
-            demoStyles.chip,
-            skiaFontFamily === "platformMono" && demoStyles.chipActive,
-          ]}
-          onPress={() => setSkiaFontFamily("platformMono")}
-        >
-          <Text
-            style={[
-              demoStyles.chipText,
-              skiaFontFamily === "platformMono" && demoStyles.chipTextActive,
-            ]}
-          >
-            Platform mono
-          </Text>
-        </Pressable>
-        <Pressable
-          style={[
-            demoStyles.chip,
-            skiaFontFamily === "jetbrainsMono" && demoStyles.chipActive,
-          ]}
-          onPress={() => setSkiaFontFamily("jetbrainsMono")}
-        >
-          <Text
-            style={[
-              demoStyles.chipText,
-              skiaFontFamily === "jetbrainsMono" && demoStyles.chipTextActive,
-              jetbrainsLoaded && { fontFamily: "JetBrainsMono_400Regular" },
-            ]}
-          >
-            JetBrains Mono
-          </Text>
-        </Pressable>
-        <Pressable
-          style={[
-            demoStyles.chip,
-            skiaFontFamily === "googleSansCode" && demoStyles.chipActive,
-          ]}
-          onPress={() => setSkiaFontFamily("googleSansCode")}
-        >
-          <Text
-            style={[
-              demoStyles.chipText,
-              skiaFontFamily === "googleSansCode" && demoStyles.chipTextActive,
-              googleSansLoaded && { fontFamily: "GoogleSansCodeRegular" },
-            ]}
-          >
-            Google Sans Code
-          </Text>
-        </Pressable>
-      </View>
+      <FontControls
+        family={skiaFontFamily}
+        setFamily={setSkiaFontFamily}
+        jetbrainsLoaded={jetbrainsLoaded}
+        googleSansLoaded={googleSansLoaded}
+      />
       <Text style={[demoStyles.chipText, { opacity: 0.65, marginBottom: 8 }]}>
         Bundled fonts use Skia{" "}
         <Text style={{ fontFamily: "monospace" }}>font.typeface</Text> with{" "}

--- a/app/demo/transitions.tsx
+++ b/app/demo/transitions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import { Text } from "react-native";
 import { LiveChart, LiveChartTransition } from "react-native-livechart";
 
@@ -61,6 +61,225 @@ const ACCENT_OPTIONS: { value: Accent; label: string }[] = [
   { value: "violet", label: "violet" },
 ];
 
+type TransitionChartProps = {
+  example: Example;
+  mode: Mode;
+  accent: Accent;
+  keepMounted: boolean;
+  instant: boolean;
+  timeframe: Timeframe;
+  snap: boolean;
+  bucket: Bucket;
+  candleSnap: boolean;
+  data: ReturnType<typeof useSimulatedChartData>["data"];
+  value: ReturnType<typeof useSimulatedChartData>["value"];
+  candles: ReturnType<typeof useSimulatedChartData>["candles"];
+  liveCandle: ReturnType<typeof useSimulatedChartData>["liveCandle"];
+};
+
+function TransitionChart(props: TransitionChartProps) {
+  const { example, data, value, candles, liveCandle } = props;
+  switch (example) {
+    case "mode":
+      return (
+        <LiveChart
+          data={data}
+          value={value}
+          mode={props.mode}
+          candles={candles}
+          liveCandle={liveCandle}
+          candleWidth={CANDLE_WIDTH}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={WINDOW}
+          transitions={props.instant ? false : undefined}
+          accessibilityLabel={`Price ${props.mode} chart`}
+          scrub={false}
+        />
+      );
+    case "snap":
+      return (
+        <LiveChart
+          data={data}
+          value={value}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={TIMEFRAME_WINDOW[props.timeframe]}
+          smoothing={0.4}
+          snapKey={props.snap ? props.timeframe : undefined}
+          transitions={{ reveal: 0 }}
+          accessibilityLabel={`Price chart, ${props.timeframe} window`}
+          scrub={false}
+        />
+      );
+    case "candleWidth":
+      return (
+        <LiveChart
+          data={data}
+          value={value}
+          mode="candle"
+          candles={candles}
+          liveCandle={liveCandle}
+          candleWidth={props.bucket}
+          accentColor={ACCENT}
+          theme={APP_THEME}
+          timeWindow={WINDOW}
+          transitions={{ candleLerpSpeed: props.candleSnap ? 1 : undefined }}
+          accessibilityLabel={`Candle chart, ${props.bucket}s buckets`}
+          scrub={false}
+        />
+      );
+    case "crossfade":
+      return (
+        <LiveChartTransition
+          active={props.accent}
+          duration={350}
+          keepMounted={props.keepMounted}
+        >
+          <LiveChart
+            key="blue"
+            data={data}
+            value={value}
+            accentColor="#3b82f6"
+            theme={APP_THEME}
+            timeWindow={WINDOW}
+            scrub={false}
+          />
+          <LiveChart
+            key="violet"
+            data={data}
+            value={value}
+            accentColor="#a855f7"
+            theme={APP_THEME}
+            timeWindow={WINDOW}
+            scrub={false}
+          />
+        </LiveChartTransition>
+      );
+  }
+}
+
+type TransitionControlsProps = {
+  example: Example;
+  mode: Mode;
+  setMode: Dispatch<SetStateAction<Mode>>;
+  instant: boolean;
+  setInstant: Dispatch<SetStateAction<boolean>>;
+  timeframe: Timeframe;
+  setTimeframe: Dispatch<SetStateAction<Timeframe>>;
+  snap: boolean;
+  setSnap: Dispatch<SetStateAction<boolean>>;
+  bucket: Bucket;
+  setBucket: Dispatch<SetStateAction<Bucket>>;
+  candleSnap: boolean;
+  setCandleSnap: Dispatch<SetStateAction<boolean>>;
+  accent: Accent;
+  setAccent: Dispatch<SetStateAction<Accent>>;
+  keepMounted: boolean;
+  setKeepMounted: Dispatch<SetStateAction<boolean>>;
+};
+
+function TransitionControls(props: TransitionControlsProps) {
+  switch (props.example) {
+    case "mode":
+      return (
+        <>
+          <ChipRow
+            label="Mode"
+            options={MODE_OPTIONS}
+            value={props.mode}
+            onChange={props.setMode}
+          />
+          <ControlRow label="transitions">
+            <ToggleChip
+              label="Instant (no animation)"
+              value={props.instant}
+              onChange={props.setInstant}
+            />
+          </ControlRow>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            One LiveChart with a toggled mode — the engine morphs line↔candle
+            and the y-axis eases between the two ranges (no re-reveal). Flip
+            Instant ({`transitions={false}`}) to switch with no animation.
+          </Text>
+        </>
+      );
+    case "snap":
+      return (
+        <>
+          <ChipRow
+            label="Timeframe"
+            options={TIMEFRAME_OPTIONS}
+            value={props.timeframe}
+            onChange={props.setTimeframe}
+          />
+          <ControlRow label="snapKey">
+            <ToggleChip
+              label="Snap on change"
+              value={props.snap}
+              onChange={props.setSnap}
+            />
+          </ControlRow>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            Switch the timeframe. With Snap on ({`snapKey={timeframe}`}) the
+            window and y-range jump to the new framing in one frame; live ticks
+            still glide ({`smoothing={0.4}`}). Toggle Snap off to feel the same
+            change slide in instead — that slide is the easing, not a
+            transition.
+          </Text>
+        </>
+      );
+    case "candleWidth":
+      return (
+        <>
+          <ChipRow
+            label="Bucket"
+            options={BUCKET_OPTIONS}
+            value={props.bucket}
+            onChange={props.setBucket}
+          />
+          <ControlRow label="transitions.candleLerpSpeed">
+            <ToggleChip
+              label="Instant (candleLerpSpeed: 1)"
+              value={props.candleSnap}
+              onChange={props.setCandleSnap}
+            />
+          </ControlRow>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            Switch the Bucket to re-aggregate the candles. With Instant on (
+            {`transitions={{ candleLerpSpeed: 1 }}`}) the bodies resize in one
+            frame; toggle it off for the default 0.08 ease — the slow “fat →
+            thin” slide from #176. Independent of {`snapKey`} / {`smoothing`}.
+          </Text>
+        </>
+      );
+    case "crossfade":
+      return (
+        <>
+          <ChipRow
+            label="Active layer"
+            options={ACCENT_OPTIONS}
+            value={props.accent}
+            onChange={props.setAccent}
+          />
+          <ControlRow label="LiveChartTransition">
+            <ToggleChip
+              label="keepMounted"
+              value={props.keepMounted}
+              onChange={props.setKeepMounted}
+            />
+          </ControlRow>
+          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
+            LiveChartTransition cross-fades two chart instances (here: accent
+            color, blue↔violet). keepMounted on = both engines stay mounted and
+            switching is a pure cross-fade; off = the incoming chart mounts
+            fresh and re-reveals (range re-animates) on each switch.
+          </Text>
+        </>
+      );
+  }
+}
+
 export default function TransitionsScreen() {
   const [example, setExample] = useState<Example>("mode");
   const [mode, setMode] = useState<Mode>("line");
@@ -101,87 +320,21 @@ export default function TransitionsScreen() {
       docs="guides/transitions"
       description="Line↔candle uses one chart's mode prop (shared y-axis morph); LiveChartTransition cross-fades two instances (here: accent color)"
       chart={
-        example === "mode" ? (
-          // Built-in line↔candle morph — ONE engine, so the y-axis eases
-          // smoothly between the line and candle ranges (no re-reveal).
-          <LiveChart
-            data={data}
-            value={value}
-            mode={mode}
-            candles={candles}
-            liveCandle={liveCandle}
-            candleWidth={CANDLE_WIDTH}
-            accentColor={ACCENT}
-            theme={APP_THEME}
-            timeWindow={WINDOW}
-            transitions={instant ? false : undefined}
-            accessibilityLabel={`Price ${mode} chart`}
-            scrub={false}
-          />
-        ) : example === "snap" ? (
-          // Snap-on-timeframe: a high smoothing keeps live ticks gliding, while
-          // `snapKey={timeframe}` makes a window change land in one frame. Toggle
-          // Snap off (snapKey omitted) to feel the framing slide instead.
-          <LiveChart
-            data={data}
-            value={value}
-            accentColor={ACCENT}
-            theme={APP_THEME}
-            timeWindow={TIMEFRAME_WINDOW[timeframe]}
-            smoothing={0.4}
-            snapKey={snap ? timeframe : undefined}
-            transitions={{ reveal: 0 }}
-            accessibilityLabel={`Price chart, ${timeframe} window`}
-            scrub={false}
-          />
-        ) : example === "candleWidth" ? (
-          // Candle-width resize: switching the bucket re-buckets the OHLC (the
-          // candle count + width both change). With Instant on, the bodies snap to
-          // the new width in one frame (candleLerpSpeed: 1); off uses the 0.08
-          // default ease, the "fat → thin" slide from #176.
-          <LiveChart
-            data={data}
-            value={value}
-            mode="candle"
-            candles={candles}
-            liveCandle={liveCandle}
-            candleWidth={bucket}
-            accentColor={ACCENT}
-            theme={APP_THEME}
-            timeWindow={WINDOW}
-            transitions={{ candleLerpSpeed: candleSnap ? 1 : undefined }}
-            accessibilityLabel={`Candle chart, ${bucket}s buckets`}
-            scrub={false}
-          />
-        ) : (
-          // Cross-fade between two instances. keepMounted lets both settle their
-          // y-range up front, so switching is a pure opacity fade. Same data +
-          // scale, so the two layers line up — only the accent color differs.
-          <LiveChartTransition
-            active={accent}
-            duration={350}
-            keepMounted={keepMounted}
-          >
-            <LiveChart
-              key="blue"
-              data={data}
-              value={value}
-              accentColor="#3b82f6"
-              theme={APP_THEME}
-              timeWindow={WINDOW}
-              scrub={false}
-            />
-            <LiveChart
-              key="violet"
-              data={data}
-              value={value}
-              accentColor="#a855f7"
-              theme={APP_THEME}
-              timeWindow={WINDOW}
-              scrub={false}
-            />
-          </LiveChartTransition>
-        )
+        <TransitionChart
+          example={example}
+          mode={mode}
+          accent={accent}
+          keepMounted={keepMounted}
+          instant={instant}
+          timeframe={timeframe}
+          snap={snap}
+          bucket={bucket}
+          candleSnap={candleSnap}
+          data={data}
+          value={value}
+          candles={candles}
+          liveCandle={liveCandle}
+        />
       }
     >
       <ChipRow
@@ -191,95 +344,25 @@ export default function TransitionsScreen() {
         onChange={setExample}
       />
 
-      {example === "mode" ? (
-        <>
-          <ChipRow
-            label="Mode"
-            options={MODE_OPTIONS}
-            value={mode}
-            onChange={setMode}
-          />
-          <ControlRow label="transitions">
-            {/* transitions={false} → instant reveal + instant line↔candle switch. */}
-            <ToggleChip
-              label="Instant (no animation)"
-              value={instant}
-              onChange={setInstant}
-            />
-          </ControlRow>
-          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-            One LiveChart with a toggled mode — the engine morphs line↔candle and
-            the y-axis eases between the two ranges (no re-reveal). Flip Instant
-            ({`transitions={false}`}) to switch with no animation.
-          </Text>
-        </>
-      ) : example === "snap" ? (
-        <>
-          <ChipRow
-            label="Timeframe"
-            options={TIMEFRAME_OPTIONS}
-            value={timeframe}
-            onChange={setTimeframe}
-          />
-          <ControlRow label="snapKey">
-            <ToggleChip
-              label="Snap on change"
-              value={snap}
-              onChange={setSnap}
-            />
-          </ControlRow>
-          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-            Switch the timeframe. With Snap on ({`snapKey={timeframe}`}) the window
-            and y-range jump to the new framing in one frame; live ticks still
-            glide ({`smoothing={0.4}`}). Toggle Snap off to feel the same change
-            slide in instead — that slide is the easing, not a transition.
-          </Text>
-        </>
-      ) : example === "candleWidth" ? (
-        <>
-          <ChipRow
-            label="Bucket"
-            options={BUCKET_OPTIONS}
-            value={bucket}
-            onChange={setBucket}
-          />
-          <ControlRow label="transitions.candleLerpSpeed">
-            <ToggleChip
-              label="Instant (candleLerpSpeed: 1)"
-              value={candleSnap}
-              onChange={setCandleSnap}
-            />
-          </ControlRow>
-          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-            Switch the Bucket to re-aggregate the candles. With Instant on
-            ({`transitions={{ candleLerpSpeed: 1 }}`}) the bodies resize in one
-            frame; toggle it off for the default 0.08 ease — the slow “fat → thin”
-            slide from #176. Independent of {`snapKey`} / {`smoothing`}.
-          </Text>
-        </>
-      ) : (
-        <>
-          <ChipRow
-            label="Active layer"
-            options={ACCENT_OPTIONS}
-            value={accent}
-            onChange={setAccent}
-          />
-          <ControlRow label="LiveChartTransition">
-            <ToggleChip
-              label="keepMounted"
-              value={keepMounted}
-              onChange={setKeepMounted}
-            />
-          </ControlRow>
-          <Text style={[demoStyles.chipText, { opacity: 0.6, marginTop: 8 }]}>
-            LiveChartTransition cross-fades two chart instances (here: accent
-            color, blue↔violet). keepMounted on = both engines stay mounted and
-            switching is a pure cross-fade; off = the incoming chart mounts fresh
-            and re-reveals (range re-animates) on each switch.
-          </Text>
-        </>
-      )}
+      <TransitionControls
+        example={example}
+        mode={mode}
+        setMode={setMode}
+        instant={instant}
+        setInstant={setInstant}
+        timeframe={timeframe}
+        setTimeframe={setTimeframe}
+        snap={snap}
+        setSnap={setSnap}
+        bucket={bucket}
+        setBucket={setBucket}
+        candleSnap={candleSnap}
+        setCandleSnap={setCandleSnap}
+        accent={accent}
+        setAccent={setAccent}
+        keepMounted={keepMounted}
+        setKeepMounted={setKeepMounted}
+      />
     </DemoScreen>
   );
 }


### PR DESCRIPTION
## Summary

- decompose the axes, empty-state, markers, multi-series, scrubbing, theming, and transitions demos into focused render sections
- preserve the same demo state, controls, gestures, and chart props
- eliminate the remaining demo maintainability findings with real component boundaries

## QA

- focused demo coverage: 174 tests passed
- `npm run verify`: 111 suites passed; 1,650 tests passed, 5 skipped
- React Doctor 0.9.13 suppression-neutralized scan: 15 diagnostics, down from 23
- production Expo web export: passed with all 47 routes
- production JS bundle delta: +9,900 bytes raw / +2,545 bytes gzip, about 0.22%

Part of #307.