### PR TITLE
refactor: reconcile reference state from stable values

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -479,26 +479,29 @@ function useLiveReferenceState(
   const dragActive = useSharedValue<boolean[]>([]);
   const seededRef = useRef<(number | undefined)[]>([]);
   const refValueSig = allRefLines.map((line) => line.value ?? "_").join(",");
+  const propValues = useMemo<(number | undefined)[]>(() => {
+    if (refValueSig === "") return [];
+    return refValueSig
+      .split(",")
+      .map((encoded) => (encoded === "_" ? undefined : Number(encoded)));
+  }, [refValueSig]);
   useEffect(() => {
     const active = dragActive.get();
     const current = dragValues.get();
     const seeded = seededRef.current;
     dragValues.set(
-      allRefLines.map((line, index) => {
-        const prop = line.value ?? 0;
+      propValues.map((value, index) => {
+        const prop = value ?? 0;
         if (active[index]) return current[index] ?? prop;
-        if (line.value !== seeded[index]) return prop;
+        if (value !== seeded[index]) return prop;
         return current[index] ?? prop;
       }),
     );
-    seededRef.current = allRefLines.map((line) => line.value);
-    if (dragActive.get().length !== allRefLines.length) {
-      dragActive.set(allRefLines.map((_, index) => active[index] ?? false));
+    seededRef.current = propValues;
+    if (dragActive.get().length !== propValues.length) {
+      dragActive.set(propValues.map((_, index) => active[index] ?? false));
     }
-    // The line list is reconstructed from props; its value signature and length
-    // are the stable reconciliation inputs.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refValueSig, allRefLines.length]);
+  }, [dragActive, dragValues, propValues]);
 
   const refLineCustomTagWidths = useSharedValue<number[]>([]);
   const liveRefValues = useDerivedValue<number[]>(() => {


### PR DESCRIPTION
## Summary

- decode the stable reference-value signature into memoized reconciliation input
- give the drag-state synchronization effect complete dependencies
- preserve active drag values while accepting external line-value changes

## QA

- `LiveChart` and reference-line coverage passed as part of the full suite
- `npm run verify`: 111 suites passed; 1,650 tests passed, 5 skipped
- React Doctor 0.9.13 suppression-neutralized scan: both workspaces 100/100, zero diagnostics
- production Expo web export: passed with all 47 routes
- production JS bundle delta: +585 bytes raw / +338 bytes gzip

Part of #307.