### PR TITLE
refactor: initialize trend text from animated reaction

### DIFF
--- a/demo-lib/AnimatedTrendTextInput.tsx
+++ b/demo-lib/AnimatedTrendTextInput.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useState } from "react";
 import { StyleSheet, type TextStyle } from "react-native";
 import Animated, {
   Easing,
@@ -68,17 +68,10 @@ export function AnimatedTrendTextInput({
 }: AnimatedTrendTextInputProps) {
   const flash = useSharedValue(0);
 
-  // Seed off the render path: reading a SharedValue during render (incl. a
-  // useState initializer) trips Reanimated's strict-mode warning. useLayoutEffect
-  // runs before paint, so there's no placeholder flash; the reaction below keeps
-  // it live thereafter. react-doctor's "derive during render" fix is exactly what
-  // Reanimated forbids here, so suppress its effect-read rules at this seed.
+  // The reaction emits the current SharedValue on its first evaluation, then
+  // keeps the React snapshot in sync. Starting with the placeholder avoids both
+  // a render-time SharedValue read and a synchronous state update in an effect.
   const [rawValue, setRawValue] = useState(NaN);
-  // react-doctor-disable-next-line react-doctor/no-derived-state-effect -- Reanimated: must read the SharedValue off the render path
-  useLayoutEffect(() => {
-    // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- Reanimated: seeding from a SharedValue off render is the warning-free path
-    setRawValue(sharedValue.get());
-  }, [sharedValue]);
 
   const display = formatValue(rawValue, formatter, maximumFractionDigits);
 


### PR DESCRIPTION
## Summary

- remove effect-driven state seeding from the animated trend readout
- use the existing animated reaction for the initial snapshot and subsequent values
- avoid both render-time SharedValue reads and synchronous effect updates

## QA

- `npm run verify`: 111 suites passed; 1,650 tests passed, 5 skipped
- React Doctor 0.9.13 suppression-neutralized scan: 3 diagnostics, down from 4
- production Expo web export: passed with all 47 routes
- production JS bundle delta: -110 bytes raw / -52 bytes gzip

Part of #307.