### PR TITLE
refactor: capture layout sample from animated reaction

### DIFF
--- a/packages/react-native-livechart/src/components/LiveChart.tsx
+++ b/packages/react-native-livechart/src/components/LiveChart.tsx
@@ -2,7 +2,6 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -1321,13 +1320,7 @@ function useLiveChartLayoutResources({
   const refGroupBadgeFont = refGroupBadgeHasFont
     ? refGroupBadgeFontOverride
     : skiaFont;
-  const [valueLayoutSample, setValueLayoutSample] = useState<
-    number | undefined
-  >(undefined);
-  useLayoutEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Reanimated SharedValues cannot be read during render
-    setValueLayoutSample(value.get());
-  }, [value]);
+  const valueLayoutSample = useInitialSharedValueSample(value);
   const [scrolledBack, setScrolledBack] = useState(false);
   const effectiveYAxisFloat =
     yAxisFloat && (!timeScrollEnabled || scrolledBack);
@@ -1358,6 +1351,21 @@ function useLiveChartLayoutResources({
     setScrolledBack,
     ...layout,
   };
+}
+
+function useInitialSharedValueSample(value: SharedValue<number>) {
+  const [sample, setSample] = useState<number | undefined>(undefined);
+  const captured = useSharedValue(false);
+  useAnimatedReaction(
+    () => (captured.get() ? null : value.get()),
+    (current) => {
+      if (current === null) return;
+      captured.set(true);
+      scheduleOnRN(setSample, current);
+    },
+    [captured, value],
+  );
+  return sample;
 }
 
 function resolveLiveChartModelDefaults({


### PR DESCRIPTION
## Summary

- replace synchronous layout-effect state seeding with a one-shot animated reaction
- capture the initial live value without reading a SharedValue during render
- gate the reaction after the first sample so later ticks do not cross to the JS thread

## QA

- focused `LiveChart`: 87 tests passed
- `npm run verify`: 111 suites passed; 1,650 tests passed, 5 skipped
- configured React Doctor 0.9.13 scan: Expo app 100/100, library 100/100, zero aggregate diagnostics
- production Expo web export: passed with all 47 routes
- production JS bundle delta: +869 bytes raw / +218 bytes gzip
- library build, npm pack, and packed iOS bundle-mode consumer export passed

Part of #307.