### PR TITLE
refactor: store frame scratch in a lazy ref

### DIFF
--- a/packages/react-native-livechart/src/core/useLiveChartEngine.ts
+++ b/packages/react-native-livechart/src/core/useLiveChartEngine.ts
@@ -586,9 +586,12 @@ export function useLiveChartEngine(
     extremaMinTime,
     extremaMaxTime,
   };
-  const [frameScratchRef] = useState(() => ({
-    current: makeEngineFrameScratch(),
-  }));
+  const frameScratchRef = useRef<EngineFrameScratch | null>(null);
+  if (frameScratchRef.current === null) {
+    // React permits this predictable lazy-ref initialization: https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents
+    // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- false positive for React's documented lazy-ref exception
+    frameScratchRef.current = makeEngineFrameScratch();
+  }
 
   // `autostart=false` registers the frame callback without running it — the live
   // loop is fully inert in static mode (the invariant that makes this worth it).


### PR DESCRIPTION
## Summary

- replace state containing a mutable `{ current }` box with a real `useRef`
- initialize the single-series frame scratch buffer with the documented predictable null-guarded React pattern
- link the initializer directly to the official React guidance

The repository-wide audit found and corrected all three mutable state/ref workarounds: particle pool and multi-series scratch in #310, plus the pre-existing single-series scratch container here.

## QA

- focused particle and engine coverage: 135 tests passed
- `npm run verify`: 111 suites passed; 1,650 tests passed, 5 skipped
- configured React Doctor 0.9.13 scan: Expo app 100/100, library 100/100, zero diagnostics
- suppression-neutralized audit: exactly three diagnostics, all three being React-documented lazy-ref initializers that React Doctor 0.9.13 misclassifies
- source audit: zero mutable state-backed refs, zero state objects containing mutable `current` boxes
- production Expo web export: passed with all 47 routes
- production JS bundle delta: +85 bytes raw / +61 bytes gzip
- shader benchmark remained byte-identical; optimized path was 3.9% faster than legacy in this run
- library build, npm pack, and packed iOS bundle-mode consumer export passed (2,772 modules; 3.9 MB bundle)

Closes #307.